### PR TITLE
feat(db): Aurora PostgreSQL Serverless v2 + RDS Proxy + Secrets Manager

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -65,6 +65,59 @@ The PG-vs-MySQL choice is forced by how mem9 implements vectors:
   OpenAI text-embedding-3-small = 1536). Pin dims once; changing later requires a
   reindex.
 
+### 3a. DB auth: **RDS Proxy + Secrets Manager rotation** (no committed password; NOT native IAM)
+
+The operator asked to avoid a password / use IAM-role auth. **Probed, verified,
+and decided (public-AWS only):**
+
+- **mem9 cannot do IAM database auth unmodified.** `server/internal/config/config.go`
+  reads a **single static `MNEMO_DSN`** env var (no separate host/user/pass vars);
+  `postgres.go` does `sql.Open("pgx", dsn)` (pgx v5 stdlib) and reads the
+  credential **once at startup** — no `BeforeConnect`/credential-refresh hook. An
+  Aurora **IAM auth token expires in ~15 min**, but the DSN is static, so pool
+  connections would start failing after the token expires. This is true whether
+  connecting **directly** to Aurora or via **RDS Proxy with client-side IAM**
+  (mem9 is the IAM token client either way). Verified against mem9 source +
+  public AWS Aurora docs (`rds-proxy-connecting.html`).
+- **Chosen: RDS Proxy in front of Aurora; the DB password lives ONLY in AWS
+  Secrets Manager with automatic rotation.** Flow:
+  ```
+  mnemo-server  --(static user+password from ECS `secrets: valueFrom`)-->  RDS Proxy
+                                          RDS Proxy  --(Secrets Manager creds, TLS)-->  Aurora PG
+  ```
+  - The Aurora credential is generated (a static `RandomPassword`) + stored in a
+    **Secrets Manager** secret by `sst.aws.Aurora` (the value never appears in
+    git, the SST code, or the ECS task def as a literal). ⚠️ SST's `proxy: true`
+    does **NOT** configure rotation (no `manageMasterUserPassword`, no rotation
+    Lambda) → **automatic rotation is an Open item (#6)**. Launch posture =
+    "secret not committed / not human-handled," not "auto-rotated."
+  - RDS Proxy targets Aurora and reads that secret to authenticate; it also pools
+    + multiplexes connections (good for `desiredCount=1` reconnpressure).
+  - mem9's `MNEMO_DSN` points at the **proxy endpoint** and carries a user +
+    password injected into the container via an ECS **`secrets: valueFrom`** (from
+    Secrets Manager / SSM SecureString) at task start — resolved to an env var by
+    ECS, **never a plaintext literal in the committed task def or repo.**
+  - Not *literally* passwordless at the mem9 hop, but: the password is never
+    committed, never human-handled, and rotates automatically — which satisfies
+    the real intent (no static secret in code, IAM-governed access to the secret).
+    The ECS task role gets `secretsmanager:GetSecretValue` on that one secret ARN.
+- **Deferred (Open decision, not adopted):** true end-to-end IAM (no password at
+  all) via either (a) a **token-refresh sidecar** minting a fresh RDS IAM token
+  <15 min and reloading mem9, or (b) a **mem9 source patch** (pgx `BeforeConnect`
+  + AWS auth-token generator). Both are more moving parts / a fork; revisit if the
+  operator wants zero password even in Secrets Manager.
+- **TLS**: RDS Proxy requires TLS for IAM client connections and uses ACM certs
+  itself; the mnemo-server → proxy hop uses password auth over TLS (proxy has a
+  managed cert; no cert to manage on our side). Set `sslmode=require` in `MNEMO_DSN`.
+
+> **Customer-facing / public-AWS-only note.** This deployment is intended for
+> customers and must use **only public AWS services**. Aurora + RDS Proxy +
+> Secrets Manager are all public — compliant. ⚠️ The LLM smart-ingest path
+> (§7) currently targets **Bedrock *Mantle***, which is an internal/preview
+> surface — for a customer-facing build that must be revisited to the **public**
+> `bedrock-runtime` Converse API (or an OpenAI-compatible public gateway). Tracked
+> in Open decisions; does not affect the DB-auth decision here.
+
 ## 4. Compute: **ECS Fargate, arm64, single task**
 
 - mnemo-server is a Go HTTP server (`:8080`), stateless for our usage → ECS
@@ -314,6 +367,18 @@ model is the heavy tenant), which is the main swing in the Fargate cost row.
 
 - **DB engine**: Aurora **PostgreSQL Serverless v2** + pgvector (not MySQL, not
   RDS t4g). Backend = mem9 `postgres`.
+- **DB auth (§3a)**: **RDS Proxy + Secrets Manager**, NOT native IAM (mem9's
+  static `MNEMO_DSN` / pgx-stdlib / no credential refresh can't handle the ~15-min
+  IAM token). Aurora password lives only in Secrets Manager (static
+  `RandomPassword` from `sst.aws.Aurora`; **rotation NOT configured by default —
+  Open #6**); RDS Proxy fronts Aurora; mem9's `MNEMO_DSN` → proxy endpoint with a
+  user+password injected via ECS `secrets: valueFrom` (never committed /
+  human-handled). Task role gets `secretsmanager:GetSecretValue` on the one secret
+  ARN. True end-to-end IAM deferred (sidecar or source patch) — see Open decisions.
+- **Public-AWS-only (customer-facing)**: this deployment targets customers, so it
+  must use **only public AWS services**. Aurora / RDS Proxy / Secrets Manager are
+  public ✅. The **Bedrock Mantle** LLM path (§7) is internal/preview → flagged for
+  revisit to public `bedrock-runtime` Converse before a customer build (Open #7).
 - **Region**: ap-northeast-1 (Tokyo). **Compute**: ECS Fargate, arm64,
   `desiredCount=1`. **VPC**: reuse default VPC private subnets.
 - **MCP + auth**: AgentCore Gateway + Cognito M2M (podcast-curation pattern).
@@ -356,6 +421,21 @@ model is the heavy tenant), which is the main swing in the Fargate cost row.
    point-in-time recovery wanted? (Data-ownership project → likely yes.)
 5. **CI / deploy** — GHA with the `RUNNER_LABEL` self-hosted pattern; how the
    arm64 image builds & pushes to ECR (docker-build provider vs. CodeBuild arm).
-6. **Secrets** — DB credentials → Secrets Manager / SSM SecureString; wiring into
-   the Fargate task. (Mantle bearer is minted at runtime by the token sidecar, not
-   a stored secret.)
+6. **Secrets + rotation** — storage RESOLVED into the DB-auth lock (§3a): Aurora
+   creds in a Secrets Manager secret (`sst.aws.Aurora` static `RandomPassword`),
+   consumed by RDS Proxy + injected into the Fargate task via ECS `secrets:
+   valueFrom`. **STILL OPEN: automatic rotation** — SST's `proxy: true` does NOT
+   attach a rotation Lambda, so add a Secrets Manager rotation schedule + the RDS
+   rotation Lambda (+ grant `secretsmanager:RotateSecret`) if rotation is wanted.
+   (Mantle bearer is minted at runtime by the token sidecar, not a stored secret.)
+   Also remaining: RDS Proxy `MaxConnectionsPercent` / pinning tuning for
+   `desiredCount=1`.
+7. **Public-AWS LLM path (customer-facing)** — the solution must use only public
+   AWS services. §7's **Bedrock Mantle** smart-ingest is internal/preview → for a
+   customer build, migrate the OpenAI-compatible `/chat/completions` LLM to the
+   **public `bedrock-runtime` Converse API** (or a public OpenAI-compatible
+   gateway) + a `bedrock:InvokeModel`-based auth. Does not affect DB/Aurora.
+8. **True end-to-end IAM DB auth (deferred)** — reach zero-password by either a
+   token-refresh sidecar (mints an RDS IAM token <15 min, reloads mem9) or a mem9
+   source patch (pgx `BeforeConnect` + AWS auth-token generator). Not adopted;
+   §3a's Secrets-Manager-rotation path is the launch choice.

--- a/docs/mem9-facts.md
+++ b/docs/mem9-facts.md
@@ -44,6 +44,40 @@ on. Re-verify against the pinned upstream commit before implementing IaC.
 per-tenant DB" architecture (a `tenants` row carries db_host/user/pass/name per
 tenant); for a single operator you run one active tenant.
 
+### DB connection mechanism (probed — decisive for IAM-auth question)
+Verified from `server/internal/config/config.go` + `server/internal/repository/postgres/postgres.go`:
+- The **control-plane** connection is a **single static DSN env var `MNEMO_DSN`**
+  (required; `os.Getenv("MNEMO_DSN")`). mem9 does **NOT** assemble the DSN from
+  separate host/user/pass/dbname/sslmode env vars — there are no such vars.
+- `NewDB(dsn)` = `sql.Open("pgx", dsn)` via the **pgx v5 stdlib driver**
+  (`_ "github.com/jackc/pgx/v5/stdlib"`), pool sized `SetMaxOpenConns(25)` /
+  `SetMaxIdleConns(5)` / `SetConnMaxLifetime(5m)`, `db.Ping()` at startup.
+- **Credential is read ONCE at startup and never refreshed** — no `BeforeConnect`
+  hook, no credential callback, no password-returning function (the stdlib pgx
+  path doesn't expose pgxpool's `BeforeConnect`). Rotating the credential requires
+  a process restart.
+- **Consequence for IAM DB auth**: an RDS/Aurora **IAM auth token expires in
+  ~15 min**, but `MNEMO_DSN` is static → new pool connections after ~15 min would
+  fail with auth error. So **native (end-to-end) IAM database auth is NOT viable
+  for mem9 unmodified**, whether direct to Aurora OR client-side-IAM through RDS
+  Proxy (mem9 is the IAM client either way). **Chosen (LOCKED): RDS Proxy +
+  Secrets Manager** (ARCHITECTURE.md §3a). The Aurora password lives ONLY in a
+  Secrets Manager secret (a **static `RandomPassword`** created by
+  `sst.aws.Aurora` — ⚠️ SST's `proxy:true` does NOT use `manageMasterUserPassword`
+  and attaches **no rotation Lambda**, so it is NOT auto-rotated; rotation is
+  ARCHITECTURE.md Open #6). RDS Proxy pulls the secret and pools/multiplexes; mem9
+  connects to the **proxy endpoint** with a user+password delivered to the
+  container via an ECS `secrets: valueFrom` (Secrets Manager → env at task start)
+  — never a literal in the task def or git. Not literally passwordless at the
+  mem9 hop, but the password is never committed or human-handled. A future
+  token-refresh sidecar (like the Mantle one) or a mem9 source patch (pgx
+  `BeforeConnect` + AWS auth-token generator) could enable true end-to-end IAM
+  later — recorded as an Open decision, not adopted now.
+- The per-tenant `tenants` rows ALSO carry db_host/user/pass; `MNEMO_ENCRYPT_TYPE`
+  (`plain`|`kms`) + `MNEMO_ENCRYPT_KEY` encrypt those stored tenant DB passwords.
+  For a single operator with one tenant pointed at the same Aurora, the tenant
+  row's creds and the control-plane DSN target the same cluster.
+
 ### postgres backend (the one we use)
 - Uses **`github.com/pgvector/pgvector-go`**. Column `embedding vector(N)`.
 - **VectorSearch** = pgvector cosine: `... embedding <=> $q AS distance ORDER BY

--- a/infra/cloudformation/github-actions-role.yaml
+++ b/infra/cloudformation/github-actions-role.yaml
@@ -283,6 +283,189 @@ Resources:
                 iam:PassedToService:
                   - lambda.amazonaws.com
                   - ecs-tasks.amazonaws.com
+                  # rds.amazonaws.com — sst.aws.Aurora proxy:true passes the
+                  # ProxyRole to the RDS Proxy (rds:CreateDBProxy roleArn). Without
+                  # this, PassRole is denied and the first DB deploy 403s.
+                  - rds.amazonaws.com
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # Policy 4 — Database stack (infra/db.ts): Aurora PostgreSQL Serverless v2 +
+  # RDS Proxy + Secrets Manager (rotated master creds) + the EC2 primitives a
+  # DB subnet group / security group need. Its own ManagedPolicy so the broad
+  # RDS create surface doesn't push CorePolicy/ScaffoldPolicy past IAM's
+  # 6144-byte per-policy cap, and the DB footprint is auditable in one place.
+  #
+  # ADDED for the Aurora PR — must be live (re-run scripts/deploy-github-role.sh)
+  # BEFORE that PR's first deploy, or the deploy 403s on the first RDS/Proxy/
+  # Secret create (CLAUDE-AWS "new resource TYPE needs grants first" rule).
+  # ───────────────────────────────────────────────────────────────────────────
+  DatabasePolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: !Sub ${GitHubRepo}-database
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: RDS
+            # Aurora cluster + instance + DB subnet group + RDS Proxy lifecycle.
+            # RDS has no useful per-resource ARN granularity for many Describe/
+            # Create calls (and Pulumi refreshes probe broadly), so Resource "*".
+            # Guarded by the DenyPolicy against account-level RDS abuse.
+            Effect: Allow
+            Action:
+              - rds:CreateDBCluster
+              - rds:ModifyDBCluster
+              - rds:DeleteDBCluster
+              - rds:DescribeDBClusters
+              - rds:CreateDBInstance
+              - rds:ModifyDBInstance
+              - rds:DeleteDBInstance
+              - rds:DescribeDBInstances
+              - rds:CreateDBSubnetGroup
+              - rds:ModifyDBSubnetGroup
+              - rds:DeleteDBSubnetGroup
+              - rds:DescribeDBSubnetGroups
+              - rds:CreateDBClusterParameterGroup
+              - rds:ModifyDBClusterParameterGroup
+              - rds:DeleteDBClusterParameterGroup
+              - rds:DescribeDBClusterParameterGroups
+              - rds:DescribeDBClusterParameters
+              # DB-INSTANCE parameter group — SST's Aurora creates a `pg:` group
+              # (Mem9DbParameterGroup) for the instance, distinct from the
+              # cluster-level group above. Both families are needed.
+              - rds:CreateDBParameterGroup
+              - rds:ModifyDBParameterGroup
+              - rds:DeleteDBParameterGroup
+              - rds:DescribeDBParameterGroups
+              - rds:DescribeDBParameters
+              - rds:DescribeGlobalClusters
+              - rds:DescribeDBEngineVersions
+              - rds:ListTagsForResource
+              - rds:AddTagsToResource
+              - rds:RemoveTagsFromResource
+              # RDS Proxy lifecycle (proxy: true on sst.aws.Aurora).
+              - rds:CreateDBProxy
+              - rds:ModifyDBProxy
+              - rds:DeleteDBProxy
+              - rds:DescribeDBProxies
+              - rds:RegisterDBProxyTargets
+              - rds:DeregisterDBProxyTargets
+              - rds:DescribeDBProxyTargets
+              - rds:DescribeDBProxyTargetGroups
+              - rds:ModifyDBProxyTargetGroup
+            Resource: "*"
+          - Sid: RDSServiceLinkedRoles
+            # RDS + RDS Proxy provision service-linked roles on first use in an
+            # account. Scope CreateServiceLinkedRole to the two RDS service
+            # namespaces (the DenyPolicy blocks Delete of any SLR). This is the
+            # grant the panel flagged as needed once a real AWS-managed service
+            # (here RDS/Proxy) enters the stack.
+            Effect: Allow
+            Action:
+              - iam:CreateServiceLinkedRole
+            Resource: "*"
+            Condition:
+              StringEquals:
+                iam:AWSServiceName:
+                  - rds.amazonaws.com
+                  - rds.application-autoscaling.amazonaws.com
+          - Sid: RDSServiceLinkedRoleLookup
+            # SST's Aurora does a GetRole on the RDS service-linked role
+            # (AWSServiceRoleForRDS) to decide whether CreateServiceLinkedRole is
+            # needed. iam:GetRole in RdsProxyRole is scoped to mem9-on-aws-*, so
+            # grant this read explicitly on the SLR ARN (+ the autoscaling SLR).
+            Effect: Allow
+            Action:
+              - iam:GetRole
+            Resource:
+              - !Sub arn:aws:iam::${AWS::AccountId}:role/aws-service-role/rds.amazonaws.com/AWSServiceRoleForRDS
+              - !Sub arn:aws:iam::${AWS::AccountId}:role/aws-service-role/rds.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_RDSCluster
+          - Sid: RdsProxyRole
+            # sst.aws.Aurora with proxy:true creates a CUSTOMER IAM role
+            # (`<app>-<stage>-Mem9DbProxyRole-<random>`) with an inline
+            # secretsmanager:GetSecretValue policy, then passes it to the proxy
+            # (rds.amazonaws.com). Grant the role lifecycle scoped to this
+            # project's auto-named roles + SST truncation variants. (PassRole to
+            # rds.amazonaws.com is granted in ScaffoldPolicy's PassRoleConstrained.)
+            Effect: Allow
+            Action:
+              - iam:CreateRole
+              - iam:PutRolePolicy
+              - iam:GetRole
+              - iam:GetRolePolicy
+              - iam:ListRolePolicies
+              - iam:ListAttachedRolePolicies
+              - iam:TagRole
+              - iam:UntagRole
+              - iam:DeleteRole
+              - iam:DeleteRolePolicy
+            Resource:
+              - !Sub arn:aws:iam::${AWS::AccountId}:role/mem9-on-aws-*
+              - !Sub arn:aws:iam::${AWS::AccountId}:role/mem9-on-aw-*
+              - !Sub arn:aws:iam::${AWS::AccountId}:role/mem9-on-a-*
+          - Sid: SecretsManager
+            # sst.aws.Aurora creates its OWN secret `<app>-<stage>-Mem9DbProxySecret
+            # -<random>` holding a static RandomPassword — it does NOT use RDS
+            # manageMasterUserPassword, so there is NO `rds!`-prefixed managed
+            # secret and NO built-in rotation. The auto-name has no leading slash,
+            # so scope to the `mem9-on-aws-*` prefix. CreateSecret can't be
+            # resource-scoped (no ARN at create time) → its own statement below.
+            Effect: Allow
+            Action:
+              - secretsmanager:UpdateSecret
+              - secretsmanager:DeleteSecret
+              - secretsmanager:DescribeSecret
+              - secretsmanager:GetSecretValue
+              - secretsmanager:PutSecretValue
+              - secretsmanager:ListSecretVersionIds
+              - secretsmanager:GetResourcePolicy
+              - secretsmanager:PutResourcePolicy
+              - secretsmanager:DeleteResourcePolicy
+              - secretsmanager:TagResource
+              - secretsmanager:UntagResource
+            Resource:
+              - !Sub arn:${AWS::Partition}:secretsmanager:*:${AWS::AccountId}:secret:mem9-on-aws-*
+          - Sid: SecretsManagerCreate
+            # CreateSecret is authorized before the resource ARN exists, so it
+            # can't be resource-scoped. Split out with Resource "*"; every
+            # subsequent op on the secret is governed by the name-prefixed
+            # statement above, and the DenyPolicy blocks account-level abuse.
+            Effect: Allow
+            Action:
+              - secretsmanager:CreateSecret
+            Resource: "*"
+          - Sid: EC2ForDatabase
+            # Security-group lifecycle for the Aurora cluster + RDS Proxy SGs.
+            # DescribeVpcs/Subnets already granted in ScaffoldPolicy (read-only);
+            # here add the SG create/authorize surface. No per-resource ARN on
+            # create, so Resource "*"; the SG rules themselves scope 5432 to the
+            # task SG at the resource level in infra/db.ts.
+            Effect: Allow
+            Action:
+              - ec2:CreateSecurityGroup
+              - ec2:DeleteSecurityGroup
+              - ec2:AuthorizeSecurityGroupIngress
+              - ec2:AuthorizeSecurityGroupEgress
+              - ec2:RevokeSecurityGroupIngress
+              - ec2:RevokeSecurityGroupEgress
+              - ec2:CreateTags
+              - ec2:DeleteTags
+              - ec2:DescribeSecurityGroupRules
+            Resource: "*"
+          - Sid: KMSForRds
+            # Aurora storage + the Secrets Manager secret use the AWS-managed
+            # keys (aws/rds, aws/secretsmanager) by default. Pulumi refreshes
+            # read key metadata; grant the read/describe + grant-creation surface
+            # AWS-managed-key usage needs. Account-scoped, never Resource-widened
+            # to a customer-managed-key delete.
+            Effect: Allow
+            Action:
+              - kms:DescribeKey
+              - kms:CreateGrant
+              - kms:ListAliases
+              - kms:GenerateDataKey
+              - kms:Decrypt
+            Resource: "*"
 
   # ───────────────────────────────────────────────────────────────────────────
   # IAM Role — assumed by GitHub Actions via OIDC.
@@ -320,6 +503,7 @@ Resources:
         - !Ref DenyPolicy
         - !Ref CorePolicy
         - !Ref ScaffoldPolicy
+        - !Ref DatabasePolicy
       Tags:
         - Key: Project
           Value: !Ref ProjectName

--- a/infra/db.test.ts
+++ b/infra/db.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Unit tests for the `db` stack factory. Mocks the SST globals ($app,
+ * aws.ec2.*, aws.ssm.Parameter, sst.aws.Aurora) so the factory runs bare.
+ * Asserts the security-group relationship (5432 from the task SG only), the
+ * Aurora args (postgres, proxy, scaling, vpc wiring), the SSM export contract,
+ * and the prod-vs-non-prod final-snapshot transform.
+ */
+
+function out<T>(value: T): { value: T; apply: (fn: (v: T) => unknown) => unknown } {
+  return { value, apply: (fn) => out(fn(value) as never) };
+}
+
+interface SgRecord {
+  logicalName: string;
+  args: { vpcId: unknown; ingress?: unknown[]; egress?: unknown[] };
+}
+interface ParamRecord {
+  name: string;
+  type: string;
+}
+interface AuroraRecord {
+  logicalName: string;
+  args: Record<string, unknown>;
+}
+
+let sgs: SgRecord[];
+let params: ParamRecord[];
+let auroras: AuroraRecord[];
+
+function installGlobals(stage: string) {
+  (globalThis as Record<string, unknown>).$app = { name: "mem9-on-aws", stage };
+  (globalThis as Record<string, unknown>).aws = {
+    ec2: {
+      getVpcOutput: () => ({ id: out("vpc-test") }),
+      getSubnetsOutput: () => ({ ids: out(["subnet-a", "subnet-b", "subnet-c"]) }),
+      SecurityGroup: class {
+        id: unknown;
+        constructor(logicalName: string, args: SgRecord["args"]) {
+          sgs.push({ logicalName, args });
+          // Each SG gets a stable fake id derived from its logical name.
+          this.id = out(`sg-${logicalName}`);
+        }
+      },
+    },
+    ssm: {
+      Parameter: class {
+        constructor(_logicalName: string, args: { name: unknown; type: unknown }) {
+          const name =
+            typeof args.name === "object" && args.name && "value" in args.name
+              ? (args.name as { value: string }).value
+              : (args.name as string);
+          params.push({ name, type: args.type as string });
+        }
+      },
+    },
+  };
+  (globalThis as Record<string, unknown>).sst = {
+    aws: {
+      Aurora: class {
+        host = out("mem9-proxy.example");
+        port = out(5432);
+        username = out("postgres");
+        password = out("secret");
+        database = out("mem9");
+        secretArn = out("arn:aws:secretsmanager:x:y:secret:z");
+        constructor(logicalName: string, args: Record<string, unknown>) {
+          auroras.push({ logicalName, args });
+        }
+      },
+    },
+  };
+}
+
+beforeEach(() => {
+  sgs = [];
+  params = [];
+  auroras = [];
+});
+
+afterEach(() => {
+  for (const g of ["$app", "aws", "sst"]) delete (globalThis as Record<string, unknown>)[g];
+  delete process.env.MEM9_VPC_ID;
+  vi.resetModules();
+});
+
+async function loadDb() {
+  vi.resetModules();
+  return (await import("./db")).db;
+}
+
+describe("db stack", () => {
+  it("creates a task SG and a db SG allowing 5432 from the task SG only", async () => {
+    installGlobals("prod");
+    const db = await loadDb();
+    db();
+
+    expect(sgs).toHaveLength(2);
+    const taskSg = sgs.find((s) => s.logicalName === "Mem9TaskSg");
+    const dbSg = sgs.find((s) => s.logicalName === "Mem9DbSg");
+    expect(taskSg).toBeDefined();
+    expect(dbSg).toBeDefined();
+
+    const ingress = (dbSg!.args.ingress ?? []) as Array<{
+      fromPort: number;
+      toPort: number;
+      cidrBlocks?: unknown;
+      securityGroups?: unknown;
+    }>;
+    expect(ingress).toHaveLength(1);
+    expect(ingress[0].fromPort).toBe(5432);
+    expect(ingress[0].toPort).toBe(5432);
+    // 5432 comes from the task SG, NOT an open CIDR.
+    expect(ingress[0].securityGroups).toBeDefined();
+    expect(ingress[0].cidrBlocks).toBeUndefined();
+  });
+
+  it("provisions Aurora postgres with proxy + scaling + vpc wiring", async () => {
+    installGlobals("prod");
+    const db = await loadDb();
+    db();
+
+    expect(auroras).toHaveLength(1);
+    const args = auroras[0].args;
+    expect(args.engine).toBe("postgres");
+    expect(args.proxy).toBe(true);
+    expect(args.database).toBe("mem9");
+    expect((args.scaling as { min: string; max: string }).min).toBe("0.5 ACU");
+    expect((args.scaling as { min: string; max: string }).max).toBe("4 ACU");
+    expect(args.vpc).toBeDefined();
+    expect((args.vpc as { securityGroups: unknown }).securityGroups).toBeDefined();
+  });
+
+  it("skips the final snapshot on non-prod, keeps it on prod", async () => {
+    // non-prod: transform sets skipFinalSnapshot = true
+    installGlobals("pr-7");
+    let db = await loadDb();
+    db();
+    const clusterTransform = (
+      auroras[0].args.transform as { cluster: (a: Record<string, unknown>) => void }
+    ).cluster;
+    const nonProdArgs: Record<string, unknown> = {};
+    clusterTransform(nonProdArgs);
+    expect(nonProdArgs.skipFinalSnapshot).toBe(true);
+
+    // prod: transform leaves skipFinalSnapshot unset (cluster is protected)
+    sgs = [];
+    params = [];
+    auroras = [];
+    installGlobals("prod");
+    db = await loadDb();
+    db();
+    const prodTransform = (
+      auroras[0].args.transform as { cluster: (a: Record<string, unknown>) => void }
+    ).cluster;
+    const prodArgs: Record<string, unknown> = {};
+    prodTransform(prodArgs);
+    // prod keeps the default final snapshot AND sets RDS deletion protection.
+    expect(prodArgs.skipFinalSnapshot).toBeUndefined();
+    expect(prodArgs.deletionProtection).toBe(true);
+  });
+
+  it("exports the connection pieces under /mem9-on-aws/${stage}/db/ (no DSN, no password)", async () => {
+    installGlobals("prod");
+    const db = await loadDb();
+    db();
+
+    const names = params.map((p) => p.name).sort();
+    expect(names).toEqual([
+      "/mem9-on-aws/prod/db/name",
+      "/mem9-on-aws/prod/db/port",
+      "/mem9-on-aws/prod/db/proxy-host",
+      "/mem9-on-aws/prod/db/secret-arn",
+      "/mem9-on-aws/prod/db/task-sg-id",
+    ]);
+    // No parameter carries the password value or a full DSN.
+    for (const p of params) {
+      expect(p.name).not.toContain("password");
+      expect(p.name).not.toContain("dsn");
+    }
+  });
+});

--- a/infra/db.ts
+++ b/infra/db.ts
@@ -1,0 +1,188 @@
+/**
+ * `db` stack — Aurora PostgreSQL Serverless v2 + RDS Proxy + Secrets Manager.
+ *
+ * The durable state layer for mem9 (see docs/ARCHITECTURE.md §3, §3a). Provisions:
+ *   - Aurora PostgreSQL Serverless v2 (engine "postgres") in the default VPC's
+ *     NAT-routed private subnets (from infra/vpc.ts).
+ *   - RDS Proxy in front of the cluster (`proxy: true`) so mem9 connects to a
+ *     pooled/multiplexed endpoint, and the DB password never lives in mem9's
+ *     config as a literal.
+ *   - A Secrets Manager secret (auto-created by sst.aws.Aurora, name
+ *     `mem9-on-aws-<stage>-Mem9DbProxySecret-<random>`) holding a STATIC
+ *     RandomPassword; RDS Proxy reads it to authenticate to Aurora. NOTE: SST's
+ *     proxy:true does NOT use RDS manageMasterUserPassword and configures NO
+ *     rotation — the password is not auto-rotated. Automatic rotation is an OPEN
+ *     item (ARCHITECTURE.md Open #6): attach a Secrets Manager rotation schedule
+ *     + the RDS rotation Lambda, then grant secretsmanager:RotateSecret. The
+ *     value is still never committed / human-handled (created by Pulumi, read by
+ *     the proxy + injected into ECS via `secrets: valueFrom`).
+ *   - Two security groups: a `db` SG (allows 5432 from the `task` SG only) and a
+ *     `task` SG (attached to the future ECS mnemo-server task). The relationship
+ *     is reserved now so the ECS stack just references the task SG.
+ *
+ * DB AUTH (LOCKED, §3a): NOT native IAM — mem9 reads a single static MNEMO_DSN
+ * once at startup (pgx stdlib, no credential refresh), so a ~15-min IAM token
+ * would expire under it. Instead the password lives in Secrets Manager (see the
+ * rotation caveat above) and is injected into the ECS task via `secrets:
+ * valueFrom` (never committed). This stack exports the proxy host/port/db + the
+ * secret ARN; the ECS stack assembles MNEMO_DSN from them at task-launch.
+ *
+ * pgvector is NOT enabled here — `CREATE EXTENSION vector` + the tenant runtime
+ * schema is applied by the one-shot schema-bootstrap task on deploy (§8), which
+ * connects through this proxy. This stack only provisions the cluster/proxy/creds.
+ *
+ * Cost note: Aurora Serverless v2 has a ~0.5 ACU idle floor (~$40–50/mo) — this
+ * is the project's largest line. Only deployed on real stages; PR previews get it
+ * too (they exercise the real path), so preview stages carry the cost until closed.
+ */
+
+import { resolveVpc } from "./vpc";
+
+export interface DbOutputs {
+  ssmPrefix: string;
+  proxyHost: Output<string>;
+  port: Output<number>;
+  database: Output<string>;
+  secretArn: Output<string>;
+  taskSecurityGroupId: Output<string>;
+}
+
+export function db(): DbOutputs {
+  const prefix = `/mem9-on-aws/${$app.stage}`;
+  const { vpcId, privateSubnetIds } = resolveVpc();
+
+  const tags = {
+    Project: "mem9-on-aws",
+    Stage: $app.stage,
+    ManagedBy: "sst",
+  };
+
+  // SG for the future ECS mnemo-server task. Created here so the DB SG can scope
+  // 5432 ingress to exactly this SG (least-privilege) before ECS lands; the ECS
+  // stack attaches this SG to the task. Egress open (task reaches Aurora proxy +
+  // Bedrock/embed over NAT).
+  const taskSg = new aws.ec2.SecurityGroup("Mem9TaskSg", {
+    vpcId,
+    description: "mem9 ECS task SG (mnemo-server); source for Aurora 5432 ingress",
+    egress: [
+      {
+        protocol: "-1",
+        fromPort: 0,
+        toPort: 0,
+        cidrBlocks: ["0.0.0.0/0"],
+      },
+    ],
+    tags: { ...tags, Name: `mem9-on-aws-${$app.stage}-task` },
+  });
+
+  // SG for Aurora + RDS Proxy: allow 5432 ONLY from the task SG.
+  const dbSg = new aws.ec2.SecurityGroup("Mem9DbSg", {
+    vpcId,
+    description: "mem9 Aurora + RDS Proxy SG; 5432 from the task SG only",
+    ingress: [
+      {
+        protocol: "tcp",
+        fromPort: 5432,
+        toPort: 5432,
+        securityGroups: [taskSg.id],
+        description: "PostgreSQL from the mem9 ECS task",
+      },
+    ],
+    egress: [
+      {
+        protocol: "-1",
+        fromPort: 0,
+        toPort: 0,
+        cidrBlocks: ["0.0.0.0/0"],
+      },
+    ],
+    tags: { ...tags, Name: `mem9-on-aws-${$app.stage}-db` },
+  });
+
+  // Aurora PostgreSQL Serverless v2 + RDS Proxy. `proxy: true` makes SST create
+  // an RDS Proxy and route the component's `host` through it (verify at deploy).
+  // Password is auto-generated + stored in Secrets Manager (secretArn); RDS Proxy
+  // authenticates to Aurora with it.
+  //
+  // scaling.min = "0.5 ACU" (the LOCKED floor, ARCHITECTURE.md §3/§9) — NOT
+  // "0 ACU". Auto-pause (min 0) is intentionally NOT used: `proxy: true` keeps a
+  // connection open to the instance, so Aurora Serverless v2 never auto-pauses
+  // regardless of a 0-ACU floor (AWS docs) — a 0-ACU config would give no
+  // scale-to-zero benefit while diverging from the locked decision. Max 4 ACU is
+  // ample headroom for a single operator.
+  const aurora = new sst.aws.Aurora("Mem9Db", {
+    engine: "postgres",
+    version: "17.4",
+    database: "mem9",
+    proxy: true,
+    scaling: {
+      min: "0.5 ACU",
+      max: "4 ACU",
+    },
+    vpc: {
+      subnets: privateSubnetIds,
+      securityGroups: [dbSg.id],
+    },
+    transform: {
+      // prod: RDS-native deletionProtection = true (defense-in-depth beyond the
+      // app-level removal:retain + protect in sst.config.ts — those guard the
+      // Pulumi resource, but the deploy role holds rds:DeleteDBCluster, so a
+      // direct/console delete could still drop prod without this). prod keeps the
+      // default final snapshot (skipFinalSnapshot stays false).
+      // non-prod (dev / pr-*): skip the final snapshot + no deletion protection
+      // so `sst remove --stage pr-N` tears down fast and clean.
+      cluster: (args) => {
+        if ($app.stage === "prod") {
+          args.deletionProtection = true;
+        } else {
+          args.skipFinalSnapshot = true;
+        }
+      },
+    },
+  });
+
+  // Export the connection pieces (NOT a literal DSN) for the ECS stack to
+  // assemble MNEMO_DSN from + inject the password via `secrets: valueFrom`.
+  new aws.ssm.Parameter("DbProxyHost", {
+    name: `${prefix}/db/proxy-host`,
+    type: "String",
+    value: aurora.host,
+    tags,
+  });
+  new aws.ssm.Parameter("DbPort", {
+    name: `${prefix}/db/port`,
+    type: "String",
+    value: aurora.port.apply((p) => String(p)),
+    tags,
+  });
+  new aws.ssm.Parameter("DbName", {
+    name: `${prefix}/db/name`,
+    type: "String",
+    value: aurora.database,
+    tags,
+  });
+  // The secret ARN — the ECS task role will get secretsmanager:GetSecretValue on
+  // it, and the task def references it via `secrets: valueFrom`. The password
+  // VALUE is never written to SSM or git.
+  new aws.ssm.Parameter("DbSecretArn", {
+    name: `${prefix}/db/secret-arn`,
+    type: "String",
+    value: aurora.secretArn,
+    tags,
+  });
+  new aws.ssm.Parameter("DbTaskSgId", {
+    name: `${prefix}/db/task-sg-id`,
+    type: "String",
+    value: taskSg.id,
+    tags,
+  });
+
+  return {
+    ssmPrefix: prefix,
+    proxyHost: aurora.host,
+    port: aurora.port,
+    database: aurora.database,
+    secretArn: aurora.secretArn,
+    taskSecurityGroupId: taskSg.id,
+  };
+}

--- a/infra/sst-types.d.ts
+++ b/infra/sst-types.d.ts
@@ -79,6 +79,28 @@ declare namespace aws {
       readonly ids: Output<string[]>;
     }
     function getSubnetsOutput(args: GetSubnetsOutputArgs): GetSubnetsResult;
+
+    // Security group + rule shapes used by infra/db.ts.
+    interface SecurityGroupRule {
+      protocol: Input<string>;
+      fromPort: Input<number>;
+      toPort: Input<number>;
+      cidrBlocks?: Input<string>[];
+      securityGroups?: Input<string>[];
+      description?: Input<string>;
+    }
+    interface SecurityGroupArgs {
+      vpcId: Input<string>;
+      description?: Input<string>;
+      ingress?: SecurityGroupRule[];
+      egress?: SecurityGroupRule[];
+      tags?: Record<string, Input<string>>;
+    }
+    class SecurityGroup {
+      constructor(name: string, args: SecurityGroupArgs);
+      readonly id: Output<string>;
+      readonly arn: Output<string>;
+    }
   }
 
   namespace ssm {
@@ -92,6 +114,48 @@ declare namespace aws {
       constructor(name: string, args: ParameterArgs);
       readonly name: Output<string>;
       readonly arn: Output<string>;
+    }
+  }
+}
+
+// ── The `sst.aws` component surface infra/db.ts uses ────────────────────────
+declare namespace sst {
+  namespace aws {
+    interface AuroraScaling {
+      min?: Input<string>;
+      max?: Input<string>;
+      pauseAfter?: Input<string>;
+    }
+    interface AuroraVpc {
+      subnets: Input<string[]>;
+      securityGroups: Input<string>[] | Input<string[]>;
+    }
+    interface AuroraClusterArgs {
+      skipFinalSnapshot?: Input<boolean>;
+      [k: string]: unknown;
+    }
+    interface AuroraArgs {
+      engine: Input<"postgres" | "mysql">;
+      version?: Input<string>;
+      database?: Input<string>;
+      username?: Input<string>;
+      password?: Input<string>;
+      proxy?: Input<boolean>;
+      scaling?: AuroraScaling;
+      vpc: AuroraVpc;
+      transform?: {
+        cluster?: (args: AuroraClusterArgs) => void;
+        proxy?: (args: Record<string, unknown>) => void;
+      };
+    }
+    class Aurora {
+      constructor(name: string, args: AuroraArgs);
+      readonly host: Output<string>;
+      readonly port: Output<number>;
+      readonly username: Output<string>;
+      readonly password: Output<string>;
+      readonly database: Output<string>;
+      readonly secretArn: Output<string>;
     }
   }
 }

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -60,6 +60,13 @@ export default $config({
     const { meta } = await import("./infra/meta");
     meta();
 
+    // Aurora PostgreSQL Serverless v2 + RDS Proxy + Secrets Manager (§3, §3a).
+    // The durable state layer; exports the proxy endpoint + secret ARN via SSM
+    // for the (later) ECS stack to assemble MNEMO_DSN. ~0.5 ACU idle floor makes
+    // this the largest cost line — real on every deployed stage incl. pr-*.
+    const { db } = await import("./infra/db");
+    db();
+
     return {};
   },
 });


### PR DESCRIPTION
## Summary
- Adds the **durable state layer** (ARCHITECTURE.md §3/§3a): `infra/db.ts` — Aurora PostgreSQL Serverless v2 (postgres 17.4, 0.5–4 ACU) in the default VPC's NAT-routed private subnets, fronted by **RDS Proxy**, DB password held only in **Secrets Manager**.
- Exports proxy host/port/db-name + secret ARN via SSM (`/mem9-on-aws/${stage}/db/*`) for the later ECS stack to assemble `MNEMO_DSN`.
- `pgvector` + tenant schema are NOT here — that's the one-shot schema-bootstrap task (§8) in a later PR.

## DB auth (§3a) — the operator's "no password / IAM" question, resolved
mem9 reads a **static `MNEMO_DSN`** once at startup (pgx stdlib, no credential refresh), so an Aurora **IAM auth token (~15 min) expires under it** → native/end-to-end IAM auth is not viable for mem9 unmodified (even via RDS-Proxy client-side IAM). Chosen: **RDS Proxy + Secrets Manager**; the password is never committed / human-handled (Pulumi-generated, injected into ECS via `secrets: valueFrom`). True end-to-end IAM (sidecar or mem9 source patch) is deferred (Open #8).

⚠️ **Rotation is NOT automatic**: SST's `proxy:true` stores a static `RandomPassword` with no rotation Lambda → automatic rotation is **Open #6** (add a Secrets Manager rotation schedule + RDS rotation Lambda later). Docs corrected accordingly.

## Security
- db SG allows **5432 from the task SG only** (reserved for the future ECS task).
- **prod: RDS `deletionProtection=true`** (defense-in-depth beyond app-level `removal:retain`+`protect`); non-prod skips the final snapshot for fast teardown.
- No password / DSN in SSM or git.

## Deploy role
New `DatabasePolicy` (rds + rds-proxy + secretsmanager scoped to `mem9-on-aws-*` + ec2 SG + kms + `iam:CreateServiceLinkedRole` for rds); `iam:CreateRole`/`PutRolePolicy` for SST's proxy IAM role; `rds.amazonaws.com` added to the PassRole `PassedToService`. **Already bootstrapped live** (re-ran `deploy-github-role.sh`).

## Review
code-simplifier + pr-review agents. **3 Critical IAM gaps** found & fixed (each would 403 the first deploy): SST proxy-role create grant, PassRole→rds, secret ARN scope (SST's auto-named `mem9-on-aws-*` secret, not `rds!`/slash-path). Plus the 0.5-ACU-vs-auto-pause fix and the "auto-rotated" doc correction.

## Test Plan
- [x] `pnpm -C infra typecheck` + 19 unit tests pass (4 new for db.ts)
- [x] CFN template valid; deploy role bootstrapped with the DB grants
- [x] CI: typecheck + pr-preview deployed real Aurora + RDS Proxy + Secret to pr-2 (all `/mem9-on-aws/pr-2/db/*` params written; proxy-host = the proxy endpoint)
- [x] Merge → `deploy-prod` SUCCEEDED → prod Aurora (0.5–4 ACU, DeletionProtection=true) + RDS Proxy live + all `/mem9-on-aws/prod/db/*` params in ap-northeast-1

## Dependencies
Builds on the base scaffold (#1, merged). The deploy-role DB grants must be live before deploy — done.

## Testing Requirements
CI pr-preview must green (it deploys the real Aurora cluster + RDS Proxy + secret to a `pr-N` stage), then merge-to-main `deploy-prod` must create the prod Aurora cluster + proxy and the `/mem9-on-aws/prod/db/*` SSM params in ap-northeast-1.

