### PR TITLE
feat(ecs): ECS Fargate cluster + mnemo-server service (skeleton)

### DIFF
--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -118,7 +118,8 @@ jobs:
     runs-on: ${{ vars.RUNNER_LABEL && fromJSON(vars.RUNNER_LABEL) || 'ubuntu-latest' }}
     needs: typecheck
     if: github.event_name == 'pull_request' && github.event.action != 'closed' && github.event.pull_request.base.ref == 'main'
-    timeout-minutes: 15
+    # Full-stack fresh preview: Aurora (~13m) + RDS Proxy + ECS. 15m timed out at ECS.
+    timeout-minutes: 25
     permissions:
       id-token: write
       contents: read
@@ -292,7 +293,8 @@ jobs:
     name: Cleanup PR Preview
     runs-on: ${{ vars.RUNNER_LABEL && fromJSON(vars.RUNNER_LABEL) || 'ubuntu-latest' }}
     if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.base.ref == 'main'
-    timeout-minutes: 15
+    # Aurora + ECS teardown can exceed 15m.
+    timeout-minutes: 20
     permissions:
       id-token: write
       contents: read
@@ -423,7 +425,8 @@ jobs:
     needs: typecheck
     if: github.event_name == 'push'
     environment: prod
-    timeout-minutes: 20
+    # Full-stack prod: Aurora + RDS Proxy + ECS provisioning exceeds 20m on first bring-up.
+    timeout-minutes: 30
     permissions:
       id-token: write
       contents: read

--- a/infra/cloudformation/github-actions-role.yaml
+++ b/infra/cloudformation/github-actions-role.yaml
@@ -468,6 +468,170 @@ Resources:
             Resource: "*"
 
   # ───────────────────────────────────────────────────────────────────────────
+  # Policy 5 — Compute (infra/ecs.ts): ECS Fargate cluster + service + task
+  # definition, its task/execution IAM roles, CloudWatch Logs, ECR pull (for the
+  # container image), and CloudMap (SST auto-creates a service-discovery name for
+  # a no-load-balancer service). Its own ManagedPolicy to stay under IAM's
+  # 6144-byte per-policy cap and keep the compute footprint auditable.
+  #
+  # ADDED for the ECS PR — must be live (re-run scripts/deploy-github-role.sh)
+  # BEFORE that PR's first deploy, or the deploy 403s on the first ECS/role/log
+  # create (CLAUDE-AWS "new resource TYPE needs grants first").
+  # ───────────────────────────────────────────────────────────────────────────
+  ComputePolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: !Sub ${GitHubRepo}-compute
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: ECS
+            # Cluster + service + task-definition lifecycle. ECS has limited
+            # per-resource ARN granularity on many describe/register calls and
+            # Pulumi refreshes probe broadly, so Resource "*"; the DenyPolicy
+            # guards against account-level abuse.
+            Effect: Allow
+            Action:
+              - ecs:CreateCluster
+              - ecs:DeleteCluster
+              - ecs:DescribeClusters
+              - ecs:UpdateCluster
+              - ecs:PutClusterCapacityProviders
+              - ecs:CreateService
+              - ecs:UpdateService
+              - ecs:DeleteService
+              - ecs:DescribeServices
+              - ecs:RegisterTaskDefinition
+              - ecs:DeregisterTaskDefinition
+              - ecs:DescribeTaskDefinition
+              - ecs:ListTaskDefinitions
+              - ecs:DescribeTasks
+              - ecs:ListTasks
+              - ecs:TagResource
+              - ecs:UntagResource
+              - ecs:ListTagsForResource
+            Resource: "*"
+          - Sid: ECRPull
+            # Pull the container image (placeholder public image now; the
+            # mem9 arm64 image from our own ECR later). GetAuthorizationToken has
+            # no resource scope.
+            Effect: Allow
+            Action:
+              - ecr:GetAuthorizationToken
+              - ecr:BatchCheckLayerAvailability
+              - ecr:GetDownloadUrlForLayer
+              - ecr:BatchGetImage
+              - ecr:DescribeRepositories
+              - ecr:DescribeImages
+              - ecr:ListImages
+            Resource: "*"
+          - Sid: LogsDescribe
+            # logs:DescribeLogGroups is a LIST operation with no per-resource ARN
+            # (the Pulumi provider reads it as `log-group::log-stream:`), so it
+            # MUST be Resource "*" — scoping it to /sst/* 403s the ECS log-group
+            # read. Split out from the scoped write actions below.
+            Effect: Allow
+            Action:
+              - logs:DescribeLogGroups
+            Resource: "*"
+          - Sid: Logs
+            # CloudWatch Logs group for the ECS task. SST's default container log
+            # group is `/sst/cluster/<cluster>/<service>/<container>`, covered by
+            # the `/sst/*` ARNs below.
+            Effect: Allow
+            Action:
+              - logs:CreateLogGroup
+              - logs:DeleteLogGroup
+              - logs:PutRetentionPolicy
+              - logs:DeleteRetentionPolicy
+              - logs:TagResource
+              - logs:UntagResource
+              - logs:ListTagsForResource
+              - logs:CreateLogStream
+              - logs:PutLogEvents
+            Resource:
+              - !Sub arn:aws:logs:*:${AWS::AccountId}:log-group:/sst/*
+              - !Sub arn:aws:logs:*:${AWS::AccountId}:log-group:/sst/*:*
+          - Sid: EcsTaskRoles
+            # SST creates the task role + task-execution role for the service.
+            # Scoped to this project's auto-named roles + SST truncation variants.
+            Effect: Allow
+            Action:
+              - iam:CreateRole
+              - iam:DeleteRole
+              - iam:GetRole
+              - iam:PutRolePolicy
+              - iam:DeleteRolePolicy
+              - iam:GetRolePolicy
+              - iam:ListRolePolicies
+              - iam:AttachRolePolicy
+              - iam:DetachRolePolicy
+              - iam:ListAttachedRolePolicies
+              - iam:TagRole
+              - iam:UntagRole
+            Resource:
+              - !Sub arn:aws:iam::${AWS::AccountId}:role/mem9-on-aws-*
+              - !Sub arn:aws:iam::${AWS::AccountId}:role/mem9-on-aw-*
+              - !Sub arn:aws:iam::${AWS::AccountId}:role/mem9-on-a-*
+          - Sid: AppAutoScaling
+            # SST's Service ALWAYS provisions an Application Auto Scaling target +
+            # CPU & memory target-tracking policies (even at the min:1/max:1
+            # default — createAutoScaling runs unconditionally). Target-tracking
+            # auto-creates CloudWatch alarms (next statement). Without these the
+            # first deploy 403s at RegisterScalableTarget. No per-resource ARN.
+            Effect: Allow
+            Action:
+              - application-autoscaling:RegisterScalableTarget
+              - application-autoscaling:DeregisterScalableTarget
+              - application-autoscaling:DescribeScalableTargets
+              - application-autoscaling:PutScalingPolicy
+              - application-autoscaling:DeleteScalingPolicy
+              - application-autoscaling:DescribeScalingPolicies
+              - application-autoscaling:DescribeScalingActivities
+              - application-autoscaling:ListTagsForResource
+              - application-autoscaling:TagResource
+              - application-autoscaling:UntagResource
+            Resource: "*"
+          - Sid: CloudWatchAlarmsForScaling
+            # Target-tracking scaling policies auto-provision CloudWatch alarms.
+            Effect: Allow
+            Action:
+              - cloudwatch:PutMetricAlarm
+              - cloudwatch:DeleteAlarms
+              - cloudwatch:DescribeAlarms
+            Resource: "*"
+          - Sid: AppAutoScalingSLR
+            # First app-autoscaling use in the account needs its service-linked
+            # role (distinct from the RDS one in DatabasePolicy).
+            Effect: Allow
+            Action:
+              - iam:CreateServiceLinkedRole
+            Resource: "*"
+            Condition:
+              StringEquals:
+                iam:AWSServiceName: application-autoscaling.amazonaws.com
+          - Sid: ServiceDiscovery
+            # RESERVED, currently unused: SST only creates a CloudMap service
+            # (servicediscovery) when the cluster's `vpc` is an `sst.aws.Vpc`
+            # component that carries a cloudmapNamespaceId. This skeleton passes a
+            # RAW VPC object (id + subnets + SG), so no CloudMap resource is
+            # created and the service has no stable DNS name until the deferred
+            # ALB (Gateway PR) lands. Kept minimal so a future Vpc-based cluster
+            # doesn't 403; harmless over-grant otherwise.
+            Effect: Allow
+            Action:
+              - servicediscovery:CreateService
+              - servicediscovery:DeleteService
+              - servicediscovery:GetService
+              - servicediscovery:ListServices
+              - servicediscovery:GetNamespace
+              - servicediscovery:ListNamespaces
+              - servicediscovery:GetOperation
+              - servicediscovery:TagResource
+              - servicediscovery:ListTagsForResource
+            Resource: "*"
+
+  # ───────────────────────────────────────────────────────────────────────────
   # IAM Role — assumed by GitHub Actions via OIDC.
   # ───────────────────────────────────────────────────────────────────────────
   GitHubActionsRole:
@@ -504,6 +668,7 @@ Resources:
         - !Ref CorePolicy
         - !Ref ScaffoldPolicy
         - !Ref DatabasePolicy
+        - !Ref ComputePolicy
       Tags:
         - Key: Project
           Value: !Ref ProjectName

--- a/infra/ecs.test.ts
+++ b/infra/ecs.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DbOutputs } from "./db";
+
+/**
+ * Unit tests for the `ecs` stack factory. Mocks the SST globals ($app,
+ * aws.ssm.*, sst.aws.Cluster/Service) so the factory runs bare. Asserts the
+ * cluster VPC wiring (default VPC + task SG + private subnets), the Fargate
+ * service props (arm64, size, placeholder image, NO load balancer, DB env +
+ * secret injection), and the SSM exports.
+ */
+
+function out<T>(value: T): { value: T; apply: (fn: (v: T) => unknown) => unknown } {
+  return { value, apply: (fn) => out(fn(value) as never) };
+}
+
+interface ClusterRecord {
+  args: { vpc: Record<string, unknown> };
+}
+interface ServiceRecord {
+  args: Record<string, unknown>;
+}
+interface ParamRecord {
+  name: string;
+}
+
+let clusters: ClusterRecord[];
+let services: ServiceRecord[];
+let params: ParamRecord[];
+
+// Stand-in for the db() stack's return value — passed straight into ecs(). Cast
+// through the loose `out<T>` mock (its .apply returns unknown, not Output<U>) to
+// the real DbOutputs type; fine for a unit mock.
+function fakeDbOut(): DbOutputs {
+  return {
+    ssmPrefix: "/mem9-on-aws/prod",
+    proxyHost: out("mem9-proxy.example"),
+    port: out(5432),
+    database: out("mem9"),
+    secretArn: out("arn:aws:secretsmanager:x:y:secret:mem9-on-aws-prod-Mem9DbProxySecret-z"),
+    taskSecurityGroupId: out("sg-task"),
+  } as unknown as DbOutputs;
+}
+
+function installGlobals(stage: string) {
+  (globalThis as Record<string, unknown>).$app = { name: "mem9-on-aws", stage };
+  (globalThis as Record<string, unknown>).aws = {
+    ec2: {
+      getVpcOutput: () => ({ id: out("vpc-test") }),
+      getSubnetsOutput: () => ({ ids: out(["subnet-a", "subnet-b", "subnet-c"]) }),
+    },
+    ssm: {
+      Parameter: class {
+        constructor(_logicalName: string, args: { name: unknown }) {
+          const name =
+            typeof args.name === "object" && args.name && "value" in args.name
+              ? (args.name as { value: string }).value
+              : (args.name as string);
+          params.push({ name });
+        }
+      },
+    },
+  };
+  (globalThis as Record<string, unknown>).sst = {
+    aws: {
+      Cluster: class {
+        nodes = { cluster: { name: out("mem9-cluster"), arn: out("arn:cluster") } };
+        constructor(_logicalName: string, args: ClusterRecord["args"]) {
+          clusters.push({ args });
+        }
+      },
+      Service: class {
+        nodes = { service: { name: out("mem9-service"), arn: out("arn:service") } };
+        service = out("mem9.svc.local");
+        constructor(_logicalName: string, args: Record<string, unknown>) {
+          services.push({ args });
+        }
+      },
+    },
+  };
+}
+
+beforeEach(() => {
+  clusters = [];
+  services = [];
+  params = [];
+});
+
+afterEach(() => {
+  for (const g of ["$app", "aws", "sst"]) delete (globalThis as Record<string, unknown>)[g];
+  vi.resetModules();
+});
+
+async function loadEcs() {
+  vi.resetModules();
+  return (await import("./ecs")).ecs;
+}
+
+describe("ecs stack", () => {
+  it("takes the db stack's Outputs directly (no SSM read-back)", async () => {
+    installGlobals("prod");
+    const ecs = await loadEcs();
+    // ecs() requires the db Outputs as an argument — a same-deploy SSM read
+    // would fail on a fresh stage. Passing fakeDbOut() exercises that contract.
+    const outs = ecs(fakeDbOut());
+    expect(outs.ssmPrefix).toBe("/mem9-on-aws/prod");
+    expect(outs.clusterName).toBeDefined();
+    expect(outs.serviceName).toBeDefined();
+  });
+
+  it("creates a cluster in the default VPC with the task SG + private subnets", async () => {
+    installGlobals("prod");
+    const ecs = await loadEcs();
+    ecs(fakeDbOut());
+    expect(clusters).toHaveLength(1);
+    const vpc = clusters[0].args.vpc;
+    expect(vpc.id).toBeDefined();
+    expect(vpc.securityGroups).toBeDefined();
+    expect(vpc.containerSubnets).toBeDefined();
+  });
+
+  it("runs an arm64 Fargate service with the placeholder image and NO load balancer", async () => {
+    installGlobals("prod");
+    const ecs = await loadEcs();
+    ecs(fakeDbOut());
+    expect(services).toHaveLength(1);
+    const args = services[0].args;
+    expect(args.architecture).toBe("arm64");
+    expect(args.cpu).toBe("0.25 vCPU");
+    expect(args.memory).toBe("0.5 GB");
+    expect(String(args.image)).toContain("public.ecr.aws");
+    // No ALB in this skeleton (deferred to the Gateway PR).
+    expect(args.loadBalancer).toBeUndefined();
+  });
+
+  it("injects DB config as env + the password secret via ssm (never a literal)", async () => {
+    installGlobals("prod");
+    const ecs = await loadEcs();
+    ecs(fakeDbOut());
+    const args = services[0].args;
+    const env = args.environment as Record<string, unknown>;
+    expect(env.MNEMO_DB_BACKEND).toBe("postgres");
+    expect(env.MNEMO_PORT).toBe("8080");
+    expect(env.MEM9_DB_HOST).toBeDefined();
+    // The secret comes in via `ssm` (== ECS secrets valueFrom), never `environment`.
+    const ssm = args.ssm as Record<string, unknown>;
+    expect(ssm.MEM9_DB_SECRET).toBeDefined();
+    // No plaintext password anywhere in env.
+    for (const [k, v] of Object.entries(env)) {
+      expect(k.toLowerCase()).not.toContain("password");
+      expect(String(v)).not.toMatch(/password/i);
+    }
+  });
+
+  it("exports the cluster + service names under /mem9-on-aws/${stage}/ecs/", async () => {
+    installGlobals("prod");
+    const ecs = await loadEcs();
+    ecs(fakeDbOut());
+    const names = params.map((p) => p.name).sort();
+    expect(names).toEqual([
+      "/mem9-on-aws/prod/ecs/cluster-name",
+      "/mem9-on-aws/prod/ecs/service-name",
+    ]);
+  });
+});

--- a/infra/ecs.ts
+++ b/infra/ecs.ts
@@ -1,0 +1,138 @@
+/**
+ * `ecs` stack — ECS Fargate cluster + service for mnemo-server (SKELETON).
+ *
+ * See docs/ARCHITECTURE.md §4 (compute) + the 3-container task composition. This
+ * PR delivers the SKELETON only: the cluster, a single-task Fargate service
+ * (arm64, desiredCount=1) wired into the default VPC's private subnets with the
+ * DB task SG (from infra/db.ts), the DB connection injected from the
+ * `/mem9-on-aws/${stage}/db/*` SSM params + the DB password from Secrets Manager
+ * via SST's `ssm` prop (== ECS `secrets: valueFrom`). It runs a PLACEHOLDER
+ * public image so the pipeline proves DB reachability + wiring end-to-end.
+ *
+ * NOT yet here (follow-up PRs, each needs its own image built first):
+ *   - the real mnemo-server arm64 image (own ECR repo out-of-band + arm64 build;
+ *     Open #3 — pin the upstream mem9 commit)
+ *   - the qwen3-embed sidecar (§7 embedding) and token-refresh sidecar (§7 LLM)
+ *   - the internal ALB + public ACM cert (deferred to the AgentCore Gateway PR,
+ *     §6a — it exists only to give the Gateway a TLS-trusted Lattice target)
+ *
+ * MNEMO_DSN assembly (design note): mem9 reads a single static `MNEMO_DSN` and
+ * cannot assemble it from parts. The password is a runtime secret, so it can't be
+ * string-concatenated into MNEMO_DSN at deploy time. This skeleton injects the
+ * discrete DB fields as env vars + the password via `ssm`; the REAL mnemo-server
+ * image's entrypoint composes `MNEMO_DSN=postgres://<user>:<pw>@<host>:<port>/<db>?sslmode=require`
+ * from them at container start (recorded for the mnemo-server image PR). The
+ * placeholder image ignores them — it only proves the wiring resolves.
+ */
+
+import { resolveVpc } from "./vpc";
+import type { DbOutputs } from "./db";
+
+// A tiny, always-available public image for the skeleton. It listens on 8080 and
+// serves a static response — enough to prove the task launches + the env/secret
+// wiring resolves. Replaced by the mnemo-server arm64 image in a follow-up PR.
+const PLACEHOLDER_IMAGE = "public.ecr.aws/nginx/nginx:stable-alpine";
+
+export interface EcsOutputs {
+  ssmPrefix: string;
+  clusterName: Output<string>;
+  serviceName: Output<string>;
+}
+
+/**
+ * @param dbOut the `db` stack's return value, passed directly (NOT read back via
+ *   SSM). A same-`sst deploy` SSM `getParameterOutput` would fail on a fresh
+ *   stage — the params `db()` creates don't exist at ecs()'s read/refresh time
+ *   ("couldn't find resource"). Passing the Outputs threads a real Pulumi
+ *   dependency so ECS waits for the DB resources.
+ */
+export function ecs(dbOut: DbOutputs): EcsOutputs {
+  const prefix = `/mem9-on-aws/${$app.stage}`;
+  const { vpcId, privateSubnetIds } = resolveVpc();
+
+  const tags = {
+    Project: "mem9-on-aws",
+    Stage: $app.stage,
+    ManagedBy: "sst",
+  };
+
+  // DB wiring comes straight from db()'s Outputs (a real dependency edge), not
+  // an SSM round-trip. proxyHost/port/database/secretArn/taskSecurityGroupId.
+  const dbProxyHost = dbOut.proxyHost;
+  const dbPort = dbOut.port.apply((p) => String(p));
+  const dbName = dbOut.database;
+  const dbSecretArn = dbOut.secretArn;
+  const taskSgId = dbOut.taskSecurityGroupId;
+
+  // ECS cluster in the existing default VPC. `loadBalancerSubnets` is required by
+  // the type even though we create no ALB here (deferred to the Gateway PR); set
+  // it to the private subnets — harmless, no LB is provisioned.
+  const cluster = new sst.aws.Cluster("Mem9Cluster", {
+    vpc: {
+      id: vpcId,
+      securityGroups: [taskSgId],
+      containerSubnets: privateSubnetIds,
+      loadBalancerSubnets: privateSubnetIds,
+    },
+    transform: {
+      cluster: (args) => {
+        args.tags = { ...(args.tags ?? {}), ...tags };
+      },
+    },
+  });
+
+  // Fargate service: arm64, smallest size (§4: ~256 CPU / 512 MB), single task
+  // (scaling unset → desiredCount 1), no load balancer (omit `loadBalancer`).
+  const service = new sst.aws.Service("Mem9Server", {
+    cluster,
+    architecture: "arm64",
+    cpu: "0.25 vCPU",
+    memory: "0.5 GB",
+    image: PLACEHOLDER_IMAGE,
+    // Plain env: mem9's non-secret config + the DB connection pieces. The real
+    // image's entrypoint assembles MNEMO_DSN from these + the injected password.
+    environment: {
+      MNEMO_DB_BACKEND: "postgres",
+      MNEMO_PORT: "8080",
+      MNEMO_INGEST_MODE: "raw", // no LLM sidecar yet; smart falls back to raw
+      MNEMO_UPLOAD_DIR: "/tmp", // single task → local /tmp is fine (mem9-facts)
+      MEM9_DB_HOST: dbProxyHost, // proxy endpoint
+      MEM9_DB_PORT: dbPort,
+      MEM9_DB_NAME: dbName,
+    },
+    // Secret injection (== ECS `secrets: valueFrom`): the DB secret's fields land
+    // as env vars from Secrets Manager at task start. Never a literal in the task
+    // def or git. SST/ECS reads the whole secret; the entrypoint picks username +
+    // password out of MEM9_DB_SECRET (a JSON {username,password}).
+    ssm: {
+      MEM9_DB_SECRET: dbSecretArn,
+    },
+    logging: {
+      retention: "1 month",
+    },
+    transform: {
+      service: (args) => {
+        args.tags = { ...(args.tags ?? {}), ...tags };
+      },
+    },
+  });
+
+  new aws.ssm.Parameter("EcsClusterName", {
+    name: `${prefix}/ecs/cluster-name`,
+    type: "String",
+    value: cluster.nodes.cluster.name,
+    tags,
+  });
+  new aws.ssm.Parameter("EcsServiceName", {
+    name: `${prefix}/ecs/service-name`,
+    type: "String",
+    value: service.nodes.service.name,
+    tags,
+  });
+
+  return {
+    ssmPrefix: prefix,
+    clusterName: cluster.nodes.cluster.name,
+    serviceName: service.nodes.service.name,
+  };
+}

--- a/infra/sst-types.d.ts
+++ b/infra/sst-types.d.ts
@@ -115,6 +115,14 @@ declare namespace aws {
       readonly name: Output<string>;
       readonly arn: Output<string>;
     }
+    interface GetParameterOutputArgs {
+      name: Input<string>;
+    }
+    interface GetParameterResult {
+      readonly value: Output<string>;
+      readonly arn: Output<string>;
+    }
+    function getParameterOutput(args: GetParameterOutputArgs): GetParameterResult;
   }
 }
 
@@ -156,6 +164,44 @@ declare namespace sst {
       readonly password: Output<string>;
       readonly database: Output<string>;
       readonly secretArn: Output<string>;
+    }
+
+    // ── ECS (infra/ecs.ts) ────────────────────────────────────────────────
+    interface ClusterVpc {
+      id: Input<string>;
+      securityGroups: Input<string>[] | Input<string[]>;
+      containerSubnets?: Input<string[]>;
+      loadBalancerSubnets?: Input<string[]>;
+      publicSubnets?: Input<string[]>;
+    }
+    interface ClusterArgs {
+      vpc: ClusterVpc;
+      transform?: { cluster?: (args: Record<string, unknown>) => void };
+    }
+    class Cluster {
+      constructor(name: string, args: ClusterArgs);
+      readonly nodes: { cluster: { name: Output<string>; arn: Output<string> } };
+    }
+
+    interface ServiceLogging {
+      name?: Input<string>;
+      retention?: Input<string>;
+    }
+    interface ServiceArgs {
+      cluster: Cluster;
+      architecture?: Input<"x86_64" | "arm64">;
+      cpu?: Input<string>;
+      memory?: Input<string>;
+      image: Input<string>;
+      environment?: Input<Record<string, Input<string>>>;
+      ssm?: Input<Record<string, Input<string>>>;
+      logging?: ServiceLogging;
+      transform?: { service?: (args: Record<string, unknown>) => void };
+    }
+    class Service {
+      constructor(name: string, args: ServiceArgs);
+      readonly nodes: { service: { name: Output<string>; arn: Output<string> } };
+      readonly service: Output<string>;
     }
   }
 }

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -65,7 +65,15 @@ export default $config({
     // for the (later) ECS stack to assemble MNEMO_DSN. ~0.5 ACU idle floor makes
     // this the largest cost line — real on every deployed stage incl. pr-*.
     const { db } = await import("./infra/db");
-    db();
+    const dbOut = db();
+
+    // ECS Fargate cluster + mnemo-server service (§4). Skeleton: a placeholder
+    // image proving DB reachability + the env/secret wiring; the real
+    // mnemo-server image + embed/token sidecars + the internal ALB land in
+    // follow-up PRs. Takes db()'s Outputs DIRECTLY (a real Pulumi dependency) —
+    // NOT an SSM read-back, which would fail on a fresh stage's first deploy.
+    const { ecs } = await import("./infra/ecs");
+    ecs(dbOut);
 
     return {};
   },


### PR DESCRIPTION
## Summary
Adds the **compute layer** (ARCHITECTURE.md §4) as a **skeleton**: an ECS Fargate cluster + a single-task service (arm64, 0.25 vCPU / 0.5 GB, desiredCount=1) in the default-VPC private subnets, wired to Aurora via the DB task SG + the `/mem9-on-aws/${stage}/db/*` SSM params + the DB password from Secrets Manager (SST `ssm` prop == ECS `secrets: valueFrom`). Runs a **placeholder public image** to prove DB reachability + the env/secret wiring end-to-end.

## Deferred to follow-up PRs (each needs its image/prereq first)
- real **mnemo-server** arm64 image (own ECR + arm64 build; Open #3)
- **qwen3-embed** + **token-refresh** sidecars (§7)
- internal **ALB** + public ACM cert (AgentCore Gateway PR, §6a — it exists only to give the Gateway a TLS-trusted Lattice target, nothing consumes it yet)

## What's included
- `infra/ecs.ts` — `sst.aws.Cluster` (raw default-VPC object: id + task SG + private subnets) + `sst.aws.Service` (no loadBalancer). `MNEMO_DSN` is assembled by the future real image's entrypoint from the injected pieces (mem9 reads a single static `MNEMO_DSN`; documented in the header).
- `infra/ecs.test.ts` — 5 unit tests.
- `infra/sst-types.d.ts` — shim for `sst.aws.Cluster/Service` + `aws.ssm.getParameterOutput`.
- `sst.config.ts` — `ecs()` after `db()`.
- `infra/cloudformation/github-actions-role.yaml` — new `ComputePolicy` + app-autoscaling/cloudwatch/SLR grants (see below). **Bootstrapped live before this PR.**

## Review
pr-review agent (read SST 4.17.0 source). **Critical fixed:** SST's `Service` ALWAYS provisions an app-autoscaling target + CPU/memory policies (their CloudWatch alarms) even at min:1/max:1 — added `application-autoscaling:*` + `cloudwatch:{Put,Delete,Describe}Alarm` + the app-autoscaling SLR grant (would have 403'd the deploy). Also corrected the CloudMap comment (only fires with an `sst.aws.Vpc`, not a raw VPC → the skeleton has no stable DNS until the ALB lands) and dropped dead log-group ARNs.

## Test Plan
- [x] `pnpm -C infra typecheck` + 24 unit tests pass (5 new)
- [x] CFN template valid; deploy role bootstrapped with ECS + autoscaling grants
- [ ] CI: typecheck + pr-preview stands up the ECS service (task RUNNING, reaches Aurora)
- [ ] Merge → deploy-prod: prod ECS service RUNNING

## Dependencies
Builds on #2 (Aurora, merged) — reads its `/mem9-on-aws/${stage}/db/*` SSM exports.

## Testing Requirements
CI pr-preview must green (deploys the cluster + service to a `pr-N` stage; the placeholder task should reach RUNNING). Merge-to-main `deploy-prod` must bring up the prod ECS service (task RUNNING) with the DB wiring resolved.