### PR TITLE
feat(image): build+push pinned arm64 mnemo-server image; ECS runs it

### DIFF
--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -477,9 +477,20 @@ jobs:
       - name: Resolve image tag
         id: tag
         if: steps.gate.outputs.skip != 'true'
-        # GITHUB_SHA is trusted (GitHub-controlled), so it's safe in run:. On a PR,
-        # GITHUB_SHA is the ephemeral merge commit — fine as a unique preview tag.
-        run: echo "image_tag=mem9-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+        # Distinct prefixes so PR-preview churn and release images don't share a
+        # lifecycle-expiry window (ecr-repositories.yaml): `pr-<sha7>` for PR
+        # builds (expired aggressively), `mem9-<sha7>` for release builds on main
+        # (retained long). A prod task pins the release tag by name, so it must
+        # never be aged out by preview traffic. GITHUB_SHA is trusted (GitHub-
+        # controlled), so it's safe in run:; on a PR it's the ephemeral merge SHA.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [ "$EVENT_NAME" = "push" ]; then
+            echo "image_tag=mem9-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          else
+            echo "image_tag=pr-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Configure AWS credentials (OIDC)
         if: steps.gate.outputs.skip != 'true'

--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -26,6 +26,7 @@ on:
     types: [opened, synchronize, reopened, closed]
     paths:
       - "infra/**"
+      - "docker/**"
       - "sst.config.ts"
       - ".github/workflows/infra-ci.yml"
       - "scripts/**"
@@ -33,14 +34,16 @@ on:
       - "package-lock.json"
       - "tsconfig.json"
       - "vitest.config.ts"
-      # The OIDC role is bootstrapped out-of-band via
-      # scripts/deploy-github-role.sh — it is NOT part of the per-PR SST
-      # deploy. Skip the workflow when a PR only touches that template.
+      # The OIDC role + ECR repo are bootstrapped out-of-band via
+      # scripts/deploy-github-role.sh / deploy-ecr-repositories.sh — NOT part of
+      # the per-PR SST deploy. Skip the workflow when a PR only touches those
+      # CloudFormation templates.
       - "!infra/cloudformation/**"
   push:
     branches: [main]
     paths:
       - "infra/**"
+      - "docker/**"
       - "sst.config.ts"
       - ".github/workflows/infra-ci.yml"
       - "scripts/**"
@@ -68,6 +71,10 @@ concurrency:
 env:
   AWS_REGION: ap-northeast-1
   ROLE_NAME: github-actions-mem9-on-aws
+  # The out-of-band ECR repo (infra/cloudformation/ecr-repositories.yaml) that
+  # holds the mnemo-server arm64 image. build-and-push-image pushes here;
+  # deploy-prod references <acct>.dkr.ecr.<region>/<repo>:<tag>.
+  ECR_REPO: mem9-on-aws/mnemo-server
 
 jobs:
   # ───────────────────────────────────────────────────────────────────────────
@@ -116,7 +123,9 @@ jobs:
   deploy-preview:
     name: Deploy PR Preview
     runs-on: ${{ vars.RUNNER_LABEL && fromJSON(vars.RUNNER_LABEL) || 'ubuntu-latest' }}
-    needs: typecheck
+    # Depends on the image build so the preview pulls THIS PR's freshly-built
+    # image (it wouldn't exist yet otherwise on the PR that introduces it).
+    needs: [typecheck, build-and-push-image]
     if: github.event_name == 'pull_request' && github.event.action != 'closed' && github.event.pull_request.base.ref == 'main'
     # Full-stack fresh preview: Aurora (~13m) + RDS Proxy + ECS. 15m timed out at ECS.
     timeout-minutes: 25
@@ -196,6 +205,10 @@ jobs:
         id: deploy
         if: steps.gate.outputs.skip != 'true'
         shell: bash
+        # Deploy the image this PR just built. If the build was skipped (no
+        # AWS_ROLE_ARN), fall back to `latest` — infra/ecs.ts's own default.
+        env:
+          MEM9_IMAGE_TAG: ${{ needs.build-and-push-image.outputs.image_tag || 'latest' }}
         run: |
           # PR_NUMBER comes from GitHub's pull_request payload (integer);
           # validate to short-circuit any injection risk.
@@ -417,12 +430,124 @@ jobs:
             });
 
   # ───────────────────────────────────────────────────────────────────────────
+  # build-and-push-image — build the mnemo-server arm64 image
+  # (docker/mnemo-server/, pinned mem9 commit) and push it to the out-of-band ECR
+  # repo, tagged `mem9-<sha7>` (immutable per-commit). On push-to-main it ALSO
+  # tags `latest`. Runs on BOTH PR (non-closed) and push so the PR preview
+  # exercises the real image (the image only exists once this job pushes it) and
+  # prod pins the exact commit. Exposes the per-commit tag as an output that both
+  # deploy-preview and deploy-prod consume. HARD-FAILS on push without
+  # AWS_ROLE_ARN; on PR it skips gracefully (matching deploy-preview's gate).
+  # ───────────────────────────────────────────────────────────────────────────
+  build-and-push-image:
+    name: Build & push mnemo-server image
+    runs-on: ${{ vars.RUNNER_LABEL && fromJSON(vars.RUNNER_LABEL) || 'ubuntu-latest' }}
+    needs: typecheck
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed' && github.event.pull_request.base.ref == 'main')
+    # arm64 build: native on the self-hosted arm64 pool, QEMU-emulated on
+    # ubuntu-latest (slower). Give the go build + emulation headroom.
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      contents: read
+    outputs:
+      # The per-commit tag, or empty when skipped (PR with no AWS_ROLE_ARN) so
+      # downstream jobs can fall back to `latest`.
+      image_tag: ${{ steps.tag.outputs.image_tag }}
+    steps:
+      - name: Gate on AWS_ROLE_ARN
+        id: gate
+        env:
+          HAS_AWS: ${{ secrets.AWS_ROLE_ARN }}
+        run: |
+          if [ -z "$HAS_AWS" ]; then
+            if [ "${{ github.event_name }}" = "push" ]; then
+              echo "::error::AWS_ROLE_ARN not configured — cannot build/push the image for prod. Bootstrap the role (scripts/deploy-github-role.sh) and set the secret."
+              exit 1
+            fi
+            echo "::notice::AWS_ROLE_ARN not configured — skipping image build (preview will fall back to :latest)"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v5
+        if: steps.gate.outputs.skip != 'true'
+
+      - name: Resolve image tag
+        id: tag
+        if: steps.gate.outputs.skip != 'true'
+        # GITHUB_SHA is trusted (GitHub-controlled), so it's safe in run:. On a PR,
+        # GITHUB_SHA is the ephemeral merge commit — fine as a unique preview tag.
+        run: echo "image_tag=mem9-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      - name: Configure AWS credentials (OIDC)
+        if: steps.gate.outputs.skip != 'true'
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Log in to Amazon ECR
+        id: ecr-login
+        if: steps.gate.outputs.skip != 'true'
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Resolve image tags
+        id: tags
+        if: steps.gate.outputs.skip != 'true'
+        # Build the newline-delimited `tags` list in shell (NOT an inline GHA
+        # ternary) so there's never a blank line — docker/build-push-action's
+        # handling of an empty tag entry is undocumented. Always push the
+        # per-commit tag; ADD `latest` only on push-to-main so PR previews can't
+        # clobber the tag local/PR deploys fall back to.
+        env:
+          REGISTRY: ${{ steps.ecr-login.outputs.registry }}
+          IMAGE_TAG: ${{ steps.tag.outputs.image_tag }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          {
+            echo "tags<<EOF"
+            echo "${REGISTRY}/${ECR_REPO}:${IMAGE_TAG}"
+            if [ "$EVENT_NAME" = "push" ]; then
+              echo "${REGISTRY}/${ECR_REPO}:latest"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        # Enables linux/arm64 emulation on x86 runners (ubuntu-latest). A no-op
+        # cost on the native-arm64 self-hosted pool.
+        if: steps.gate.outputs.skip != 'true'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        if: steps.gate.outputs.skip != 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build & push arm64 image
+        if: steps.gate.outputs.skip != 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/mnemo-server/Dockerfile
+          platforms: linux/arm64
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          # GHA cache so repeated builds reuse the Go build layer.
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # ───────────────────────────────────────────────────────────────────────────
   # deploy-prod — push to main → stage `prod`. HARD-FAILS without AWS_ROLE_ARN.
+  # Runs AFTER the image is built+pushed and pins prod to that exact `mem9-<sha7>`.
   # ───────────────────────────────────────────────────────────────────────────
   deploy-prod:
     name: Deploy prod
     runs-on: ${{ vars.RUNNER_LABEL && fromJSON(vars.RUNNER_LABEL) || 'ubuntu-latest' }}
-    needs: typecheck
+    needs: [typecheck, build-and-push-image]
     if: github.event_name == 'push'
     environment: prod
     # Full-stack prod: Aurora + RDS Proxy + ECS provisioning exceeds 20m on first bring-up.
@@ -538,6 +663,10 @@ jobs:
 
       - name: Deploy prod stage
         shell: bash
+        # Pin prod to the exact image built by build-and-push-image (this commit's
+        # `mem9-<sha7>`); infra/ecs.ts reads MEM9_IMAGE_TAG (defaults to `latest`).
+        env:
+          MEM9_IMAGE_TAG: ${{ needs.build-and-push-image.outputs.image_tag }}
         run: |
           set +e
           pnpm -C infra exec sst deploy --stage prod --print-logs 2>&1 | tee sst-deploy.log

--- a/docker/mnemo-server/Dockerfile
+++ b/docker/mnemo-server/Dockerfile
@@ -1,0 +1,68 @@
+# mnemo-server (upstream mem9) — self-contained arm64 build.
+#
+# Why this exists (docs/ARCHITECTURE.md §4, docs/mem9-facts.md "Build / architecture"):
+#   - mem9-ai/mem9 publishes NO release, NO tag, NO public image. Its own CI
+#     pushes `<branch>-<sha7>` to the maintainers' PRIVATE ECR (a different AWS
+#     account) — unusable for us. So we PIN a source commit and build our own.
+#   - Upstream's shipped server/Dockerfile assumes a PRE-BUILT binary (its golang
+#     builder stage is commented out; the binary is compiled on the CI host, then
+#     COPYed into alpine). We restore a proper multi-stage build so CI needs only
+#     Docker — no host Go toolchain, no separate mem9 checkout.
+#   - mem9 is pure Go (CGO_ENABLED=0), so it cross-compiles to arm64 with zero
+#     source change (GOARCH=arm64). Targets AWS Graviton Fargate (§4, arm64).
+#
+# Pin: mem9-ai/mem9 @ d4638c8458abeb209a1b3a20472a1328c4acd149 (main, 2026-07-10).
+# Bump = change MEM9_REF below + re-verify docs/mem9-facts.md against the new tree.
+# Module path is github.com/qiffang/mnemos/server; the server lives under server/.
+
+# ── builder ──────────────────────────────────────────────────────────────────
+# go.mod requires Go 1.24 (toolchain go1.24.6). Alpine builder keeps the image
+# small; the binary is static (CGO off) so the runtime needs no libc from here.
+FROM golang:1.24-alpine AS builder
+
+# git to fetch the pinned source; ca-certificates so `go mod download` can reach
+# the module proxy over TLS.
+RUN apk add --no-cache git ca-certificates
+
+# The exact upstream commit to vendor. A full 40-char SHA (not a branch/tag) so
+# the build is reproducible and can never drift under us.
+ARG MEM9_REF=d4638c8458abeb209a1b3a20472a1328c4acd149
+# Target arch for the static binary. arm64 for Graviton Fargate; overridable so
+# the same Dockerfile can build amd64 for a local x86 smoke test.
+ARG TARGETARCH=arm64
+
+WORKDIR /src
+# Shallow-fetch just the pinned commit (no full history) to keep the build fast.
+RUN git init -q . \
+    && git remote add origin https://github.com/mem9-ai/mem9.git \
+    && git fetch -q --depth 1 origin "${MEM9_REF}" \
+    && git checkout -q FETCH_HEAD
+
+# Build the server. go.mod + the whole module live under server/.
+WORKDIR /src/server
+RUN go mod download \
+    && CGO_ENABLED=0 GOOS=linux GOARCH="${TARGETARCH}" \
+       go build -trimpath -ldflags="-s -w" -o /out/mnemo-server ./cmd/mnemo-server
+
+# ── runtime ──────────────────────────────────────────────────────────────────
+# Matches upstream's runtime base (alpine:3.19 + ca-certificates) so behavior
+# tracks what the maintainers ship; the static binary + certs are all we need.
+FROM alpine:3.19
+
+# ca-certificates: TLS to RDS Proxy / Bedrock / embed. jq: the entrypoint parses
+# the Secrets Manager JSON ({username,password}) and URL-encodes the password
+# (RDS RandomPassword can contain DSN-reserved chars: @ / : ? #) via jq's @uri —
+# far more robust than hand-rolled sed/awk. Both are small (~1-2 MB total).
+RUN apk add --no-cache ca-certificates jq
+
+COPY --from=builder /out/mnemo-server /usr/local/bin/mnemo-server
+# entrypoint assembles MNEMO_DSN from the ECS-injected DB env + secret, then
+# execs the server (mem9 reads a single static MNEMO_DSN and can't compose it
+# from parts — see docs/mem9-facts.md "DB connection mechanism").
+COPY docker/mnemo-server/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# mnemo-server listens on MNEMO_PORT (default 8080). No secrets baked in — all
+# config arrives as env vars / ECS secrets at task start.
+EXPOSE 8080
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker/mnemo-server/Dockerfile
+++ b/docker/mnemo-server/Dockerfile
@@ -18,7 +18,14 @@
 # ── builder ──────────────────────────────────────────────────────────────────
 # go.mod requires Go 1.24 (toolchain go1.24.6). Alpine builder keeps the image
 # small; the binary is static (CGO off) so the runtime needs no libc from here.
-FROM golang:1.24-alpine AS builder
+#
+# `--platform=$BUILDPLATFORM` runs the Go toolchain NATIVELY on the builder host
+# (fast on any runner) and cross-compiles to the target arch via GOARCH — instead
+# of running the whole compiler under QEMU emulation, which would be slow on x86
+# CI runners. mem9 is pure Go (CGO off), so cross-compiling is a plain GOARCH
+# switch, no emulation needed. BUILDPLATFORM/TARGETARCH are auto-injected by
+# buildx.
+FROM --platform=$BUILDPLATFORM golang:1.24-alpine AS builder
 
 # git to fetch the pinned source; ca-certificates so `go mod download` can reach
 # the module proxy over TLS.
@@ -27,8 +34,8 @@ RUN apk add --no-cache git ca-certificates
 # The exact upstream commit to vendor. A full 40-char SHA (not a branch/tag) so
 # the build is reproducible and can never drift under us.
 ARG MEM9_REF=d4638c8458abeb209a1b3a20472a1328c4acd149
-# Target arch for the static binary. arm64 for Graviton Fargate; overridable so
-# the same Dockerfile can build amd64 for a local x86 smoke test.
+# Target arch for the static binary, auto-injected by buildx from --platform
+# (linux/arm64 → arm64). Defaulted so a plain `docker build` still works.
 ARG TARGETARCH=arm64
 
 WORKDIR /src
@@ -38,7 +45,8 @@ RUN git init -q . \
     && git fetch -q --depth 1 origin "${MEM9_REF}" \
     && git checkout -q FETCH_HEAD
 
-# Build the server. go.mod + the whole module live under server/.
+# Build the server. go.mod + the whole module live under server/. GOARCH targets
+# the requested arch while the compiler itself runs on the native BUILDPLATFORM.
 WORKDIR /src/server
 RUN go mod download \
     && CGO_ENABLED=0 GOOS=linux GOARCH="${TARGETARCH}" \

--- a/docker/mnemo-server/entrypoint.sh
+++ b/docker/mnemo-server/entrypoint.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+# entrypoint.sh — assemble MNEMO_DSN from the ECS-injected DB pieces, then exec
+# mnemo-server. Runs as PID 1 in the mnemo-server container.
+#
+# WHY (docs/mem9-facts.md "DB connection mechanism"): mem9 reads a SINGLE static
+# `MNEMO_DSN` env var and does NOT compose it from host/user/pass/dbname parts —
+# there are no such vars in mem9. The DB password is a runtime secret (Secrets
+# Manager → ECS `secrets: valueFrom`), so it CANNOT be string-concatenated into a
+# committed task def. This script does the composition at container start, from:
+#
+#   MEM9_DB_HOST    - RDS Proxy endpoint            (plain env, from infra/ecs.ts)
+#   MEM9_DB_PORT    - 5432                           (plain env)
+#   MEM9_DB_NAME    - "mem9"                          (plain env)
+#   MEM9_DB_SECRET  - JSON {"username":..,"password":..}  (ECS secret, whole value)
+#
+#   → MNEMO_DSN=postgres://<user>:<url-encoded-pw>@<host>:<port>/<db>?sslmode=require
+#
+# If MNEMO_DSN is ALREADY set (e.g. a local run, or a future non-proxy path), it
+# is respected as-is and this assembly is skipped.
+#
+# Fail LOUD on any missing piece — a silent fallback to a malformed DSN would let
+# the container start and then fail every query with a confusing auth error.
+
+set -eu
+
+if [ -z "${MNEMO_DSN:-}" ]; then
+  : "${MEM9_DB_HOST:?MEM9_DB_HOST is required to assemble MNEMO_DSN}"
+  : "${MEM9_DB_PORT:?MEM9_DB_PORT is required to assemble MNEMO_DSN}"
+  : "${MEM9_DB_NAME:?MEM9_DB_NAME is required to assemble MNEMO_DSN}"
+  : "${MEM9_DB_SECRET:?MEM9_DB_SECRET (Secrets Manager JSON) is required to assemble MNEMO_DSN}"
+
+  # Extract user + password from the secret JSON and URL-encode BOTH (the
+  # password can hold DSN-reserved chars; the username is encoded defensively).
+  # The field is validated for null/absence BEFORE @uri: `jq -e '.x | @uri'`
+  # would turn a null field into the STRING "null" (a truthy output → exit 0),
+  # silently producing "postgres://null:null@...". So assert non-null first
+  # (`// error(...)` → jq exits 5), THEN encode. The value is never printed —
+  # only the field name appears in the error message.
+  extract_field() {
+    printf '%s' "$MEM9_DB_SECRET" | jq -re "(.$1 // error(\"missing .$1\")) | @uri" || {
+      echo "entrypoint: MEM9_DB_SECRET has no .$1 field" >&2
+      exit 1
+    }
+  }
+  DB_USER=$(extract_field username)
+  DB_PASS=$(extract_field password)
+
+  # sslmode=require: RDS Proxy mandates TLS; mem9 uses the pgx stdlib driver which
+  # honors the DSN query param (docs/ARCHITECTURE.md §3a).
+  export MNEMO_DSN="postgres://${DB_USER}:${DB_PASS}@${MEM9_DB_HOST}:${MEM9_DB_PORT}/${MEM9_DB_NAME}?sslmode=require"
+
+  # Log the DSN with the password redacted (host/port/db/user are safe to show
+  # and help diagnose connectivity; the secret value never appears in logs).
+  echo "entrypoint: assembled MNEMO_DSN=postgres://${DB_USER}:***@${MEM9_DB_HOST}:${MEM9_DB_PORT}/${MEM9_DB_NAME}?sslmode=require"
+fi
+
+# Hand off to the server as PID 1 (proper signal handling / graceful shutdown).
+exec /usr/local/bin/mnemo-server "$@"

--- a/docs/mem9-facts.md
+++ b/docs/mem9-facts.md
@@ -181,6 +181,40 @@ Verified against AWS docs + the operator's podcast-curation prod usage:
   switch to `GOARCH=arm64` + `docker build --platform=linux/arm64` for Graviton.
   No source change needed.
 
+### Packaging: no release/tag/public image → we PIN a source SHA (verified 2026-07-11)
+
+- **mem9-ai/mem9 publishes NO GitHub release, NO tag, and NO public image.**
+  `gh api repos/mem9-ai/mem9/{releases,tags}` both return empty. Their own CI
+  (`.github/workflows/deploy-dev.yml` / `deploy-prod.yml`) builds
+  `<branch>-<sha7>` and pushes to the **maintainers' PRIVATE ECR** (a different
+  AWS account) + deploys to their EKS — **unusable for us**. So self-hosting
+  REQUIRES pinning an upstream commit and building our own image.
+- Upstream's build model: the Makefile's `build-linux` compiles the binary on
+  the CI host (`CGO_ENABLED=0 GOOS=linux GOARCH=amd64`), then `docker build`
+  merely `COPY`s the prebuilt binary into `alpine:3.19` (the Dockerfile's golang
+  builder stage is commented out). Module path is
+  **`github.com/qiffang/mnemos/server`**; the server module lives under `server/`
+  (`server/{go.mod,go.sum,cmd/mnemo-server/main.go,internal,schema_pg.sql}`).
+- **Our build (this repo, `docker/mnemo-server/Dockerfile`):** a self-contained
+  **multi-stage** build — `golang:1.24-alpine` builder git-fetches the pinned
+  commit, `CGO_ENABLED=0 GOARCH=arm64 go build ./cmd/mnemo-server`, into
+  `alpine:3.19` — so CI needs only Docker (no host Go, no separate mem9
+  checkout). Built for **arm64** (Graviton Fargate) via `docker buildx
+  --platform=linux/arm64`.
+- **Vendored pin (LOCKED): `mem9-ai/mem9` @ `d4638c8458abeb209a1b3a20472a1328c4acd149`**
+  (main tip, committed 2026-07-10). It is the `MEM9_REF` build-arg default in the
+  Dockerfile. **Bumping the pin = change `MEM9_REF` + re-verify every fact in
+  this file against the new tree** (schema, config env vars, DB driver path).
+- **Entrypoint (`docker/mnemo-server/entrypoint.sh`)** bridges the static-DSN
+  constraint (see "DB connection mechanism"): mem9 reads one static `MNEMO_DSN`
+  and can't compose it from parts, and the DB password is a runtime secret
+  (Secrets Manager → ECS `secrets: valueFrom`), so the entrypoint assembles
+  `MNEMO_DSN=postgres://<user>:<url-encoded-pw>@<host>:<port>/<db>?sslmode=require`
+  at container start from the injected `MEM9_DB_HOST/PORT/NAME` env + the
+  `MEM9_DB_SECRET` JSON (`{username,password}`), URL-encoding the password (RDS
+  RandomPassword can contain `@ / : ? #`) via `jq @uri`. It respects a pre-set
+  `MNEMO_DSN` and fails loud on any missing/null field. **No mem9 source change.**
+
 ## Concurrency model
 
 - Server is the single process fronting the DB; concurrency is handled at the DB

--- a/infra/cloudformation/ecr-repositories.yaml
+++ b/infra/cloudformation/ecr-repositories.yaml
@@ -5,10 +5,12 @@ Description: >
   (prod + every pr-N preview) references this ONE repo read-only, so a stray
   `sst remove --stage pr-N` can never wipe the image history that prod runs on.
 
-  The arm64 mnemo-server image is built + pushed to this repo by CI on push-to-
-  main (.github/workflows/infra-ci.yml → build-and-push-image), tagged both
-  `mem9-<sha7>` (immutable-in-practice, per-commit) and `latest`. Deploy stages
-  reference the URI `<acct>.dkr.ecr.<region>.amazonaws.com/mem9-on-aws/mnemo-server:<tag>`.
+  The arm64 mnemo-server image is built + pushed to this repo by CI
+  (.github/workflows/infra-ci.yml → build-and-push-image): push-to-main tags
+  `mem9-<sha7>` (release, per-commit) + `latest`; PR builds tag `pr-<sha7>`
+  (preview). The lifecycle policy retains the two prefixes on separate schedules
+  (see below). Deploy stages reference the URI
+  `<acct>.dkr.ecr.<region>.amazonaws.com/mem9-on-aws/mnemo-server:<tag>`.
 
   Deploy out-of-band via `scripts/deploy-ecr-repositories.sh` (ONCE per account;
   re-run only if this template changes). Region MUST be ap-northeast-1 (Tokyo) —

--- a/infra/cloudformation/ecr-repositories.yaml
+++ b/infra/cloudformation/ecr-repositories.yaml
@@ -42,26 +42,49 @@ Resources:
       # data-ownership is satisfied — the images live in the operator's account).
       EncryptionConfiguration:
         EncryptionType: AES256
-      # Keep only the most recent per-commit images so the repo doesn't grow
-      # unbounded across every main merge. `latest` is a tag on one of the kept
-      # images, so it stays pullable. 10 keeps a useful rollback window.
+      # PR-preview (`pr-<sha7>`) and release (`mem9-<sha7>`) images use DISTINCT
+      # tag prefixes (.github/workflows/infra-ci.yml → Resolve image tag) so they
+      # don't share one expiry window. This matters because a prod task pins its
+      # release tag BY NAME and Fargate re-resolves tag→digest on every task
+      # (re)start — if preview churn aged a still-referenced release tag out of a
+      # shared window, a prod restart would hit ImageNotFound and fail to recover.
+      # So:
+      #   - `pr-*`   → expire aggressively (7 days) — previews are torn down with
+      #     their stage; images just need to outlive an open PR's review cycle.
+      #   - `mem9-*` → keep the last 30 releases (a generous rollback window that
+      #     preview traffic can never encroach on).
+      #   - untagged → expire after 3 days (orphaned layers from overwritten
+      #     `latest`, which floats to the newest `mem9-*` on each main merge).
+      # Rule priority: pr-* first (lowest number = evaluated first).
       LifecyclePolicy:
         LifecyclePolicyText: |
           {
             "rules": [
               {
                 "rulePriority": 1,
-                "description": "Keep the last 10 mem9-<sha> images; expire older per-commit builds.",
+                "description": "Expire pr-<sha> preview images after 7 days (they die with their PR stage).",
                 "selection": {
                   "tagStatus": "tagged",
-                  "tagPrefixList": ["mem9-"],
-                  "countType": "imageCountMoreThan",
-                  "countNumber": 10
+                  "tagPrefixList": ["pr-"],
+                  "countType": "sinceImagePushed",
+                  "countUnit": "days",
+                  "countNumber": 7
                 },
                 "action": { "type": "expire" }
               },
               {
                 "rulePriority": 2,
+                "description": "Keep the last 30 mem9-<sha> release images; expire older ones. Prod pins one of these by name — never let preview traffic age it out.",
+                "selection": {
+                  "tagStatus": "tagged",
+                  "tagPrefixList": ["mem9-"],
+                  "countType": "imageCountMoreThan",
+                  "countNumber": 30
+                },
+                "action": { "type": "expire" }
+              },
+              {
+                "rulePriority": 3,
                 "description": "Expire untagged images after 3 days (orphaned layers from overwritten `latest`).",
                 "selection": {
                   "tagStatus": "untagged",

--- a/infra/cloudformation/ecr-repositories.yaml
+++ b/infra/cloudformation/ecr-repositories.yaml
@@ -1,0 +1,95 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  ECR repository for the mem9-on-aws mnemo-server container image — owned
+  OUT-OF-BAND (not by SST/Pulumi). See docs/ARCHITECTURE.md §4: every SST stage
+  (prod + every pr-N preview) references this ONE repo read-only, so a stray
+  `sst remove --stage pr-N` can never wipe the image history that prod runs on.
+
+  The arm64 mnemo-server image is built + pushed to this repo by CI on push-to-
+  main (.github/workflows/infra-ci.yml → build-and-push-image), tagged both
+  `mem9-<sha7>` (immutable-in-practice, per-commit) and `latest`. Deploy stages
+  reference the URI `<acct>.dkr.ecr.<region>.amazonaws.com/mem9-on-aws/mnemo-server:<tag>`.
+
+  Deploy out-of-band via `scripts/deploy-ecr-repositories.sh` (ONCE per account;
+  re-run only if this template changes). Region MUST be ap-northeast-1 (Tokyo) —
+  ECR is regional and Fargate pulls same-region to avoid cross-region data cost.
+
+Parameters:
+  ProjectName:
+    Type: String
+    Default: mem9-on-aws
+    Description: SST app name; used as the ECR repository namespace prefix so the
+      repo URI reads .../mem9-on-aws/mnemo-server.
+
+Resources:
+  # ───────────────────────────────────────────────────────────────────────────
+  # mnemo-server image repository. Namespaced under the project so a single
+  # account can host sibling projects' repos without collision.
+  # ───────────────────────────────────────────────────────────────────────────
+  MnemoServerRepo:
+    Type: AWS::ECR::Repository
+    # Retain on stack delete — the image history is the deploy artifact; never
+    # let tearing down this bootstrap stack drop the images prod depends on.
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      RepositoryName: !Sub ${ProjectName}/mnemo-server
+      # MUTABLE: CI pushes a rolling `latest` tag alongside the immutable
+      # per-commit `mem9-<sha7>` tag; `latest` must be overwritable. The
+      # per-commit tag is never re-pushed in practice (new commit = new sha).
+      ImageTagMutability: MUTABLE
+      # Encryption at rest with the ECR-managed AES256 key (no CMK to manage;
+      # data-ownership is satisfied — the images live in the operator's account).
+      EncryptionConfiguration:
+        EncryptionType: AES256
+      # Keep only the most recent per-commit images so the repo doesn't grow
+      # unbounded across every main merge. `latest` is a tag on one of the kept
+      # images, so it stays pullable. 10 keeps a useful rollback window.
+      LifecyclePolicy:
+        LifecyclePolicyText: |
+          {
+            "rules": [
+              {
+                "rulePriority": 1,
+                "description": "Keep the last 10 mem9-<sha> images; expire older per-commit builds.",
+                "selection": {
+                  "tagStatus": "tagged",
+                  "tagPrefixList": ["mem9-"],
+                  "countType": "imageCountMoreThan",
+                  "countNumber": 10
+                },
+                "action": { "type": "expire" }
+              },
+              {
+                "rulePriority": 2,
+                "description": "Expire untagged images after 3 days (orphaned layers from overwritten `latest`).",
+                "selection": {
+                  "tagStatus": "untagged",
+                  "countType": "sinceImagePushed",
+                  "countUnit": "days",
+                  "countNumber": 3
+                },
+                "action": { "type": "expire" }
+              }
+            ]
+          }
+      Tags:
+        - Key: Project
+          Value: !Ref ProjectName
+        - Key: ManagedBy
+          Value: cloudformation
+
+Outputs:
+  MnemoServerRepoUri:
+    Description: >
+      The mnemo-server ECR repository URI (without a tag). CI appends
+      `:mem9-<sha7>` / `:latest`; infra/ecs.ts composes the same URI from the
+      account + region + this namespace to reference the image read-only.
+    Value: !GetAtt MnemoServerRepo.RepositoryUri
+    Export:
+      Name: !Sub ${AWS::StackName}-MnemoServerRepoUri
+  MnemoServerRepoName:
+    Description: The ECR repository name (namespace/repo form).
+    Value: !Ref MnemoServerRepo
+    Export:
+      Name: !Sub ${AWS::StackName}-MnemoServerRepoName

--- a/infra/cloudformation/github-actions-role.yaml
+++ b/infra/cloudformation/github-actions-role.yaml
@@ -632,6 +632,56 @@ Resources:
             Resource: "*"
 
   # ───────────────────────────────────────────────────────────────────────────
+  # Policy 6 — Image build+push (.github/workflows/infra-ci.yml →
+  # build-and-push-image). CI on push-to-main builds the mnemo-server arm64 image
+  # (docker buildx) and pushes it to the OUT-OF-BAND ECR repo
+  # (infra/cloudformation/ecr-repositories.yaml → mem9-on-aws/mnemo-server).
+  #
+  # DISTINCT from ComputePolicy's ECRPull (the task PULLS at runtime): this is the
+  # CI PUSH surface. Its own ManagedPolicy so (a) ComputePolicy stays under IAM's
+  # 6144-byte per-policy cap, and (b) the "who can push images" footprint is
+  # auditable in one place. GetAuthorizationToken is already granted (ECRPull).
+  # Push actions are scoped to the ONE mnemo-server repo ARN (Tokyo — where the
+  # out-of-band repo lives; the role stack itself is in us-west-2 but ECR ARNs are
+  # regional).
+  #
+  # ADDED for the mnemo-server image PR — must be live (re-run
+  # scripts/deploy-github-role.sh) BEFORE that PR's first push-to-main build, or
+  # the build 403s on the first PutImage.
+  # ───────────────────────────────────────────────────────────────────────────
+  ImageBuildPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: !Sub ${GitHubRepo}-image-build
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: ECRPushToken
+            # GetAuthorizationToken has no resource scope; needed for `docker
+            # login` before pushing. (Also granted in ComputePolicy's ECRPull for
+            # the deploy path; harmless to have on both, keeps this policy
+            # self-contained.)
+            Effect: Allow
+            Action:
+              - ecr:GetAuthorizationToken
+            Resource: "*"
+          - Sid: ECRPush
+            # Upload layers + put the manifest, scoped to the mnemo-server repo.
+            # BatchCheckLayerAvailability lets buildx skip re-uploading existing
+            # layers. DescribeRepositories confirms the out-of-band repo exists
+            # before pushing (clear error if the bootstrap wasn't run).
+            Effect: Allow
+            Action:
+              - ecr:BatchCheckLayerAvailability
+              - ecr:InitiateLayerUpload
+              - ecr:UploadLayerPart
+              - ecr:CompleteLayerUpload
+              - ecr:PutImage
+              - ecr:DescribeRepositories
+            Resource:
+              - !Sub arn:aws:ecr:ap-northeast-1:${AWS::AccountId}:repository/${ProjectName}/mnemo-server
+
+  # ───────────────────────────────────────────────────────────────────────────
   # IAM Role — assumed by GitHub Actions via OIDC.
   # ───────────────────────────────────────────────────────────────────────────
   GitHubActionsRole:
@@ -669,6 +719,7 @@ Resources:
         - !Ref ScaffoldPolicy
         - !Ref DatabasePolicy
         - !Ref ComputePolicy
+        - !Ref ImageBuildPolicy
       Tags:
         - Key: Project
           Value: !Ref ProjectName

--- a/infra/ecs.test.ts
+++ b/infra/ecs.test.ts
@@ -41,9 +41,37 @@ function fakeDbOut(): DbOutputs {
   } as unknown as DbOutputs;
 }
 
+// $interpolate mock: mirror Pulumi's tagged-template — unwrap out<T> values (and
+// plain values), join with the literal strings, and return an out<string> so the
+// result flows through .value/.apply like the real Output. ecs() uses it to
+// compose the ECR image URI from the account Output + literal strings.
+function installInterpolate() {
+  (globalThis as Record<string, unknown>).$interpolate = (
+    strings: TemplateStringsArray,
+    ...values: unknown[]
+  ) => {
+    let s = "";
+    strings.forEach((str, i) => {
+      s += str;
+      if (i < values.length) {
+        const v = values[i];
+        s +=
+          typeof v === "object" && v && "value" in v
+            ? String((v as { value: unknown }).value)
+            : String(v);
+      }
+    });
+    return out(s);
+  };
+}
+
 function installGlobals(stage: string) {
   (globalThis as Record<string, unknown>).$app = { name: "mem9-on-aws", stage };
+  installInterpolate();
   (globalThis as Record<string, unknown>).aws = {
+    // ecs() composes the ECR image URI from the caller's account id — never a
+    // hardcoded 12-digit account number in committed code.
+    getCallerIdentityOutput: () => ({ accountId: out("123456789012") }),
     ec2: {
       getVpcOutput: () => ({ id: out("vpc-test") }),
       getSubnetsOutput: () => ({ ids: out(["subnet-a", "subnet-b", "subnet-c"]) }),
@@ -86,7 +114,9 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  for (const g of ["$app", "aws", "sst"]) delete (globalThis as Record<string, unknown>)[g];
+  for (const g of ["$app", "aws", "sst", "$interpolate"])
+    delete (globalThis as Record<string, unknown>)[g];
+  delete process.env.MEM9_IMAGE_TAG;
   vi.resetModules();
 });
 
@@ -118,7 +148,7 @@ describe("ecs stack", () => {
     expect(vpc.containerSubnets).toBeDefined();
   });
 
-  it("runs an arm64 Fargate service with the placeholder image and NO load balancer", async () => {
+  it("runs an arm64 Fargate service with the ECR image URI and NO load balancer", async () => {
     installGlobals("prod");
     const ecs = await loadEcs();
     ecs(fakeDbOut());
@@ -127,9 +157,33 @@ describe("ecs stack", () => {
     expect(args.architecture).toBe("arm64");
     expect(args.cpu).toBe("0.25 vCPU");
     expect(args.memory).toBe("0.5 GB");
-    expect(String(args.image)).toContain("public.ecr.aws");
+    // The image is our out-of-band ECR repo URI (account.dkr.ecr.<region>...),
+    // composed from the caller's account id — NOT a public/placeholder image.
+    const image = String((args.image as { value: string }).value ?? args.image);
+    expect(image).toContain(".dkr.ecr.ap-northeast-1.amazonaws.com/mem9-on-aws/mnemo-server:");
+    expect(image).not.toContain("public.ecr.aws");
     // No ALB in this skeleton (deferred to the Gateway PR).
     expect(args.loadBalancer).toBeUndefined();
+  });
+
+  it("defaults the image tag to `latest` and honors MEM9_IMAGE_TAG", async () => {
+    // Default tag.
+    installGlobals("prod");
+    let ecs = await loadEcs();
+    ecs(fakeDbOut());
+    let image = String((services[0].args.image as { value: string }).value);
+    expect(image).toMatch(/:latest$/);
+
+    // Reset + override via env (how CI pins prod to the exact built commit).
+    for (const g of ["$app", "aws", "sst", "$interpolate"])
+      delete (globalThis as Record<string, unknown>)[g];
+    services = [];
+    process.env.MEM9_IMAGE_TAG = "mem9-abc1234";
+    installGlobals("prod");
+    ecs = await loadEcs();
+    ecs(fakeDbOut());
+    image = String((services[0].args.image as { value: string }).value);
+    expect(image).toMatch(/:mem9-abc1234$/);
   });
 
   it("injects DB config as env + the password secret via ssm (never a literal)", async () => {
@@ -151,13 +205,14 @@ describe("ecs stack", () => {
     }
   });
 
-  it("exports the cluster + service names under /mem9-on-aws/${stage}/ecs/", async () => {
+  it("exports the cluster + service names + image under /mem9-on-aws/${stage}/ecs/", async () => {
     installGlobals("prod");
     const ecs = await loadEcs();
     ecs(fakeDbOut());
     const names = params.map((p) => p.name).sort();
     expect(names).toEqual([
       "/mem9-on-aws/prod/ecs/cluster-name",
+      "/mem9-on-aws/prod/ecs/image",
       "/mem9-on-aws/prod/ecs/service-name",
     ]);
   });

--- a/infra/ecs.ts
+++ b/infra/ecs.ts
@@ -1,42 +1,52 @@
 /**
- * `ecs` stack — ECS Fargate cluster + service for mnemo-server (SKELETON).
+ * `ecs` stack — ECS Fargate cluster + service running the REAL mnemo-server.
  *
- * See docs/ARCHITECTURE.md §4 (compute) + the 3-container task composition. This
- * PR delivers the SKELETON only: the cluster, a single-task Fargate service
- * (arm64, desiredCount=1) wired into the default VPC's private subnets with the
- * DB task SG (from infra/db.ts), the DB connection injected from the
- * `/mem9-on-aws/${stage}/db/*` SSM params + the DB password from Secrets Manager
- * via SST's `ssm` prop (== ECS `secrets: valueFrom`). It runs a PLACEHOLDER
- * public image so the pipeline proves DB reachability + wiring end-to-end.
+ * See docs/ARCHITECTURE.md §4 (compute). Provisions the cluster + a single-task
+ * Fargate service (arm64, desiredCount=1) in the default VPC's private subnets
+ * with the DB task SG (from infra/db.ts), the DB connection injected from db()'s
+ * Outputs + the DB password from Secrets Manager via SST's `ssm` prop
+ * (== ECS `secrets: valueFrom`). The task runs the mnemo-server arm64 image
+ * built + pushed to our OUT-OF-BAND ECR repo (docker/mnemo-server/, pinned to a
+ * mem9 source commit — see docs/mem9-facts.md). Its entrypoint assembles
+ * MNEMO_DSN from the injected pieces at container start.
  *
- * NOT yet here (follow-up PRs, each needs its own image built first):
- *   - the real mnemo-server arm64 image (own ECR repo out-of-band + arm64 build;
- *     Open #3 — pin the upstream mem9 commit)
+ * NOT yet here (follow-up PRs, each needs its own prerequisite):
  *   - the qwen3-embed sidecar (§7 embedding) and token-refresh sidecar (§7 LLM)
  *   - the internal ALB + public ACM cert (deferred to the AgentCore Gateway PR,
  *     §6a — it exists only to give the Gateway a TLS-trusted Lattice target)
+ *   - the one-shot schema-bootstrap task (§8: pgvector + tenant runtime schema).
+ *     Until it runs, mnemo-server boots + reaches the DB but list/search fail on
+ *     the missing tenant schema; this stack proves the server starts + connects.
  *
- * MNEMO_DSN assembly (design note): mem9 reads a single static `MNEMO_DSN` and
- * cannot assemble it from parts. The password is a runtime secret, so it can't be
- * string-concatenated into MNEMO_DSN at deploy time. This skeleton injects the
- * discrete DB fields as env vars + the password via `ssm`; the REAL mnemo-server
- * image's entrypoint composes `MNEMO_DSN=postgres://<user>:<pw>@<host>:<port>/<db>?sslmode=require`
- * from them at container start (recorded for the mnemo-server image PR). The
- * placeholder image ignores them — it only proves the wiring resolves.
+ * MNEMO_DSN assembly: mem9 reads a single static `MNEMO_DSN` and cannot compose
+ * it from parts, and the password is a runtime secret. So this stack injects the
+ * discrete DB fields as env vars + the password JSON via `ssm`; the image's
+ * entrypoint (docker/mnemo-server/entrypoint.sh) composes
+ * `MNEMO_DSN=postgres://<user>:<url-encoded-pw>@<host>:<port>/<db>?sslmode=require`
+ * from them at container start.
  */
 
 import { resolveVpc } from "./vpc";
 import type { DbOutputs } from "./db";
 
-// A tiny, always-available public image for the skeleton. It listens on 8080 and
-// serves a static response — enough to prove the task launches + the env/secret
-// wiring resolves. Replaced by the mnemo-server arm64 image in a follow-up PR.
-const PLACEHOLDER_IMAGE = "public.ecr.aws/nginx/nginx:stable-alpine";
+// The out-of-band ECR repo namespace (infra/cloudformation/ecr-repositories.yaml).
+// The full URI is composed at deploy time as
+// `<account>.dkr.ecr.<region>.amazonaws.com/<namespace>:<tag>` — account from the
+// caller identity (never hardcoded), region = the app region.
+const ECR_NAMESPACE = "mem9-on-aws/mnemo-server";
+const ECR_REGION = "ap-northeast-1"; // must match sst.config.ts providers.aws.region
+
+// Image tag to deploy. CI (push-to-main) sets MEM9_IMAGE_TAG to the exact
+// `mem9-<sha7>` it just built + pushed, so prod runs that precise commit's image.
+// Local `sst deploy` / PR previews default to `latest` — the image most recently
+// pushed by main's CI (the out-of-band repo is shared across all stages).
+const IMAGE_TAG = process.env.MEM9_IMAGE_TAG || "latest";
 
 export interface EcsOutputs {
   ssmPrefix: string;
   clusterName: Output<string>;
   serviceName: Output<string>;
+  image: Output<string>;
 }
 
 /**
@@ -64,6 +74,13 @@ export function ecs(dbOut: DbOutputs): EcsOutputs {
   const dbSecretArn = dbOut.secretArn;
   const taskSgId = dbOut.taskSecurityGroupId;
 
+  // The mnemo-server arm64 image URI, composed from the caller's account (never
+  // hardcoded), the app region, the out-of-band repo namespace, and the tag.
+  // The repo is owned by infra/cloudformation/ecr-repositories.yaml and pushed
+  // to by CI — this stack only REFERENCES it (SST does not build/push it).
+  const accountId = aws.getCallerIdentityOutput().accountId;
+  const image = $interpolate`${accountId}.dkr.ecr.${ECR_REGION}.amazonaws.com/${ECR_NAMESPACE}:${IMAGE_TAG}`;
+
   // ECS cluster in the existing default VPC. `loadBalancerSubnets` is required by
   // the type even though we create no ALB here (deferred to the Gateway PR); set
   // it to the private subnets — harmless, no LB is provisioned.
@@ -83,14 +100,16 @@ export function ecs(dbOut: DbOutputs): EcsOutputs {
 
   // Fargate service: arm64, smallest size (§4: ~256 CPU / 512 MB), single task
   // (scaling unset → desiredCount 1), no load balancer (omit `loadBalancer`).
+  // `architecture: "arm64"` makes SST set the task's runtimePlatform
+  // cpuArchitecture=ARM64 — must match the image (built linux/arm64).
   const service = new sst.aws.Service("Mem9Server", {
     cluster,
     architecture: "arm64",
     cpu: "0.25 vCPU",
     memory: "0.5 GB",
-    image: PLACEHOLDER_IMAGE,
-    // Plain env: mem9's non-secret config + the DB connection pieces. The real
-    // image's entrypoint assembles MNEMO_DSN from these + the injected password.
+    image,
+    // Plain env: mem9's non-secret config + the DB connection pieces. The image's
+    // entrypoint assembles MNEMO_DSN from these + the injected password JSON.
     environment: {
       MNEMO_DB_BACKEND: "postgres",
       MNEMO_PORT: "8080",
@@ -129,10 +148,19 @@ export function ecs(dbOut: DbOutputs): EcsOutputs {
     value: service.nodes.service.name,
     tags,
   });
+  // Record the deployed image URI (incl. tag) so it's auditable which mem9
+  // commit each stage is running without inspecting the task definition.
+  new aws.ssm.Parameter("EcsImage", {
+    name: `${prefix}/ecs/image`,
+    type: "String",
+    value: image,
+    tags,
+  });
 
   return {
     ssmPrefix: prefix,
     clusterName: cluster.nodes.cluster.name,
     serviceName: service.nodes.service.name,
+    image,
   };
 }

--- a/infra/ecs.ts
+++ b/infra/ecs.ts
@@ -37,9 +37,15 @@ const ECR_NAMESPACE = "mem9-on-aws/mnemo-server";
 const ECR_REGION = "ap-northeast-1"; // must match sst.config.ts providers.aws.region
 
 // Image tag to deploy. CI (push-to-main) sets MEM9_IMAGE_TAG to the exact
-// `mem9-<sha7>` it just built + pushed, so prod runs that precise commit's image.
-// Local `sst deploy` / PR previews default to `latest` — the image most recently
-// pushed by main's CI (the out-of-band repo is shared across all stages).
+// `mem9-<sha7>` it just built + pushed, so prod runs that precise commit's image;
+// CI PR previews set `pr-<sha7>`. Local `sst deploy` / any deploy without the env
+// defaults to `latest` — the image most recently pushed by main's CI (the
+// out-of-band repo is shared across all stages).
+// NOTE: on a freshly-bootstrapped account where CI has NOT yet merged to main,
+// `latest` does not exist yet, so a manual local `sst deploy` would leave the
+// task unable to pull. First bring-up is always via a merge to main (which builds
+// + pushes before deploying); do local deploys only after that, or pass an
+// explicit MEM9_IMAGE_TAG that exists in ECR.
 const IMAGE_TAG = process.env.MEM9_IMAGE_TAG || "latest";
 
 export interface EcsOutputs {

--- a/infra/sst-types.d.ts
+++ b/infra/sst-types.d.ts
@@ -49,6 +49,15 @@ declare function $interpolate(
 
 // ── The `aws` provider surface the scaffold touches ─────────────────────────
 declare namespace aws {
+  // Caller identity — infra/ecs.ts uses accountId to compose the ECR image URI
+  // (never a hardcoded account id in committed code).
+  interface GetCallerIdentityResult {
+    readonly accountId: Output<string>;
+    readonly arn: Output<string>;
+    readonly userId: Output<string>;
+  }
+  function getCallerIdentityOutput(): GetCallerIdentityResult;
+
   namespace lambda {
     // Only referenced as the $transform target + its arg shape.
     interface FunctionArgs {

--- a/scripts/deploy-ecr-repositories.sh
+++ b/scripts/deploy-ecr-repositories.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# deploy-ecr-repositories.sh — Create or update the OUT-OF-BAND ECR repository
+# for the mem9-on-aws mnemo-server container image.
+#
+# Scope: **ECR repository only**. The SST/Pulumi app does NOT manage this repo —
+# it references it read-only (see docs/ARCHITECTURE.md §4). Owning it out-of-band
+# means `sst remove --stage pr-N` can never wipe the image history prod runs on.
+#
+# Bootstrap ONCE per AWS account (in the Tokyo region — ECR is regional and
+# Fargate pulls same-region), and RE-RUN only if
+# infra/cloudformation/ecr-repositories.yaml changes.
+#
+# Region: ap-northeast-1 (Tokyo) — MUST match the SST app region (sst.config.ts)
+# so Fargate pulls the image from the same region (no cross-region pull cost /
+# latency). This is UNLIKE deploy-github-role.sh, which pins us-west-2 for the
+# global IAM role stack; the ECR repo is a regional data resource.
+#
+# Local deploy profile: kane-global-mengxinz (set AWS_PROFILE), account <aws-account-id>.
+#
+# Usage:
+#   AWS_PROFILE=kane-global-mengxinz scripts/deploy-ecr-repositories.sh   # auto create/update
+#   scripts/deploy-ecr-repositories.sh --create   # force create-stack
+#   scripts/deploy-ecr-repositories.sh --update   # force update-stack
+
+set -euo pipefail
+
+STACK_NAME="${STACK_NAME:-ecr-repositories-mem9-on-aws}"
+TEMPLATE_FILE="infra/cloudformation/ecr-repositories.yaml"
+# Tokyo — MUST equal sst.config.ts's providers.aws.region so Fargate pulls the
+# image same-region. Hard-coded, NOT read from the ambient AWS_REGION: a stray
+# AWS_REGION in the shell (e.g. left over from deploy-github-role.sh's us-west-2)
+# would silently create the repo in the wrong region, and Fargate would then pull
+# cross-region (cost + latency) or fail. Override deliberately with ECR_REGION
+# only if the whole app moves regions.
+REGION="${ECR_REGION:-ap-northeast-1}"
+
+MODE=""
+for arg in "$@"; do
+  case "$arg" in
+    --create) MODE="create" ;;
+    --update) MODE="update" ;;
+    -h|--help)
+      sed -n '2,/^$/p' "$0" | sed 's/^# \?//'
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ ! -f "$TEMPLATE_FILE" ]]; then
+  echo "Error: template not found at $TEMPLATE_FILE (run from repo root)" >&2
+  exit 2
+fi
+
+echo "Stack:    $STACK_NAME"
+echo "Region:   $REGION"
+echo "Template: $TEMPLATE_FILE"
+
+# Auto-detect create vs update when the caller did not pass --create / --update.
+if [[ -z "$MODE" ]]; then
+  if aws cloudformation describe-stacks \
+      --stack-name "$STACK_NAME" \
+      --region "$REGION" \
+      >/dev/null 2>&1; then
+    MODE="update"
+  else
+    MODE="create"
+  fi
+fi
+
+case "$MODE" in
+  create)
+    echo "Creating stack..."
+    aws cloudformation create-stack \
+      --stack-name "$STACK_NAME" \
+      --template-body "file://$TEMPLATE_FILE" \
+      --region "$REGION" \
+      --tags Key=Project,Value=mem9-on-aws Key=ManagedBy,Value=cli
+    aws cloudformation wait stack-create-complete \
+      --stack-name "$STACK_NAME" \
+      --region "$REGION"
+    ;;
+  update)
+    echo "Updating stack..."
+    # update-stack exits non-zero with "No updates are to be performed" when the
+    # template is unchanged — swallow that so re-running for idempotency is safe.
+    set +e
+    UPDATE_OUTPUT=$(aws cloudformation update-stack \
+      --stack-name "$STACK_NAME" \
+      --template-body "file://$TEMPLATE_FILE" \
+      --region "$REGION" 2>&1)
+    UPDATE_EXIT=$?
+    set -e
+    if [[ $UPDATE_EXIT -ne 0 ]]; then
+      if echo "$UPDATE_OUTPUT" | grep -q "No updates are to be performed"; then
+        echo "No changes to apply."
+      else
+        echo "$UPDATE_OUTPUT" >&2
+        exit $UPDATE_EXIT
+      fi
+    else
+      aws cloudformation wait stack-update-complete \
+        --stack-name "$STACK_NAME" \
+        --region "$REGION"
+    fi
+    ;;
+esac
+
+REPO_URI=$(aws cloudformation describe-stacks \
+  --stack-name "$STACK_NAME" \
+  --region "$REGION" \
+  --query "Stacks[0].Outputs[?OutputKey=='MnemoServerRepoUri'].OutputValue" \
+  --output text)
+
+echo
+echo "MnemoServerRepoUri: $REPO_URI"
+echo
+echo "Next steps:"
+echo "  1. CI (push to main) builds the arm64 image + pushes to this repo."
+echo "  2. infra/ecs.ts composes the same URI from account+region+namespace and"
+echo "     references \${uri}:\${tag} read-only (default tag: 'latest')."


### PR DESCRIPTION
## Summary
- mem9 publishes **no release / tag / public image** (its CI pushes to the maintainers' private ECR + EKS), so self-hosting requires pinning an upstream source commit and building our own. This PR wires the full path and points ECS at the real image (replacing the nginx placeholder from #4).
- **Pin:** `mem9-ai/mem9` @ `d4638c8` (main tip, 2026-07-10). Recorded in `docs/mem9-facts.md`.
- **Out-of-band ECR repo** (CloudFormation, `DeletionPolicy: Retain`) so `sst remove --stage pr-N` can never wipe the image history prod runs on.

## What's in it
| File | Change |
|---|---|
| `docker/mnemo-server/Dockerfile` | Self-contained multi-stage arm64 build — `FROM --platform=$BUILDPLATFORM golang:1.24-alpine` git-fetches the pinned SHA, `CGO_ENABLED=0 GOARCH=arm64` cross-compile → `alpine:3.19` |
| `docker/mnemo-server/entrypoint.sh` | Assembles the static `MNEMO_DSN` from injected `MEM9_DB_*` env + the `MEM9_DB_SECRET` JSON, URL-encoding the password via `jq @uri`; **fails loud** (never builds a `null` DSN) |
| `infra/cloudformation/ecr-repositories.yaml` + `scripts/deploy-ecr-repositories.sh` | The out-of-band `mem9-on-aws/mnemo-server` ECR repo (Tokyo). Lifecycle: `pr-*` expire 7d, keep last 30 `mem9-*` releases, untagged 3d |
| `infra/ecs.ts` | Replaces the placeholder with the ECR image URI composed from the caller account (no hardcoded id) + region + namespace + `MEM9_IMAGE_TAG` (default `latest`); exports the image via SSM |
| `infra/cloudformation/github-actions-role.yaml` | New `ImageBuildPolicy` (ECR **push** scoped to the one repo) — distinct from the runtime pull |
| `.github/workflows/infra-ci.yml` | New `build-and-push-image` job (buildx `linux/arm64`) on PR + push; tags `pr-<sha7>` (preview) / `mem9-<sha7>` + `latest` (release). `deploy-preview`/`deploy-prod` consume the built tag so each stage runs the exact image it built |

## Design notes
- **Tag separation** so preview churn can't age out the `mem9-<sha7>` release tag prod pins by name (would otherwise `ImageNotFound` on a prod task restart).
- **Native cross-compile** (`$BUILDPLATFORM`) so the Go toolchain doesn't run under QEMU on x86 CI runners; the arm64 runtime stage still needs QEMU for its `apk add` (setup-qemu-action retained).
- **First bring-up** must go through a main merge (which builds+pushes before deploying); the ECR repo is bootstrapped out-of-band (already applied in the target account).

## Bootstrap already applied (out-of-band, not part of SST deploy)
- ECR repo stack `ecr-repositories-mem9-on-aws` created in ap-northeast-1.
- Deploy role re-bootstrapped with `ImageBuildPolicy` (6 managed policies now attached).

## Test Plan
- [x] `docker/mnemo-server/entrypoint.sh` DSN-assembly tested locally under both `bash` and `dash`: URL-encodes DSN-reserved chars, fails loud on missing/null/malformed secret, respects a pre-set `MNEMO_DSN`, never logs the password
- [x] `infra` typecheck + 25 unit tests pass (added `MEM9_IMAGE_TAG`/ECR-URI + image-export tests)
- [x] `actionlint` clean on the new `build-and-push-image` job
- [x] Both CFN templates validated (`aws cloudformation validate-template`)
- [x] Secret scan clean (only the AWS-docs `123456789012` placeholder in a test mock)
- [x] Code-simplifier + pr-review-toolkit passes (1 HIGH + 1 MED + 2 LOW all addressed; re-review confirms fixes complete, no new issues)
- [x] CI: `build-and-push-image` PASS (59s) + preview deploy PASS (11m55s) — ECS task RUNNING the real `mnemo-server:pr-54184ac` image; logs show the entrypoint assembled `MNEMO_DSN` (password redacted) to the RDS Proxy endpoint
- [ ] Merge → prod build+push + ECS runs the real image (verified post-merge)

## Follow-ups (each its own PR, per ARCHITECTURE.md)
- qwen3-embed + token-refresh sidecars (§7)
- one-shot schema-bootstrap task (§8) — until it runs, mnemo-server boots + reaches the DB but list/search need the tenant schema
- internal ALB + public ACM cert + AgentCore Gateway + Cognito (§6/§6a)