### PR TITLE
fix(iam): grant iam:ListInstanceProfilesForRole so sst remove can delete roles

### DIFF
--- a/infra/cloudformation/github-actions-role.yaml
+++ b/infra/cloudformation/github-actions-role.yaml
@@ -395,6 +395,12 @@ Resources:
               - iam:GetRolePolicy
               - iam:ListRolePolicies
               - iam:ListAttachedRolePolicies
+              # iam:DeleteRole triggers the AWS provider to first read the role's
+              # instance profiles (to detach any) — so ListInstanceProfilesForRole
+              # is REQUIRED for delete to succeed. Without it, `sst remove` 403s on
+              # the proxy role and leaks it on every pr-* teardown (observed on the
+              # pr-5 cleanup). AWS's own DeleteIAMRole runbook lists it as required.
+              - iam:ListInstanceProfilesForRole
               - iam:TagRole
               - iam:UntagRole
               - iam:DeleteRole
@@ -567,6 +573,9 @@ Resources:
               - iam:AttachRolePolicy
               - iam:DetachRolePolicy
               - iam:ListAttachedRolePolicies
+              # Required for iam:DeleteRole on teardown — the provider reads the
+              # role's instance profiles before deleting (see RdsProxyRole note).
+              - iam:ListInstanceProfilesForRole
               - iam:TagRole
               - iam:UntagRole
             Resource:


### PR DESCRIPTION
## Summary
The pr-5 preview teardown (`cleanup-preview` → `sst remove --stage pr-5`) **failed** deleting the RDS Proxy IAM role:

```
AccessDenied: ... not authorized to perform: iam:ListInstanceProfilesForRole
on resource: role mem9-on-aws-pr-5-Mem9DbProxyRole-...
```

The AWS provider reads a role's instance profiles (to detach any) **before** `iam:DeleteRole`, so DeleteRole 403s without the List grant. The deploy role's `RdsProxyRole` (DatabasePolicy) and `EcsTaskRoles` (ComputePolicy) statements had `iam:DeleteRole` but not `iam:ListInstanceProfilesForRole`.

**Impact if unfixed:** every future pr-* stage's `sst remove` would fail the same way, leaking the proxy + task IAM roles on each teardown.

AWS's own `AWSConfigRemediation-DeleteIAMRole` runbook lists `iam:ListInstanceProfilesForRole` as a **required** permission for role deletion.

## Change
- Add `iam:ListInstanceProfilesForRole` to both `DeleteRole`-bearing statements, still scoped to the project's `mem9-on-aws-*` role ARNs.

## Applied
- Template validated (`aws cloudformation validate-template`).
- Deploy role re-bootstrapped out-of-band (`scripts/deploy-github-role.sh`); verified the action is now present in both the `mem9-on-aws-database` and `mem9-on-aws-compute` managed policies.
- The orphaned pr-5 proxy role + all other pr-5 resources (Aurora already gone, ECS roles, SGs, secret, log group, stale SST state) were manually cleaned up — no orphan cost remains.

## Note
This PR only touches `infra/cloudformation/**`, which the CI workflow's path filter excludes (the OIDC role is bootstrapped out-of-band, not via SST deploy) — so no deploy pipeline runs, by design. The grant is already live in the account.