### PR TITLE
fix(iam): trim dead RDS-Proxy grants from the deploy role

### DIFF
--- a/infra/bootstrap.test.ts
+++ b/infra/bootstrap.test.ts
@@ -41,7 +41,7 @@ function fakeDbOut(): DbOutputs {
     host: out("mem9-writer.example"),
     port: out(5432),
     database: out("mem9"),
-    secretArn: out("arn:aws:secretsmanager:x:y:secret:mem9-on-aws-prod-Mem9DbProxySecret-z"),
+    secretArn: out("arn:aws:secretsmanager:x:y:secret:mem9-on-aws-prod-Mem9DbSecret-z"),
     taskSecurityGroupId: out("sg-task"),
   } as unknown as DbOutputs;
 }

--- a/infra/cloudformation/github-actions-role.yaml
+++ b/infra/cloudformation/github-actions-role.yaml
@@ -276,6 +276,8 @@ Resources:
             # task/execution roles, Lambda roles) will. Pre-scope PassRole to
             # this project's role names + SST's name-truncation variants, gated
             # by PassedToService — never Resource "*", never unconstrained.
+            # (rds.amazonaws.com was dropped with the RDS Proxy — plain Aurora
+            # cluster/instance take no roleArn, so nothing passes a role to RDS.)
             Effect: Allow
             Action: iam:PassRole
             Resource:
@@ -287,21 +289,18 @@ Resources:
                 iam:PassedToService:
                   - lambda.amazonaws.com
                   - ecs-tasks.amazonaws.com
-                  # rds.amazonaws.com — sst.aws.Aurora proxy:true passes the
-                  # ProxyRole to the RDS Proxy (rds:CreateDBProxy roleArn). Without
-                  # this, PassRole is denied and the first DB deploy 403s.
-                  - rds.amazonaws.com
 
   # ───────────────────────────────────────────────────────────────────────────
   # Policy 4 — Database stack (infra/db.ts): Aurora PostgreSQL Serverless v2 +
-  # RDS Proxy + Secrets Manager (rotated master creds) + the EC2 primitives a
-  # DB subnet group / security group need. Its own ManagedPolicy so the broad
-  # RDS create surface doesn't push CorePolicy/ScaffoldPolicy past IAM's
-  # 6144-byte per-policy cap, and the DB footprint is auditable in one place.
+  # Secrets Manager (static master creds) + the EC2 primitives a DB subnet
+  # group / security group need. NO RDS Proxy (dropped 2026-07-12, §3a — mem9
+  # connects to the Aurora writer endpoint directly). Its own ManagedPolicy so
+  # the broad RDS create surface doesn't push CorePolicy/ScaffoldPolicy past
+  # IAM's 6144-byte per-policy cap, and the DB footprint is auditable in one place.
   #
   # ADDED for the Aurora PR — must be live (re-run scripts/deploy-github-role.sh)
-  # BEFORE that PR's first deploy, or the deploy 403s on the first RDS/Proxy/
-  # Secret create (CLAUDE-AWS "new resource TYPE needs grants first" rule).
+  # BEFORE that PR's first deploy, or the deploy 403s on the first RDS/Secret
+  # create (CLAUDE-AWS "new resource TYPE needs grants first" rule).
   # ───────────────────────────────────────────────────────────────────────────
   DatabasePolicy:
     Type: AWS::IAM::ManagedPolicy
@@ -311,10 +310,12 @@ Resources:
         Version: "2012-10-17"
         Statement:
           - Sid: RDS
-            # Aurora cluster + instance + DB subnet group + RDS Proxy lifecycle.
+            # Aurora cluster + instance + DB subnet group + parameter groups.
             # RDS has no useful per-resource ARN granularity for many Describe/
             # Create calls (and Pulumi refreshes probe broadly), so Resource "*".
             # Guarded by the DenyPolicy against account-level RDS abuse.
+            # (RDS Proxy dropped 2026-07-12 — no rds:*DBProxy* actions here; see
+            # infra/db.ts header + docs/ARCHITECTURE.md §3a for why.)
             Effect: Allow
             Action:
               - rds:CreateDBCluster
@@ -347,23 +348,13 @@ Resources:
               - rds:ListTagsForResource
               - rds:AddTagsToResource
               - rds:RemoveTagsFromResource
-              # RDS Proxy lifecycle (proxy: true on sst.aws.Aurora).
-              - rds:CreateDBProxy
-              - rds:ModifyDBProxy
-              - rds:DeleteDBProxy
-              - rds:DescribeDBProxies
-              - rds:RegisterDBProxyTargets
-              - rds:DeregisterDBProxyTargets
-              - rds:DescribeDBProxyTargets
-              - rds:DescribeDBProxyTargetGroups
-              - rds:ModifyDBProxyTargetGroup
             Resource: "*"
           - Sid: RDSServiceLinkedRoles
-            # RDS + RDS Proxy provision service-linked roles on first use in an
-            # account. Scope CreateServiceLinkedRole to the two RDS service
-            # namespaces (the DenyPolicy blocks Delete of any SLR). This is the
-            # grant the panel flagged as needed once a real AWS-managed service
-            # (here RDS/Proxy) enters the stack.
+            # RDS provisions service-linked roles on first use in an account.
+            # Scope CreateServiceLinkedRole to the two RDS service namespaces
+            # (the DenyPolicy blocks Delete of any SLR). This is the grant the
+            # panel flagged as needed once a real AWS-managed service (RDS)
+            # enters the stack.
             Effect: Allow
             Action:
               - iam:CreateServiceLinkedRole
@@ -376,50 +367,28 @@ Resources:
           - Sid: RDSServiceLinkedRoleLookup
             # SST's Aurora does a GetRole on the RDS service-linked role
             # (AWSServiceRoleForRDS) to decide whether CreateServiceLinkedRole is
-            # needed. iam:GetRole in RdsProxyRole is scoped to mem9-on-aws-*, so
-            # grant this read explicitly on the SLR ARN (+ the autoscaling SLR).
+            # needed. Grant this read explicitly on the SLR ARN (+ the
+            # autoscaling SLR); the customer role lifecycle (CreateRole/etc.) for
+            # this project's mem9-on-aws-* roles lives in ComputePolicy's
+            # EcsTaskRoles now — the RDS-Proxy customer role is gone.
             Effect: Allow
             Action:
               - iam:GetRole
             Resource:
               - !Sub arn:aws:iam::${AWS::AccountId}:role/aws-service-role/rds.amazonaws.com/AWSServiceRoleForRDS
               - !Sub arn:aws:iam::${AWS::AccountId}:role/aws-service-role/rds.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_RDSCluster
-          - Sid: RdsProxyRole
-            # sst.aws.Aurora with proxy:true creates a CUSTOMER IAM role
-            # (`<app>-<stage>-Mem9DbProxyRole-<random>`) with an inline
-            # secretsmanager:GetSecretValue policy, then passes it to the proxy
-            # (rds.amazonaws.com). Grant the role lifecycle scoped to this
-            # project's auto-named roles + SST truncation variants. (PassRole to
-            # rds.amazonaws.com is granted in ScaffoldPolicy's PassRoleConstrained.)
-            Effect: Allow
-            Action:
-              - iam:CreateRole
-              - iam:PutRolePolicy
-              - iam:GetRole
-              - iam:GetRolePolicy
-              - iam:ListRolePolicies
-              - iam:ListAttachedRolePolicies
-              # iam:DeleteRole triggers the AWS provider to first read the role's
-              # instance profiles (to detach any) — so ListInstanceProfilesForRole
-              # is REQUIRED for delete to succeed. Without it, `sst remove` 403s on
-              # the proxy role and leaks it on every pr-* teardown (observed on the
-              # pr-5 cleanup). AWS's own DeleteIAMRole runbook lists it as required.
-              - iam:ListInstanceProfilesForRole
-              - iam:TagRole
-              - iam:UntagRole
-              - iam:DeleteRole
-              - iam:DeleteRolePolicy
-            Resource:
-              - !Sub arn:aws:iam::${AWS::AccountId}:role/mem9-on-aws-*
-              - !Sub arn:aws:iam::${AWS::AccountId}:role/mem9-on-aw-*
-              - !Sub arn:aws:iam::${AWS::AccountId}:role/mem9-on-a-*
+          # (Sid: RdsProxyRole removed 2026-07-12 — the RDS Proxy was dropped, so
+          # SST no longer creates the Mem9DbProxyRole customer role. The generic
+          # mem9-on-aws-* IAM role lifecycle needed by the rest of the stack is
+          # granted in ComputePolicy's EcsTaskRoles.)
           - Sid: SecretsManager
-            # sst.aws.Aurora creates its OWN secret `<app>-<stage>-Mem9DbProxySecret
-            # -<random>` holding a static RandomPassword — it does NOT use RDS
-            # manageMasterUserPassword, so there is NO `rds!`-prefixed managed
-            # secret and NO built-in rotation. The auto-name has no leading slash,
-            # so scope to the `mem9-on-aws-*` prefix. CreateSecret can't be
-            # resource-scoped (no ARN at create time) → its own statement below.
+            # sst.aws.Aurora creates its OWN secret `<app>-<stage>-Mem9DbSecret
+            # -<random>` (the cluster master creds) holding a static RandomPassword
+            # — it does NOT use RDS manageMasterUserPassword, so there is NO
+            # `rds!`-prefixed managed secret and NO built-in rotation. The
+            # auto-name has no leading slash, so scope to the `mem9-on-aws-*`
+            # prefix. CreateSecret can't be resource-scoped (no ARN at create
+            # time) → its own statement below.
             Effect: Allow
             Action:
               - secretsmanager:UpdateSecret

--- a/infra/ecs.test.ts
+++ b/infra/ecs.test.ts
@@ -36,7 +36,7 @@ function fakeDbOut(): DbOutputs {
     host: out("mem9-writer.example"),
     port: out(5432),
     database: out("mem9"),
-    secretArn: out("arn:aws:secretsmanager:x:y:secret:mem9-on-aws-prod-Mem9DbProxySecret-z"),
+    secretArn: out("arn:aws:secretsmanager:x:y:secret:mem9-on-aws-prod-Mem9DbSecret-z"),
     taskSecurityGroupId: out("sg-task"),
   } as unknown as DbOutputs;
 }


### PR DESCRIPTION
## Summary
- The RDS Proxy was dropped 2026-07-12 (Serverless v2 0.5-ACU starves proxy capacity → `PENDING_PROXY_CAPACITY`; mem9 now connects to the Aurora **writer endpoint** directly — see `infra/db.ts` header + `docs/ARCHITECTURE.md` §3a). The GitHub-Actions deploy role still carried the proxy's now-unused IAM grants.
- This removes them for least-privilege — a pure over-permission trim, no functional grant lost.

## What changed (`infra/cloudformation/github-actions-role.yaml`)
| Removed | Where |
|---|---|
| 9 `rds:*DBProxy*` actions | `DatabasePolicy` / `RDS` Sid |
| entire `RdsProxyRole` Sid | `DatabasePolicy` (customer `Mem9DbProxyRole` no longer created) |
| `rds.amazonaws.com` from `iam:PassedToService` | `ScaffoldPolicy` / `PassRoleConstrained` |

Plus a cosmetic fixture rename `Mem9DbProxySecret` → `Mem9DbSecret` in `ecs.test.ts` / `bootstrap.test.ts` (tests assert on the `mem9-on-aws-*` prefix only).

**Not lost:** the generic `mem9-on-aws-*` IAM role lifecycle the rest of the stack needs is already granted by `ComputePolicy` / `EcsTaskRoles` (a strict superset of the removed `RdsProxyRole` actions, incl. `iam:ListInstanceProfilesForRole`). Load-bearing RDS grants kept: `*DBCluster/Instance/SubnetGroup/ParameterGroup`, the RDS service-linked-role create+lookup, `SecretsManager`, `KMSForRds`, `EC2ForDatabase`.

## Test Plan
- [x] `cfn-lint` clean
- [x] `aws cloudformation validate-template` OK
- [x] Change-set vs the live us-west-2 stack modifies **only** `DatabasePolicy` + `ScaffoldPolicy` in place (`Replacement: False`, no role replacement)
- [x] infra tests (32) pass
- [x] PR review agent — no findings (independently verified the `EcsTaskRoles` superset claim)
- [x] Account-ID / ARN scan clean (all `${AWS::AccountId}`)

## Post-merge follow-up
This is **out-of-band CFN** (not Pulumi-managed): re-run `scripts/deploy-github-role.sh` (us-west-2) after merge to apply the trimmed role. Safe to defer — removing unused permissions cannot break an in-flight deploy.


---
**Status:** ✅ Ready for merge — all CI green (preview deploy proved the trimmed role still deploys the full stack), no review findings, mergeStateStatus CLEAN. Awaiting merge decision.