### PR TITLE
feat(llm): LLM smart-ingest via a Bedrock Mantle proxy sidecar

### DIFF
--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -72,8 +72,8 @@ env:
   AWS_REGION: ap-northeast-1
   ROLE_NAME: github-actions-mem9-on-aws
   # The out-of-band ECR repo namespace (infra/cloudformation/ecr-repositories.yaml).
-  # build-and-push-image builds three images under it: <ns>/mnemo-server,
-  # <ns>/qwen3-embed, <ns>/bootstrap. Deploy stages reference
+  # build-and-push-image builds four images under it: <ns>/mnemo-server,
+  # <ns>/qwen3-embed, <ns>/bootstrap, <ns>/llm-proxy. Deploy stages reference
   # <acct>.dkr.ecr.<region>/<ns>/<name>:<tag>.
   ECR_NS: mem9-on-aws
 
@@ -128,11 +128,12 @@ jobs:
     # image (it wouldn't exist yet otherwise on the PR that introduces it).
     needs: [typecheck, build-and-push-image]
     if: github.event_name == 'pull_request' && github.event.action != 'closed' && github.event.pull_request.base.ref == 'main'
-    # Full-stack fresh preview: Aurora (~13m) + the 2-container ECS task (the
-    # ~1.2 GB qwen3 image pull + 180s health-check startPeriod) + the bootstrap
-    # DB-retry + run-task. No RDS Proxy (dropped — see infra/db.ts), so no proxy
-    # warmup wait. Measured first bring-up ~30-35m; 45m gives headroom without
-    # wasting runner time on a stuck deploy.
+    # Full-stack fresh preview: Aurora (~13m) + the 3-container ECS task (the
+    # ~1.2 GB qwen3 image pull + 180s health-check startPeriod, plus the tiny
+    # llm-proxy sidecar) + the bootstrap DB-retry + run-task. No RDS Proxy
+    # (dropped — see infra/db.ts), so no proxy warmup wait. Measured first
+    # bring-up ~30-35m; 45m gives headroom without wasting runner time on a stuck
+    # deploy.
     timeout-minutes: 45
     permissions:
       id-token: write
@@ -214,6 +215,11 @@ jobs:
         # AWS_ROLE_ARN), fall back to `latest` — infra/ecs.ts's own default.
         env:
           MEM9_IMAGE_TAG: ${{ needs.build-and-push-image.outputs.image_tag || 'latest' }}
+          # Bedrock Project id for the llm-proxy sidecar's OpenAI-Project cost
+          # header (infra/ecs.ts BEDROCK_PROJECT). Repo variable set out-of-band by
+          # scripts/deploy-bedrock-mantle-project.sh; empty → the proxy omits the
+          # header (still functional, just untagged).
+          MEM9_BEDROCK_PROJECT: ${{ vars.MEM9_BEDROCK_PROJECT }}
         run: |
           # PR_NUMBER comes from GitHub's pull_request payload (integer);
           # validate to short-circuit any injection risk.
@@ -546,6 +552,7 @@ jobs:
           emit mnemo-server mnemo_tags
           emit qwen3-embed  embed_tags
           emit bootstrap    bootstrap_tags
+          emit llm-proxy    llm_proxy_tags
 
       - name: Set up QEMU
         # Enables linux/arm64 emulation on x86 runners (ubuntu-latest). A no-op
@@ -596,6 +603,18 @@ jobs:
           cache-from: type=gha,scope=bootstrap
           cache-to: type=gha,mode=max,scope=bootstrap
 
+      - name: Build & push llm-proxy (arm64)
+        if: steps.gate.outputs.skip != 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/llm-proxy/Dockerfile
+          platforms: linux/arm64
+          push: true
+          tags: ${{ steps.tags.outputs.llm_proxy_tags }}
+          cache-from: type=gha,scope=llm-proxy
+          cache-to: type=gha,mode=max,scope=llm-proxy
+
   # ───────────────────────────────────────────────────────────────────────────
   # deploy-prod — push to main → stage `prod`. HARD-FAILS without AWS_ROLE_ARN.
   # Runs AFTER the image is built+pushed and pins prod to that exact `mem9-<sha7>`.
@@ -606,7 +625,7 @@ jobs:
     needs: [typecheck, build-and-push-image]
     if: github.event_name == 'push'
     environment: prod
-    # Full-stack prod: Aurora + the 2-container ECS task (qwen3 image pull + 180s
+    # Full-stack prod: Aurora + the 3-container ECS task (qwen3 image pull + 180s
     # health startPeriod) + the bootstrap run-task. No RDS Proxy (dropped — see
     # infra/db.ts). Fresh bring-up ~30-35m (measured); 50m gives headroom. Prod is
     # singleton/non-cancelable, so a long timeout doesn't waste runners on dupes.
@@ -726,6 +745,10 @@ jobs:
         # `mem9-<sha7>`); infra/ecs.ts reads MEM9_IMAGE_TAG (defaults to `latest`).
         env:
           MEM9_IMAGE_TAG: ${{ needs.build-and-push-image.outputs.image_tag }}
+          # Bedrock Project id → the llm-proxy sidecar's OpenAI-Project cost header
+          # (infra/ecs.ts BEDROCK_PROJECT). Repo variable set out-of-band by
+          # scripts/deploy-bedrock-mantle-project.sh.
+          MEM9_BEDROCK_PROJECT: ${{ vars.MEM9_BEDROCK_PROJECT }}
         run: |
           set +e
           pnpm -C infra exec sst deploy --stage prod --print-logs 2>&1 | tee sst-deploy.log

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,8 +20,10 @@ file rather than silently diverging.
     `VECTOR`/`VEC_COSINE`/`EMBED_TEXT`) → we use the **postgres backend + pgvector**.
   - **Bedrock Mantle has no `/embeddings`** (Chat Completions / Responses only) →
     embedding can't go through Mantle; we self-host qwen3.
-  - Mantle bearer tokens (`@aws/bedrock-token-generator`) are **short-lived**, but
-    mem9 reads a **static** `MNEMO_LLM_API_KEY` → a **token-refresh sidecar** bridges.
+  - mem9 reads `MNEMO_LLM_API_KEY` **once at startup (immutable)** and sends no
+    custom headers → the Mantle bearer (12h TTL, refreshable) + `OpenAI-Project`
+    cost header are bridged by a **local LLM proxy sidecar** (`docker/llm-proxy/`),
+    NOT a token file-writer.
   - mem9 schema **`idx_app` gap**: control-plane `schema_pg.sql` ≠ the tenant
     runtime schema the server validates → bootstrap must apply the runtime schema.
   - AgentCore Gateway reaches a private VPC target via **managed VPC Lattice +
@@ -54,9 +56,9 @@ file rather than silently diverging.
 | MCP surface | **AgentCore Gateway** (OpenAPI target → mnemo-server REST API) |
 | Gateway → server | **private**: `privateEndpoint` + managed VPC Lattice → **internal ALB** (public ACM cert `mem9.internal.kane.mx`, TLS terminated) → HTTP:8080. Outbound auth = API key (`X-API-Key`). No public exposure |
 | Auth (inbound) | **Cognito M2M**, reusing the podcast-curation / llm-wiki gateway pattern |
-| LLM (smart-ingest) | **Bedrock Mantle direct**, **GLM-5**, **ON at launch**. Auth via **`@aws/bedrock-token-generator`** (short-term bearer from task IAM role, same as llm-wiki) + **Bedrock Project** cost attribution + a **token-refresh sidecar** (bearer expires; mem9 reads static `MNEMO_LLM_API_KEY`). GPT-5.4/5.5 excluded (Responses-only) |
+| LLM (smart-ingest) | **Bedrock Mantle direct**, **GLM-5**, **ON at launch**. Auth via **`@aws/bedrock-token-generator`** (short-term bearer from task IAM role, same as llm-wiki) + **Bedrock Project** cost attribution + a **local LLM proxy sidecar** (`docker/llm-proxy/` — mem9 reads `MNEMO_LLM_API_KEY` once & sends no custom headers, so a request-proxy holds the live bearer + injects `OpenAI-Project`; NOT a token file-writer). GPT-5.4/5.5 excluded (Responses-only) |
 | Embedding | qwen3 OpenAI `/embeddings` as an **ECS sidecar** (localhost, always warm), **code lifted from llm-wiki qwen3 ONNX**, **dims 1024**. NOT Mantle, NOT 3P API |
-| ECS task | **3 containers**: mnemo-server + qwen3-embed sidecar + token-refresh sidecar. TLS at the ALB, not in task |
+| ECS task | **3 containers**: mnemo-server + qwen3-embed sidecar + llm-proxy sidecar (Mantle GLM-5). TLS at the ALB, not in task |
 | Schema bootstrap | **one-shot ECS task** on deploy (pgvector + tenant runtime schema incl. `idx_app`/FTS/`vector(1024)` + seed 1 tenant) |
 | Tenancy | **single tenant** (one `X-API-Key`); writes carry **`X-Mnemo-Agent-Id`** to reserve per-agent scoping |
 | Replicas | **Single** (`desiredCount=1`) — single-writer, sidesteps mem9's local-disk import dir |

--- a/docker/llm-proxy/Dockerfile
+++ b/docker/llm-proxy/Dockerfile
@@ -1,0 +1,34 @@
+# llm-proxy sidecar — OpenAI /v1/chat/completions proxy → Amazon Bedrock Mantle.
+#
+# ARCHITECTURE.md §7 (LLM smart-ingest): mem9 reads MNEMO_LLM_API_KEY once at
+# startup (immutable) and its client sends only Authorization + Content-Type. This
+# sidecar holds the live Mantle bearer (refreshed on a timer via
+# @aws/bedrock-token-generator — a LOCAL SigV4 presign, no network), and injects
+# a fresh Bearer + the OpenAI-Project header per forwarded request. So mem9 auths
+# with a static dummy key to localhost and never needs a restart on rotation, and
+# no mem9 source fork is required. See docker/llm-proxy/server.mjs header.
+#
+# Lightweight: no model, pure Node. node:24-slim (Debian bookworm) is multi-arch →
+# the arm64 variant is pulled for --platform=linux/arm64 (Graviton Fargate, project
+# standard). curl for the ECS health check (bookworm-slim ships none).
+
+FROM node:24-slim
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Deps first (layer cache). --omit=dev: only @aws/bedrock-token-generator +
+# @aws-sdk/credential-providers (+ their @smithy/@aws-sdk transitive deps).
+COPY docker/llm-proxy/package.json ./
+RUN npm install --omit=dev --no-audit --no-fund
+
+COPY docker/llm-proxy/server.mjs ./
+
+# Listens on LLM_PROXY_PORT (default 8082); mem9 reaches it at
+# http://localhost:8082/v1. Not published outside the task — localhost only.
+EXPOSE 8082
+ENV NODE_ENV=production
+ENTRYPOINT ["node", "server.mjs"]

--- a/docker/llm-proxy/package.json
+++ b/docker/llm-proxy/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "mem9-llm-proxy",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "OpenAI /v1/chat/completions proxy → Bedrock Mantle: mints/refreshes the Bedrock bearer + injects OpenAI-Project (mem9-on-aws LLM smart-ingest sidecar).",
+  "engines": {
+    "node": ">=24"
+  },
+  "scripts": {
+    "start": "node server.mjs"
+  },
+  "dependencies": {
+    "@aws/bedrock-token-generator": "^1.1.0",
+    "@aws-sdk/credential-providers": "^3.700.0"
+  }
+}

--- a/docker/llm-proxy/server.mjs
+++ b/docker/llm-proxy/server.mjs
@@ -1,0 +1,259 @@
+// OpenAI-compatible /v1/chat/completions PROXY → Amazon Bedrock Mantle.
+//
+// Why this sidecar exists (ARCHITECTURE.md §7, corrected 2026-07-12):
+// mem9's smart-ingest LLM client (server/internal/llm/client.go @ pinned commit)
+// reads MNEMO_LLM_API_KEY ONCE at startup into an immutable field — there is NO
+// reload/SIGHUP/file-watch — and its hand-rolled net/http client sends ONLY
+// `Authorization` + `Content-Type` (no way to add the `OpenAI-Project` header
+// Bedrock Mantle needs for cost attribution). Both were verified against the
+// pinned mem9 source.
+//
+// A Bedrock bearer minted by @aws/bedrock-token-generator expires (default/max
+// 12h), so a static MNEMO_LLM_API_KEY would eventually 401. And mem9 can't emit
+// the OpenAI-Project header at all. This proxy resolves BOTH without a mem9 fork
+// and without restarting mnemo-server on rotation:
+//
+//   mnemo-server ──(localhost, static dummy key)──▶ THIS PROXY ──(fresh bearer +
+//   OpenAI-Project)──▶ https://bedrock-mantle.<region>.api.aws/v1/chat/completions
+//
+// mem9 is configured with:
+//   MNEMO_LLM_BASE_URL=http://localhost:<PORT>/v1
+//   MNEMO_LLM_API_KEY=<any non-empty dummy>   (mem9 needs it non-empty or it
+//                                               nil's the client → raw mode)
+//   MNEMO_LLM_MODEL=zai.glm-5
+//   MNEMO_INGEST_MODE=smart
+//
+// The proxy holds the LIVE Mantle bearer, refreshing it on a timer well before
+// expiry (minting is a LOCAL SigV4 presign — no network call — so refresh can't
+// fail on connectivity), and injects it + OpenAI-Project per forwarded request.
+//
+// Verified live 2026-07-12: getToken({credentials,region}) → bearer;
+// POST bedrock-mantle.ap-northeast-1.../v1/chat/completions {model:"zai.glm-5"}
+// → HTTP 200 (see the mantle-token-12h-expiry memory).
+//
+// Testability: the HTTP server is built by createProxyServer(cfg), with the
+// token minter + upstream fetch injectable, so unit tests exercise the real
+// routing / header-injection / error paths without touching AWS or Mantle. When
+// run directly (node server.mjs) the module wires the real deps + starts listening.
+
+import { createServer } from "node:http";
+
+// ── Config from env (read once) ──────────────────────────────────────────────
+export function readConfig(env = process.env) {
+  const region = env.LLM_PROXY_REGION || env.AWS_REGION || "ap-northeast-1";
+  return {
+    port: Number(env.LLM_PROXY_PORT || 8082),
+    region,
+    // Upstream Mantle base — regional. Overridable for tests.
+    upstreamBase: env.LLM_PROXY_UPSTREAM_BASE || `https://bedrock-mantle.${region}.api.aws/v1`,
+    // Bedrock Project id for Mantle cost attribution (the OpenAI-Project header).
+    // Mantle does NOT support IAM-principal attribution, so this is how GLM-5
+    // spend is tagged. Empty → header omitted (still functional, just untagged).
+    openaiProject: env.LLM_PROXY_OPENAI_PROJECT || "",
+    // The bearer's lifetime. getToken's default+max is 12h (43200s); we mint at
+    // max and refresh at a fraction so a fresh token is always well within expiry.
+    tokenTtlSeconds: Number(env.LLM_PROXY_TOKEN_TTL_SECONDS || 43200),
+    // Refresh interval. Default = 1h (well under 12h TTL); a long safety margin
+    // costs nothing since minting is a local presign, not an API call.
+    refreshIntervalMs: Number(env.LLM_PROXY_REFRESH_INTERVAL_MS || 60 * 60 * 1000),
+    // Per-request upstream timeout. mem9's own client uses 120s; match it so the
+    // proxy never times out before mem9 would.
+    upstreamTimeoutMs: Number(env.LLM_PROXY_UPSTREAM_TIMEOUT_MS || 120_000),
+  };
+}
+
+// ── HTTP helpers ──────────────────────────────────────────────────────────────
+function sendJson(res, status, obj) {
+  const body = JSON.stringify(obj);
+  res.writeHead(status, {
+    "content-type": "application/json",
+    "content-length": Buffer.byteLength(body),
+  });
+  res.end(body);
+}
+
+function sendError(res, status, message, type = "invalid_request_error") {
+  sendJson(res, status, { error: { message, type } });
+}
+
+async function readBody(req, limitBytes = 8 * 1024 * 1024) {
+  const chunks = [];
+  let size = 0;
+  for await (const chunk of req) {
+    size += chunk.length;
+    if (size > limitBytes) throw new Error("request body too large");
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks);
+}
+
+/**
+ * Build the proxy HTTP server + its token lifecycle.
+ *
+ * @param cfg config from readConfig()
+ * @param deps.mintToken async () => bearerString — mints a fresh Bedrock bearer
+ *        (default: @aws/bedrock-token-generator over the task role).
+ * @param deps.fetchImpl fetch-compatible fn (default: global fetch).
+ * @returns { server, start, tokenState } — `start()` mints the first bearer +
+ *          arms the refresh timer; `tokenState` exposes current token/age for tests.
+ */
+export function createProxyServer(cfg, deps = {}) {
+  const mintToken = deps.mintToken;
+  const fetchImpl = deps.fetchImpl || globalThis.fetch;
+  if (typeof mintToken !== "function") {
+    throw new Error("createProxyServer requires deps.mintToken");
+  }
+
+  const state = { token: null, firstMint: null, lastMintAt: 0, refreshTimer: null };
+
+  async function refresh() {
+    const token = await mintToken();
+    state.token = token;
+    state.lastMintAt = Date.now();
+    return token;
+  }
+
+  // Ensure a token exists (blocking on the first mint); return the current one.
+  // If the first mint REJECTS, clear the cached promise so a later request can
+  // retry — otherwise `state.firstMint` would pin the rejected promise forever
+  // and the proxy could never self-heal a transient cold-start credential hiccup
+  // (belt-and-suspenders: the entrypoint also exits non-zero so ECS restarts).
+  async function ensureToken() {
+    if (state.token) return state.token;
+    if (!state.firstMint) {
+      state.firstMint = refresh().catch((err) => {
+        state.firstMint = null;
+        throw err;
+      });
+    }
+    return state.firstMint;
+  }
+
+  async function forwardToMantle(bodyBuf) {
+    const token = await ensureToken();
+    const headers = {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    };
+    if (cfg.openaiProject) headers["OpenAI-Project"] = cfg.openaiProject;
+
+    const ac = new AbortController();
+    const timer = setTimeout(() => ac.abort(), cfg.upstreamTimeoutMs);
+    try {
+      return await fetchImpl(`${cfg.upstreamBase}/chat/completions`, {
+        method: "POST",
+        headers,
+        body: bodyBuf,
+        signal: ac.signal,
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  const server = createServer(async (req, res) => {
+    try {
+      const url = new URL(req.url, `http://localhost:${cfg.port}`);
+
+      // Readiness: 200 once the first bearer is minted. The ECS health check gates
+      // the task on this so mnemo-server isn't marked healthy before the proxy can
+      // auth. NON-BLOCKING: report the CURRENT token state — never await the
+      // in-flight mint (that would hang the health probe until Mantle auth is up).
+      if (req.method === "GET" && (url.pathname === "/health" || url.pathname === "/healthz")) {
+        const ready = !!state.token;
+        return sendJson(res, ready ? 200 : 503, {
+          status: ready ? "ok" : "starting",
+          lastMintAgeSeconds: state.lastMintAt
+            ? Math.round((Date.now() - state.lastMintAt) / 1000)
+            : null,
+        });
+      }
+
+      // mem9 posts to `${MNEMO_LLM_BASE_URL}/chat/completions`; base is
+      // http://localhost:PORT/v1 → accept /v1/chat/completions and /chat/completions.
+      if (req.method === "POST" && /\/(v1\/)?chat\/completions$/.test(url.pathname)) {
+        const bodyBuf = await readBody(req);
+        const upstream = await forwardToMantle(bodyBuf);
+        // Pass the upstream status + JSON body straight through. mem9 handles
+        // non-2xx itself (it strips provider-specific flags on 400 and retries).
+        const text = await upstream.text();
+        res.writeHead(upstream.status, {
+          "content-type": upstream.headers.get("content-type") || "application/json",
+          "content-length": Buffer.byteLength(text),
+        });
+        return res.end(text);
+      }
+
+      return sendError(res, 404, `no route for ${req.method} ${url.pathname}`, "not_found");
+    } catch (err) {
+      // AbortError = upstream timeout; everything else = proxy/mint failure. Never
+      // leak internals; log server-side, return an OpenAI-shaped error.
+      const isTimeout = err?.name === "AbortError";
+      console.error("llm-proxy request error:", err?.message || err);
+      return sendError(
+        res,
+        isTimeout ? 504 : 502,
+        isTimeout ? "upstream Mantle request timed out" : "llm-proxy failed to reach Mantle",
+        "server_error",
+      );
+    }
+  });
+
+  // Mint the first bearer + arm the refresh timer. Returns the first-mint promise
+  // so callers (and the health check) can await readiness.
+  function start() {
+    const p = ensureToken();
+    p.then(() => {
+      state.refreshTimer = setInterval(() => {
+        refresh()
+          .then(() => console.log("llm-proxy refreshed Bedrock bearer"))
+          .catch((err) =>
+            // A refresh failure keeps the previous (still-valid, 12h) token; log
+            // and let the next tick retry. Do NOT crash — the current token works.
+            console.error(
+              "llm-proxy bearer refresh failed (keeping current):",
+              err?.message || err,
+            ),
+          );
+      }, cfg.refreshIntervalMs);
+      state.refreshTimer.unref?.(); // don't keep the process alive on the timer alone
+    }).catch(() => {
+      /* surfaced to the caller via the returned promise */
+    });
+    return p;
+  }
+
+  return { server, start, state };
+}
+
+// ── Direct-run entrypoint (node server.mjs) ────────────────────────────────────
+// Only wires the real AWS deps + listens when executed as the main module, so
+// importing this file in a test does not require AWS credentials.
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const cfg = readConfig();
+  // Real minter: presign a Bedrock bearer from the task role. Local (no network).
+  const { getToken } = await import("@aws/bedrock-token-generator");
+  const { fromNodeProviderChain } = await import("@aws-sdk/credential-providers");
+  const credentialProvider = fromNodeProviderChain();
+  const mintToken = async () => {
+    const credentials = await credentialProvider();
+    return getToken({ credentials, region: cfg.region, expiresInSeconds: cfg.tokenTtlSeconds });
+  };
+
+  const { server, start } = createProxyServer(cfg, { mintToken });
+  server.listen(cfg.port, () => {
+    console.log(
+      `llm-proxy listening on :${cfg.port} → ${cfg.upstreamBase} (region ${cfg.region}` +
+        `${cfg.openaiProject ? `, project ${cfg.openaiProject}` : ", no project"})`,
+    );
+    start()
+      .then(() => console.log("llm-proxy minted initial Bedrock bearer, ready"))
+      .catch((err) => {
+        console.error("llm-proxy INITIAL bearer mint FAILED:", err?.message || err);
+        // No token at all → the sidecar is useless; exit non-zero so ECS restarts
+        // the task (e.g. a transient credential-provider hiccup at cold start).
+        process.exit(1);
+      });
+  });
+}

--- a/docker/llm-proxy/server.test.mjs
+++ b/docker/llm-proxy/server.test.mjs
@@ -1,0 +1,228 @@
+// Unit tests for the llm-proxy sidecar (docker/llm-proxy/server.mjs).
+//
+// Exercises the REAL HTTP server built by createProxyServer() over a loopback
+// socket, with the token minter + upstream fetch injected — so we assert the
+// actual routing, per-request header injection (fresh Bearer + OpenAI-Project),
+// health gating, and error mapping without touching AWS or Bedrock Mantle.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createProxyServer, readConfig } from "./server.mjs";
+
+// Start `server` on an ephemeral port; return {url, close}.
+async function listen(server) {
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () => new Promise((resolve) => server.close(resolve)),
+  };
+}
+
+const baseCfg = {
+  port: 0,
+  region: "ap-northeast-1",
+  upstreamBase: "https://mantle.test/v1",
+  openaiProject: "proj-abc",
+  tokenTtlSeconds: 43200,
+  refreshIntervalMs: 60 * 60 * 1000,
+  upstreamTimeoutMs: 120_000,
+};
+
+const openInstances = [];
+afterEach(async () => {
+  while (openInstances.length) {
+    const c = openInstances.pop();
+    await c.close();
+  }
+  vi.restoreAllMocks();
+});
+
+async function boot(cfg, deps) {
+  const { server, start, state } = createProxyServer(cfg, deps);
+  const inst = await listen(server);
+  openInstances.push(inst);
+  return { ...inst, start, state };
+}
+
+describe("readConfig", () => {
+  it("derives the Mantle upstream from the region", () => {
+    const c = readConfig({ LLM_PROXY_REGION: "us-west-2" });
+    expect(c.upstreamBase).toBe("https://bedrock-mantle.us-west-2.api.aws/v1");
+    expect(c.region).toBe("us-west-2");
+  });
+
+  it("defaults the token TTL to 12h and refresh to 1h", () => {
+    const c = readConfig({});
+    expect(c.tokenTtlSeconds).toBe(43200); // getToken max/default
+    expect(c.refreshIntervalMs).toBe(3_600_000);
+  });
+
+  it("honors an explicit upstream override + project", () => {
+    const c = readConfig({ LLM_PROXY_UPSTREAM_BASE: "https://x/v1", LLM_PROXY_OPENAI_PROJECT: "p1" });
+    expect(c.upstreamBase).toBe("https://x/v1");
+    expect(c.openaiProject).toBe("p1");
+  });
+});
+
+describe("createProxyServer", () => {
+  it("throws without a mintToken dep", () => {
+    expect(() => createProxyServer(baseCfg, {})).toThrow(/mintToken/);
+  });
+
+  it("injects a fresh Bearer + OpenAI-Project and forwards to Mantle /chat/completions", async () => {
+    const mintToken = vi.fn().mockResolvedValue("bedrock-api-key-XYZ");
+    let captured;
+    const fetchImpl = vi.fn(async (targetUrl, opts) => {
+      captured = { targetUrl, opts };
+      return new Response(JSON.stringify({ choices: [{ message: { content: "PONG" } }] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const { url, start } = await boot(baseCfg, { mintToken, fetchImpl });
+    await start();
+
+    const res = await fetch(`${url}/v1/chat/completions`, {
+      method: "POST",
+      headers: { Authorization: "Bearer dummy-static-key", "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "zai.glm-5", messages: [{ role: "user", content: "hi" }] }),
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json()).choices[0].message.content).toBe("PONG");
+
+    // Forwarded to the right upstream URL.
+    expect(captured.targetUrl).toBe("https://mantle.test/v1/chat/completions");
+    // The dummy inbound key is REPLACED with the minted bearer.
+    expect(captured.opts.headers.Authorization).toBe("Bearer bedrock-api-key-XYZ");
+    // Cost-attribution header injected.
+    expect(captured.opts.headers["OpenAI-Project"]).toBe("proj-abc");
+    // The minter was called exactly once (first mint), then cached.
+    expect(mintToken).toHaveBeenCalledTimes(1);
+  });
+
+  it("accepts the /chat/completions path without the /v1 prefix", async () => {
+    const fetchImpl = vi.fn(
+      async () => new Response("{}", { status: 200, headers: { "content-type": "application/json" } }),
+    );
+    const { url, start } = await boot(baseCfg, { mintToken: async () => "t", fetchImpl });
+    await start();
+    const res = await fetch(`${url}/chat/completions`, { method: "POST", body: "{}" });
+    expect(res.status).toBe(200);
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it("omits OpenAI-Project when no project is configured", async () => {
+    let captured;
+    const fetchImpl = vi.fn(async (_u, opts) => {
+      captured = opts;
+      return new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
+    });
+    const { url, start } = await boot({ ...baseCfg, openaiProject: "" }, { mintToken: async () => "t", fetchImpl });
+    await start();
+    await fetch(`${url}/v1/chat/completions`, { method: "POST", body: "{}" });
+    expect(captured.headers["OpenAI-Project"]).toBeUndefined();
+  });
+
+  it("passes the upstream status + body straight through on a Mantle 4xx", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ error: { message: "bad model" } }), {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    const { url, start } = await boot(baseCfg, { mintToken: async () => "t", fetchImpl });
+    await start();
+    const res = await fetch(`${url}/v1/chat/completions`, { method: "POST", body: "{}" });
+    expect(res.status).toBe(400); // mem9 relies on seeing the real upstream status
+    expect((await res.json()).error.message).toBe("bad model");
+  });
+
+  it("returns 502 when the upstream fetch throws (Mantle unreachable)", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("ECONNREFUSED");
+    });
+    const { url, start } = await boot(baseCfg, { mintToken: async () => "t", fetchImpl });
+    await start();
+    const res = await fetch(`${url}/v1/chat/completions`, { method: "POST", body: "{}" });
+    expect(res.status).toBe(502);
+    expect((await res.json()).error.type).toBe("server_error");
+  });
+
+  it("returns 504 when the upstream fetch aborts (timeout)", async () => {
+    const fetchImpl = vi.fn(async () => {
+      const e = new Error("aborted");
+      e.name = "AbortError";
+      throw e;
+    });
+    const { url, start } = await boot(baseCfg, { mintToken: async () => "t", fetchImpl });
+    await start();
+    const res = await fetch(`${url}/v1/chat/completions`, { method: "POST", body: "{}" });
+    expect(res.status).toBe(504);
+  });
+
+  it("404s unknown routes", async () => {
+    const { url, start } = await boot(baseCfg, { mintToken: async () => "t", fetchImpl: vi.fn() });
+    await start();
+    const res = await fetch(`${url}/nope`);
+    expect(res.status).toBe(404);
+    expect((await res.json()).error.type).toBe("not_found");
+  });
+
+  describe("/health readiness gating", () => {
+    it("is 503 before the first mint completes, 200 after", async () => {
+      let release;
+      const gate = new Promise((r) => {
+        release = r;
+      });
+      const mintToken = vi.fn(async () => {
+        await gate;
+        return "bedrock-api-key-ready";
+      });
+      const { url, start } = await boot(baseCfg, { mintToken, fetchImpl: vi.fn() });
+      const startPromise = start(); // kicks off the (blocked) first mint
+
+      const before = await fetch(`${url}/health`);
+      expect(before.status).toBe(503);
+      expect((await before.json()).status).toBe("starting");
+
+      release();
+      await startPromise;
+
+      const after = await fetch(`${url}/health`);
+      expect(after.status).toBe(200);
+      expect((await after.json()).status).toBe("ok");
+    });
+
+    it("stays 503 when the first mint fails (creds missing at cold start)", async () => {
+      const mintToken = vi.fn().mockRejectedValue(new Error("no credentials"));
+      const { url, start } = await boot(baseCfg, { mintToken, fetchImpl: vi.fn() });
+      await start().catch(() => {}); // start surfaces the failure; swallow here
+      const res = await fetch(`${url}/health`);
+      expect(res.status).toBe(503);
+    });
+  });
+
+  it("recovers on a later request after the first mint rejected (no permanently-cached rejection)", async () => {
+    // First mint fails, second succeeds — the proxy must NOT pin the rejected
+    // first-mint promise forever, or it could never self-heal a transient
+    // cold-start credential hiccup via the request path.
+    const mintToken = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("transient creds hiccup"))
+      .mockResolvedValue("bedrock-api-key-recovered");
+    const fetchImpl = vi.fn(
+      async () => new Response("{}", { status: 200, headers: { "content-type": "application/json" } }),
+    );
+    const { url } = await boot(baseCfg, { mintToken, fetchImpl });
+
+    // First request: the mint rejects → proxy returns 502.
+    const first = await fetch(`${url}/v1/chat/completions`, { method: "POST", body: "{}" });
+    expect(first.status).toBe(502);
+
+    // Second request: mint now succeeds → the proxy self-heals and forwards.
+    const second = await fetch(`${url}/v1/chat/completions`, { method: "POST", body: "{}" });
+    expect(second.status).toBe(200);
+    expect(mintToken).toHaveBeenCalledTimes(2); // retried, not cached-rejected
+  });
+});

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -252,18 +252,26 @@ OpenAI-compatible* endpoint. mem9's LLM client POSTs to `/chat/completions`, so:
   llm-wiki uses `@aws/bedrock-token-generator@^1.1.0` to mint a **short-term
   Bedrock bearer token** from the task's IAM credentials (no long-lived API key to
   manage). Cost attribution = a **Bedrock Project** (`AWS::BedrockMantle::Project`,
-  out-of-band CFN like llm-wiki's `bedrock-mantle-project.yaml` +
-  `deploy-mantle-project.sh`), passed as the `OpenAI-Project` header. Mantle does
-  NOT support IAM-principal attribution (podcast-curation verified), so the Project
-  is how GLM-5 spend gets tagged.
-- **Token-lifetime bridge (LOCKED — this is the one non-obvious wiring):** the
-  bearer token from the generator is **short-lived and expires**, but mem9 reads a
-  **static** `MNEMO_LLM_API_KEY` env var. So a **token-refresh sidecar** in the ECS
-  task periodically mints a fresh bearer via `@aws/bedrock-token-generator` and
-  writes it where mnemo-server reads it (a shared file the container re-reads, or a
-  restart-free refresh mechanism), refreshing before expiry. **No mem9 source
-  change.** (Detail + the exact refresh mechanism = an IaC-stage item; the approach
-  is locked.)
+  out-of-band CFN — this repo's `infra/cloudformation/bedrock-mantle-project.yaml` +
+  `scripts/deploy-bedrock-mantle-project.sh`, modeled on llm-wiki's), passed as the
+  `OpenAI-Project` header. Mantle does NOT support IAM-principal attribution
+  (podcast-curation verified), so the Project is how GLM-5 spend gets tagged.
+- **Token-lifetime + header bridge (LOCKED; mechanism corrected 2026-07-12):** the
+  Mantle bearer expires (**12h TTL**, verified live), but mem9 reads
+  `MNEMO_LLM_API_KEY` **once at startup into an immutable field — NO reload** (no
+  SIGHUP/watch/re-read, verified in mem9 source), and its hand-rolled client sends
+  **only** `Authorization` (no hook to add the `OpenAI-Project` cost header). So the
+  originally-sketched "sidecar rewrites a file mem9 re-reads" **cannot work**. The
+  LOCKED mechanism is a **local LLM proxy sidecar** (`docker/llm-proxy/`): mem9
+  points `MNEMO_LLM_BASE_URL=http://localhost:8082/v1` with a **static dummy**
+  `MNEMO_LLM_API_KEY` (must be non-empty, else mem9 nils the LLM client → silent
+  raw); the proxy holds the live bearer (minted by `@aws/bedrock-token-generator` —
+  a **local SigV4 presign**, refreshed on a ~hourly timer well under the 12h TTL)
+  and injects a fresh `Authorization: Bearer` + the `OpenAI-Project` header per
+  forwarded request. Solves BOTH the read-once-key and no-custom-header limits —
+  **no mem9 source change, no restart on rotation.** Task-role IAM:
+  `bedrock:CallWithBearerToken` (mint) + `bedrock:InvokeModel` on the `zai.glm-5`
+  FM ARN. See `docs/mem9-facts.md` "LLM key is read ONCE" + `docker/llm-proxy/server.mjs`.
 
 ### Embedding → **NOT Mantle** (Mantle has no `/embeddings`)
 
@@ -300,9 +308,12 @@ qwen3 output, and the PG `vector(1024)` column. Changing later = full reindex.
 
 The single Fargate task (`desiredCount=1`, arm64) runs **three containers**:
 1. **mnemo-server** (upstream mem9, HTTP :8080) — the memory server.
-2. **qwen3-embed sidecar** — OpenAI `/v1/embeddings` on localhost (§7 embedding).
-3. **token-refresh sidecar** — mints/refreshes the Bedrock bearer for Mantle
-   (§7 LLM auth) so mnemo-server's `MNEMO_LLM_API_KEY` stays valid.
+2. **qwen3-embed sidecar** — OpenAI `/v1/embeddings` on localhost:8081 (§7 embedding).
+3. **llm-proxy sidecar** — OpenAI `/v1/chat/completions` proxy on localhost:8082 →
+   Bedrock Mantle GLM-5 (§7 LLM). Holds + refreshes the Mantle bearer and injects
+   `OpenAI-Project`, so mnemo-server auths with a static dummy key locally. (This
+   replaces the originally-named "token-refresh sidecar" — mem9's read-once key +
+   no-custom-header limits require a request proxy, not a token file-writer.)
 
 (TLS is NOT in the task — the internal ALB terminates it, §6a. So no nginx/TLS
 sidecar needed.) Task memory must fit mnemo-server + the qwen3 ONNX model; the
@@ -384,7 +395,7 @@ model is the heavy tenant), which is the main swing in the Fargate cost row.
 | Tool authz | REQUEST interceptor Lambda | podcast-curation `infra/functions.ts` |
 | Embedding | qwen3 OpenAI `/embeddings` as an **ECS sidecar** (lifted from llm-wiki qwen3 ONNX), localhost, dims 1024 | llm-wiki qwen3 ONNX code |
 | LLM (smart-ingest) | **Bedrock Mantle direct**, **GLM-5**, ON at launch; auth via **`@aws/bedrock-token-generator`** + **token-refresh sidecar** + Bedrock Project | llm-wiki (`@aws/bedrock-token-generator`, `bedrock-mantle-project.yaml`) + podcast-curation `bedrock-mantle.ts` |
-| Bedrock Project | `AWS::BedrockMantle::Project` for GLM-5 cost attribution (out-of-band CFN) | llm-wiki `cloudformation/bedrock-mantle-project.yaml` + `deploy-mantle-project.sh` |
+| Bedrock Project | `AWS::BedrockMantle::Project` for GLM-5 cost attribution (out-of-band CFN) | this repo: `infra/cloudformation/bedrock-mantle-project.yaml` + `scripts/deploy-bedrock-mantle-project.sh` (modeled on llm-wiki) |
 | Config | SST v4 `sst.config.ts` (Tokyo, Node 24) | llm-wiki `sst.config.ts` |
 | Cross-module wiring | SSM Parameter Store `/mem9-on-aws/${stage}/...` | both |
 

--- a/docs/mem9-facts.md
+++ b/docs/mem9-facts.md
@@ -158,16 +158,50 @@ Verified from `server/internal/middleware/auth.go` + `service/tenant.go` +
 - OpenAI-compatible `/chat/completions`. Env: `MNEMO_LLM_BASE_URL`,
   `MNEMO_LLM_MODEL` (default `gpt-4o-mini`), `MNEMO_LLM_API_KEY`.
 - `MNEMO_INGEST_MODE` = `smart` (default, LLM extraction/reconciliation) or
-  `raw`. **If no LLM key/base-url, smart falls back to raw** (server logs
-  "no LLM configured, ingest will use raw mode"). Raw = store as-is (no extraction).
+  `raw`. **The nil-client downgrade is keyed on the API KEY, not the mode:**
+  `llm.New()` returns `nil` iff `MNEMO_LLM_API_KEY == ""` (base-url alone defaults
+  to `api.openai.com/v1`), and the ingest pipeline silently does raw whenever the
+  client is nil — regardless of `MNEMO_INGEST_MODE`. So `smart` needs a **non-empty**
+  `MNEMO_LLM_API_KEY` or it logs "no LLM configured, ingest will use raw mode" and
+  downgrades. (Verified in `server/internal/llm/client.go` + `service/ingest.go`.)
 - Startup also logs "no embedding configured, keyword-only search active" when no
   embedder is set → **without an embedding endpoint, PG backend does keyword-only
   (FTS), NO vector search.** So the embedding MaaS is required for semantic recall.
 
+### LLM key is read ONCE at startup, immutable — decisive for the sidecar (verified 2026-07-12)
+Probed at the pinned commit (`server/internal/config/config.go` + `llm/client.go`):
+- `MNEMO_LLM_API_KEY` / `_BASE_URL` / `_MODEL` are read **once** in `config.Load()`
+  (called once in `main`) and copied into an **immutable `Client` struct field**
+  (`apiKey`/`baseURL`/`model`). **NO reload path** — no SIGHUP handler (only
+  SIGINT/SIGTERM for shutdown), no file watch, no periodic re-read, no setter.
+  Rotating the key requires a **process restart**.
+- The LLM client is **hand-rolled `net/http`** (NOT go-openai/sashabaranov). Its
+  `doRequest` sets **only** `Content-Type` + `Authorization: Bearer <apiKey>` and
+  POSTs to `{baseURL}/chat/completions`. There is **no hook to add extra headers**
+  → mem9 **cannot** emit the `OpenAI-Project` header Bedrock Mantle needs for cost
+  attribution.
+- **Consequence (design pivot from the original §7):** a token-refresh sidecar that
+  rewrites a shared file/env for mem9 to re-read **cannot work** (mem9 never
+  re-reads), and mem9 can't tag Mantle spend. Both are solved WITHOUT a mem9 fork by
+  a **local LLM proxy sidecar** (`docker/llm-proxy/`): mem9 points
+  `MNEMO_LLM_BASE_URL=http://localhost:8082/v1` with a **static dummy**
+  `MNEMO_LLM_API_KEY`; the proxy holds the live Mantle bearer (minted by
+  `@aws/bedrock-token-generator` — a **local SigV4 presign, 12h TTL**, refreshed on
+  a timer) and injects a fresh `Authorization` + `OpenAI-Project` per request. See
+  ARCHITECTURE.md §7 + `docker/llm-proxy/server.mjs`.
+
 ## Bedrock Mantle facts (for the LLM/embedding decision)
 
-Verified against AWS docs + the operator's podcast-curation prod usage:
+Verified against AWS docs + the operator's podcast-curation prod usage, and — for
+this repo — **empirically live 2026-07-12** (ap-northeast-1):
 
+- **Live proof:** `getToken({credentials, region})` (from `@aws/bedrock-token-generator`)
+  → a `bedrock-api-key-…` bearer; `POST https://bedrock-mantle.ap-northeast-1.api.aws/v1/chat/completions`
+  with `{model:"zai.glm-5", messages:[…]}` + `Authorization: Bearer <bearer>` →
+  **HTTP 200**, OpenAI-shaped body (`choices[0].message.content`). The bearer's
+  default+max TTL is **12h** (`token.js`: `DEFAULT/MAX_TOKEN_EXPIRES_IN_SECONDS = 43200`),
+  and minting is a **pure local SigV4 presign** (no network call) → the token-refresh
+  cadence is ~hourly, not the 15-min figure that was the *RDS IAM* token, not this one.
 - **Mantle IS OpenAI-compatible.** Endpoint `https://bedrock-mantle.{region}.api.aws/v1`;
   surfaces = **Chat Completions** + **Responses** (OpenAI-compatible) + **Messages**
   (Anthropic). "Bring OpenAI SDK code by changing only base URL + API key."

--- a/infra/cloudformation/bedrock-mantle-project.yaml
+++ b/infra/cloudformation/bedrock-mantle-project.yaml
@@ -1,0 +1,50 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  OUT-OF-BAND Bedrock Mantle Project for mem9-on-aws LLM cost attribution (§7).
+  The llm-proxy sidecar (docker/llm-proxy) passes this project's Id as the
+  `OpenAI-Project` header on every Mantle /chat/completions call, so GLM-5
+  smart-ingest spend is tagged to this project. Mantle does NOT support
+  IAM-principal / session-tag attribution (verified in podcast-curation prod), so
+  a Project is the ONLY way to attribute GLM-5 spend.
+
+  NOT SST-managed — managed out-of-band (like the ECR repos + the GitHub Actions
+  role) so `sst remove` on a PR stage can't drop the shared project. Deploy in
+  ap-northeast-1 (where the ECS task calls Mantle) via
+  scripts/deploy-bedrock-mantle-project.sh, then feed the ProjectId output to CI
+  as the MEM9_BEDROCK_PROJECT env the deploy reads (infra/ecs.ts BEDROCK_PROJECT).
+
+Parameters:
+  ProjectName:
+    Type: String
+    Default: mem9-on-aws
+    Description: SST app name; used to name the Bedrock Project.
+
+Resources:
+  MantleProject:
+    Type: AWS::BedrockMantle::Project
+    # Retain: the project id is referenced by the running task's OpenAI-Project
+    # header + accumulates cost history; never let a stack teardown drop it.
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      Name: !Sub ${ProjectName}-llm
+      Tags:
+        - Key: Project
+          Value: !Ref ProjectName
+        - Key: ManagedBy
+          Value: cloudformation
+
+Outputs:
+  ProjectId:
+    Description: >
+      The Bedrock Mantle Project Id — set as the CI env MEM9_BEDROCK_PROJECT so
+      infra/ecs.ts injects it into the llm-proxy sidecar's LLM_PROXY_OPENAI_PROJECT
+      (the OpenAI-Project header). This is what tags GLM-5 spend.
+    Value: !GetAtt MantleProject.Id
+    Export:
+      Name: !Sub ${AWS::StackName}-ProjectId
+  ProjectArn:
+    Description: The Bedrock Mantle Project ARN.
+    Value: !GetAtt MantleProject.Arn
+    Export:
+      Name: !Sub ${AWS::StackName}-ProjectArn

--- a/infra/cloudformation/ecr-repositories.yaml
+++ b/infra/cloudformation/ecr-repositories.yaml
@@ -2,8 +2,9 @@ AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   OUT-OF-BAND ECR repos for mem9-on-aws (not SST-managed) so `sst remove` can't
   wipe image history: mnemo-server (server, §4), qwen3-embed (embed sidecar, §7),
-  bootstrap (schema-bootstrap task, §8). CI tags mem9-<sha>/latest (release) +
-  pr-<sha> (preview); each repo's lifecycle keeps them on separate schedules.
+  bootstrap (schema-bootstrap task, §8), llm-proxy (LLM smart-ingest sidecar, §7).
+  CI tags mem9-<sha>/latest (release) + pr-<sha> (preview); each repo's lifecycle
+  keeps them on separate schedules.
   Deploy via scripts/deploy-ecr-repositories.sh in ap-northeast-1. See §4.
 
 Parameters:
@@ -161,6 +162,39 @@ Resources:
         - Key: ManagedBy
           Value: cloudformation
 
+  # ───────────────────────────────────────────────────────────────────────────
+  # llm-proxy sidecar image (§7 LLM smart-ingest). Same tag scheme + lifecycle.
+  # ───────────────────────────────────────────────────────────────────────────
+  LlmProxyRepo:
+    Type: AWS::ECR::Repository
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      RepositoryName: !Sub ${ProjectName}/llm-proxy
+      ImageTagMutability: MUTABLE
+      EncryptionConfiguration:
+        EncryptionType: AES256
+      LifecyclePolicy:
+        LifecyclePolicyText: |
+          {
+            "rules": [
+              { "rulePriority": 1, "description": "Expire pr-<sha> preview images after 7 days.",
+                "selection": { "tagStatus": "tagged", "tagPrefixList": ["pr-"], "countType": "sinceImagePushed", "countUnit": "days", "countNumber": 7 },
+                "action": { "type": "expire" } },
+              { "rulePriority": 2, "description": "Keep the last 30 mem9-<sha> release images.",
+                "selection": { "tagStatus": "tagged", "tagPrefixList": ["mem9-"], "countType": "imageCountMoreThan", "countNumber": 30 },
+                "action": { "type": "expire" } },
+              { "rulePriority": 3, "description": "Expire untagged images after 3 days.",
+                "selection": { "tagStatus": "untagged", "countType": "sinceImagePushed", "countUnit": "days", "countNumber": 3 },
+                "action": { "type": "expire" } }
+            ]
+          }
+      Tags:
+        - Key: Project
+          Value: !Ref ProjectName
+        - Key: ManagedBy
+          Value: cloudformation
+
 Outputs:
   MnemoServerRepoUri:
     Description: >
@@ -185,3 +219,8 @@ Outputs:
     Value: !GetAtt BootstrapRepo.RepositoryUri
     Export:
       Name: !Sub ${AWS::StackName}-BootstrapRepoUri
+  LlmProxyRepoUri:
+    Description: The llm-proxy sidecar ECR repository URI (without a tag).
+    Value: !GetAtt LlmProxyRepo.RepositoryUri
+    Export:
+      Name: !Sub ${AWS::StackName}-LlmProxyRepoUri

--- a/infra/cloudformation/github-actions-role.yaml
+++ b/infra/cloudformation/github-actions-role.yaml
@@ -655,8 +655,8 @@ Resources:
               - ecr:GetAuthorizationToken
             Resource: "*"
           - Sid: ECRPush
-            # Upload layers + put the manifest, scoped to the THREE out-of-band
-            # repos CI pushes to (mnemo-server, qwen3-embed, bootstrap).
+            # Upload layers + put the manifest, scoped to the FOUR out-of-band
+            # repos CI pushes to (mnemo-server, qwen3-embed, bootstrap, llm-proxy).
             # BatchCheckLayerAvailability lets buildx skip re-uploading existing
             # layers. DescribeRepositories confirms a repo exists before pushing
             # (clear error if the ECR bootstrap wasn't run).
@@ -672,6 +672,7 @@ Resources:
               - !Sub arn:aws:ecr:ap-northeast-1:${AWS::AccountId}:repository/${ProjectName}/mnemo-server
               - !Sub arn:aws:ecr:ap-northeast-1:${AWS::AccountId}:repository/${ProjectName}/qwen3-embed
               - !Sub arn:aws:ecr:ap-northeast-1:${AWS::AccountId}:repository/${ProjectName}/bootstrap
+              - !Sub arn:aws:ecr:ap-northeast-1:${AWS::AccountId}:repository/${ProjectName}/llm-proxy
 
   # ───────────────────────────────────────────────────────────────────────────
   # IAM Role — assumed by GitHub Actions via OIDC.

--- a/infra/ecs.test.ts
+++ b/infra/ecs.test.ts
@@ -159,7 +159,7 @@ describe("ecs stack", () => {
     return String((c.image as { value?: string })?.value ?? c.image);
   }
 
-  it("runs an arm64 2-container task (mnemo-server + qwen3-embed) sized for the model, NO load balancer", async () => {
+  it("runs an arm64 3-container task (mnemo-server + qwen3-embed + llm-proxy) sized for the model, NO load balancer", async () => {
     installGlobals("prod");
     const ecs = await loadEcs();
     ecs(fakeDbOut());
@@ -167,26 +167,48 @@ describe("ecs stack", () => {
     const args = services[0].args;
     expect(args.architecture).toBe("arm64");
     // Task total sized for the ~3.85 GB qwen3 model + headroom (§9). 2 vCPU/6 GB
-    // is a valid Fargate pair.
+    // is a valid Fargate pair; the tiny llm-proxy sidecar rides the same pool.
     expect(args.cpu).toBe("2 vCPU");
     expect(args.memory).toBe("6 GB");
     // Multi-container mode: containers[], and NO top-level image (SST rejects both).
     expect(args.image).toBeUndefined();
     const byName = containersByName();
-    expect(Object.keys(byName).sort()).toEqual(["mnemo-server", "qwen3-embed"]);
-    // Both images are our out-of-band ECR repos, from the caller account — not public.
+    expect(Object.keys(byName).sort()).toEqual(["llm-proxy", "mnemo-server", "qwen3-embed"]);
+    // All images are our out-of-band ECR repos, from the caller account — not public.
     expect(imgStr(byName["mnemo-server"])).toContain(
       ".dkr.ecr.ap-northeast-1.amazonaws.com/mem9-on-aws/mnemo-server:",
     );
     expect(imgStr(byName["qwen3-embed"])).toContain(
       ".dkr.ecr.ap-northeast-1.amazonaws.com/mem9-on-aws/qwen3-embed:",
     );
+    expect(imgStr(byName["llm-proxy"])).toContain(
+      ".dkr.ecr.ap-northeast-1.amazonaws.com/mem9-on-aws/llm-proxy:",
+    );
     expect(imgStr(byName["mnemo-server"])).not.toContain("public.ecr.aws");
     // No ALB (deferred to the Gateway PR).
     expect(args.loadBalancer).toBeUndefined();
   });
 
-  it("defaults the image tag to `latest` and honors MEM9_IMAGE_TAG (both containers)", async () => {
+  it("grants the task role least-privilege Bedrock (CallWithBearerToken + InvokeModel on GLM-5), no wildcard model", async () => {
+    installGlobals("prod");
+    const ecs = await loadEcs();
+    ecs(fakeDbOut());
+    const perms = services[0].args.permissions as { actions: string[]; resources: string[] }[];
+    expect(Array.isArray(perms)).toBe(true);
+    const actions = perms.flatMap((p) => p.actions);
+    expect(actions).toContain("bedrock:CallWithBearerToken"); // mint the bearer
+    expect(actions).toContain("bedrock:InvokeModel"); // the GLM-5 call via Mantle
+    // InvokeModel is scoped to the zai.glm-5 foundation-model ARN (wildcard region
+    // per CLAUDE-AWS Bedrock guidance) — never Resource "*" on the model.
+    const invoke = perms.find((p) => p.actions.includes("bedrock:InvokeModel"));
+    expect(invoke?.resources.some((r) => r.includes("foundation-model/zai.glm-5"))).toBe(true);
+    expect(invoke?.resources).not.toContain("*");
+    // No committed 12-digit account id in any permission ARN (FM ARNs have none).
+    for (const p of perms)
+      for (const r of p.resources) expect(r).not.toMatch(/\d{12}/);
+  });
+
+  it("defaults the image tag to `latest` and honors MEM9_IMAGE_TAG (all containers)", async () => {
     installGlobals("prod");
     let ecs = await loadEcs();
     ecs(fakeDbOut());
@@ -214,11 +236,16 @@ describe("ecs stack", () => {
     const env = mnemo.environment as Record<string, unknown>;
     expect(env.MNEMO_DB_BACKEND).toBe("postgres");
     expect(env.MNEMO_PORT).toBe("8080");
-    expect(env.MNEMO_INGEST_MODE).toBe("raw"); // LLM sidecar deferred
+    expect(env.MNEMO_INGEST_MODE).toBe("smart"); // LLM extraction via llm-proxy
     expect(env.MEM9_DB_HOST).toBeDefined();
     // Embed wiring: localhost sidecar, dims MUST be 1024 (matches PG vector(1024)).
     expect(String(env.MNEMO_EMBED_BASE_URL)).toBe("http://localhost:8081/v1");
     expect(env.MNEMO_EMBED_DIMS).toBe("1024");
+    // LLM wiring: mem9 talks to the llm-proxy sidecar on localhost with a NON-EMPTY
+    // dummy key (empty would nil mem9's LLM client → silent smart→raw downgrade).
+    expect(String(env.MNEMO_LLM_BASE_URL)).toBe("http://localhost:8082/v1");
+    expect(env.MNEMO_LLM_MODEL).toBe("zai.glm-5");
+    expect(String(env.MNEMO_LLM_API_KEY ?? "")).not.toBe(""); // dummy, but non-empty
     // Secret via ssm (== ECS secrets valueFrom), never environment.
     const ssm = mnemo.ssm as Record<string, unknown>;
     expect(ssm.MEM9_DB_SECRET).toBeDefined();
@@ -243,6 +270,28 @@ describe("ecs stack", () => {
     expect(String(health.startPeriod)).toMatch(/180/);
     // The embed container carries NO DB secret (only mnemo-server needs it).
     expect(embed.ssm).toBeUndefined();
+  });
+
+  it("llm-proxy container: localhost port + region env + health check, no DB secret", async () => {
+    installGlobals("prod");
+    const ecs = await loadEcs();
+    ecs(fakeDbOut());
+    const proxy = containersByName()["llm-proxy"];
+    const env = proxy.environment as Record<string, unknown>;
+    expect(env.LLM_PROXY_PORT).toBe("8082"); // matches MNEMO_LLM_BASE_URL localhost:8082
+    expect(env.LLM_PROXY_REGION).toBe("ap-northeast-1"); // pinned Mantle region
+    // OpenAI-Project header key is present (value comes from CI env; empty is fine
+    // — the proxy omits the header when unset).
+    expect("LLM_PROXY_OPENAI_PROJECT" in env).toBe(true);
+    const health = proxy.health as Record<string, unknown>;
+    expect(String((health.command as string[]).join(" "))).toContain("/health");
+    // The proxy carries NO DB secret (only mnemo-server needs it) and no real key
+    // in env — the bearer is minted at runtime from the task role.
+    expect(proxy.ssm).toBeUndefined();
+    for (const [k, v] of Object.entries(env)) {
+      expect(k.toLowerCase()).not.toContain("secret");
+      expect(String(v)).not.toMatch(/bedrock-api-key-/); // never a baked bearer
+    }
   });
 
   it("exports the cluster + service names + image under /mem9-on-aws/${stage}/ecs/", async () => {

--- a/infra/ecs.ts
+++ b/infra/ecs.ts
@@ -10,17 +10,25 @@
  * mem9 source commit — see docs/mem9-facts.md). Its entrypoint assembles
  * MNEMO_DSN from the injected pieces at container start.
  *
- * SIDECAR (this PR): the task now runs TWO containers (ARCHITECTURE.md §7):
+ * SIDECARS (ARCHITECTURE.md §7): the task runs THREE containers:
  *   1. mnemo-server (the memory server, HTTP :8080)
  *   2. qwen3-embed  (OpenAI /v1/embeddings on localhost:8081; docker/qwen3-embed/)
+ *   3. llm-proxy    (OpenAI /v1/chat/completions → Bedrock Mantle, localhost:8082;
+ *                    docker/llm-proxy/) — enables LLM smart-ingest.
  * mem9 reaches the embedder at MNEMO_EMBED_BASE_URL=http://localhost:8081/v1 with
- * MNEMO_EMBED_DIMS=1024 (matches the PG vector(1024) column the bootstrap creates).
- * The qwen3 ONNX model is heavy (~3.85 GB resident), so the task memory jumps to
- * fit it — the main §7/§9 cost swing.
+ * MNEMO_EMBED_DIMS=1024 (matches the PG vector(1024) column the bootstrap creates),
+ * and the LLM at MNEMO_LLM_BASE_URL=http://localhost:8082/v1. The qwen3 ONNX model
+ * is heavy (~3.85 GB resident), so the task memory fits it — the main §7/§9 swing.
  *
- * NOT yet here (follow-up PRs):
- *   - the token-refresh sidecar + LLM smart-ingest (§7 LLM). Until then
- *     MNEMO_INGEST_MODE=raw (store as-is); embedding/semantic search still works.
+ * LLM SMART-INGEST (this PR): MNEMO_INGEST_MODE=smart. mem9 reads MNEMO_LLM_API_KEY
+ * ONCE at startup (immutable) and its LLM client sends only Authorization — so it
+ * can neither refresh a rotating Bedrock bearer nor add the OpenAI-Project cost
+ * header. The llm-proxy sidecar bridges both: mem9 auths with a static DUMMY key to
+ * localhost, and the proxy holds the live Mantle bearer (refreshed on a timer, a
+ * local presign) + injects OpenAI-Project per request. No mem9 fork, no restart on
+ * rotation. See docker/llm-proxy/server.mjs + docs/mem9-facts.md.
+ *
+ * NOT yet here (follow-up PR):
  *   - the internal ALB + public ACM cert (AgentCore Gateway PR, §6a).
  *
  * SCHEMA BOOTSTRAP (this PR, separate one-shot task — infra/bootstrap.ts):
@@ -52,6 +60,22 @@ const IMAGE_TAG = process.env.MEM9_IMAGE_TAG || "latest";
 // The qwen3-embed sidecar listens here; mem9 calls it over localhost. Not exposed
 // outside the task.
 const EMBED_PORT = 8081;
+
+// The llm-proxy sidecar listens here; mem9 calls it over localhost for
+// smart-ingest LLM (proxied to Bedrock Mantle). Not exposed outside the task.
+const LLM_PROXY_PORT = 8082;
+
+// The GLM-5 model id mem9 sends as `model` on each /chat/completions (Mantle
+// Chat-Completions model, verified live — see docs/mem9-facts.md). Overridable
+// via env for a model swap without a code change.
+const LLM_MODEL = process.env.MEM9_LLM_MODEL || "zai.glm-5";
+
+// Bedrock Project id for Mantle cost attribution (the OpenAI-Project header the
+// proxy injects). Mantle does NOT support IAM-principal attribution, so this is
+// how GLM-5 spend is tagged. CI sets MEM9_BEDROCK_PROJECT from the out-of-band
+// Bedrock Project stack output; empty → the proxy omits the header (still works,
+// just untagged). See infra/cloudformation/bedrock-mantle-project.yaml.
+const BEDROCK_PROJECT = process.env.MEM9_BEDROCK_PROJECT || "";
 
 export interface EcsOutputs {
   ssmPrefix: string;
@@ -87,10 +111,11 @@ export function ecs(dbOut: DbOutputs): EcsOutputs {
   const dbSecretArn = dbOut.secretArn;
   const taskSgId = dbOut.taskSecurityGroupId;
 
-  // Image URIs (out-of-band ECR, referenced read-only). Both share IMAGE_TAG so a
-  // single CI run pins the whole task consistently.
+  // Image URIs (out-of-band ECR, referenced read-only). All three share IMAGE_TAG
+  // so a single CI run pins the whole task consistently.
   const mnemoImage = ecrImage("mem9-on-aws/mnemo-server", IMAGE_TAG);
   const embedImage = ecrImage("mem9-on-aws/qwen3-embed", IMAGE_TAG);
+  const llmProxyImage = ecrImage("mem9-on-aws/llm-proxy", IMAGE_TAG);
 
   // ECS cluster in the existing default VPC. `loadBalancerSubnets` is required by
   // the type even though we create no ALB here (deferred to the Gateway PR); set
@@ -133,6 +158,29 @@ export function ecs(dbOut: DbOutputs): EcsOutputs {
     architecture: "arm64", // runtimePlatform cpuArchitecture=ARM64; images are linux/arm64
     cpu: "2 vCPU",
     memory: "6 GB",
+    // Task-role IAM for the llm-proxy sidecar's Bedrock Mantle calls (§7). SST
+    // attaches `permissions` to the TASK role (not the execution role), which is
+    // the identity the container's default credential chain resolves — exactly
+    // what @aws/bedrock-token-generator signs the bearer with, and what Mantle
+    // authorizes the model call against.
+    //   - bedrock:CallWithBearerToken — the presigned action the minted bearer
+    //     carries (getToken signs Action=CallWithBearerToken); without it the
+    //     bearer is rejected. No resource ARN granularity → "*", guarded by scope
+    //     to this one action.
+    //   - bedrock:InvokeModel — the actual GLM-5 inference via Mantle. Scoped to
+    //     the zai.glm-5 foundation-model ARN (FM ARNs carry no account id) with a
+    //     wildcard region so a region change doesn't silently deny (per CLAUDE-AWS
+    //     Bedrock guidance); never widened to Resource "*".
+    permissions: [
+      {
+        actions: ["bedrock:CallWithBearerToken"],
+        resources: ["*"],
+      },
+      {
+        actions: ["bedrock:InvokeModel"],
+        resources: [`arn:aws:bedrock:*::foundation-model/${LLM_MODEL}`],
+      },
+    ],
     containers: [
       {
         name: "mnemo-server",
@@ -142,7 +190,7 @@ export function ecs(dbOut: DbOutputs): EcsOutputs {
         environment: {
           MNEMO_DB_BACKEND: "postgres",
           MNEMO_PORT: "8080",
-          MNEMO_INGEST_MODE: "raw", // LLM sidecar deferred; smart falls back to raw
+          MNEMO_INGEST_MODE: "smart", // LLM extraction via the llm-proxy sidecar
           MNEMO_UPLOAD_DIR: "/tmp", // single task → local /tmp is fine (mem9-facts)
           MEM9_DB_HOST: dbHost, // Aurora cluster writer endpoint (no proxy)
           MEM9_DB_PORT: dbPort,
@@ -154,6 +202,14 @@ export function ecs(dbOut: DbOutputs): EcsOutputs {
           MNEMO_EMBED_DIMS: "1024",
           // mem9's embedder treats "local"/"" as no-auth (localhost sidecar).
           MNEMO_EMBED_API_KEY: "local",
+          // LLM MaaS = the llm-proxy sidecar on localhost → Bedrock Mantle GLM-5.
+          // mem9 reads MNEMO_LLM_API_KEY once + can't add headers, so it auths with
+          // a static DUMMY key; the proxy swaps in the live Mantle bearer +
+          // OpenAI-Project. The key MUST be non-empty or mem9 nils the LLM client
+          // and silently downgrades smart→raw (verified in mem9 source).
+          MNEMO_LLM_BASE_URL: `http://localhost:${LLM_PROXY_PORT}/v1`,
+          MNEMO_LLM_MODEL: LLM_MODEL,
+          MNEMO_LLM_API_KEY: "local", // dummy; the proxy holds the real bearer
         },
         // Secret injection (== ECS `secrets: valueFrom`): the DB secret lands as an
         // env var from Secrets Manager at task start. Never a literal in git.
@@ -183,6 +239,31 @@ export function ecs(dbOut: DbOutputs): EcsOutputs {
           // unhealthy until the model finishes loading.
           command: ["CMD-SHELL", `curl -fsS http://localhost:${EMBED_PORT}/health || exit 1`],
           startPeriod: "180 seconds",
+          interval: "30 seconds",
+          timeout: "5 seconds",
+          retries: 3,
+        },
+      },
+      {
+        name: "llm-proxy",
+        image: llmProxyImage,
+        environment: {
+          LLM_PROXY_PORT: String(LLM_PROXY_PORT),
+          // The proxy derives the Mantle upstream from the region (AWS_REGION is
+          // set by Fargate); pin it explicitly so a region change can't silently
+          // point it at the wrong Mantle endpoint.
+          LLM_PROXY_REGION: "ap-northeast-1",
+          // OpenAI-Project header for Bedrock cost attribution. Empty → omitted.
+          LLM_PROXY_OPENAI_PROJECT: BEDROCK_PROJECT,
+        },
+        logging: { retention: "1 month" },
+        // /health flips to 200 only once the first Bedrock bearer is minted (a
+        // local presign, sub-second) — fast, no model load. curl -f keeps the
+        // container unhealthy until then so mnemo-server isn't marked healthy
+        // before smart-ingest can actually auth.
+        health: {
+          command: ["CMD-SHELL", `curl -fsS http://localhost:${LLM_PROXY_PORT}/health || exit 1`],
+          startPeriod: "30 seconds",
           interval: "30 seconds",
           timeout: "5 seconds",
           retries: 3,

--- a/infra/sst-types.d.ts
+++ b/infra/sst-types.d.ts
@@ -255,6 +255,14 @@ declare namespace sst {
       health?: Input<ContainerHealth>;
       logging?: ServiceLogging;
     }
+    // A task-role IAM statement (FunctionPermissionArgs shape, shared by Service).
+    // SST attaches these to the TASK role — the identity the container's default
+    // credential chain resolves. Used here for the llm-proxy sidecar's Bedrock calls.
+    interface FargatePermission {
+      effect?: Input<"allow" | "deny">;
+      actions: Input<string>[];
+      resources: Input<Input<string>[]>;
+    }
     interface ServiceArgs {
       cluster: Cluster;
       architecture?: Input<"x86_64" | "arm64">;
@@ -267,6 +275,8 @@ declare namespace sst {
       // Multi-container (sidecar) mode: mutually exclusive with the above.
       containers?: Input<FargateContainer>[];
       logging?: ServiceLogging;
+      // IAM statements attached to the task role (SST's `permissions`).
+      permissions?: Input<FargatePermission>[];
       transform?: { service?: (args: Record<string, unknown>) => void };
     }
     class Service {

--- a/scripts/deploy-bedrock-mantle-project.sh
+++ b/scripts/deploy-bedrock-mantle-project.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# deploy-bedrock-mantle-project.sh — Create or update the OUT-OF-BAND Bedrock
+# Mantle Project for mem9-on-aws LLM (GLM-5 smart-ingest) cost attribution.
+#
+# Scope: **the Bedrock Mantle Project only**. The SST/Pulumi app does NOT manage
+# it — the llm-proxy sidecar (docker/llm-proxy) just passes its Id as the
+# `OpenAI-Project` header on every Mantle call. Owning it out-of-band (like the
+# ECR repos + the GitHub Actions role) means `sst remove --stage pr-N` can never
+# drop the shared project + its accumulated cost history (§7).
+#
+# Bootstrap ONCE per AWS account (in the Tokyo region — where the ECS task calls
+# Mantle), and RE-RUN only if bedrock-mantle-project.yaml changes.
+#
+# Region: ap-northeast-1 (Tokyo) — MUST match the SST app region so the project
+# is in the same region the llm-proxy sidecar targets. Hard-coded (not the
+# ambient AWS_REGION) so a leftover AWS_REGION can't create it in the wrong one.
+#
+# Local deploy profile: kane-global-mengxinz (set AWS_PROFILE).
+#
+# Usage:
+#   AWS_PROFILE=kane-global-mengxinz scripts/deploy-bedrock-mantle-project.sh   # auto create/update
+#   scripts/deploy-bedrock-mantle-project.sh --create   # force create-stack
+#   scripts/deploy-bedrock-mantle-project.sh --update   # force update-stack
+#
+# After success, feed the ProjectId output to CI so infra/ecs.ts injects it:
+#   gh variable set MEM9_BEDROCK_PROJECT --repo zxkane/mem9-on-aws --body "<project-id>"
+
+set -euo pipefail
+
+STACK_NAME="${STACK_NAME:-bedrock-mantle-project-mem9-on-aws}"
+TEMPLATE_FILE="infra/cloudformation/bedrock-mantle-project.yaml"
+# Tokyo — MUST equal sst.config.ts's providers.aws.region. Hard-coded, NOT read
+# from the ambient AWS_REGION (a stray value would create it in the wrong region).
+# Override deliberately with PROJECT_REGION only if the whole app moves regions.
+REGION="${PROJECT_REGION:-ap-northeast-1}"
+
+MODE=""
+for arg in "$@"; do
+  case "$arg" in
+    --create) MODE="create" ;;
+    --update) MODE="update" ;;
+    -h|--help)
+      sed -n '2,/^$/p' "$0" | sed 's/^# \?//'
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ ! -f "$TEMPLATE_FILE" ]]; then
+  echo "Error: template not found at $TEMPLATE_FILE (run from repo root)" >&2
+  exit 2
+fi
+
+echo "Stack:    $STACK_NAME"
+echo "Region:   $REGION"
+echo "Template: $TEMPLATE_FILE"
+
+# Auto-detect create vs update when the caller did not pass --create / --update.
+if [[ -z "$MODE" ]]; then
+  if aws cloudformation describe-stacks \
+      --stack-name "$STACK_NAME" \
+      --region "$REGION" \
+      >/dev/null 2>&1; then
+    MODE="update"
+  else
+    MODE="create"
+  fi
+fi
+
+case "$MODE" in
+  create)
+    echo "Creating stack..."
+    aws cloudformation create-stack \
+      --stack-name "$STACK_NAME" \
+      --template-body "file://$TEMPLATE_FILE" \
+      --region "$REGION" \
+      --tags Key=Project,Value=mem9-on-aws Key=ManagedBy,Value=cli
+    aws cloudformation wait stack-create-complete \
+      --stack-name "$STACK_NAME" \
+      --region "$REGION"
+    ;;
+  update)
+    echo "Updating stack..."
+    # update-stack exits non-zero with "No updates are to be performed" when the
+    # template is unchanged — swallow that so re-running for idempotency is safe.
+    set +e
+    UPDATE_OUTPUT=$(aws cloudformation update-stack \
+      --stack-name "$STACK_NAME" \
+      --template-body "file://$TEMPLATE_FILE" \
+      --region "$REGION" 2>&1)
+    UPDATE_EXIT=$?
+    set -e
+    if [[ $UPDATE_EXIT -ne 0 ]]; then
+      if echo "$UPDATE_OUTPUT" | grep -q "No updates are to be performed"; then
+        echo "No changes to apply."
+      else
+        echo "$UPDATE_OUTPUT" >&2
+        exit $UPDATE_EXIT
+      fi
+    else
+      aws cloudformation wait stack-update-complete \
+        --stack-name "$STACK_NAME" \
+        --region "$REGION"
+    fi
+    ;;
+esac
+
+PROJECT_ID=$(aws cloudformation describe-stacks \
+  --stack-name "$STACK_NAME" \
+  --region "$REGION" \
+  --query "Stacks[0].Outputs[?OutputKey=='ProjectId'].OutputValue" \
+  --output text)
+
+echo
+echo "ProjectId: $PROJECT_ID"
+echo
+echo "Next steps:"
+echo "  1. Set the CI variable so deploys inject it into the llm-proxy sidecar:"
+echo "       gh variable set MEM9_BEDROCK_PROJECT --repo zxkane/mem9-on-aws --body \"$PROJECT_ID\""
+echo "  2. infra/ecs.ts reads MEM9_BEDROCK_PROJECT → LLM_PROXY_OPENAI_PROJECT →"
+echo "     the OpenAI-Project header on every Mantle /chat/completions call."

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,11 +1,12 @@
 import { defineConfig } from "vitest/config";
 
-// Root vitest project. The scaffold has no root-level source yet — the SST
-// app + its unit tests live under `infra/` (see `infra/vitest.config.ts`).
-// This config exists so the CI `npm test` step has a target; it runs with
-// `--passWithNoTests` until root-level tooling gains its own tests.
+// Root vitest project. The SST app + its unit tests live under `infra/` (see
+// `infra/vitest.config.ts`); this config covers the repo-root/sidecar tests:
+//   - scripts/**/*.test.ts    (any shell-wrapper helpers gaining tests)
+//   - docker/**/*.test.mjs    (the ECS sidecar servers, e.g. llm-proxy)
+// Runs with `--passWithNoTests` so CI's `npm test` never fails on an empty glob.
 export default defineConfig({
   test: {
-    include: ["scripts/**/*.test.ts"],
+    include: ["scripts/**/*.test.ts", "docker/**/*.test.mjs"],
   },
 });


### PR DESCRIPTION
## Summary
Enables mem9 **smart-ingest** (`MNEMO_INGEST_MODE=smart`) against **Bedrock Mantle GLM-5**, resolving two mem9 constraints **without forking mem9**:
- mem9 reads `MNEMO_LLM_API_KEY` **once at startup** (immutable, no reload) → can't consume a rotating Bedrock bearer; and
- mem9's hand-rolled client sends **only `Authorization`** → can't add the `OpenAI-Project` header Mantle needs for cost attribution.

Both verified against the pinned mem9 source.

## Approach — local `llm-proxy` sidecar
mem9 → `MNEMO_LLM_BASE_URL=http://localhost:8082/v1` with a **static dummy key**. The proxy (`docker/llm-proxy/`) holds the live Mantle bearer (minted via `@aws/bedrock-token-generator` — a **local SigV4 presign, 12h TTL**, refreshed on a ~hourly timer), replaces `Authorization`, injects `OpenAI-Project`, forwards to Mantle. No restart on rotation, no mem9 fork.

**Empirically verified** (ap-northeast-1): `POST bedrock-mantle.../v1/chat/completions {model:"zai.glm-5"}` with a minted bearer **+ the real `OpenAI-Project` header** → **HTTP 200**.

## What's in it
| Piece | Detail |
|---|---|
| `docker/llm-proxy/` | Node sidecar (built-ins + token-generator), `node:24-slim` arm64 Dockerfile, **14 unit tests** (routing, header injection, `/health` gating, error mapping, refresh-after-reject recovery) via injectable `mintToken`+`fetch`. |
| `infra/ecs.ts` | 3rd container `llm-proxy`; mnemo-server → `MNEMO_INGEST_MODE=smart` + `MNEMO_LLM_*`; task-role `permissions` = `bedrock:CallWithBearerToken` + `bedrock:InvokeModel` scoped to the `zai.glm-5` FM ARN (wildcard region, no account id). |
| `ecr-repositories.yaml` | +`llm-proxy` repo (same lifecycle). |
| `github-actions-role.yaml` | +`llm-proxy` to the ECR push scope. |
| `bedrock-mantle-project.yaml` + `scripts/deploy-bedrock-mantle-project.sh` | out-of-band `AWS::BedrockMantle::Project` for cost attribution → CI var `MEM9_BEDROCK_PROJECT` → `LLM_PROXY_OPENAI_PROJECT`. |
| `infra-ci.yml` | build+push the **4th** image. |
| docs | `mem9-facts.md` / `ARCHITECTURE.md §7` / `CLAUDE.md`: corrected the sidecar design (proxy, not token file-writer) + recorded the read-once/12h-TTL facts. |

## Out-of-band prerequisites (already bootstrapped)
- ✅ `llm-proxy` ECR repo created (Tokyo).
- ✅ Deploy role updated (llm-proxy ECR push; also applied #8's proxy-grant trim to the live role).
- ✅ Bedrock Mantle Project created; `MEM9_BEDROCK_PROJECT` CI variable set.

## Test Plan
- [x] 14 llm-proxy unit tests pass
- [x] 34 infra tests pass (incl. new Bedrock-permissions + llm-proxy-container assertions)
- [x] typecheck clean; cfn-lint clean (ecr + role); Bedrock Project template validates AWS-side
- [x] Empirical Mantle GLM-5 + `OpenAI-Project` → 200
- [x] PR review agent — no Critical/High; both Low items fixed
- [x] CI checks pass — preview deploy green; live pr-9 task HEALTHY (all 3 containers); llm-proxy minted a Bedrock bearer + shows project proj_ncwypvx6...
- [x] No committed account-ids / account-scoped ARNs / real bearers

Base is post-#8 main (rebased), so the role template is trimmed **and** carries the llm-proxy addition.


---
**Status:** ✅ CI green + E2E verified (live pr-9 task HEALTHY; llm-proxy minted bearer + OpenAI-Project header wired). Ready for merge — merging flips prod MNEMO_INGEST_MODE raw→smart.