### PR TITLE
fix(ingest): grant bedrock-mantle:* + bootstrap upload_tasks (prod ingest broken)

### DIFF
--- a/docker/bootstrap/schema.sql
+++ b/docker/bootstrap/schema.sql
@@ -43,6 +43,23 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_tenant_name ON tenants(name);
 CREATE INDEX IF NOT EXISTS idx_tenant_status ON tenants(status);
 CREATE INDEX IF NOT EXISTS idx_tenant_provider ON tenants(provider);
 
+-- 2b) `tenant_activity` — the server's ActivityTracker.RecordMemoryStats upserts
+--     into this on EVERY memory write (hot path). Like upload_tasks it lives in the
+--     control-plane schema_pg.sql we don't run, so without it every write logs
+--     `record tenant memory stats failed ... relation "tenant_activity" does not
+--     exist (SQLSTATE 42P01)`. Non-fatal (a WARN — the write/ingest still succeeds)
+--     but noisy. FK → tenants(id), so it must follow the tenants table above. DDL
+--     verbatim from schema_pg.sql @ d4638c8458abeb209a1b3a20472a1328c4acd149.
+CREATE TABLE IF NOT EXISTS tenant_activity (
+    tenant_id                  VARCHAR(36) PRIMARY KEY,
+    last_activity_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    active_memory_total        BIGINT      NOT NULL DEFAULT 0,
+    active_memory_7d_total     BIGINT      NOT NULL DEFAULT 0,
+    memory_stats_observed_at   TIMESTAMPTZ NULL,
+    CONSTRAINT fk_tenant_activity FOREIGN KEY (tenant_id) REFERENCES tenants(id)
+);
+CREATE INDEX IF NOT EXISTS idx_tenant_activity_last_activity ON tenant_activity(last_activity_at);
+
 -- 3) Tenant runtime `memories` schema — the table + indexes the server validates
 --    and uses. Derived from mem9's TenantMemorySchemaPostgres constant, with:
 --      * embedding vector(1024)  (qwen3 dims, NOT the default 1536)

--- a/docker/bootstrap/schema.sql
+++ b/docker/bootstrap/schema.sql
@@ -91,3 +91,37 @@ $$ LANGUAGE plpgsql;
 DROP TRIGGER IF EXISTS trg_memories_updated ON memories;
 CREATE TRIGGER trg_memories_updated BEFORE UPDATE ON memories
     FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+-- 4) `upload_tasks` — the mnemo-server "upload worker" starts UNCONDITIONALLY at
+--    boot (cmd/mnemo-server/main.go: uploadWorker.Run) and immediately runs
+--    `reset processing tasks` against this table. Unlike the webhook tables
+--    (which the server creates itself via webhookStore.EnsureSchema), the upload
+--    worker has NO EnsureSchema — it assumes upload_tasks already exists (it lives
+--    in the CONTROL-PLANE server/schema_pg.sql we do not run). Without it the
+--    worker logs, every startup: `upload worker error ... reset upload task
+--    processing: ERROR: relation "upload_tasks" does not exist (SQLSTATE 42P01)`.
+--    DDL copied verbatim from the pinned mem9 source (schema_pg.sql @
+--    d4638c8458abeb209a1b3a20472a1328c4acd149). We do not use the file-upload path
+--    (writes go through the memory content API), but the worker must find the table.
+CREATE TABLE IF NOT EXISTS upload_tasks (
+    task_id       VARCHAR(36)   PRIMARY KEY,
+    tenant_id     VARCHAR(36)   NOT NULL,
+    file_name     VARCHAR(255)  NOT NULL,
+    file_path     TEXT          NOT NULL,
+    agent_id      VARCHAR(100)  NULL,
+    session_id    VARCHAR(100)  NULL,
+    file_type     VARCHAR(20)   NOT NULL,
+    total_chunks  INT           NOT NULL DEFAULT 0,
+    done_chunks   INT           NOT NULL DEFAULT 0,
+    status        VARCHAR(20)   NOT NULL DEFAULT 'pending',
+    error_msg     TEXT          NULL,
+    created_at    TIMESTAMPTZ   DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ   DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_upload_tenant ON upload_tasks(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_upload_poll ON upload_tasks(status, created_at);
+-- upload_tasks' updated_at auto-touch trigger (also from schema_pg.sql). Reuses
+-- the update_updated_at() function defined above for `memories`.
+DROP TRIGGER IF EXISTS trg_upload_tasks_updated ON upload_tasks;
+CREATE TRIGGER trg_upload_tasks_updated BEFORE UPDATE ON upload_tasks
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at();

--- a/infra/bootstrap.test.ts
+++ b/infra/bootstrap.test.ts
@@ -208,3 +208,31 @@ describe("bootstrap stack", () => {
     expect(secrets[0].args.recoveryWindowInDays).toBe(0);
   });
 });
+
+// The bootstrap image applies docker/bootstrap/schema.sql (entrypoint.sh: psql -f).
+// mnemo-server's background workers assume some tables pre-exist (they live in
+// mem9's control-plane server/schema_pg.sql, which we do NOT run). Guard that our
+// hand-maintained runtime schema covers every table a worker touches at startup,
+// so the "relation ... does not exist" class of bug (prod issue #11: upload_tasks)
+// can't silently regress. We assert on the SQL source (a live PG round-trip is the
+// E2E's job), which is exactly where a dropped table would show up.
+describe("bootstrap schema.sql", () => {
+  it("creates the tables mnemo-server's boot-time workers require", async () => {
+    const { readFileSync } = await import("node:fs");
+    const { fileURLToPath } = await import("node:url");
+    const path = await import("node:path");
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    const sql = readFileSync(
+      path.resolve(here, "..", "docker", "bootstrap", "schema.sql"),
+      "utf8",
+    );
+    // The upload worker (uploadWorker.Run) runs UNCONDITIONALLY at boot against
+    // upload_tasks and has no EnsureSchema — so the table must be bootstrapped.
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS upload_tasks\b/);
+    // The auth + memory-content path the MCP write→search E2E exercises.
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS tenants\b/);
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS memories\b/);
+    // Embedding width MUST stay 1024 (qwen3), not mem9's default 1536.
+    expect(sql).toMatch(/embedding\s+vector\(1024\)/);
+  });
+});

--- a/infra/bootstrap.test.ts
+++ b/infra/bootstrap.test.ts
@@ -229,6 +229,8 @@ describe("bootstrap schema.sql", () => {
     // The upload worker (uploadWorker.Run) runs UNCONDITIONALLY at boot against
     // upload_tasks and has no EnsureSchema — so the table must be bootstrapped.
     expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS upload_tasks\b/);
+    // ActivityTracker.RecordMemoryStats upserts tenant_activity on every write.
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS tenant_activity\b/);
     // The auth + memory-content path the MCP write→search E2E exercises.
     expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS tenants\b/);
     expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS memories\b/);

--- a/infra/ecr.ts
+++ b/infra/ecr.ts
@@ -16,10 +16,11 @@
 // (scripts/deploy-ecr-repositories.sh). Tokyo — Fargate pulls same-region.
 export const ECR_REGION = "ap-northeast-1";
 
-// Cache the caller-identity Output so repeated ecrImage() calls don't each create
-// a new getCallerIdentityOutput invoke.
+// Cache the caller-identity Output so repeated ecrImage()/accountId() calls don't
+// each create a new getCallerIdentityOutput invoke. Exported so ecs.ts can build
+// the Bedrock Mantle project ARN with the same deploy-time-resolved account id.
 let accountIdOut: Output<string> | undefined;
-function accountId(): Output<string> {
+export function accountId(): Output<string> {
   if (!accountIdOut) accountIdOut = aws.getCallerIdentityOutput().accountId;
   return accountIdOut;
 }

--- a/infra/ecs.test.ts
+++ b/infra/ecs.test.ts
@@ -163,6 +163,7 @@ afterEach(() => {
   for (const g of ["$app", "aws", "sst", "command", "$interpolate"])
     delete (globalThis as Record<string, unknown>)[g];
   delete process.env.MEM9_IMAGE_TAG;
+  delete process.env.MEM9_BEDROCK_PROJECT;
   vi.resetModules();
 });
 
@@ -274,23 +275,51 @@ describe("ecs stack", () => {
     expect(outs.taskSecurityGroupId).toBeDefined();
   });
 
-  it("grants the task role least-privilege Bedrock (CallWithBearerToken + InvokeModel on GLM-5), no wildcard model", async () => {
+  it("grants the task role Bedrock MANTLE inference perms (not the wrong bedrock:* namespace)", async () => {
     installGlobals("prod");
     const ecs = await loadEcs();
     ecs(fakeDbOut());
     const perms = services[0].args.permissions as { actions: string[]; resources: string[] }[];
     expect(Array.isArray(perms)).toBe(true);
     const actions = perms.flatMap((p) => p.actions);
-    expect(actions).toContain("bedrock:CallWithBearerToken"); // mint the bearer
-    expect(actions).toContain("bedrock:InvokeModel"); // the GLM-5 call via Mantle
-    // InvokeModel is scoped to the zai.glm-5 foundation-model ARN (wildcard region
-    // per CLAUDE-AWS Bedrock guidance) — never Resource "*" on the model.
-    const invoke = perms.find((p) => p.actions.includes("bedrock:InvokeModel"));
-    expect(invoke?.resources.some((r) => r.includes("foundation-model/zai.glm-5"))).toBe(true);
-    expect(invoke?.resources).not.toContain("*");
-    // No committed 12-digit account id in any permission ARN (FM ARNs have none).
-    for (const p of perms)
-      for (const r of p.resources) expect(r).not.toMatch(/\d{12}/);
+    // Smart-ingest calls the Bedrock MANTLE endpoint (/chat/completions), which
+    // authorizes against the `bedrock-mantle:` namespace — NOT `bedrock:`. The old
+    // grant used `bedrock:InvokeModel` + `bedrock:CallWithBearerToken`, so every
+    // inference 401'd (prod issue #11 / prod-smart-ingest-mantle-iam-gap memory).
+    expect(actions).toContain("bedrock-mantle:CreateInference"); // the GLM-5 inference
+    expect(actions).toContain("bedrock-mantle:CallWithBearerToken"); // the bearer at the Mantle endpoint
+    // The read actions the Mantle inference path also checks (AWS docs
+    // inference-how.html "bedrock-mantle endpoint" / AmazonBedrockMantleInferenceAccess).
+    expect(actions).toContain("bedrock-mantle:GetProject");
+    expect(actions).toContain("bedrock-mantle:ListProjects");
+    // The old, WRONG-namespace grants must be gone.
+    expect(actions).not.toContain("bedrock:InvokeModel");
+    expect(actions).not.toContain("bedrock:CallWithBearerToken");
+    // CreateInference is scoped to the project ARN (deploy-time interpolated account
+    // id, resolved by getCallerIdentityOutput — not a committed literal), so no
+    // hardcoded 12-digit account id appears in the committed source.
+    const createInf = perms.find((p) => p.actions.includes("bedrock-mantle:CreateInference"));
+    expect(
+      createInf?.resources.some((r) => String(r).includes("bedrock-mantle") || r === "*"),
+    ).toBe(true);
+  });
+
+  it("scopes CreateInference to the Bedrock Project ARN when MEM9_BEDROCK_PROJECT is set (no literal account id)", async () => {
+    installGlobals("prod");
+    process.env.MEM9_BEDROCK_PROJECT = "proj_testxyz";
+    const ecs = await loadEcs();
+    ecs(fakeDbOut());
+    const perms = services[0].args.permissions as { actions: string[]; resources: string[] }[];
+    const createInf = perms.find((p) => p.actions.includes("bedrock-mantle:CreateInference"));
+    // The resource is a $interpolate-composed Mantle project ARN. The harness's
+    // $interpolate mock returns an out<string> (with `.value`), so unwrap it — same
+    // way ecs() composes it from the account Output + literals at deploy time.
+    const res = (createInf?.resources ?? []).map((r) =>
+      typeof r === "object" && r && "value" in r ? String((r as { value: unknown }).value) : String(r),
+    );
+    expect(res).not.toContain("*");
+    // Scoped to THIS project's ARN, correct shape, and it's a bedrock-mantle ARN.
+    expect(res.some((r) => /^arn:aws:bedrock-mantle:[^:]+:[^:]*:project\/proj_testxyz$/.test(r))).toBe(true);
   });
 
   it("defaults the image tag to `latest` and honors MEM9_IMAGE_TAG (all containers)", async () => {

--- a/infra/ecs.ts
+++ b/infra/ecs.ts
@@ -50,7 +50,11 @@
 
 import { resolveVpc } from "./vpc";
 import type { DbOutputs } from "./db";
-import { ecrImage } from "./ecr";
+import { ecrImage, accountId, ECR_REGION } from "./ecr";
+
+// Bedrock Mantle is called in the app region (= the ECR/app region, Tokyo). Used
+// only to scope the bedrock-mantle:CreateInference project ARN.
+const region = ECR_REGION;
 
 // Image tags. CI (push-to-main) sets MEM9_IMAGE_TAG to the exact `mem9-<sha7>` it
 // just built + pushed, so prod runs that precise commit's images; CI PR previews
@@ -233,23 +237,44 @@ export function ecs(dbOut: DbOutputs): EcsOutputs {
     // attaches `permissions` to the TASK role (not the execution role), which is
     // the identity the container's default credential chain resolves — exactly
     // what @aws/bedrock-token-generator signs the bearer with, and what Mantle
-    // authorizes the model call against.
-    //   - bedrock:CallWithBearerToken — the presigned action the minted bearer
-    //     carries (getToken signs Action=CallWithBearerToken); without it the
-    //     bearer is rejected. No resource ARN granularity → "*", guarded by scope
-    //     to this one action.
-    //   - bedrock:InvokeModel — the actual GLM-5 inference via Mantle. Scoped to
-    //     the zai.glm-5 foundation-model ARN (FM ARNs carry no account id) with a
-    //     wildcard region so a region change doesn't silently deny (per CLAUDE-AWS
-    //     Bedrock guidance); never widened to Resource "*".
+    // authorizes the inference against.
+    //
+    // CRITICAL — the MANTLE endpoint uses the `bedrock-mantle:` namespace, NOT
+    // `bedrock:`. Smart-ingest posts to https://bedrock-mantle.<region>.api.aws/
+    // v1/chat/completions (see docker/llm-proxy/server.mjs), which authorizes
+    // against `bedrock-mantle:*` — a DIFFERENT service from `bedrock:*`. The
+    // original grant used `bedrock:InvokeModel` + `bedrock:CallWithBearerToken`,
+    // so the bearer minted fine (a local SigV4 presign, no IAM call) but every
+    // real inference 401'd `access_denied: bedrock-mantle:CreateInference ... no
+    // identity-based policy allows` → the memory was accepted but never indexed →
+    // search stayed empty. (Prod issue #11; verified against AWS docs
+    // inference-how.html "bedrock-mantle endpoint" + Service Authorization ref.)
+    //   - bedrock-mantle:CreateInference — the GLM-5 inference itself. Scoped to
+    //     the Bedrock Project ARN when MEM9_BEDROCK_PROJECT is set (account id via
+    //     getCallerIdentityOutput, resolved at DEPLOY time — never a committed
+    //     literal), falling back to "*" when the project is unset (local/typecheck).
+    //   - bedrock-mantle:CallWithBearerToken — the Mantle-endpoint variant of the
+    //     bearer-token action the minted bearer carries (distinct from the
+    //     `bedrock:` one). Account-wide by nature → "*".
+    //   - GetProject / ListProjects / ListTagsForResources — the read actions the
+    //     Mantle inference path also checks (mirrors AmazonBedrockMantleInferenceAccess).
     permissions: [
       {
-        actions: ["bedrock:CallWithBearerToken"],
-        resources: ["*"],
+        actions: ["bedrock-mantle:CreateInference"],
+        resources: [
+          BEDROCK_PROJECT
+            ? $interpolate`arn:aws:bedrock-mantle:${region}:${accountId()}:project/${BEDROCK_PROJECT}`
+            : "*",
+        ],
       },
       {
-        actions: ["bedrock:InvokeModel"],
-        resources: [`arn:aws:bedrock:*::foundation-model/${LLM_MODEL}`],
+        actions: [
+          "bedrock-mantle:CallWithBearerToken",
+          "bedrock-mantle:GetProject",
+          "bedrock-mantle:ListProjects",
+          "bedrock-mantle:ListTagsForResources",
+        ],
+        resources: ["*"],
       },
     ],
     containers: [


### PR DESCRIPTION
## Summary
Fixes the prod smart-ingest outage (issue #11): memories were **accepted but never indexed**, so `search_memories` always returned empty. Two root causes, both verified against prod CloudWatch logs + AWS docs.

- **Wrong Bedrock IAM namespace.** The `mnemo-server` ECS task role granted `bedrock:InvokeModel` + `bedrock:CallWithBearerToken`, but mem9 smart-ingest posts to the Bedrock **Mantle** endpoint (`bedrock-mantle.<region>.api.aws/v1/chat/completions`), which authorizes against `bedrock-mantle:*`. The bearer minted fine (a local SigV4 presign — no IAM call), but every fact-extraction inference `401`'d: `access_denied: bedrock-mantle:CreateInference ... no identity-based policy allows`. → memory reconciliation failed → never indexed.
- **Missing `upload_tasks` table.** `docker/bootstrap/schema.sql` only created `tenants` + `memories`. mem9's upload worker starts unconditionally and errored on every boot: `relation "upload_tasks" does not exist (SQLSTATE 42P01)`.

Preview E2E stayed green through #8/#9/#10 because it runs `E2E_SOFT=1` (a search timeout → warning + exit 0), silently masking this. The **prod** E2E is hard, so it caught it.

## Changes
- `infra/ecs.ts` — task role now grants the Mantle inference set: `bedrock-mantle:CreateInference` (scoped to the Bedrock Project ARN via deploy-time `getCallerIdentityOutput` when `MEM9_BEDROCK_PROJECT` is set, else `*`), `bedrock-mantle:CallWithBearerToken`, `GetProject`, `ListProjects`, `ListTagsForResources`. Matches the AWS-managed `AmazonBedrockMantleInferenceAccess`.
- `infra/ecr.ts` — export the memoized `accountId()` helper for the project ARN.
- `docker/bootstrap/schema.sql` — add `upload_tasks` (+2 indexes + `updated_at` trigger), copied from the pinned mem9 `schema_pg.sql` @ `d4638c8`.
- Tests — rewrite the task-role IAM assertion to the Mantle grant (+ a scoped-ARN case), add a `schema.sql` guard for the worker-required tables.

## Test Plan
- [x] Build passes (infra typecheck clean)
- [x] Unit tests pass (44 infra + 14 root)
- [x] Code review passed (no Critical/High/Medium; both Low notes applied)
- [x] CI checks pass
- [x] Preview hard-verified: E2E round-trip found the marker + logs show `facts extracted`, 401 gone (prod round-trip runs on merge)

## Checklist
- [x] New/updated unit tests for the changed behavior
- [x] Verified the fix's tests fail against the old code (non-vacuous TDD)
- [x] No secrets / real account ids in committed source

Closes #11