### PR TITLE
feat(mcp): OAuth2 browser login (authorization-code + PKCE façade)

### DIFF
--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -270,6 +270,13 @@ jobs:
           E2E_SOFT: "1"
         run: bash scripts/run-mcp-e2e.sh
 
+      - name: OAuth façade smoke (preview)
+        if: steps.gate.outputs.skip != 'true' && steps.deploy.outputs.stage != ''
+        env:
+          STAGE: ${{ steps.deploy.outputs.stage }}
+          AWS_REGION: ap-northeast-1
+        run: bash scripts/run-oauth-facade-smoke.sh
+
       - name: Auto-cleanup on deploy failure
         # Best-effort — if the deploy half-applied resources, remove them so the
         # next push doesn't accumulate orphan state.
@@ -795,6 +802,13 @@ jobs:
         env:
           STAGE: prod
         run: bash scripts/run-mcp-e2e.sh
+
+      - name: OAuth façade smoke (prod)
+        if: steps.gate.outputs.skip != 'true'
+        env:
+          STAGE: prod
+          AWS_REGION: ap-northeast-1
+        run: bash scripts/run-oauth-facade-smoke.sh
 
       - name: Create issue on prod deploy failure
         # failure() fires for any failed step (gate, preflight, lock recovery,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -191,6 +191,30 @@ Mirror podcast-curation `gateway.ts` + `cognito.ts` + `api.ts`:
 - SSM parameter exports for Gateway URL / Cognito endpoints / client IDs
   (podcast-curation convention: `/mem9-on-aws/${stage}/...`).
 
+### 6b. Inbound auth — **two coexisting modes** (the gateway trusts both clients)
+
+The MCP surface now accepts **two** inbound-auth flows against the same Cognito
+pool; the AgentCore Gateway's JWT authorizer trusts both app clients:
+
+1. **Cognito M2M (`client_credentials`)** — for CI / headless callers
+   (`scripts/run-mcp-e2e.sh`). Unchanged from §6.
+2. **OAuth2 authorization-code + PKCE (browser login)** — for humans (Claude Code
+   desktop). Served by the **OAuth façade** (`infra/oauth-facade.ts`, an
+   ApiGatewayV2 + Lambda surface — see the façade unit tests in
+   `infra/src/oauth-facade/`) that bridges the PKCE authorization-code flow to the
+   Cognito Hosted UI, so a human logs in via the browser instead of a client
+   secret.
+
+One-time setup per stage (never committed; run by the operator):
+- Seed the state-signing HMAC key:
+  `sst secret set OauthStateHmacKey "$(openssl rand -base64 32)" --stage <stage>`
+  (empty default → the façade returns 503 until seeded).
+- Create the operator user: `aws cognito-idp admin-create-user ...`.
+
+The operator then points Claude Code at the façade MCP endpoint published in SSM
+at `/mem9-on-aws/<stage>/facade/mcp-endpoint` and logs in via the browser. Full
+design + flow: [`docs/superpowers/specs/2026-07-15-oauth2-mcp-browser-login-design.md`](superpowers/specs/2026-07-15-oauth2-mcp-browser-login-design.md).
+
 ### 6a. Gateway → mnemo-server network path (Lambda-proxy — the ALB/Lattice path was abandoned)
 
 **mnemo-server stays fully private; the Gateway reaches it via a VPC-attached proxy
@@ -432,7 +456,13 @@ model is the heavy tenant), which is the main swing in the Fargate cost row.
   the account default VPC's NAT-routed private subnets (selected by the `private-1*`
   Name tag — the Tokyo default VPC also has no-NAT `secondary-private-subnet-*` ones
   that a generic public-ip filter would wrongly include; see infra/vpc.ts).
-- **MCP + auth**: AgentCore Gateway + Cognito M2M (podcast-curation pattern).
+- **MCP + auth**: AgentCore Gateway + Cognito (podcast-curation pattern). **Two
+  coexisting inbound modes** (§6b): **Cognito M2M** (`client_credentials`, for
+  CI / headless callers) **and** **OAuth2 authorization-code + PKCE** browser
+  login for humans (Claude Code desktop) via the **OAuth façade**
+  (`infra/oauth-facade.ts`, ApiGatewayV2 → Cognito Hosted UI). One-time per-stage
+  setup: seed `OauthStateHmacKey` + `admin-create-user`; the operator points
+  Claude Code at `/mem9-on-aws/<stage>/facade/mcp-endpoint`.
 - **Gateway → mnemo-server**: **private** via AgentCore `privateEndpoint` +
   **managed VPC Lattice** → **internal ALB (public ACM cert, TLS terminated here)**
   → mnemo-server over HTTP:8080. Outbound auth = **API key** (`X-API-Key` = tenant

--- a/docs/superpowers/plans/2026-07-15-oauth2-mcp-browser-login.md
+++ b/docs/superpowers/plans/2026-07-15-oauth2-mcp-browser-login.md
@@ -1,0 +1,934 @@
+# OAuth2 Browser Login (MCP surface) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an interactive OAuth2 authorization-code + PKCE (browser login) flow to the mem9 MCP surface, alongside the existing Cognito M2M auth, via an OAuth "façade" Lambda fronted by ApiGatewayV2.
+
+**Architecture:** A façade Lambda (lifted from `zxkane/llm-wiki`'s `infra/src/oauth-facade/`) sits in front of the AgentCore Gateway. It serves RFC 8414/9728 metadata + RFC 7591 DCR, proxies the authorization-code+PKCE flow to Cognito Hosted-UI (bridging the MCP client's random loopback port via HMAC-signed state), and reverse-proxies `/mcp` to the gateway. A new Cognito "reader" client (`code` flow) is added; the gateway trusts both it and the M2M client. The Lambda-proxy target chain (Cloud Map → mnemo-server) is untouched.
+
+**Tech Stack:** SST v4 (Pulumi), TypeScript, Node.js 24, AWS ApiGatewayV2 + Lambda + Cognito Hosted-UI + AgentCore Gateway. Tests: Vitest.
+
+**Design spec:** `docs/superpowers/specs/2026-07-15-oauth2-mcp-browser-login-design.md` (read it first).
+
+**Working directory:** all paths are relative to the repo root `/Users/mengxinz/git/mem9-on-aws/.worktrees/feat/oauth2-mcp-login`. Run infra commands from `infra/` unless stated. Use Node 24 (`nvm use 24`).
+
+**Reference source to lift (fetch fresh at implementation time):**
+```bash
+for f in handler.ts config.ts state.ts handler.test.ts config.test.ts state.test.ts; do
+  gh api "repos/zxkane/llm-wiki/contents/infra/src/oauth-facade/$f?ref=main" --jq '.content' | base64 -d > "/tmp/llmw-$f"
+done
+```
+These are the proven façade. Copy them, then apply the adaptations each task lists (SSM prefix `/mem9-on-aws/${stage}`, scope `mem9-mcp/read`, resource-server id `mem9-mcp`, `.js` import extensions). Routing/HMAC logic is UNCHANGED.
+
+---
+
+## File Structure
+
+- **Create** `infra/src/oauth-facade/state.ts` — HMAC-SHA-256 sign/verify of the opaque state blob (no AWS deps).
+- **Create** `infra/src/oauth-facade/config.ts` — `loadConfig()`: env + SSM (injected `SsmLike`) config loader.
+- **Create** `infra/src/oauth-facade/handler.ts` — the pure `route(event, cfg)` router + Lambda `handler`.
+- **Create** `infra/src/oauth-facade/{state,config,handler}.test.ts` — lifted unit tests (run under the ROOT vitest, like `docker/**`).
+- **Create** `infra/oauth-facade.ts` — SST factory `oauthFacade(cognitoOut)`: ApiGatewayV2 + reader client + façade Function + HMAC Secret + SSM exports; returns `{ readerClientId, facadeUrl, ssmPrefix }`.
+- **Create** `infra/oauth-facade.test.ts` — infra unit test (mock-the-globals).
+- **Create** `scripts/run-oauth-facade-smoke.sh` — CI smoke check of the façade metadata endpoints.
+- **Modify** `infra/cognito.ts` — add Hosted-UI pool config + export extra endpoint URLs. M2M client unchanged.
+- **Modify** `infra/cognito.test.ts` — assert the new pool config; M2M unchanged.
+- **Modify** `infra/gateway.ts` — `gateway()` gains a `readerClientId` param; `allowedClients` = `[m2m, reader]`.
+- **Modify** `infra/gateway.test.ts` — assert both client ids in `allowedClients`.
+- **Modify** `sst.config.ts` — wire `oauthFacade(cognitoOut)` → feed `readerClientId` to `gateway(...)`. Fix stale header comment.
+- **Modify** `infra/sst-types.d.ts` — add `sst.aws.ApiGatewayV2`, `sst.Secret`, `aws.cognito.*`, `aws.getRegionOutput`, and widen `sst.aws.Function` (architecture/memory/environment).
+- **Modify** `infra/cloudformation/github-actions-role.yaml` — add the deploy-role grants (ApiGatewayV2, lambda:AddPermission, cognito-idp reader-client, `/sst/*` SSM).
+- **Modify** `.github/workflows/infra-ci.yml` — add the façade smoke step after the E2E in preview + prod.
+- **Modify** `docs/ARCHITECTURE.md` — note the OAuth façade as an inbound-auth option.
+
+---
+
+## Task 1: Vendor the façade `state.ts` + its test (HMAC state, no AWS)
+
+**Files:**
+- Create: `infra/src/oauth-facade/state.ts`
+- Test: `infra/src/oauth-facade/state.test.ts`
+
+- [ ] **Step 1: Fetch + copy the reference files**
+
+```bash
+gh api "repos/zxkane/llm-wiki/contents/infra/src/oauth-facade/state.ts?ref=main" --jq '.content' | base64 -d > infra/src/oauth-facade/state.ts
+gh api "repos/zxkane/llm-wiki/contents/infra/src/oauth-facade/state.test.ts?ref=main" --jq '.content' | base64 -d > infra/src/oauth-facade/state.test.ts
+```
+
+- [ ] **Step 2: Adapt the header comment only**
+
+`state.ts` has no AWS deps and no mem9-specific values — it's HMAC over `{cs, r, ts}`. Change ONLY the doc-comment line that says "wiki MCP gateway" → "mem9 MCP surface". The `import { createHmac, timingSafeEqual } from "node:crypto"`, `signState`, `verifyState`, `STATE_TTL_MS = 10*60*1000`, b64url helpers, and future-date reject stay verbatim. Verify the test imports `./state.js` (ESM extension) — keep it.
+
+- [ ] **Step 3: Run the test (should pass — pure logic, no adaptation needed)**
+
+Run (from repo root, Node 24):
+```bash
+./node_modules/.bin/vitest run infra/src/oauth-facade/state.test.ts
+```
+Expected: PASS (all state sign/verify/TTL/tamper cases). If the root vitest config doesn't glob `infra/src/**`, note it — Task 12 confirms the root config includes `infra/src/**/*.test.ts`. If it fails to collect, run it explicitly as above (the file path override works regardless of glob).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add infra/src/oauth-facade/state.ts infra/src/oauth-facade/state.test.ts
+git commit -m "feat(oauth): vendor HMAC state util from llm-wiki façade"
+```
+
+---
+
+## Task 2: Vendor the façade `config.ts` + its test (env + SSM loader)
+
+**Files:**
+- Create: `infra/src/oauth-facade/config.ts`
+- Test: `infra/src/oauth-facade/config.test.ts`
+
+- [ ] **Step 1: Copy the reference files**
+
+```bash
+gh api "repos/zxkane/llm-wiki/contents/infra/src/oauth-facade/config.ts?ref=main" --jq '.content' | base64 -d > infra/src/oauth-facade/config.ts
+gh api "repos/zxkane/llm-wiki/contents/infra/src/oauth-facade/config.test.ts?ref=main" --jq '.content' | base64 -d > infra/src/oauth-facade/config.test.ts
+```
+
+- [ ] **Step 2: Confirm no mem9 adaptation needed in `config.ts`**
+
+`config.ts` is generic: `loadConfig({ssm, env})` reads env keys (`SSM_PREFIX`, `COGNITO_ISSUER`, `COGNITO_AUTHORIZE_ENDPOINT`, `COGNITO_TOKEN_ENDPOINT`, `COGNITO_USERINFO_ENDPOINT`, `COGNITO_REVOCATION_ENDPOINT`, `COGNITO_JWKS_URI`, `RESOURCE_SCOPES`, `OAUTH_STATE_HMAC_KEY`) and reads 3 SSM params (`${prefix}/gateway/url`, `${prefix}/cognito/reader/client-id`, `${prefix}/cognito/reader/client-secret`). None of these are wiki-specific — the values are supplied by `infra/oauth-facade.ts` (Task 6). Change ONLY the doc comment "wiki MCP gateway" → "mem9 MCP surface". Keep the `@aws-sdk/client-ssm` import and the injected `SsmLike` interface.
+
+- [ ] **Step 3: Add the `@aws-sdk/client-ssm` dep to infra**
+
+```bash
+cd infra && corepack pnpm add @aws-sdk/client-ssm && cd ..
+```
+Expected: adds to `infra/package.json` dependencies + lockfile. (llm-wiki's façade uses it; our infra didn't yet.)
+
+- [ ] **Step 4: Run the test**
+
+```bash
+./node_modules/.bin/vitest run infra/src/oauth-facade/config.test.ts
+```
+Expected: PASS (env+SSM loader with injected mock SSM; missing-env throws; missing-SSM throws).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add infra/src/oauth-facade/config.ts infra/src/oauth-facade/config.test.ts infra/package.json infra/pnpm-lock.yaml
+git commit -m "feat(oauth): vendor façade config loader (env + SSM) from llm-wiki"
+```
+
+---
+
+## Task 3: Vendor the façade `handler.ts` + its test (the router)
+
+**Files:**
+- Create: `infra/src/oauth-facade/handler.ts`
+- Test: `infra/src/oauth-facade/handler.test.ts`
+
+- [ ] **Step 1: Copy the reference files**
+
+```bash
+gh api "repos/zxkane/llm-wiki/contents/infra/src/oauth-facade/handler.ts?ref=main" --jq '.content' | base64 -d > infra/src/oauth-facade/handler.ts
+gh api "repos/zxkane/llm-wiki/contents/infra/src/oauth-facade/handler.test.ts?ref=main" --jq '.content' | base64 -d > infra/src/oauth-facade/handler.test.ts
+```
+
+- [ ] **Step 2: Adapt ONLY the doc comment**
+
+`handler.ts` is config-driven: every mem9-vs-wiki difference (scopes, issuer, endpoints, gateway URL) comes from the injected `cfg` (Task 2's config), NOT hardcoded. The router logic — metadata endpoints, `/register` DCR (returns `cfg.userClientId`/`cfg.userClientSecret` with `client_secret_expires_at: 0`), `/oauth/authorize` (loopback validation + PKCE-S256 enforcement + HMAC state), `/oauth/callback`, `/oauth/token`, `/oauth/logout`, catch-all proxy to `cfg.upstream` + `WWW-Authenticate` rewrite — stays VERBATIM. Change ONLY the doc comment "wiki MCP gateway" → "mem9 MCP surface". Keep imports `./config.js`, `./state.js`.
+
+- [ ] **Step 3: Run the test**
+
+```bash
+./node_modules/.bin/vitest run infra/src/oauth-facade/handler.test.ts
+```
+Expected: PASS (metadata shapes, PKCE-S256 reject missing/`plain`, loopback-only redirect at authorize/callback/token, HMAC round-trip, DCR fields, token redirect rewrite, catch-all proxy). The handler tests inject `cfg` + fake `fetch`, so they need no AWS/network.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add infra/src/oauth-facade/handler.ts infra/src/oauth-facade/handler.test.ts
+git commit -m "feat(oauth): vendor façade router (metadata/DCR/authorize/callback/token/proxy)"
+```
+
+---
+
+## Task 4: Extend `infra/cognito.ts` — Hosted-UI pool config + endpoint exports
+
+**Files:**
+- Modify: `infra/cognito.ts`
+- Test: `infra/cognito.test.ts`
+
+- [ ] **Step 1: Write the failing test additions**
+
+Add to `infra/cognito.test.ts` (inside the existing `describe`, mirroring its `installGlobals`/`loadCognito` harness):
+
+```typescript
+it("configures the pool for Hosted-UI (email schema + no forced re-verify)", async () => {
+  installGlobals("prod");
+  const cognito = await loadCognito();
+  cognito();
+  const pool = pools[0].args as {
+    schema?: { name: string; mutable: boolean; required: boolean }[];
+    userAttributeUpdateSettings?: { attributesRequireVerificationBeforeUpdate: string[] };
+    autoVerifiedAttributes?: string[];
+  };
+  expect(pool.schema?.some((s) => s.name === "email" && s.mutable === true && s.required === false)).toBe(true);
+  expect(pool.userAttributeUpdateSettings?.attributesRequireVerificationBeforeUpdate).toEqual([]);
+  expect(pool.autoVerifiedAttributes).toEqual([]);
+});
+
+it("exports the Hosted-UI endpoint URLs the façade needs", async () => {
+  installGlobals("prod");
+  const cognito = await loadCognito();
+  const out = cognito();
+  expect(out.authorizeEndpoint).toBeDefined();
+  expect(out.userInfoEndpoint).toBeDefined();
+  expect(out.revocationEndpoint).toBeDefined();
+  expect(out.jwksUri).toBeDefined();
+});
+```
+
+If the test harness has no `pools` capture array, add one: in the mocked `aws.cognito.UserPool` constructor push `{ args }` to a module-scope `let pools: {args:unknown}[]` reset in `beforeEach`, exactly like the existing capture for other resources in that file. (Read the file first; match its existing capture style — it already mocks `aws.cognito.UserPool`.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+cd infra && ./node_modules/.bin/vitest run cognito.test.ts && cd ..
+```
+Expected: FAIL — `pool.schema` undefined / `out.authorizeEndpoint` undefined.
+
+- [ ] **Step 3: Implement in `infra/cognito.ts`**
+
+In the `new awsAny.cognito.UserPool("Mem9McpPool", {...})` call, add the Hosted-UI fields alongside `name`/`tags`:
+
+```typescript
+const pool = new awsAny.cognito.UserPool(
+  "Mem9McpPool",
+  {
+    name: `${stage}-mem9-mcp`,
+    // Hosted-UI enablers (exact minimal set from llm-wiki). Without these an
+    // admin-created user can land unverified / FORCE_CHANGE_PASSWORD and break login.
+    schema: [{ name: "email", attributeDataType: "String", mutable: true, required: false }],
+    userAttributeUpdateSettings: { attributesRequireVerificationBeforeUpdate: [] },
+    autoVerifiedAttributes: [],
+    tags,
+  },
+  { deleteBeforeReplace: nonProd },
+);
+```
+
+Then add the extra endpoint URLs (near the existing `issuer`/`tokenEndpoint` `$interpolate`s):
+
+```typescript
+const authorizeEndpoint = $interpolate`https://${domain.domain}.auth.${region}.amazoncognito.com/oauth2/authorize`;
+const userInfoEndpoint = $interpolate`https://${domain.domain}.auth.${region}.amazoncognito.com/oauth2/userInfo`;
+const revocationEndpoint = $interpolate`https://${domain.domain}.auth.${region}.amazoncognito.com/oauth2/revoke`;
+const jwksUri = $interpolate`https://cognito-idp.${region}.amazonaws.com/${pool.id}/.well-known/jwks.json`;
+```
+
+Add these four to the `CognitoOutputs` interface (all `Output<string>`) and to the returned object. Do NOT touch the M2M client.
+
+- [ ] **Step 4: Run to verify it passes**
+
+```bash
+cd infra && ./node_modules/.bin/vitest run cognito.test.ts && cd ..
+```
+Expected: PASS (all cognito tests, old + 2 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add infra/cognito.ts infra/cognito.test.ts
+git commit -m "feat(oauth): configure Cognito pool for Hosted-UI + export endpoint URLs"
+```
+
+---
+
+## Task 5: Extend the `sst-types.d.ts` stub for the new SST/AWS surface
+
+**Files:**
+- Modify: `infra/sst-types.d.ts`
+
+This task has no test of its own; it's the type surface Tasks 6/8 need. Verified by `tsc` in later tasks.
+
+- [ ] **Step 1: Add `aws.getRegionOutput` + `aws.cognito.*` to the `aws` namespace**
+
+Inside `declare namespace aws { ... }`, add:
+
+```typescript
+interface GetRegionResult { readonly name: Output<string>; }
+function getRegionOutput(): GetRegionResult;
+
+namespace cognito {
+  interface UserPoolArgs {
+    name?: Input<string>;
+    schema?: { name: string; attributeDataType: string; mutable?: boolean; required?: boolean }[];
+    userAttributeUpdateSettings?: { attributesRequireVerificationBeforeUpdate: string[] };
+    autoVerifiedAttributes?: string[];
+    tags?: Record<string, Input<string>>;
+    [k: string]: unknown;
+  }
+  class UserPool { constructor(name: string, args: UserPoolArgs, opts?: unknown); readonly id: Output<string>; }
+  class UserPoolDomain { constructor(name: string, args: Record<string, unknown>, opts?: unknown); readonly domain: Output<string>; }
+  class ResourceServer { constructor(name: string, args: Record<string, unknown>); readonly identifier: Output<string>; }
+  interface UserPoolClientArgs {
+    name?: Input<string>;
+    userPoolId: Input<string>;
+    generateSecret?: Input<boolean>;
+    explicitAuthFlows?: Input<string>[];
+    allowedOauthFlows?: Input<string>[];
+    allowedOauthScopes?: Input<Input<string>[]>;
+    allowedOauthFlowsUserPoolClient?: Input<boolean>;
+    callbackUrls?: Input<Input<string>[]>;
+    logoutUrls?: Input<Input<string>[]>;
+    supportedIdentityProviders?: Input<string>[];
+    preventUserExistenceErrors?: Input<string>;
+    enableTokenRevocation?: Input<boolean>;
+    [k: string]: unknown;
+  }
+  class UserPoolClient { constructor(name: string, args: UserPoolClientArgs, opts?: unknown); readonly id: Output<string>; readonly clientSecret: Output<string>; }
+}
+```
+
+If `cognito` is already partially declared elsewhere in the file, MERGE into it rather than redeclaring (read the file first — the current stub may not have a `cognito` namespace since `cognito.ts` uses `awsAny` casts; if absent, add it as above).
+
+- [ ] **Step 2: Widen `sst.aws.Function` + add `sst.aws.ApiGatewayV2` + `sst.Secret`**
+
+In `declare namespace sst { namespace aws { ... } }`, extend `FunctionArgs`:
+
+```typescript
+interface FunctionArgs {
+  handler: Input<string>;
+  runtime?: Input<string>;
+  architecture?: Input<"x86_64" | "arm64">;
+  timeout?: Input<string>;
+  memory?: Input<string>;
+  vpc?: FunctionVpc;
+  environment?: Input<Record<string, Input<string>>>;
+  permissions?: { actions: string[]; resources: Input<string>[] }[];
+  link?: unknown[];
+}
+```
+
+Add the ApiGatewayV2 component:
+
+```typescript
+interface ApiGatewayV2Cors {
+  allowOrigins?: Input<string>[];
+  allowMethods?: Input<string>[];
+  allowHeaders?: Input<string>[];
+  maxAge?: Input<string>;
+}
+interface ApiGatewayV2Args { cors?: ApiGatewayV2Cors; }
+class ApiGatewayV2 {
+  constructor(name: string, args?: ApiGatewayV2Args);
+  readonly url: Output<string>;
+  route(route: string, handler: Input<string>, args?: unknown): void;
+}
+```
+
+And in `declare namespace sst { ... }` (top level, sibling of `aws`), add the Secret:
+
+```typescript
+class Secret {
+  constructor(name: string, defaultValue?: string);
+  readonly value: Output<string>;
+}
+```
+
+- [ ] **Step 3: Verify tsc still passes (no consumer yet, just no syntax errors)**
+
+```bash
+cd infra && ./node_modules/.bin/tsc --noEmit && cd ..
+```
+Expected: PASS (clean — the additions are declarations only).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add infra/sst-types.d.ts
+git commit -m "chore(oauth): extend sst-types stub for ApiGatewayV2, Secret, cognito, getRegion"
+```
+
+---
+
+## Task 6: Create `infra/oauth-facade.ts` — the SST factory
+
+**Files:**
+- Create: `infra/oauth-facade.ts`
+- Test: `infra/oauth-facade.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `infra/oauth-facade.test.ts` (mirror `infra/gateway.test.ts`'s harness — read it for the exact `installGlobals`/capture-arrays/`loadX` pattern; reuse its mocks for `sst.aws.Function`, `aws.cognito.UserPoolClient`, `aws.ssm.Parameter`, and add mocks for `sst.aws.ApiGatewayV2` + `sst.Secret`). Key assertions:
+
+```typescript
+it("creates an ApiGatewayV2 with MCP-scoped CORS (not *)", async () => {
+  installGlobals("prod");
+  const { oauthFacade } = await loadFacade();
+  oauthFacade(fakeCognitoOut());
+  const api = apis[0].args as { cors?: { allowHeaders?: string[] } };
+  expect(api.cors?.allowHeaders).toContain("MCP-Protocol-Version");
+  expect(api.cors?.allowHeaders).toContain("Authorization");
+});
+
+it("creates a reader client (code flow, loopback callback)", async () => {
+  installGlobals("prod");
+  const { oauthFacade } = await loadFacade();
+  oauthFacade(fakeCognitoOut());
+  const reader = clients.find((c) => (c.args.name as string)?.includes("reader"));
+  expect(reader?.args.allowedOauthFlows).toEqual(["code"]);
+  expect(String((reader?.args.callbackUrls as unknown[])?.[0])).toContain("/oauth/callback");
+});
+
+it("creates the façade Function: nodejs24.x, arm64, NOT vpc-attached, SSM read scoped to the stage", async () => {
+  installGlobals("prod");
+  const { oauthFacade } = await loadFacade();
+  oauthFacade(fakeCognitoOut());
+  const fn = fns.find((f) => (f.args.handler as string)?.includes("oauth-facade/handler"));
+  expect(fn?.args.runtime).toBe("nodejs24.x");
+  expect(fn?.args.architecture).toBe("arm64");
+  expect(fn?.args.vpc).toBeUndefined();
+  const perms = fn?.args.permissions as { actions: string[]; resources: string[] }[];
+  const ssmPerm = perms.find((p) => p.actions.some((a) => a.startsWith("ssm:GetParameter")));
+  expect(ssmPerm?.resources.some((r) => String(r).includes("/mem9-on-aws/") && String(r).includes("prod"))).toBe(true);
+});
+
+it("creates the HMAC secret and returns the reader client id", async () => {
+  installGlobals("prod");
+  const { oauthFacade } = await loadFacade();
+  const out = oauthFacade(fakeCognitoOut());
+  expect(secrets.some((s) => s.name === "OauthStateHmacKey")).toBe(true);
+  expect(out.readerClientId).toBeDefined();
+  expect(out.facadeUrl).toBeDefined();
+});
+
+it("exports reader client id/secret + facade url via SSM (secret is SecureString)", async () => {
+  installGlobals("prod");
+  const { oauthFacade } = await loadFacade();
+  oauthFacade(fakeCognitoOut());
+  const names = params.map((p) => p.args.name as string);
+  expect(names).toContain("/mem9-on-aws/prod/cognito/reader/client-id");
+  const secretParam = params.find((p) => (p.args.name as string) === "/mem9-on-aws/prod/cognito/reader/client-secret");
+  expect(secretParam?.args.type).toBe("SecureString");
+  expect(names).toContain("/mem9-on-aws/prod/facade/mcp-endpoint");
+});
+```
+
+`fakeCognitoOut()` returns an object with `ssmPrefix`, `issuer`, `tokenEndpoint`, `authorizeEndpoint`, `userInfoEndpoint`, `revocationEndpoint`, `jwksUri`, `resourceServerId: "mem9-mcp"` as `out()`-wrapped values (mirror `fakeDbOut()` in ecs.test.ts).
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+cd infra && ./node_modules/.bin/vitest run oauth-facade.test.ts && cd ..
+```
+Expected: FAIL — `Cannot find module './oauth-facade'`.
+
+- [ ] **Step 3: Implement `infra/oauth-facade.ts`**
+
+```typescript
+/**
+ * `oauth-facade` stack — OAuth2 browser-login façade for the MCP surface (§6).
+ *
+ * An ApiGatewayV2-fronted Lambda (lifted from llm-wiki's oauth-facade) that
+ * bridges the MCP client's authorization-code + PKCE + DCR flow to Cognito
+ * Hosted-UI, and reverse-proxies /mcp to the AgentCore Gateway. Sits IN FRONT of
+ * the gateway; the Lambda-proxy target chain is untouched. Adds a `code`-flow
+ * reader client (the M2M client stays); gateway.ts trusts both.
+ *
+ * Cycle break: create the ApiGatewayV2 FIRST (its url is independent of the
+ * Lambda) → reader client callbackUrls ← facadeApi.url → façade Lambda + routes.
+ * The Lambda reads gateway/url + reader creds from SSM at RUNTIME, so it takes
+ * neither the gateway nor the reader client as a constructor input — hence
+ * oauthFacade(cognitoOut) takes ONLY cognitoOut and RETURNS readerClientId for
+ * gateway() to consume.
+ */
+import type { CognitoOutputs } from "./cognito";
+
+// @ts-ignore - `aws`/`sst` injected globally by SST.
+const awsAny = aws as unknown as Record<string, any>;
+
+const RESOURCE_SERVER_ID = "mem9-mcp";
+const SCOPE_READ = "read";
+
+export interface OauthFacadeOutputs {
+  ssmPrefix: string;
+  readerClientId: Output<string>;
+  facadeUrl: Output<string>;
+}
+
+export function oauthFacade(cognitoOut: CognitoOutputs): OauthFacadeOutputs {
+  const prefix = `/mem9-on-aws/${$app.stage}`;
+  const stage = $app.stage;
+  const tags = { Project: "mem9-on-aws", Stage: stage, ManagedBy: "sst" };
+  const region = awsAny.getRegionOutput().name;
+  const accountId = awsAny.getCallerIdentityOutput().accountId;
+
+  // --- Façade HTTP API (created FIRST — cycle break) ---
+  const facadeApi = new sst.aws.ApiGatewayV2("Mem9OauthFacadeApi", {
+    cors: {
+      allowOrigins: ["*"],
+      allowMethods: ["*"],
+      allowHeaders: ["Authorization", "Content-Type", "Accept", "MCP-Protocol-Version"],
+      maxAge: "1 day",
+    },
+  });
+
+  // --- Reader client (authorization_code + Hosted UI; callback = the façade) ---
+  const readerClient = new awsAny.cognito.UserPoolClient(
+    "Mem9McpReaderClient",
+    {
+      name: `${stage}-mem9-mcp-reader`,
+      userPoolId: cognitoOut.userPoolId,
+      generateSecret: true,
+      explicitAuthFlows: ["ALLOW_REFRESH_TOKEN_AUTH"],
+      supportedIdentityProviders: ["COGNITO"],
+      callbackUrls: [$interpolate`${facadeApi.url}/oauth/callback`],
+      logoutUrls: [$interpolate`${facadeApi.url}/oauth/logout`],
+      allowedOauthFlows: ["code"],
+      allowedOauthScopes: [`openid`, `email`, `${RESOURCE_SERVER_ID}/${SCOPE_READ}`],
+      allowedOauthFlowsUserPoolClient: true,
+      preventUserExistenceErrors: "ENABLED",
+      enableTokenRevocation: true,
+    },
+  );
+
+  // --- HMAC state key (empty default → façade 503 until seeded per stage) ---
+  const hmacKey = new sst.Secret("OauthStateHmacKey", "");
+
+  // --- Façade Lambda (NOT VPC-attached; only reaches Cognito + the public gateway) ---
+  const facadeFn = new sst.aws.Function("Mem9OauthFacadeFn", {
+    handler: "infra/src/oauth-facade/handler.handler",
+    runtime: "nodejs24.x",
+    architecture: "arm64",
+    timeout: "30 seconds",
+    memory: "256 MB",
+    environment: {
+      SSM_PREFIX: prefix,
+      COGNITO_ISSUER: cognitoOut.issuer,
+      COGNITO_AUTHORIZE_ENDPOINT: cognitoOut.authorizeEndpoint,
+      COGNITO_TOKEN_ENDPOINT: cognitoOut.tokenEndpoint,
+      COGNITO_USERINFO_ENDPOINT: cognitoOut.userInfoEndpoint,
+      COGNITO_REVOCATION_ENDPOINT: cognitoOut.revocationEndpoint,
+      COGNITO_JWKS_URI: cognitoOut.jwksUri,
+      RESOURCE_SCOPES: `${RESOURCE_SERVER_ID}/${SCOPE_READ}`,
+      OAUTH_STATE_HMAC_KEY: hmacKey.value,
+    },
+    permissions: [
+      {
+        actions: ["ssm:GetParameter", "ssm:GetParameters", "ssm:GetParametersByPath"],
+        resources: [$interpolate`arn:aws:ssm:${region}:${accountId}:parameter${prefix}/*`],
+      },
+    ],
+  });
+
+  // Route ALL paths to the façade (OAuth + /.well-known + /register + /mcp proxy).
+  facadeApi.route("ANY /{proxy+}", facadeFn.arn);
+  facadeApi.route("ANY /", facadeFn.arn);
+
+  // --- SSM exports (the façade reads reader creds + gateway/url at runtime) ---
+  const param = (res: string, suffix: string, value: Input<string>, secure = false): void => {
+    new awsAny.ssm.Parameter(res, { name: `${prefix}/${suffix}`, type: secure ? "SecureString" : "String", value, tags });
+  };
+  param("SsmReaderClientId", "cognito/reader/client-id", readerClient.id);
+  param("SsmReaderClientSecret", "cognito/reader/client-secret", readerClient.clientSecret, true);
+  param("SsmFacadeUrl", "facade/url", facadeApi.url);
+  param("SsmFacadeMcpEndpoint", "facade/mcp-endpoint", $interpolate`${facadeApi.url}/mcp`);
+
+  return { ssmPrefix: prefix, readerClientId: readerClient.id, facadeUrl: facadeApi.url };
+}
+```
+
+- [ ] **Step 4: Run to verify it passes + tsc clean**
+
+```bash
+cd infra && ./node_modules/.bin/vitest run oauth-facade.test.ts && ./node_modules/.bin/tsc --noEmit && cd ..
+```
+Expected: PASS (all 5 façade tests) + tsc clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add infra/oauth-facade.ts infra/oauth-facade.test.ts
+git commit -m "feat(oauth): SST factory — ApiGatewayV2 + reader client + façade Lambda + SSM"
+```
+
+---
+
+## Task 7: Wire the reader client into the gateway's `allowedClients`
+
+**Files:**
+- Modify: `infra/gateway.ts`
+- Test: `infra/gateway.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+In `infra/gateway.test.ts`, update the call site to pass a reader id and add an assertion. Find the existing `gateway(cognitoOut, ecsOut, bootstrapOut)` calls in the test and change the signature to `gateway(cognitoOut, ecsOut, bootstrapOut, out("reader-client-id"))`. Add:
+
+```typescript
+it("trusts BOTH the M2M and the reader client in allowedClients", async () => {
+  installGlobals("prod");
+  const gw = await loadGateway();
+  gw(fakeCognitoOut(), fakeEcsOut(), fakeBootstrapOut(), out("reader-client-id"));
+  const g = gateways[0].args as { authorizerConfiguration: { customJwtAuthorizer: { allowedClients: unknown[] } } };
+  const allowed = g.authorizerConfiguration.customJwtAuthorizer.allowedClients.map((v) => String((v as { value?: unknown })?.value ?? v));
+  expect(allowed).toContain("m2m-client-id"); // whatever fakeCognitoOut's clientId resolves to
+  expect(allowed).toContain("reader-client-id");
+});
+```
+
+Adjust `"m2m-client-id"` to match what `fakeCognitoOut().clientId` is set to in the harness (read the file). If the harness's `fakeCognitoOut` returns `clientId: out("m2m-client-id")`, this matches.
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+cd infra && ./node_modules/.bin/vitest run gateway.test.ts && cd ..
+```
+Expected: FAIL — signature mismatch (4th arg) / `reader-client-id` not in allowedClients.
+
+- [ ] **Step 3: Implement in `infra/gateway.ts`**
+
+Change the `gateway` signature and `allowedClients`:
+
+```typescript
+export function gateway(
+  cognitoOut: CognitoOutputs,
+  ecsOut: EcsOutputs,
+  bootstrapOut: BootstrapOutputs,
+  readerClientId: Output<string>,
+): GatewayOutputs {
+```
+
+In the `authorizerConfiguration.customJwtAuthorizer`, change:
+
+```typescript
+allowedClients: cognitoOut.allowedClientIds,
+```
+to:
+```typescript
+// Trust BOTH the M2M client (CI/headless) AND the browser-login reader client.
+allowedClients: [...cognitoOut.allowedClientIds, readerClientId],
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+```bash
+cd infra && ./node_modules/.bin/vitest run gateway.test.ts && cd ..
+```
+Expected: PASS (old gateway tests + the new one).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add infra/gateway.ts infra/gateway.test.ts
+git commit -m "feat(oauth): gateway trusts the reader client alongside M2M (allowedClients)"
+```
+
+---
+
+## Task 8: Wire `oauthFacade` into `sst.config.ts`
+
+**Files:**
+- Modify: `sst.config.ts`
+
+No unit test (the wiring is validated by tsc + the deploy). This task changes `run()` ordering.
+
+- [ ] **Step 1: Update the `run()` wiring**
+
+Replace the current cognito/gateway block:
+
+```typescript
+    const { cognito } = await import("./infra/cognito");
+    const cognitoOut = cognito();
+    const { gateway } = await import("./infra/gateway");
+    gateway(cognitoOut, ecsOut, bootstrapOut);
+```
+with:
+
+```typescript
+    const { cognito } = await import("./infra/cognito");
+    const cognitoOut = cognito();
+    // OAuth2 browser-login façade (§6): ApiGatewayV2 + reader client + façade
+    // Lambda. Built BEFORE gateway() because it produces the reader client id the
+    // gateway must trust. The façade reads gateway/url from SSM at RUNTIME, so it
+    // takes only cognitoOut (no gateway dep) — keeping the graph acyclic.
+    const { oauthFacade } = await import("./infra/oauth-facade");
+    const facadeOut = oauthFacade(cognitoOut);
+    const { gateway } = await import("./infra/gateway");
+    gateway(cognitoOut, ecsOut, bootstrapOut, facadeOut.readerClientId);
+```
+
+- [ ] **Step 2: Fix the stale header comment**
+
+The file's top doc-comment (lines ~8-9, ~17-22) still describes "ACM cert → internal ALB" and "the AgentCore interceptor Lambda". Update the `run()` summary line to: `... → the MCP surface (Cognito M2M + OAuth2 façade → AgentCore Gateway → Lambda-proxy target)`. In the "TWO STANDING RULES" block, keep rule 1 (nodejs24.x) and reword rule 2 to: `NO Lambda Function URL — the OAuth façade is fronted by ApiGatewayV2, the MCP proxy Lambda by the AgentCore Gateway.` (Match the current Lambda-proxy reality.)
+
+- [ ] **Step 3: Verify tsc clean**
+
+```bash
+cd infra && ./node_modules/.bin/tsc --noEmit && cd ..
+```
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add sst.config.ts
+git commit -m "feat(oauth): wire oauthFacade into run() before gateway; fix stale header"
+```
+
+---
+
+## Task 9: Full local verification (all infra + root tests)
+
+**Files:** none (verification gate).
+
+- [ ] **Step 1: Run the full suite**
+
+```bash
+export NVM_DIR="$HOME/.nvm"; . "$NVM_DIR/nvm.sh"; nvm use 24
+cd infra && ./node_modules/.bin/tsc --noEmit && ./node_modules/.bin/vitest run && cd ..
+./node_modules/.bin/vitest run --passWithNoTests
+```
+Expected: infra tsc clean; ALL infra tests pass (existing + oauth-facade + cognito + gateway additions); root tests pass (llm-proxy + the new `infra/src/oauth-facade/*.test.ts` if the root config globs them — if not, they ran under the infra vitest in Tasks 1-3; confirm at least one runner collects them).
+
+- [ ] **Step 2: Confirm the façade unit tests are collected by SOME runner**
+
+```bash
+./node_modules/.bin/vitest run infra/src/oauth-facade/ 2>&1 | tail -8
+```
+Expected: 3 test files (state/config/handler) collected + passing. If neither runner globs `infra/src/**`, add `infra/src/**/*.test.ts` to the root `vitest.config` `include` (Task 12 does this if needed) — but a direct path run must pass regardless.
+
+- [ ] **Step 3: Commit (only if a config tweak was needed; else skip)**
+
+```bash
+git add -A && git commit -m "test(oauth): ensure façade unit tests are collected" || echo "nothing to commit"
+```
+
+---
+
+## Task 10: Deploy-role IAM — add the new grants
+
+**Files:**
+- Modify: `infra/cloudformation/github-actions-role.yaml`
+
+- [ ] **Step 1: Read the current template + find the policy split**
+
+```bash
+grep -nE 'PolicyName|Sid|apigateway|cognito-idp|AddPermission|/sst/' infra/cloudformation/github-actions-role.yaml | head -40
+```
+Identify which managed policy holds the Lambda + Cognito grants (from #10). Note the 6144-byte-per-policy limit — if adding pushes a policy over, create a new `${GitHubRepo}-oauth` managed policy and append it to `GitHubActionsRole.ManagedPolicyArns`.
+
+- [ ] **Step 2: Add the grants**
+
+Add these statements (into the existing gateway/compute policy, or a new `OauthFacadePolicy`):
+
+```yaml
+- Sid: ApiGatewayV2
+  Effect: Allow
+  Action:
+    - apigateway:POST
+    - apigateway:GET
+    - apigateway:PATCH
+    - apigateway:PUT
+    - apigateway:DELETE
+    - apigateway:TagResource
+    - apigateway:UpdateRestApiPolicy
+  Resource:
+    - !Sub arn:aws:apigateway:${AWS::Region}::/apis
+    - !Sub arn:aws:apigateway:${AWS::Region}::/apis/*
+    - !Sub arn:aws:apigateway:${AWS::Region}::/tags/*
+- Sid: LambdaResourcePolicyForApi
+  Effect: Allow
+  Action:
+    - lambda:AddPermission
+    - lambda:RemovePermission
+    - lambda:GetPolicy
+  Resource:
+    - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${ProjectName}-*
+- Sid: CognitoReaderClient
+  Effect: Allow
+  Action:
+    - cognito-idp:CreateUserPoolClient
+    - cognito-idp:UpdateUserPoolClient
+    - cognito-idp:DescribeUserPoolClient
+    - cognito-idp:DeleteUserPoolClient
+  Resource: '*'
+- Sid: SstSecretSsm
+  Effect: Allow
+  Action:
+    - ssm:PutParameter
+    - ssm:GetParameter
+    - ssm:GetParameters
+    - ssm:GetParametersByPath
+    - ssm:DeleteParameter
+    - ssm:AddTagsToResource
+  Resource:
+    - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/sst/*
+```
+
+Match the template's existing pseudo-param style (`${ProjectName}`, `${GitHubRepo}` — read the file for the exact names; if it uses literal `mem9-on-aws`, use that). If `cognito-idp:*` on `*` already exists from #10, skip the CognitoReaderClient block.
+
+- [ ] **Step 3: Validate the template**
+
+```bash
+cfn-lint infra/cloudformation/github-actions-role.yaml
+aws cloudformation validate-template --template-body file://infra/cloudformation/github-actions-role.yaml --region us-west-2 >/dev/null && echo VALID
+```
+Expected: cfn-lint clean; VALID.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add infra/cloudformation/github-actions-role.yaml
+git commit -m "chore(oauth): deploy-role grants for ApiGatewayV2 + facade Lambda perms + reader client + sst secret"
+```
+
+- [ ] **Step 5: Redeploy the role OUT-OF-BAND (before the PR deploys)**
+
+```bash
+AWS_PROFILE=kane-global-mengxinz bash scripts/deploy-github-role.sh
+```
+Expected: stack update succeeds (new resource types now grantable). This MUST run before the PR's preview deploy, or the first ApiGatewayV2/reader-client/secret create 403s.
+
+---
+
+## Task 11: CI façade smoke check
+
+**Files:**
+- Create: `scripts/run-oauth-facade-smoke.sh`
+- Modify: `.github/workflows/infra-ci.yml`
+
+- [ ] **Step 1: Write the smoke script**
+
+Create `scripts/run-oauth-facade-smoke.sh`:
+
+```bash
+#!/usr/bin/env bash
+# run-oauth-facade-smoke.sh — verify the OAuth façade metadata endpoints are live.
+# The full browser authorization-code flow can't run headless (needs a human at a
+# browser), so CI validates the RFC 8414/9728 metadata + registration endpoint.
+set -euo pipefail
+STAGE="${STAGE:?STAGE is required}"
+REGION="${AWS_REGION:-ap-northeast-1}"
+PREFIX="/mem9-on-aws/${STAGE}"
+ssm() { aws ssm get-parameter --name "$1" --region "$REGION" --query Parameter.Value --output text; }
+FACADE=$(ssm "${PREFIX}/facade/url")
+echo "run-oauth-facade-smoke: façade=${FACADE}"
+AS=$(curl -fsS "${FACADE}/.well-known/oauth-authorization-server")
+echo "$AS" | jq -e '.authorization_endpoint | endswith("/oauth/authorize")' >/dev/null || { echo "::error::authorization_endpoint not the façade"; exit 1; }
+echo "$AS" | jq -e '.token_endpoint | endswith("/oauth/token")' >/dev/null || { echo "::error::token_endpoint not the façade"; exit 1; }
+echo "$AS" | jq -e '.code_challenge_methods_supported == ["S256"]' >/dev/null || { echo "::error::S256 not advertised"; exit 1; }
+echo "$AS" | jq -e '.registration_endpoint | endswith("/register")' >/dev/null || { echo "::error::no registration_endpoint"; exit 1; }
+PR=$(curl -fsS "${FACADE}/.well-known/oauth-protected-resource")
+echo "$PR" | jq -e '.resource | endswith("/mcp")' >/dev/null || { echo "::error::protected-resource.resource not /mcp"; exit 1; }
+echo "run-oauth-facade-smoke: OK — façade metadata valid for stage ${STAGE}"
+```
+
+```bash
+chmod +x scripts/run-oauth-facade-smoke.sh
+```
+
+- [ ] **Step 2: Add the CI step**
+
+In `.github/workflows/infra-ci.yml`, after each existing `MCP write-search E2E` step (preview job + prod job), add:
+
+```yaml
+      - name: OAuth façade smoke (${STAGE})
+        if: steps.gate.outputs.skip != 'true' && steps.deploy.outputs.stage != ''
+        env:
+          STAGE: ${{ steps.deploy.outputs.stage }}   # or 'prod' in the prod job
+          AWS_REGION: ap-northeast-1
+        run: bash scripts/run-oauth-facade-smoke.sh
+```
+Match the exact `env`/`if` idiom of the neighboring E2E step (read the file — preview uses `steps.deploy.outputs.stage`, prod uses `STAGE: prod`). Place it after the E2E step so it runs on a deployed stage. Note: on a fresh stage the HMAC key is unseeded → the façade returns 503 on `/oauth/authorize` but the metadata endpoints (`.well-known/*`) DON'T require the HMAC key, so the smoke check passes regardless. (The 503 only gates authorize/callback.)
+
+- [ ] **Step 3: Lint the workflow (yaml sanity)**
+
+```bash
+python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/infra-ci.yml')); print('YAML OK')"
+```
+Expected: YAML OK.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/run-oauth-facade-smoke.sh .github/workflows/infra-ci.yml
+git commit -m "test(oauth): CI smoke check for the façade OAuth metadata endpoints"
+```
+
+---
+
+## Task 12: Ensure the façade unit tests are collected + docs
+
+**Files:**
+- Modify (if needed): `infra/vitest.config.ts` or root `vitest.config.*`
+- Modify: `docs/ARCHITECTURE.md`
+
+- [ ] **Step 1: Confirm which vitest globs `infra/src/**`**
+
+```bash
+cat infra/vitest.config.ts; echo "---root---"; cat vitest.config.* 2>/dev/null
+./node_modules/.bin/vitest run infra/src/oauth-facade/ 2>&1 | tail -5
+```
+If the infra vitest already collects `infra/src/**/*.test.ts` (likely — its default glob is `**/*.test.ts` under `infra/`), no change. If NOT, add `"src/**/*.test.ts"` to the infra config `include`.
+
+- [ ] **Step 2: Document the inbound-auth options in ARCHITECTURE.md**
+
+In `docs/ARCHITECTURE.md`, find the "Auth (inbound)" locked-decision row / §6 and append: the surface now supports **two** inbound auth modes — Cognito M2M (`client_credentials`, for CI/headless) **and** OAuth2 authorization-code+PKCE via the façade (browser login, for humans). Note the one-time per-stage setup: seed `OauthStateHmacKey` + `admin-create-user`, then point Claude Code at `/mem9-on-aws/<stage>/facade/mcp-endpoint`. Reference the spec file.
+
+- [ ] **Step 3: Run the full suite once more**
+
+```bash
+cd infra && ./node_modules/.bin/tsc --noEmit && ./node_modules/.bin/vitest run && cd ..
+./node_modules/.bin/vitest run --passWithNoTests
+```
+Expected: all green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "docs(oauth): document the two inbound-auth modes + façade setup"
+```
+
+---
+
+## Task 13: PR, CI, and live verification
+
+**Files:** none (integration gate). Follows the autonomous-dev workflow Steps 7-12.
+
+- [ ] **Step 1: Push + open the PR** (after Task 10's role redeploy is confirmed live)
+
+```bash
+git push -u origin feat/oauth2-mcp-login
+gh pr create --title "feat(mcp): OAuth2 browser login (authorization-code + PKCE façade)" --body "<summary + test plan; Closes the OAuth feature; references the spec>"
+```
+
+- [ ] **Step 2: Watch CI to completion (synchronously)**
+
+```bash
+gh run watch <run-id> --interval 30 --exit-status
+```
+Expected: Typecheck & Unit Tests ✓, Build ✓, Deploy PR Preview ✓ (incl. schema-bootstrap ✓, MCP write-search E2E ✓ — the M2M path unregressed — and the new OAuth façade smoke ✓).
+
+- [ ] **Step 3: Manual browser-login verification on the preview stage**
+
+```bash
+STAGE=pr-N; PREFIX=/mem9-on-aws/$STAGE
+AWS_PROFILE=kane-global-mengxinz aws ssm put-parameter --name /sst/... # OR: pnpm -C infra exec sst secret set OauthStateHmacKey "$(openssl rand -base64 32)" --stage $STAGE
+AWS_PROFILE=kane-global-mengxinz aws cognito-idp admin-create-user --user-pool-id <pool> --username <email> --temporary-password '...' --region ap-northeast-1
+# Point a local Claude Code MCP config at $(aws ssm get-parameter --name $PREFIX/facade/mcp-endpoint ...) → browser login → search_memories.
+```
+Confirm the browser flow completes and `search_memories` works. (This is manual — CI can't do the browser step.)
+
+- [ ] **Step 4: Report status (interactive mode — do NOT auto-merge)**
+
+Summarize: CI green (M2M E2E unregressed + façade smoke), manual browser login verified. Let the operator decide when to merge.
+
+---
+
+## Notes for the implementer
+
+- **Node 24 always** (`nvm use 24`). SST injects `aws`/`sst`/`command`/`random`/`$app`/`$interpolate`/`$transform` as globals — no imports; the `awsAny` cast pattern is how existing files reach un-stubbed AWS namespaces.
+- **The façade source is config-driven** — resist "improving" the lifted `handler.ts`/`state.ts`; the security properties (loopback-only, S256-only, HMAC TTL) are load-bearing and already tested. Only the doc comments change.
+- **The HMAC key reaches the Lambda as an env var** (build-time `.value` link, matching llm-wiki) — this is the accepted tradeoff in the spec; do NOT add a runtime-SSM read for it.
+- **Secret scan before every commit** touching committed files: `grep -niE '[0-9]{12}|arn:aws:[a-z0-9-]+:[a-z0-9-]*:[0-9]{12}|X-API-Key' <files>` (the mock `123456789012` in tests is fine).
+- **macOS hooks**: the pr-review + rebase pre-push hooks need the BSD-date-compensated mark + separate mark/push commands (see the `autonomous-dev-hooks-macos` memory).

--- a/docs/superpowers/specs/2026-07-15-oauth2-mcp-browser-login-design.md
+++ b/docs/superpowers/specs/2026-07-15-oauth2-mcp-browser-login-design.md
@@ -59,9 +59,21 @@ The façade routes:
   only the reader client's allowed scopes (`openid`, `email`, `mem9-mcp/read`;
   `write` is defined on the resource server but NOT advertised — advertising a scope
   the reader client doesn't allow makes Cognito's authorize step fail
-  `invalid_scope`).
+  `invalid_scope`). Metadata also advertises `token_endpoint_auth_methods_supported:
+  ["client_secret_basic","client_secret_post"]` and `code_challenge_methods_supported:
+  ["S256"]`.
 - `POST /register` — RFC 7591 DCR: returns the **pre-provisioned reader client**
-  id/secret to every caller.
+  id/secret to every caller, with the exact field set llm-wiki uses:
+  `client_id`, `client_secret`, `client_id_issued_at`, **`client_secret_expires_at: 0`**
+  (never-expires — some MCP clients discard a client without this), `redirect_uris`
+  (echoed), `grant_types:["authorization_code","refresh_token"]`,
+  `response_types:["code"]`, `token_endpoint_auth_method:"client_secret_post"`,
+  `scope`. **Note: this reader `client_secret` is NON-CONFIDENTIAL by design** — it's
+  a shared reader credential handed to every caller; **PKCE (S256) is the real
+  protection**, and the pool has no self-signup. A reviewer must not treat the
+  `/register` response as a secret leak.
+- `GET /oauth/logout` — Cognito Hosted-UI sign-out landing (returns 200
+  `"Signed out."`); the reader client's `logoutUrls` points here.
 - `GET /oauth/authorize` — validate the loopback `redirect_uri` (reject non-loopback
   = closes an open-redirector), **require PKCE `code_challenge` + `code_challenge_method=S256`**
   (reject missing/`plain`/other), wrap the client's `state` + `redirect_uri` into an
@@ -82,13 +94,32 @@ TTL 10 min, `timingSafeEqual` verify.
 ## Components
 
 ### `infra/cognito.ts` (extend — M2M client unchanged)
-- Add Hosted-UI to the existing pool: `email` schema attribute; **self-signup
-  disabled**.
+- Add Hosted-UI support to the existing pool with llm-wiki's **exact** minimal
+  config (these matter — without them an admin-created user can land in an
+  unverified / `FORCE_CHANGE_PASSWORD` state that breaks Hosted-UI login):
+  - `schema: [{ name:"email", attributeDataType:"String", mutable:true, required:false }]`
+  - `userAttributeUpdateSettings: { attributesRequireVerificationBeforeUpdate: [] }`
+  - `autoVerifiedAttributes: []`
+- **Self-signup is achieved OPERATIONALLY, not via a pool flag.** llm-wiki does NOT
+  set `adminCreateUserConfig.allowAdminCreateUserOnly` — public sign-up is simply
+  never used; the operator creates the one user with `admin-create-user`. The
+  `cognito.test.ts` assertion targets the 3 fields above (the real Hosted-UI
+  enablers), NOT a non-existent self-signup toggle.
 - Export the extra Hosted-UI endpoint URLs the façade needs: `authorize`,
-  `userInfo`, `revocation`, `jwks` (token/issuer already exported).
+  `userInfo`, `revocation`, `jwks` (token/issuer already exported). The **existing
+  `Mem9McpDomain` `UserPoolDomain` is Hosted-UI-compatible** — the same domain serves
+  `/oauth2/authorize`/`userInfo`/`revoke`/`.well-known/jwks.json` as it already does
+  `/oauth2/token`. No new/replaced domain.
 - The M2M client (`${stage}-mem9-mcp-client`, `client_credentials`) is **unchanged**.
 
-### `infra/oauth-facade.ts` (new — factory `oauthFacade(cognitoOut, gatewayOut)`)
+### `infra/oauth-facade.ts` (new — factory `oauthFacade(cognitoOut): { readerClientId, facadeUrl, ... }`)
+**Signature note (fixes a cycle the first draft had):** the factory takes ONLY
+`cognitoOut` and **returns** the `readerClientId` (+ façade URL). It does NOT take
+`gatewayOut` — the façade Lambda needs nothing from the gateway at construction (it
+reads `gateway/url` from SSM at runtime). `gateway()` then consumes the returned
+`readerClientId` for `allowedClients`. This keeps the graph acyclic (see
+§"Dependency cycle" — an earlier `oauthFacade(cognitoOut, gatewayOut)` signature was
+unsatisfiable because `gateway()` must run *after* the reader client exists).
 - `sst.aws.ApiGatewayV2` — CORS scoped to MCP transport headers (`Authorization`,
   `Content-Type`, `Accept`, `MCP-Protocol-Version`), NOT `*`. Created **first**
   (cycle break — see below).
@@ -101,11 +132,23 @@ TTL 10 min, `timingSafeEqual` verify.
 - `sst.aws.Function` `Mem9OauthFacadeFn` — handler `infra/src/oauth-facade/handler.handler`,
   nodejs24.x, arm64, 256 MB, 30 s, **NOT VPC-attached** (only reaches Cognito + the
   public gateway URL over the internet). Env: `SSM_PREFIX`, the non-cyclic Cognito
-  endpoint URLs, `RESOURCE_SCOPES`, `OAUTH_STATE_HMAC_KEY`. Permission:
-  `ssm:GetParameter(s)` scoped to `arn:aws:ssm:<region>:<acct>:parameter/mem9-on-aws/${stage}/*`.
+  endpoint URLs, `RESOURCE_SCOPES`, `OAUTH_STATE_HMAC_KEY` (= `oauthStateHmacKey.value`).
+  Permission: `ssm:GetParameter(s)` scoped to
+  `arn:aws:ssm:<region>:<acct>:parameter/mem9-on-aws/${stage}/*`.
+  - **HMAC key delivery (accepted tradeoff, matches llm-wiki):** the HMAC key reaches
+    the handler as `OAUTH_STATE_HMAC_KEY` via the `sst.Secret`'s build-time `.value`
+    link → it lands as a Lambda **env var**, visible to anyone with
+    `lambda:GetFunctionConfiguration`. This is an inherited property of the proven
+    reference, not a new weakness. We KEEP the reference approach (diverging to a
+    runtime SSM read would be untested); the key never enters git (it's an
+    `sst.Secret`), and the façade exec role does NOT need `/sst/*` read because the
+    link is build-time. The 503-until-seeded default makes it fail closed. Documented
+    here so it's a conscious decision, not an oversight.
 - Routes: `ANY /{proxy+}` + `ANY /` → the façade Lambda.
-- `sst.Secret("OauthStateHmacKey")` — empty default → façade returns 503 until seeded
-  once per stage (`sst secret set OauthStateHmacKey "$(openssl rand -base64 32)"`).
+- `sst.Secret("OauthStateHmacKey", "")` — empty default → façade returns 503 until
+  seeded once per stage (`sst secret set OauthStateHmacKey "$(openssl rand -base64 32)"
+  --stage <stage>`). The empty string (not missing) is the intended "proxy disabled"
+  sentinel.
 - SSM exports under `/mem9-on-aws/${stage}/`: `facade/url`, `facade/mcp-endpoint`,
   `cognito/reader/client-id`, `cognito/reader/client-secret` (SecureString).
 
@@ -125,16 +168,41 @@ TTL 10 min, `timingSafeEqual` verify.
   NOT rotate.
 
 ### `sst.config.ts` (wiring)
-- Order: `cognito()` → `oauthFacade` builds its API + reader client → `gateway(...)`
-  reads the reader client id for `allowedClients` → the façade Lambda + routes attach
-  last. (See cycle-break.) Concretely the reader client is produced where
-  `facadeApi.url` is available and its id is threaded into `gateway()`.
+- Order (acyclic): `const cognitoOut = cognito()` → `const { readerClientId, ... } =
+  oauthFacade(cognitoOut)` (builds the ApiGatewayV2 first, then the reader client
+  with `callbackUrls ← facadeApi.url`, then the façade Lambda + routes; publishes the
+  SSM params) → `gateway(cognitoOut, ecsOut, bootstrapOut, readerClientId)` (adds the
+  reader id to `allowedClients`). The façade Lambda reads `gateway/url` from SSM at
+  RUNTIME, so it needs nothing from `gateway()` at construction — that's what keeps
+  the graph acyclic even though `oauthFacade` runs before `gateway`.
 
 ### `infra/cloudformation/github-actions-role.yaml` (deploy-role IAM)
-- Add: ApiGatewayV2 create/manage (`apigateway:*` on the HTTP-API resource surface,
-  or the scoped SST set), `sst secret` SSM under `/sst/` if not already present.
-- The façade Lambda + its exec role are covered by the existing `mem9-on-aws-*`
-  Lambda grants from #10. Cognito Hosted-UI domain/client already covered.
+The first draft's "ApiGatewayV2 + sst secret" was incomplete. The full set the new
+resources need (verified against llm-wiki's role + the SST resource behaviors):
+- **ApiGatewayV2**: `apigateway:*` on `arn:aws:apigateway:<region>::/*` (SST creates
+  the API + integrations + routes and **tags every resource** — `apigateway:TagResource`
+  et al.; a single scoped-to-one-ARN grant is insufficient because integration/route
+  sub-resources have distinct ARNs).
+- **`lambda:AddPermission` / `lambda:RemovePermission` / `lambda:GetPolicy`** on the
+  façade fn — the `facadeApi.route(..., fn.arn)` integration writes a resource-policy
+  statement granting the API `lambda:InvokeFunction` (this is the same fresh-role
+  resource-policy-race llm-wiki documents; needed even though the fn CREATE is already
+  covered).
+- **`cognito-idp` for the NEW reader client**: `CreateUserPoolClient`,
+  `UpdateUserPoolClient`, `DescribeUserPoolClient`, `DeleteUserPoolClient`. (#10 only
+  created the M2M client + pool; the pool/domain grants exist, but a new client
+  resource still needs these actions.)
+- **`sst secret` SSM**: `ssm:PutParameter`/`GetParameter(s)`/`GetParametersByPath`/
+  `DeleteParameter`/`AddTagsToResource` on `arn:aws:ssm:<region>:<acct>:parameter/sst/*`
+  (SST stores secrets under `/sst/<app>/<stage>/Secret/...`, NOT the app's
+  `/mem9-on-aws/` prefix).
+- The façade Lambda CREATE + its exec role are covered by the existing `mem9-on-aws-*`
+  Lambda grants from #10. The façade EXEC role's SSM read scope is `/mem9-on-aws/${stage}/*`
+  (it does NOT need `/sst/*` — the HMAC key is a build-time `.value` link, not a
+  runtime read).
+- The gateway service-role invoke policy stays **single-Lambda** (only the existing
+  proxy target) — we intentionally ship NO REQUEST interceptor Lambda (single-operator,
+  single `read`-scope reader client → no per-tool scope gating needed), unlike llm-wiki.
 - Verify (`cfn-lint` + `validate-template`) and **redeploy out-of-band via
   `scripts/deploy-github-role.sh` BEFORE the PR deploys** (new resource types 403
   otherwise).
@@ -155,6 +223,14 @@ Broken two ways (llm-wiki's proven approach):
    The Lambda takes neither the reader client nor the gateway as a constructor input.
    Non-cyclic values (Cognito endpoint URLs — depend only on pool + domain; the HMAC
    key; scopes) are plain env.
+
+**Why `gateway()` consuming `readerClientId` does NOT cycle:** the reader client is a
+construction-time `Output<string>` produced by `oauthFacade`; `gateway()` reads that
+id for `allowedClients`. The client resource does not depend on the gateway, so
+`oauthFacade → gateway` is a one-way edge. The only gateway→façade need (`gateway/url`)
+is satisfied at runtime via SSM, not construction — hence `oauthFacade` takes
+`cognitoOut` only (NOT `gatewayOut`) and `gateway` runs after it. This is the fix for
+the first draft's unsatisfiable `oauthFacade(cognitoOut, gatewayOut)` signature.
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-07-15-oauth2-mcp-browser-login-design.md
+++ b/docs/superpowers/specs/2026-07-15-oauth2-mcp-browser-login-design.md
@@ -1,0 +1,202 @@
+# Design: OAuth2 browser login for the mem9 MCP surface (§6 extension)
+
+**Status:** approved design, pre-implementation.
+**Date:** 2026-07-15.
+**Scope:** add an interactive OAuth2 authorization-code + PKCE flow (browser login)
+to the existing MCP surface, **alongside** the current Cognito M2M
+(`client_credentials`) auth — not replacing it.
+
+## Problem
+
+The MCP surface (PR #10) authenticates inbound callers with Cognito **M2M**
+(`client_credentials`): one client id + secret, tokens minted offline. That works
+for CI / headless callers but not for a human at Claude Code, who expects the MCP
+**authorization spec**: RFC 8414 / 9728 metadata, RFC 7591 Dynamic Client
+Registration (DCR), and an authorization-code + PKCE flow with a **loopback**
+redirect (`http://localhost:<random-port>`). Two mismatches make Cognito unusable
+directly:
+
+1. Cognito doesn't serve the RFC 8414/9728 metadata at the discovery path the MCP
+   client (and the AgentCore Gateway) advertises, and doesn't serve RFC 7591 DCR.
+2. Cognito requires **exact-match** `callbackUrls`; the MCP client's local listener
+   picks a **random ephemeral loopback port**, which can't be pre-registered.
+
+## Decision (locked with the operator)
+
+- **Keep both auth modes.** Add a browser-login "reader" client **alongside** the
+  existing M2M client. The gateway's `allowedClients` trusts **both**. The CI
+  write→search E2E (`scripts/run-mcp-e2e.sh`, M2M) stays **unchanged**; humans use
+  browser OAuth. Mirrors `zxkane/llm-wiki` exactly.
+- **Single operator, no self-signup.** The Cognito pool gets Hosted-UI + an `email`
+  attribute, but public sign-up is disabled. The operator creates the one user via
+  `admin-create-user` (documented one-time step).
+- **Entry = ApiGatewayV2, NOT a Lambda Function URL.** A Function URL's resource
+  policy is `Principal:"*"` (an open-policy finding) and the browser endpoints must
+  be reachable without SigV4. ApiGatewayV2 keeps the endpoints public **and** scopes
+  the Lambda's resource policy to the API integration. (Complies with CLAUDE-AWS
+  "no Lambda Function URL".)
+
+## Architecture
+
+An **OAuth façade Lambda** (lifted from llm-wiki's `infra/src/oauth-facade/`) sits
+**in front of** the AgentCore Gateway. The existing Lambda-proxy target → Cloud Map
+→ mnemo-server chain is **completely untouched**.
+
+```
+Claude Code
+  │  (browser OAuth: /.well-known/*, /register, /oauth/authorize|callback|token, PKCE S256)
+  ▼
+OAuth façade Lambda  (fronted by ApiGatewayV2, nodejs24.x, arm64, NOT VPC-attached)
+  ├─► Cognito Hosted-UI          (the actual user login)
+  └─► AgentCore Gateway (/mcp)   ── existing ──►  Lambda-proxy target ─► Cloud Map ─► mnemo-server ─► Aurora ─► qwen3
+       [inbound: CUSTOM_JWT, allowedClients = [m2m.id, reader.id]]
+```
+
+The façade routes:
+- `/.well-known/oauth-authorization-server`, `/.well-known/oauth-protected-resource`,
+  `/.well-known/openid-configuration` — RFC 8414/9728 + OIDC metadata. `authorize`
+  and `token` point at the **façade**; the rest pass through to Cognito. Advertises
+  only the reader client's allowed scopes (`openid`, `email`, `mem9-mcp/read`;
+  `write` is defined on the resource server but NOT advertised — advertising a scope
+  the reader client doesn't allow makes Cognito's authorize step fail
+  `invalid_scope`).
+- `POST /register` — RFC 7591 DCR: returns the **pre-provisioned reader client**
+  id/secret to every caller.
+- `GET /oauth/authorize` — validate the loopback `redirect_uri` (reject non-loopback
+  = closes an open-redirector), **require PKCE `code_challenge` + `code_challenge_method=S256`**
+  (reject missing/`plain`/other), wrap the client's `state` + `redirect_uri` into an
+  **HMAC-SHA-256-signed opaque blob**, 302 to Cognito Hosted-UI with the façade's own
+  single registered callback + the blob as `state`.
+- `GET /oauth/callback` — verify the HMAC blob (reject on failure/expiry), re-check
+  loopback, 302 back to the client's loopback port with the upstream `code`.
+- `POST /oauth/token` — rewrite `redirect_uri` to the façade's (so Cognito's replay
+  check matches its single registered URL), proxy to Cognito's token endpoint,
+  forward the response verbatim.
+- catch-all — reverse-proxy `/mcp` (+ everything else) to the AgentCore Gateway URL,
+  rewriting `WWW-Authenticate` so `resource_metadata` points back at the façade.
+
+State is **stateless** — an HMAC-signed blob (`{cs: client_state, r: client_redirect,
+ts}`, ~150-200 bytes, under Cognito's 1024-char `state` limit), no DDB / TTL store.
+TTL 10 min, `timingSafeEqual` verify.
+
+## Components
+
+### `infra/cognito.ts` (extend — M2M client unchanged)
+- Add Hosted-UI to the existing pool: `email` schema attribute; **self-signup
+  disabled**.
+- Export the extra Hosted-UI endpoint URLs the façade needs: `authorize`,
+  `userInfo`, `revocation`, `jwks` (token/issuer already exported).
+- The M2M client (`${stage}-mem9-mcp-client`, `client_credentials`) is **unchanged**.
+
+### `infra/oauth-facade.ts` (new — factory `oauthFacade(cognitoOut, gatewayOut)`)
+- `sst.aws.ApiGatewayV2` — CORS scoped to MCP transport headers (`Authorization`,
+  `Content-Type`, `Accept`, `MCP-Protocol-Version`), NOT `*`. Created **first**
+  (cycle break — see below).
+- The **reader `UserPoolClient`** (`${stage}-mem9-mcp-reader`): `generateSecret`,
+  `allowedOauthFlows:["code"]`, `allowedOauthScopes:["openid","email","mem9-mcp/read"]`,
+  `callbackUrls:[<facadeApi.url>/oauth/callback]`, `logoutUrls:[.../oauth/logout]`,
+  `explicitAuthFlows:["ALLOW_REFRESH_TOKEN_AUTH"]`, `supportedIdentityProviders:["COGNITO"]`,
+  `preventUserExistenceErrors:"ENABLED"`, `enableTokenRevocation`. Lives here (not in
+  `cognito.ts`) because its callback needs `facadeApi.url`.
+- `sst.aws.Function` `Mem9OauthFacadeFn` — handler `infra/src/oauth-facade/handler.handler`,
+  nodejs24.x, arm64, 256 MB, 30 s, **NOT VPC-attached** (only reaches Cognito + the
+  public gateway URL over the internet). Env: `SSM_PREFIX`, the non-cyclic Cognito
+  endpoint URLs, `RESOURCE_SCOPES`, `OAUTH_STATE_HMAC_KEY`. Permission:
+  `ssm:GetParameter(s)` scoped to `arn:aws:ssm:<region>:<acct>:parameter/mem9-on-aws/${stage}/*`.
+- Routes: `ANY /{proxy+}` + `ANY /` → the façade Lambda.
+- `sst.Secret("OauthStateHmacKey")` — empty default → façade returns 503 until seeded
+  once per stage (`sst secret set OauthStateHmacKey "$(openssl rand -base64 32)"`).
+- SSM exports under `/mem9-on-aws/${stage}/`: `facade/url`, `facade/mcp-endpoint`,
+  `cognito/reader/client-id`, `cognito/reader/client-secret` (SecureString).
+
+### `infra/src/oauth-facade/{handler,config,state}.ts` (new — lifted from llm-wiki)
+- `handler.ts` — the pure `route(event, cfg)` router (all logic, config injected so
+  tests need no AWS) + the Lambda `handler` (cold-start config singleton).
+- `config.ts` — `loadConfig()`: non-cyclic values from env, the 3 cyclic values
+  (gateway url + reader client id/secret) from SSM at runtime with `WithDecryption`.
+  SSM client injected (`SsmLike`) for testability.
+- `state.ts` — HMAC-SHA-256 sign/verify of the opaque state blob, TTL, `timingSafeEqual`.
+- Adapt from llm-wiki: SSM prefix (`/mem9-on-aws/${stage}`), scope name
+  (`mem9-mcp/read`), resource-server id (`mem9-mcp`). Routing logic unchanged.
+
+### `infra/gateway.ts` (one change)
+- `allowedClients` gains the reader client id: `[m2mClientId, readerClientId]`. Only
+  `name`/`authorizerType` are RequiresReplace on the gateway → the gateway URL does
+  NOT rotate.
+
+### `sst.config.ts` (wiring)
+- Order: `cognito()` → `oauthFacade` builds its API + reader client → `gateway(...)`
+  reads the reader client id for `allowedClients` → the façade Lambda + routes attach
+  last. (See cycle-break.) Concretely the reader client is produced where
+  `facadeApi.url` is available and its id is threaded into `gateway()`.
+
+### `infra/cloudformation/github-actions-role.yaml` (deploy-role IAM)
+- Add: ApiGatewayV2 create/manage (`apigateway:*` on the HTTP-API resource surface,
+  or the scoped SST set), `sst secret` SSM under `/sst/` if not already present.
+- The façade Lambda + its exec role are covered by the existing `mem9-on-aws-*`
+  Lambda grants from #10. Cognito Hosted-UI domain/client already covered.
+- Verify (`cfn-lint` + `validate-template`) and **redeploy out-of-band via
+  `scripts/deploy-github-role.sh` BEFORE the PR deploys** (new resource types 403
+  otherwise).
+
+## Dependency cycle & runtime config (the non-obvious part)
+
+Naïve wiring cycles:
+```
+reader client .callbackUrls  ←  façade URL              (Cognito registers the callback)
+façade Lambda env            ←  reader client id/secret + gateway URL
+```
+Broken two ways (llm-wiki's proven approach):
+1. **Create the ApiGatewayV2 first.** `facadeApi.url` is a property of the API
+   resource, independent of the Lambda → wire `readerClient.callbackUrls ←
+   facadeApi.url` acyclically, then attach the Lambda as a route.
+2. **The façade reads the cyclic values from SSM at runtime**, not as construction
+   env: `gateway/url`, `cognito/reader/client-id`, `cognito/reader/client-secret`.
+   The Lambda takes neither the reader client nor the gateway as a constructor input.
+   Non-cyclic values (Cognito endpoint URLs — depend only on pool + domain; the HMAC
+   key; scopes) are plain env.
+
+## Testing
+
+### Unit (mock-the-globals pattern, matching existing `infra/*.test.ts`)
+- `infra/oauth-facade.test.ts` — ApiGatewayV2 (CORS scoped, not `*`); reader client
+  (`code` flow, loopback callback); façade Function (nodejs24.x, arm64, **not**
+  VPC-attached, SSM read scoped to `/mem9-on-aws/${stage}/*`); HMAC Secret; SSM exports.
+- `infra/cognito.test.ts` — extend: pool gains `email` + Hosted-UI; M2M client unchanged.
+- `infra/gateway.test.ts` — extend: `allowedClients` contains **both** m2m + reader ids.
+- `infra/src/oauth-facade/{handler,config,state}.test.ts` — lifted from llm-wiki (the
+  high-value ones): metadata endpoints, PKCE-S256 enforcement, loopback-only
+  redirect, HMAC round-trip + TTL + tamper, DCR, token redirect rewrite, catch-all
+  proxy + `WWW-Authenticate` rewrite, config env+SSM loader (injected SSM).
+
+### Live E2E
+- Existing `scripts/run-mcp-e2e.sh` (M2M) **unchanged** — still proves the round-trip
+  in CI (no regression to the prod-ingest fix).
+- **New CI façade smoke check** (`scripts/run-oauth-facade-smoke.sh` or inline):
+  `curl` `/.well-known/oauth-authorization-server` + `/.well-known/oauth-protected-resource`
+  → assert 200, `authorization_endpoint`/`token_endpoint` point at the façade,
+  `code_challenge_methods_supported: ["S256"]`, `registration_endpoint` present. The
+  full browser flow can't run headless → CI validates metadata + DCR; interactive
+  login verified manually once.
+
+### Manual (documented, one-time per stage)
+1. `sst secret set OauthStateHmacKey "$(openssl rand -base64 32)" --stage <stage>`.
+2. `aws cognito-idp admin-create-user ...` (the operator user).
+3. Point Claude Code at `/mem9-on-aws/<stage>/facade/mcp-endpoint` → browser login →
+   confirm `search_memories`.
+
+### Compliance
+No Lambda Function URL (ApiGatewayV2). nodejs24.x. Least-privilege (façade SSM read
+scoped to the stage prefix). No committed secrets / account ids (placeholders,
+deploy-time `accountId()`). `cfn-lint` the deploy-role template.
+
+## Out of scope (v1)
+- Custom domain on the façade (use the ApiGatewayV2 URL).
+- Per-user / per-scope authorization beyond `read` (single operator).
+- Self-service user sign-up (admin-created user only).
+
+## References
+- `zxkane/llm-wiki`: `infra/wiki-query.ts` (`wikiGateway`), `infra/src/oauth-facade/
+  {handler,config,state}.ts` — the proven façade this design lifts.
+- `docs/mem9-facts.md`, `docs/ARCHITECTURE.md` §6/§6a (the MCP surface this extends).
+- Memory: `mcp-lambda-proxy-plan`, `prod-smart-ingest-mantle-iam-gap`.

--- a/infra/cloudformation/github-actions-role.yaml
+++ b/infra/cloudformation/github-actions-role.yaml
@@ -945,6 +945,23 @@ Resources:
               - !Sub "arn:aws:apigateway:${AWS::Region}::/apis"
               - !Sub "arn:aws:apigateway:${AWS::Region}::/apis/*"
               - !Sub "arn:aws:apigateway:${AWS::Region}::/tags/*"
+          # SST's sst.aws.ApiGatewayV2 creates an access-log LogGroup under
+          # /aws/vendedlogs/apis/<app>-<stage>-<id>. The existing /sst/* and
+          # /aws/lambda/* log grants don't cover this path.
+          - Sid: ApiGatewayV2AccessLogs
+            Effect: Allow
+            Action:
+              - logs:CreateLogGroup
+              - logs:DeleteLogGroup
+              - logs:PutRetentionPolicy
+              - logs:DeleteRetentionPolicy
+              - logs:TagResource
+              - logs:UntagResource
+              - logs:ListTagsForResource
+              - logs:DescribeLogGroups
+            Resource:
+              - !Sub "arn:aws:logs:*:${AWS::AccountId}:log-group:/aws/vendedlogs/apis/${ProjectName}-*"
+              - !Sub "arn:aws:logs:*:${AWS::AccountId}:log-group:/aws/vendedlogs/apis/${ProjectName}-*:*"
 
   # ───────────────────────────────────────────────────────────────────────────
   # IAM Role — assumed by GitHub Actions via OIDC.

--- a/infra/cloudformation/github-actions-role.yaml
+++ b/infra/cloudformation/github-actions-role.yaml
@@ -942,9 +942,12 @@ Resources:
               - apigateway:TagResource
               - apigateway:UntagResource
             Resource:
-              - !Sub "arn:aws:apigateway:${AWS::Region}::/apis"
-              - !Sub "arn:aws:apigateway:${AWS::Region}::/apis/*"
-              - !Sub "arn:aws:apigateway:${AWS::Region}::/tags/*"
+              # Region wildcard: the CFN stack lives in us-west-2 but the app
+              # deploys to ap-northeast-1. API Gateway ARNs carry no account-id
+              # (empty field between the double colons), only the region matters.
+              - "arn:aws:apigateway:*::/apis"
+              - "arn:aws:apigateway:*::/apis/*"
+              - "arn:aws:apigateway:*::/tags/*"
           # SST's sst.aws.ApiGatewayV2 creates an access-log LogGroup under
           # /aws/vendedlogs/apis/<app>-<stage>-<id>. The existing /sst/* and
           # /aws/lambda/* log grants don't cover this path.

--- a/infra/cloudformation/github-actions-role.yaml
+++ b/infra/cloudformation/github-actions-role.yaml
@@ -903,6 +903,50 @@ Resources:
                 iam:PassedToService: bedrock-agentcore.amazonaws.com
 
   # ───────────────────────────────────────────────────────────────────────────
+  # Policy 9 — OAuth2 login façade (infra/facade.ts): the sst.aws.ApiGatewayV2
+  # HTTP API that fronts the OAuth2 authorization-code/PKCE flow. SST provisions
+  # the HTTP API + its routes/integrations/stage; the façade Lambda + its
+  # resource policy (lambda:AddPermission for the API→Lambda invoke) are already
+  # covered by LambdaProxyPolicy.LambdaManage (mem9-on-aws-* scope). The reader
+  # UserPoolClient is covered by GatewayMcpPolicy.Cognito (cognito-idp:*Client),
+  # and the sst.Secret's /sst/* SSM parameter by ScaffoldPolicy.SSM{Read,Write}
+  # — so this policy carries ONLY the genuinely-new apigateway control-plane
+  # surface. Its own ManagedPolicy to stay under IAM's 6144-byte per-policy cap
+  # and keep the OAuth2-façade footprint auditable in one place.
+  #
+  # API Gateway ARNs have an EMPTY account field (arn:aws:apigateway:<region>::/…)
+  # — the /apis (create), /apis/* (per-API ops), and /tags/* (tagging) resources
+  # cover the HTTP API lifecycle. apigateway:POST/GET/PATCH/PUT/DELETE are the
+  # verb-style actions the API Gateway v2 control plane authorizes against.
+  #
+  # ADDED for the OAuth2 MCP login PR — must be live (re-run
+  # scripts/deploy-github-role.sh) BEFORE that PR's first deploy, or the deploy
+  # 403s on the first apigateway create (CLAUDE-AWS "new resource TYPE needs
+  # grants first").
+  # ───────────────────────────────────────────────────────────────────────────
+  OAuth2FacadePolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: !Sub ${GitHubRepo}-oauth2-facade
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: ApiGatewayV2
+            Effect: Allow
+            Action:
+              - apigateway:POST
+              - apigateway:GET
+              - apigateway:PATCH
+              - apigateway:PUT
+              - apigateway:DELETE
+              - apigateway:TagResource
+              - apigateway:UntagResource
+            Resource:
+              - !Sub "arn:aws:apigateway:${AWS::Region}::/apis"
+              - !Sub "arn:aws:apigateway:${AWS::Region}::/apis/*"
+              - !Sub "arn:aws:apigateway:${AWS::Region}::/tags/*"
+
+  # ───────────────────────────────────────────────────────────────────────────
   # IAM Role — assumed by GitHub Actions via OIDC.
   # ───────────────────────────────────────────────────────────────────────────
   GitHubActionsRole:
@@ -943,6 +987,7 @@ Resources:
         - !Ref ImageBuildPolicy
         - !Ref LambdaProxyPolicy
         - !Ref GatewayMcpPolicy
+        - !Ref OAuth2FacadePolicy
       Tags:
         - Key: Project
           Value: !Ref ProjectName

--- a/infra/cloudformation/github-actions-role.yaml
+++ b/infra/cloudformation/github-actions-role.yaml
@@ -949,8 +949,8 @@ Resources:
               - "arn:aws:apigateway:*::/apis/*"
               - "arn:aws:apigateway:*::/tags/*"
           # SST's sst.aws.ApiGatewayV2 creates an access-log LogGroup under
-          # /aws/vendedlogs/apis/<app>-<stage>-<id>. The existing /sst/* and
-          # /aws/lambda/* log grants don't cover this path.
+          # /aws/vendedlogs/apis/<app>-<stage>-<id> AND creates a log delivery
+          # via the CloudWatch Logs Delivery API (CreateStage enables access logging).
           - Sid: ApiGatewayV2AccessLogs
             Effect: Allow
             Action:
@@ -962,9 +962,21 @@ Resources:
               - logs:UntagResource
               - logs:ListTagsForResource
               - logs:DescribeLogGroups
-            Resource:
-              - !Sub "arn:aws:logs:*:${AWS::AccountId}:log-group:/aws/vendedlogs/apis/${ProjectName}-*"
-              - !Sub "arn:aws:logs:*:${AWS::AccountId}:log-group:/aws/vendedlogs/apis/${ProjectName}-*:*"
+              # Delivery API actions needed by CreateStage's access-logging setup.
+              - logs:CreateLogDelivery
+              - logs:DeleteLogDelivery
+              - logs:GetLogDelivery
+              - logs:UpdateLogDelivery
+              - logs:PutDeliverySource
+              - logs:PutDeliveryDestination
+              - logs:CreateDelivery
+              - logs:GetDelivery
+              - logs:DeleteDelivery
+              - logs:ListDeliveries
+              - logs:PutResourcePolicy
+              - logs:DescribeResourcePolicies
+              - logs:DescribeLogGroups
+            Resource: "*"
 
   # ───────────────────────────────────────────────────────────────────────────
   # IAM Role — assumed by GitHub Actions via OIDC.

--- a/infra/cognito.test.ts
+++ b/infra/cognito.test.ts
@@ -139,4 +139,30 @@ describe("cognito stack", () => {
     // PR-stage domain gets the numeric suffix for deterministic re-deploys.
     expect(byKind("UserPoolDomain")[0].args.domain).toBe("pr-42-mem9-mcp-42");
   });
+
+  it("configures the pool for Hosted-UI (email schema + no forced re-verify)", async () => {
+    installGlobals("prod");
+    const cognito = await loadCognito();
+    cognito();
+    const poolArgs = byKind("UserPool")[0].args;
+    const schema = poolArgs.schema as { name: string; mutable: boolean; required: boolean }[];
+    expect(schema).toContainEqual(
+      expect.objectContaining({ name: "email", mutable: true, required: false }),
+    );
+    const updateSettings = poolArgs.userAttributeUpdateSettings as {
+      attributesRequireVerificationBeforeUpdate: unknown[];
+    };
+    expect(updateSettings.attributesRequireVerificationBeforeUpdate).toEqual([]);
+    expect(poolArgs.autoVerifiedAttributes).toEqual([]);
+  });
+
+  it("exports the Hosted-UI endpoint URLs the façade needs", async () => {
+    installGlobals("prod");
+    const cognito = await loadCognito();
+    const out = cognito();
+    expect(out.authorizeEndpoint).toBeDefined();
+    expect(out.userInfoEndpoint).toBeDefined();
+    expect(out.revocationEndpoint).toBeDefined();
+    expect(out.jwksUri).toBeDefined();
+  });
 });

--- a/infra/cognito.ts
+++ b/infra/cognito.ts
@@ -24,6 +24,10 @@ export interface CognitoOutputs {
   userPoolId: Output<string>;
   issuer: Output<string>;
   tokenEndpoint: Output<string>;
+  authorizeEndpoint: Output<string>;
+  userInfoEndpoint: Output<string>;
+  revocationEndpoint: Output<string>;
+  jwksUri: Output<string>;
   resourceServerId: string;
   clientId: Output<string>;
   clientSecret: Output<string>;
@@ -47,7 +51,16 @@ export function cognito(): CognitoOutputs {
   const nonProd = stage !== "prod";
   const pool = new awsAny.cognito.UserPool(
     "Mem9McpPool",
-    { name: `${stage}-mem9-mcp`, tags },
+    {
+      name: `${stage}-mem9-mcp`,
+      // Hosted-UI minimal config (llm-wiki's exact set): an `email` attribute for
+      // the login form, no forced re-verification on update, and nothing
+      // auto-verified (the OAuth2 façade owns the flow, not Cognito email/SMS).
+      schema: [{ name: "email", attributeDataType: "String", mutable: true, required: false }],
+      userAttributeUpdateSettings: { attributesRequireVerificationBeforeUpdate: [] },
+      autoVerifiedAttributes: [],
+      tags,
+    },
     { deleteBeforeReplace: nonProd },
   );
 
@@ -91,6 +104,10 @@ export function cognito(): CognitoOutputs {
   // a plain literal would stringify them and break CFN/JWT-authorizer validation.
   const issuer = $interpolate`https://cognito-idp.${region}.amazonaws.com/${pool.id}`;
   const tokenEndpoint = $interpolate`https://${domain.domain}.auth.${region}.amazoncognito.com/oauth2/token`;
+  const authorizeEndpoint = $interpolate`https://${domain.domain}.auth.${region}.amazoncognito.com/oauth2/authorize`;
+  const userInfoEndpoint = $interpolate`https://${domain.domain}.auth.${region}.amazoncognito.com/oauth2/userInfo`;
+  const revocationEndpoint = $interpolate`https://${domain.domain}.auth.${region}.amazoncognito.com/oauth2/revoke`;
+  const jwksUri = $interpolate`https://cognito-idp.${region}.amazonaws.com/${pool.id}/.well-known/jwks.json`;
 
   new awsAny.ssm.Parameter("SsmCognitoIssuer", {
     name: `${prefix}/cognito/issuer`,
@@ -128,6 +145,10 @@ export function cognito(): CognitoOutputs {
     userPoolId: pool.id,
     issuer,
     tokenEndpoint,
+    authorizeEndpoint,
+    userInfoEndpoint,
+    revocationEndpoint,
+    jwksUri,
     resourceServerId: RESOURCE_SERVER_ID,
     clientId: client.id,
     clientSecret: client.clientSecret,

--- a/infra/gateway.test.ts
+++ b/infra/gateway.test.ts
@@ -139,21 +139,37 @@ describe("gateway stack", () => {
   it("creates a CUSTOM_JWT MCP gateway matching on allowedClients (not aud)", async () => {
     installGlobals("prod");
     const gateway = await loadGateway();
-    gateway(fakeCognito(), fakeEcs(), fakeBootstrap());
+    gateway(fakeCognito(), fakeEcs(), fakeBootstrap(), out("reader-client-id-test") as unknown as Output<string>);
     const gw = only("AgentcoreGateway");
     expect(gw.protocolType).toBe("MCP");
     expect(gw.authorizerType).toBe("CUSTOM_JWT");
     const jwt = (gw.authorizerConfiguration as any).customJwtAuthorizer;
     expect(String((jwt.discoveryUrl as { value?: string }).value)).toContain("/.well-known/openid-configuration");
-    expect(jwt.allowedClients).toHaveLength(1);
+    // The M2M client plus the browser-login reader client.
+    expect(jwt.allowedClients).toHaveLength(2);
     // No interceptor in v1.
     expect(gw.interceptorConfigurations).toBeUndefined();
+  });
+
+  it("trusts BOTH the M2M and the reader client in allowedClients", async () => {
+    installGlobals("prod");
+    const gateway = await loadGateway();
+    gateway(fakeCognito(), fakeEcs(), fakeBootstrap(), out("reader-client-id-test") as unknown as Output<string>);
+    const gw = only("AgentcoreGateway");
+    const jwt = (gw.authorizerConfiguration as any).customJwtAuthorizer;
+    // The list is [...cognitoOut.allowedClientIds, readerClientId]; each entry is an
+    // out<string> wrapper, so unwrap to compare the underlying client ids.
+    const clients = (unwrap(jwt.allowedClients) as string[]);
+    // The M2M client from fakeCognito().allowedClientIds.
+    expect(clients).toContain("client-1");
+    // The browser-login reader client passed as the 4th arg.
+    expect(clients).toContain("reader-client-id-test");
   });
 
   it("provisions a VPC-attached nodejs24.x proxy Lambda carrying the Cloud Map URL + X-API-Key", async () => {
     installGlobals("prod");
     const gateway = await loadGateway();
-    gateway(fakeCognito(), fakeEcs(), fakeBootstrap());
+    gateway(fakeCognito(), fakeEcs(), fakeBootstrap(), out("reader-client-id-test") as unknown as Output<string>);
     const fn = only("SstFunction");
     expect(fn.runtime).toBe("nodejs24.x");
     expect(String(fn.handler)).toContain("proxy-handler.handler");
@@ -171,7 +187,7 @@ describe("gateway stack", () => {
   it("gateway service role grants ONLY lambda:InvokeFunction (no workload-identity/secret/ENI)", async () => {
     installGlobals("prod");
     const gateway = await loadGateway();
-    gateway(fakeCognito(), fakeEcs(), fakeBootstrap());
+    gateway(fakeCognito(), fakeEcs(), fakeBootstrap(), out("reader-client-id-test") as unknown as Output<string>);
     // Two roles are created: the Lambda exec role + the gateway service role. Find
     // the gateway-invoke RolePolicy (its doc is an apply()'d Output over the ARN).
     const rolePolicies = created.filter((r) => r.kind === "RolePolicy");
@@ -189,7 +205,7 @@ describe("gateway stack", () => {
   it("provisions the target via a command.local.Command driving a mcp.lambda CreateGatewayTarget", async () => {
     installGlobals("prod");
     const gateway = await loadGateway();
-    gateway(fakeCognito(), fakeEcs(), fakeBootstrap());
+    gateway(fakeCognito(), fakeEcs(), fakeBootstrap(), out("reader-client-id-test") as unknown as Output<string>);
     const cmd = only("LocalCommand");
     expect(String(unwrap(cmd.create))).toContain("MEM9_TGT_OP=create");
     expect(String(unwrap(cmd.create))).toContain("provision-target.mjs");

--- a/infra/gateway.ts
+++ b/infra/gateway.ts
@@ -96,6 +96,7 @@ export function gateway(
   cognitoOut: CognitoOutputs,
   ecsOut: EcsOutputs,
   bootstrapOut: BootstrapOutputs,
+  readerClientId: Output<string>,
 ): GatewayOutputs {
   const prefix = `/mem9-on-aws/${$app.stage}`;
   const stage = $app.stage;
@@ -183,7 +184,8 @@ export function gateway(
       authorizerConfiguration: {
         customJwtAuthorizer: {
           discoveryUrl: $interpolate`${cognitoOut.issuer}/.well-known/openid-configuration`,
-          allowedClients: cognitoOut.allowedClientIds,
+          // Trust BOTH the M2M client (CI/headless) AND the browser-login reader client.
+          allowedClients: [...cognitoOut.allowedClientIds, readerClientId],
         },
       },
       protocolConfiguration: { mcp: { supportedVersions: ["2025-03-26"] } },

--- a/infra/oauth-facade.test.ts
+++ b/infra/oauth-facade.test.ts
@@ -1,0 +1,226 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CognitoOutputs } from "./cognito";
+
+/**
+ * Unit tests for the `oauthFacade` factory — the OAuth2 browser-login façade
+ * that bridges MCP clients' authorization-code+PKCE flow to Cognito Hosted-UI.
+ *
+ * This is the most load-bearing test in the feature: it validates the CYCLE-BREAK
+ * wiring — the ApiGatewayV2 must be created FIRST so `facadeApi.url` is available
+ * to the reader UserPoolClient's `callbackUrls`, and the reader client's `.id` is
+ * what the factory returns.
+ *
+ * Mocks the SST globals so the factory runs bare; captures every created resource
+ * + SSM parameter and asserts the observable contract.
+ */
+
+function out<T>(value: T): { value: T; apply: (fn: (v: T) => unknown) => unknown } {
+  return { value, apply: (fn) => out(fn(value) as never) };
+}
+
+interface Rec {
+  kind: string;
+  args: Record<string, unknown>;
+}
+let created: Rec[];
+let params: { name: string; type: string }[];
+
+// Recursively unwrap the loose out<T> mock (and plain values) — env / arg values
+// come through as out<T> or $interpolate results.
+function unwrap(v: unknown): unknown {
+  if (Array.isArray(v)) return v.map(unwrap);
+  if (v && typeof v === "object") {
+    if ("value" in v) return unwrap((v as { value: unknown }).value);
+    const o: Record<string, unknown> = {};
+    for (const [k, val] of Object.entries(v)) o[k] = unwrap(val);
+    return o;
+  }
+  return v;
+}
+
+function installInterpolate() {
+  (globalThis as Record<string, unknown>).$interpolate = (
+    strings: TemplateStringsArray,
+    ...values: unknown[]
+  ) => {
+    let s = "";
+    strings.forEach((str, i) => {
+      s += str;
+      if (i < values.length) {
+        const v = values[i];
+        s += typeof v === "object" && v && "value" in v ? String((v as { value: unknown }).value) : String(v);
+      }
+    });
+    return out(s);
+  };
+}
+
+function installGlobals(stage: string) {
+  (globalThis as Record<string, unknown>).$app = { name: "mem9-on-aws", stage };
+  installInterpolate();
+  (globalThis as Record<string, unknown>).aws = {
+    getRegionOutput: () => ({ name: out("ap-northeast-1") }),
+    getCallerIdentityOutput: () => ({ accountId: out("123456789012") }),
+    cognito: {
+      // Reader UserPoolClient: captured, exposes .id + .clientSecret.
+      UserPoolClient: class {
+        id = out("reader-id");
+        clientSecret = out("reader-secret");
+        constructor(_n: string, args: Record<string, unknown>) {
+          created.push({ kind: "UserPoolClient", args });
+        }
+      },
+    },
+    ssm: {
+      Parameter: class {
+        constructor(_n: string, args: { name: unknown; type: string }) {
+          const name =
+            typeof args.name === "object" && args.name && "value" in args.name
+              ? (args.name as { value: string }).value
+              : (args.name as string);
+          params.push({ name, type: args.type });
+        }
+      },
+    },
+  };
+  (globalThis as Record<string, unknown>).sst = {
+    aws: {
+      // ApiGatewayV2 — created FIRST (cycle break). Exposes `.url` (needed by the
+      // reader client's callbackUrls) + a `.route` spy.
+      ApiGatewayV2: class {
+        url = out("https://facade.example");
+        route = vi.fn();
+        constructor(_n: string, args?: Record<string, unknown>) {
+          created.push({ kind: "ApiGatewayV2", args: args ?? {} });
+        }
+      },
+      // Façade Function — SST zips the handler + makes the exec role. Exposes `.arn`.
+      Function: class {
+        arn = out("arn:aws:lambda:ap-northeast-1:123456789012:function:facade");
+        constructor(_n: string, args: Record<string, unknown>) {
+          created.push({ kind: "SstFunction", args });
+        }
+      },
+    },
+    // sst.Secret — the HMAC signing key (empty default → façade 503 until seeded).
+    Secret: class {
+      value = out("hmac-secret-value");
+      constructor(name: string, _default?: string) {
+        created.push({ kind: "Secret", args: { name } });
+      }
+    },
+  };
+}
+
+beforeEach(() => {
+  created = [];
+  params = [];
+});
+afterEach(() => {
+  for (const g of ["$app", "aws", "sst", "$interpolate"]) delete (globalThis as Record<string, unknown>)[g];
+  vi.resetModules();
+});
+
+async function loadFacade() {
+  vi.resetModules();
+  return (await import("./oauth-facade")).oauthFacade;
+}
+
+function fakeCognitoOut(): CognitoOutputs {
+  return {
+    ssmPrefix: "/mem9-on-aws/prod",
+    userPoolId: out("pool-1"),
+    issuer: out("https://cognito-idp.ap-northeast-1.amazonaws.com/pool-1"),
+    tokenEndpoint: out("https://prod-mem9-mcp.auth.ap-northeast-1.amazoncognito.com/oauth2/token"),
+    authorizeEndpoint: out("https://prod-mem9-mcp.auth.ap-northeast-1.amazoncognito.com/oauth2/authorize"),
+    userInfoEndpoint: out("https://prod-mem9-mcp.auth.ap-northeast-1.amazoncognito.com/oauth2/userInfo"),
+    revocationEndpoint: out("https://prod-mem9-mcp.auth.ap-northeast-1.amazoncognito.com/oauth2/revoke"),
+    jwksUri: out("https://cognito-idp.ap-northeast-1.amazonaws.com/pool-1/.well-known/jwks.json"),
+    resourceServerId: "mem9-mcp",
+    clientId: out("client-1"),
+    clientSecret: out("client-1-secret"),
+    allowedClientIds: [out("client-1")],
+  } as unknown as CognitoOutputs;
+}
+
+function only(kind: string) {
+  const rs = created.filter((r) => r.kind === kind);
+  expect(rs).toHaveLength(1);
+  return rs[0].args;
+}
+
+describe("oauthFacade factory", () => {
+  it("creates an ApiGatewayV2 with MCP-scoped CORS", async () => {
+    installGlobals("prod");
+    const oauthFacade = await loadFacade();
+    oauthFacade(fakeCognitoOut());
+    const api = only("ApiGatewayV2");
+    const cors = api.cors as { allowHeaders?: string[]; allowOrigins?: string[]; allowMethods?: string[] };
+    expect(cors.allowHeaders).toContain("MCP-Protocol-Version");
+    expect(cors.allowHeaders).toContain("Authorization");
+    expect(cors.allowOrigins).toEqual(["*"]);
+    expect(cors.allowMethods).toEqual(["*"]);
+  });
+
+  it("creates the reader UserPoolClient wired to the facade callback URL (cycle break)", async () => {
+    installGlobals("prod");
+    const oauthFacade = await loadFacade();
+    oauthFacade(fakeCognitoOut());
+    const c = only("UserPoolClient");
+    expect(c.allowedOauthFlows).toEqual(["code"]);
+    expect(c.generateSecret).toBe(true);
+    // callbackUrls must resolve from facadeApi.url (created first).
+    const callbacks = (unwrap(c.callbackUrls) as string[]).map(String);
+    expect(callbacks.some((u) => u.endsWith("/oauth/callback"))).toBe(true);
+    expect(callbacks.some((u) => u.startsWith("https://facade.example"))).toBe(true);
+  });
+
+  it("provisions the façade Function on arm64 nodejs24.x with NO vpc + scoped SSM read", async () => {
+    installGlobals("prod");
+    const oauthFacade = await loadFacade();
+    oauthFacade(fakeCognitoOut());
+    const fn = only("SstFunction");
+    expect(fn.runtime).toBe("nodejs24.x");
+    expect(fn.architecture).toBe("arm64");
+    // NOT VPC-attached — the façade only talks to Cognito + SSM over the internet.
+    expect(fn.vpc).toBeUndefined();
+    expect(String(fn.handler)).toContain("oauth-facade/handler");
+    // Least-privilege SSM read scoped to this stage's parameter prefix.
+    const perms = fn.permissions as { actions: string[]; resources: unknown[] }[];
+    const ssmPerm = perms.find((p) => p.actions.includes("ssm:GetParameter"));
+    expect(ssmPerm).toBeDefined();
+    const resources = (unwrap(ssmPerm!.resources) as string[]).map(String);
+    expect(resources.some((r) => r.includes("/mem9-on-aws/prod/*"))).toBe(true);
+  });
+
+  it("creates the HMAC state-signing Secret", async () => {
+    installGlobals("prod");
+    const oauthFacade = await loadFacade();
+    oauthFacade(fakeCognitoOut());
+    const secret = only("Secret");
+    expect(secret.name).toBe("OauthStateHmacKey");
+  });
+
+  it("returns the reader client id + facade url", async () => {
+    installGlobals("prod");
+    const oauthFacade = await loadFacade();
+    const outs = oauthFacade(fakeCognitoOut());
+    expect(outs.readerClientId).toBeDefined();
+    expect(outs.facadeUrl).toBeDefined();
+    expect(outs.ssmPrefix).toBe("/mem9-on-aws/prod");
+  });
+
+  it("exports the reader client id/secret + facade url/mcp-endpoint to SSM", async () => {
+    installGlobals("prod");
+    const oauthFacade = await loadFacade();
+    oauthFacade(fakeCognitoOut());
+    const names = params.map((p) => p.name);
+    expect(names).toContain("/mem9-on-aws/prod/cognito/reader/client-id");
+    expect(names).toContain("/mem9-on-aws/prod/cognito/reader/client-secret");
+    expect(names).toContain("/mem9-on-aws/prod/facade/url");
+    expect(names).toContain("/mem9-on-aws/prod/facade/mcp-endpoint");
+    // The reader client secret is a SecureString (never plaintext String).
+    const secretParam = params.find((p) => p.name.endsWith("/cognito/reader/client-secret"));
+    expect(secretParam?.type).toBe("SecureString");
+  });
+});

--- a/infra/oauth-facade.ts
+++ b/infra/oauth-facade.ts
@@ -1,0 +1,145 @@
+/**
+ * `oauthFacade` stack — the OAuth2 browser-login façade (§7).
+ *
+ * MCP clients (Claude Desktop, etc.) speak the authorization-code + PKCE flow to
+ * a public endpoint, but Cognito's Hosted-UI is a plain OAuth2 provider that the
+ * MCP client can't drive directly (no PKCE-registered public client, no
+ * `/mcp` resource-metadata surface). This façade is an ApiGatewayV2-fronted Lambda
+ * that bridges the two: it advertises the protected-resource / authorization-server
+ * metadata, proxies /oauth/authorize → Cognito Hosted-UI, and swaps the code for
+ * tokens at /oauth/callback (HMAC-signed state guards CSRF).
+ *
+ * CYCLE BREAK (creation order matters): the ApiGatewayV2 is created FIRST because
+ * `facadeApi.url` is needed for the reader UserPoolClient's `callbackUrls`. The
+ * reader client is a SEPARATE Cognito app client from the M2M client in cognito.ts
+ * — it's a public authorization-code client (Hosted-UI), scoped to read-only
+ * (`mem9-mcp/read`), returned via `readerClientId` for gateway.ts to trust.
+ *
+ * The HMAC state-signing key is an `sst.Secret` seeded EMPTY — the handler returns
+ * 503 until the operator seeds it (config.ts treats an empty key as unconfigured),
+ * so a fresh deploy never runs the flow with a guessable state signature.
+ *
+ * The façade Function is NOT VPC-attached: it only reaches Cognito + SSM over the
+ * public internet, so a VPC/NAT hop would only add cold-start ENI latency.
+ */
+
+import type { CognitoOutputs } from "./cognito";
+
+// @ts-ignore - `aws`/`sst` injected globally by SST; cognito/ssm types loose.
+const awsAny = aws as unknown as Record<string, any>;
+
+export interface OauthFacadeOutputs {
+  ssmPrefix: string;
+  readerClientId: Output<string>;
+  facadeUrl: Output<string>;
+}
+
+export function oauthFacade(cognitoOut: CognitoOutputs): OauthFacadeOutputs {
+  const prefix = `/mem9-on-aws/${$app.stage}`;
+  const stage = $app.stage;
+  const tags = { Project: "mem9-on-aws", Stage: stage, ManagedBy: "sst" };
+  const region = awsAny.getRegionOutput().name;
+  const accountId = awsAny.getCallerIdentityOutput().accountId;
+
+  // Small helper: emit an SSM export under this stage's prefix. `secure` flips the
+  // type to SecureString (the reader client secret; the MCP client needs it to
+  // exchange the code, surfaced to the operator at setup).
+  const param = (
+    logicalName: string,
+    suffix: string,
+    value: Output<string>,
+    secure = false,
+  ) =>
+    new awsAny.ssm.Parameter(logicalName, {
+      name: `${prefix}/${suffix}`,
+      type: secure ? "SecureString" : "String",
+      value,
+      tags,
+    });
+
+  // --- ApiGatewayV2 (created FIRST — cycle break) ---
+  // CORS scoped to the headers an MCP client sends: the bearer, JSON bodies, the
+  // Accept negotiation, and the MCP protocol-version header the transport adds.
+  const facadeApi = new sst.aws.ApiGatewayV2("Mem9OauthFacadeApi", {
+    cors: {
+      allowHeaders: ["Authorization", "Content-Type", "Accept", "MCP-Protocol-Version"],
+      allowOrigins: ["*"],
+      allowMethods: ["*"],
+      maxAge: "1 day",
+    },
+  });
+
+  // --- Reader UserPoolClient (authorization-code + PKCE, read-only) ---
+  // A SEPARATE app client from cognito.ts's M2M client: this one drives the
+  // browser Hosted-UI flow. `generateSecret` (confidential client — the façade
+  // holds the secret server-side and does the code exchange). callbackUrls /
+  // logoutUrls point back at THIS api's routes (hence the create-first ordering).
+  const readerClient = new awsAny.cognito.UserPoolClient(
+    "Mem9McpReaderClient",
+    {
+      name: `${stage}-mem9-mcp-reader`,
+      userPoolId: cognitoOut.userPoolId,
+      generateSecret: true,
+      explicitAuthFlows: ["ALLOW_REFRESH_TOKEN_AUTH"],
+      supportedIdentityProviders: ["COGNITO"],
+      callbackUrls: [$interpolate`${facadeApi.url}/oauth/callback`],
+      logoutUrls: [$interpolate`${facadeApi.url}/oauth/logout`],
+      allowedOauthFlows: ["code"],
+      allowedOauthScopes: ["openid", "email", "mem9-mcp/read"],
+      allowedOauthFlowsUserPoolClient: true,
+      preventUserExistenceErrors: "ENABLED",
+      enableTokenRevocation: true,
+    },
+    { dependsOn: [facadeApi] },
+  );
+
+  // --- HMAC state-signing key (empty default → façade 503 until seeded) ---
+  const hmacKey = new sst.Secret("OauthStateHmacKey", "");
+
+  // --- Façade Function (public, NOT VPC-attached) ---
+  // arm64 nodejs24.x. Env carries the SSM prefix (the handler reads the reader
+  // client id/secret from SSM at runtime) + the Cognito endpoint URLs + the
+  // resource scope + the live HMAC key. Least-privilege: SSM read scoped to this
+  // stage's parameter path only.
+  const facadeFn = new sst.aws.Function("Mem9OauthFacadeFn", {
+    handler: "infra/src/oauth-facade/handler.handler",
+    runtime: "nodejs24.x",
+    architecture: "arm64",
+    timeout: "30 seconds",
+    memory: "256 MB",
+    environment: {
+      SSM_PREFIX: prefix,
+      COGNITO_ISSUER: cognitoOut.issuer,
+      COGNITO_AUTHORIZE_ENDPOINT: cognitoOut.authorizeEndpoint,
+      COGNITO_TOKEN_ENDPOINT: cognitoOut.tokenEndpoint,
+      COGNITO_USERINFO_ENDPOINT: cognitoOut.userInfoEndpoint,
+      COGNITO_REVOCATION_ENDPOINT: cognitoOut.revocationEndpoint,
+      COGNITO_JWKS_URI: cognitoOut.jwksUri,
+      RESOURCE_SCOPES: "mem9-mcp/read",
+      OAUTH_STATE_HMAC_KEY: hmacKey.value,
+    },
+    permissions: [
+      {
+        actions: ["ssm:GetParameter", "ssm:GetParameters", "ssm:GetParametersByPath"],
+        resources: [$interpolate`arn:aws:ssm:${region}:${accountId}:parameter${prefix}/*`],
+      },
+    ],
+  });
+
+  // --- Routes ---
+  // A catch-all proxy (the handler routes internally by path/method) + the root.
+  facadeApi.route("ANY /{proxy+}", facadeFn.arn);
+  facadeApi.route("ANY /", facadeFn.arn);
+
+  // --- SSM exports ---
+  param("SsmReaderClientId", "cognito/reader/client-id", readerClient.id);
+  param("SsmReaderClientSecret", "cognito/reader/client-secret", readerClient.clientSecret, true);
+  param("SsmFacadeUrl", "facade/url", facadeApi.url);
+  param("SsmFacadeMcpEndpoint", "facade/mcp-endpoint", $interpolate`${facadeApi.url}/mcp`);
+
+  return {
+    ssmPrefix: prefix,
+    readerClientId: readerClient.id,
+    facadeUrl: facadeApi.url,
+  };
+}

--- a/infra/src/oauth-facade/config.test.ts
+++ b/infra/src/oauth-facade/config.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Unit tests for the façade runtime config loader (cycle-break SSM reads).
+ * Covers `resolveSsm` + `loadConfig` env/SSM merge via an injected `SsmLike`
+ * (mirrors `infra/src/query/config.test.ts`). No AWS.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import { loadConfig, resolveSsm, type SsmLike } from "./config.js";
+
+const PREFIX = "/llm-wiki/pr-7/mcp";
+
+function ssmReturning(params: Record<string, string>): SsmLike {
+  return {
+    send: vi.fn(async () => ({
+      Parameters: Object.entries(params).map(([Name, Value]) => ({ Name, Value })),
+    })),
+  };
+}
+
+const fullSsm = {
+  [`${PREFIX}/gateway/url`]: "https://gw",
+  [`${PREFIX}/cognito/reader/client-id`]: "cid",
+  [`${PREFIX}/cognito/reader/client-secret`]: "csecret",
+};
+
+const baseEnv = {
+  SSM_PREFIX: PREFIX,
+  COGNITO_ISSUER: "https://issuer",
+  COGNITO_AUTHORIZE_ENDPOINT: "https://authz",
+  COGNITO_TOKEN_ENDPOINT: "https://token",
+  COGNITO_USERINFO_ENDPOINT: "https://userinfo",
+  COGNITO_REVOCATION_ENDPOINT: "https://revoke",
+  COGNITO_JWKS_URI: "https://jwks",
+  RESOURCE_SCOPES: "llm-wiki/query/read, llm-wiki/query/write",
+  OAUTH_STATE_HMAC_KEY: "the-key",
+};
+
+describe("façade config loader (cycle-break SSM reads)", () => {
+  it("resolveSsm fetches gateway/url + reader client id/secret with decryption", async () => {
+    const ssm = ssmReturning(fullSsm);
+    const out = await resolveSsm(PREFIX, ssm);
+    expect(out).toEqual({
+      upstream: "https://gw",
+      userClientId: "cid",
+      userClientSecret: "csecret",
+    });
+    const cmd = (ssm.send as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(cmd.input.WithDecryption).toBe(true);
+    expect(cmd.input.Names).toEqual([
+      `${PREFIX}/gateway/url`,
+      `${PREFIX}/cognito/reader/client-id`,
+      `${PREFIX}/cognito/reader/client-secret`,
+    ]);
+  });
+
+  it("resolveSsm throws a clear error on a missing parameter", async () => {
+    const ssm = ssmReturning({ [`${PREFIX}/gateway/url`]: "https://gw" });
+    await expect(resolveSsm(PREFIX, ssm)).rejects.toThrow(
+      /missing SSM parameter.*reader\/client-id/,
+    );
+  });
+
+  it("loadConfig merges env + SSM into a FacadeConfig", async () => {
+    const cfg = await loadConfig({ ssm: ssmReturning(fullSsm), env: baseEnv });
+    expect(cfg.upstream).toBe("https://gw");
+    expect(cfg.userClientId).toBe("cid");
+    expect(cfg.userClientSecret).toBe("csecret");
+    expect(cfg.issuer).toBe("https://issuer");
+    expect(cfg.hmacKey).toBe("the-key");
+    expect(cfg.resourceScopes).toEqual([
+      "llm-wiki/query/read",
+      "llm-wiki/query/write",
+    ]);
+  });
+
+  it("loadConfig throws when a required env var is missing", async () => {
+    const env = { ...baseEnv, COGNITO_ISSUER: undefined };
+    await expect(
+      loadConfig({ ssm: ssmReturning(fullSsm), env }),
+    ).rejects.toThrow(/missing env COGNITO_ISSUER/);
+  });
+
+  it("empty OAUTH_STATE_HMAC_KEY is preserved as the proxy-disabled sentinel", async () => {
+    const env = { ...baseEnv, OAUTH_STATE_HMAC_KEY: "" };
+    const cfg = await loadConfig({ ssm: ssmReturning(fullSsm), env });
+    expect(cfg.hmacKey).toBe("");
+  });
+
+  it("empty RESOURCE_SCOPES yields an empty scopes array", async () => {
+    const env = { ...baseEnv, RESOURCE_SCOPES: "" };
+    const cfg = await loadConfig({ ssm: ssmReturning(fullSsm), env });
+    expect(cfg.resourceScopes).toEqual([]);
+  });
+});

--- a/infra/src/oauth-facade/config.ts
+++ b/infra/src/oauth-facade/config.ts
@@ -1,0 +1,120 @@
+/**
+ * Façade runtime config (design §6.4 + the cycle break).
+ *
+ * The façade is fronted by an `ApiGatewayV2` HTTP API (NOT a Lambda Function
+ * URL — that exposes an open `Principal: "*"` resource policy). The Pulumi
+ * dependency cycle
+ *
+ *   readerClient.callbackUrls  ←  façade URL          (Cognito needs the URL)
+ *   façade env                 ←  readerClient.id/secret + gatewayUrl
+ *
+ * is broken at the infra layer by creating the API resource first
+ * (`facadeApi.url` is independent of the Lambda). Independently, the façade
+ * reads the gateway URL + reader client creds
+ * from SSM at RUNTIME (cold-start singleton in the handler) instead of taking
+ * them as construction-time env vars, keeping the Lambda free of any
+ * constructor dependency on the reader client or the gateway:
+ *   - `{mcpPrefix}/gateway/url`                    (UPSTREAM gateway)
+ *   - `{mcpPrefix}/cognito/reader/client-id`
+ *   - `{mcpPrefix}/cognito/reader/client-secret`   (SecureString)
+ *
+ * The remaining, non-cyclic values (Cognito endpoint URLs that depend only on
+ * the user pool + domain, the HMAC key from the SST Secret, and the resource
+ * scopes) are plain env vars. The SSM client is injected (`SsmLike`) so the
+ * loader is unit-testable without AWS.
+ */
+
+import { GetParametersCommand, SSMClient } from "@aws-sdk/client-ssm";
+
+export interface FacadeConfig {
+  /** AgentCore Gateway URL the façade proxies to (`/mcp` + fallthrough). */
+  upstream: string;
+  /** Cognito OIDC issuer. */
+  issuer: string;
+  /** Cognito Hosted-UI authorize / token / userinfo / revocation / jwks. */
+  authorize: string;
+  token: string;
+  userinfo: string;
+  revocation: string;
+  jwks: string;
+  /** Resource-server scopes advertised in metadata (e.g. `mem9/memory/read`). */
+  resourceScopes: string[];
+  /** Reader app client credentials returned by `/register` (DCR). */
+  userClientId: string;
+  userClientSecret: string;
+  /** HMAC key for state signing; empty disables the proxy (503). */
+  hmacKey: string;
+}
+
+/** Minimal SSM surface used here — injected so tests need no AWS. */
+export interface SsmLike {
+  send(command: unknown): Promise<{
+    Parameters?: Array<{ Name?: string; Value?: string }>;
+  }>;
+}
+
+type Env = Record<string, string | undefined>;
+
+function reqEnv(env: Env, name: string): string {
+  const v = env[name];
+  if (!v) throw new Error(`missing env ${name}`);
+  return v;
+}
+
+/** Resolve the three cyclic values from SSM (decrypting the client secret). */
+export async function resolveSsm(
+  prefix: string,
+  ssm: SsmLike,
+): Promise<{ upstream: string; userClientId: string; userClientSecret: string }> {
+  const names = [
+    `${prefix}/gateway/url`,
+    `${prefix}/cognito/reader/client-id`,
+    `${prefix}/cognito/reader/client-secret`,
+  ];
+  const res = await ssm.send(
+    new GetParametersCommand({ Names: names, WithDecryption: true }),
+  );
+  const byName = new Map(
+    (res.Parameters ?? []).map((p) => [p.Name, p.Value ?? ""]),
+  );
+  const get = (n: string): string => {
+    const v = byName.get(n);
+    if (!v) throw new Error(`missing SSM parameter ${n}`);
+    return v;
+  };
+  return {
+    upstream: get(names[0]!),
+    userClientId: get(names[1]!),
+    userClientSecret: get(names[2]!),
+  };
+}
+
+/**
+ * Build the façade config from env + SSM. The handler wraps this in a
+ * cold-start singleton; tests inject `ssm` + `env` and call it directly.
+ */
+export async function loadConfig(
+  opts: { ssm?: SsmLike; env?: Env } = {},
+): Promise<FacadeConfig> {
+  const env = opts.env ?? process.env;
+  const ssm = opts.ssm ?? new SSMClient({});
+  const prefix = reqEnv(env, "SSM_PREFIX");
+  const resolved = await resolveSsm(prefix, ssm);
+  return {
+    upstream: resolved.upstream,
+    issuer: reqEnv(env, "COGNITO_ISSUER"),
+    authorize: reqEnv(env, "COGNITO_AUTHORIZE_ENDPOINT"),
+    token: reqEnv(env, "COGNITO_TOKEN_ENDPOINT"),
+    userinfo: reqEnv(env, "COGNITO_USERINFO_ENDPOINT"),
+    revocation: reqEnv(env, "COGNITO_REVOCATION_ENDPOINT"),
+    jwks: reqEnv(env, "COGNITO_JWKS_URI"),
+    resourceScopes: (env.RESOURCE_SCOPES ?? "")
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean),
+    userClientId: resolved.userClientId,
+    userClientSecret: resolved.userClientSecret,
+    // Empty (not missing) is the intended "proxy disabled" sentinel.
+    hmacKey: env.OAUTH_STATE_HMAC_KEY ?? "",
+  };
+}

--- a/infra/src/oauth-facade/handler.test.ts
+++ b/infra/src/oauth-facade/handler.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Unit tests for the façade routing (TC-MCPGW-060..073).
+ * Exercised through the injected `route(event, cfg)` seam — no AWS/SSM.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { isAllowedClientRedirect, route } from "./handler.js";
+import { verifyState } from "./state.js";
+import type { FacadeConfig } from "./config.js";
+
+const HOST = "abc123.lambda-url.ap-northeast-1.on.aws";
+const BASE = `https://${HOST}`;
+const HMAC = "unit-test-hmac-key";
+
+function cfg(overrides: Partial<FacadeConfig> = {}): FacadeConfig {
+  return {
+    upstream: "https://gateway.example/mcp-prefix",
+    issuer: "https://cognito-idp.ap-northeast-1.amazonaws.com/pool",
+    authorize: "https://dom.auth.ap-northeast-1.amazoncognito.com/oauth2/authorize",
+    token: "https://dom.auth.ap-northeast-1.amazoncognito.com/oauth2/token",
+    userinfo: "https://dom.auth.ap-northeast-1.amazoncognito.com/oauth2/userInfo",
+    revocation: "https://dom.auth.ap-northeast-1.amazoncognito.com/oauth2/revoke",
+    jwks: "https://cognito-idp.ap-northeast-1.amazonaws.com/pool/.well-known/jwks.json",
+    // Reader-client-aligned: openid + email + read only (no write).
+    resourceScopes: ["llm-wiki/query/read"],
+    userClientId: "reader-client-id",
+    userClientSecret: "reader-client-secret",
+    hmacKey: HMAC,
+    ...overrides,
+  };
+}
+
+function ev(
+  path: string,
+  method = "GET",
+  opts: { query?: string; body?: string; headers?: Record<string, string> } = {},
+) {
+  return {
+    rawPath: path,
+    rawQueryString: opts.query ?? "",
+    headers: { host: HOST, ...(opts.headers ?? {}) },
+    body: opts.body,
+    requestContext: { http: { method }, domainName: HOST },
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("façade routing (TC-MCPGW-060..073)", () => {
+  it("TC-MCPGW-060: protected-resource metadata points at <base>/mcp", async () => {
+    const res = await route(ev("/.well-known/oauth-protected-resource"), cfg());
+    expect(res.statusCode).toBe(200);
+    const b = JSON.parse(res.body);
+    expect(b.resource).toBe(`${BASE}/mcp`);
+    expect(b.authorization_servers).toEqual([BASE]);
+  });
+
+  it("TC-MCPGW-061: AS metadata advertises the façade endpoints + S256", async () => {
+    const res = await route(
+      ev("/.well-known/oauth-authorization-server"),
+      cfg(),
+    );
+    const b = JSON.parse(res.body);
+    expect(b.authorization_endpoint).toBe(`${BASE}/oauth/authorize`);
+    expect(b.token_endpoint).toBe(`${BASE}/oauth/token`);
+    expect(b.code_challenge_methods_supported).toContain("S256");
+    // Advertised scopes must match the reader client's allowed scopes exactly
+    // — no `profile`, no `write`.
+    expect(b.scopes_supported).toEqual(["openid", "email", "llm-wiki/query/read"]);
+    expect(b.scopes_supported).not.toContain("profile");
+    expect(b.scopes_supported).not.toContain("llm-wiki/query/write");
+  });
+
+  it("TC-MCPGW-061b: OIDC discovery metadata advertises reader-aligned scopes (no profile/write)", async () => {
+    const res = await route(ev("/.well-known/openid-configuration"), cfg());
+    const b = JSON.parse(res.body);
+    expect(b.scopes_supported).toEqual(["openid", "email", "llm-wiki/query/read"]);
+    expect(b.scopes_supported).not.toContain("profile");
+    expect(b.scopes_supported).not.toContain("llm-wiki/query/write");
+  });
+
+  it("TC-MCPGW-062: /oauth/authorize 302s to Cognito with replaced redirect_uri + HMAC state", async () => {
+    const q = new URLSearchParams({
+      client_id: "c",
+      redirect_uri: "http://127.0.0.1:5000/callback",
+      state: "orig-state",
+      code_challenge: "abc",
+      code_challenge_method: "S256",
+      response_type: "code",
+    }).toString();
+    const res = await route(ev("/oauth/authorize", "GET", { query: q }), cfg());
+    expect(res.statusCode).toBe(302);
+    const loc = new URL(res.headers.location);
+    expect(loc.origin + loc.pathname).toBe(cfg().authorize);
+    expect(loc.searchParams.get("redirect_uri")).toBe(`${BASE}/oauth/callback`);
+    const decoded = verifyState(
+      loc.searchParams.get("state")!,
+      HMAC,
+      Date.now(),
+    );
+    expect(decoded!.r).toBe("http://127.0.0.1:5000/callback");
+    expect(decoded!.cs).toBe("orig-state");
+  });
+
+  it("TC-MCPGW-063: /oauth/authorize without redirect_uri → 400", async () => {
+    const res = await route(
+      ev("/oauth/authorize", "GET", { query: "code_challenge=x" }),
+      cfg(),
+    );
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toBe("invalid_request");
+  });
+
+  it("TC-MCPGW-064: /oauth/authorize with non-loopback redirect_uri → 400", async () => {
+    const q = new URLSearchParams({
+      redirect_uri: "https://evil.example/callback",
+      code_challenge: "x",
+    }).toString();
+    const res = await route(ev("/oauth/authorize", "GET", { query: q }), cfg());
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("TC-MCPGW-065: /oauth/authorize without code_challenge (no PKCE) → 400", async () => {
+    const q = new URLSearchParams({
+      redirect_uri: "http://localhost:5000/cb",
+    }).toString();
+    const res = await route(ev("/oauth/authorize", "GET", { query: q }), cfg());
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error_description).toMatch(/code_challenge/);
+  });
+
+  it("TC-MCPGW-066: /oauth/authorize with plain PKCE → 400", async () => {
+    const q = new URLSearchParams({
+      redirect_uri: "http://localhost:5000/cb",
+      code_challenge: "x",
+      code_challenge_method: "plain",
+    }).toString();
+    const res = await route(ev("/oauth/authorize", "GET", { query: q }), cfg());
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error_description).toMatch(/S256/);
+  });
+
+  it("TC-MCPGW-066b: /oauth/authorize with code_challenge but no method → 400 (no silent plain fallback)", async () => {
+    // RFC 7636 §4.3: an omitted code_challenge_method defaults to `plain`.
+    // The façade must reject it rather than silently downgrade from S256.
+    const q = new URLSearchParams({
+      redirect_uri: "http://localhost:5000/cb",
+      code_challenge: "x",
+    }).toString();
+    const res = await route(ev("/oauth/authorize", "GET", { query: q }), cfg());
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toBe("invalid_request");
+    expect(JSON.parse(res.body).error_description).toMatch(/S256/);
+  });
+
+  it("TC-MCPGW-067: /oauth/callback 302s back to the client loopback with code + orig state", async () => {
+    // Sign a state the way /oauth/authorize would.
+    const authQ = new URLSearchParams({
+      redirect_uri: "http://127.0.0.1:5000/callback",
+      state: "orig-state",
+      code_challenge: "x",
+      code_challenge_method: "S256",
+    }).toString();
+    const authRes = await route(
+      ev("/oauth/authorize", "GET", { query: authQ }),
+      cfg(),
+    );
+    const facadeState = new URL(authRes.headers.location).searchParams.get(
+      "state",
+    )!;
+
+    const cbQ = new URLSearchParams({
+      code: "auth-code-xyz",
+      state: facadeState,
+    }).toString();
+    const res = await route(ev("/oauth/callback", "GET", { query: cbQ }), cfg());
+    expect(res.statusCode).toBe(302);
+    const loc = new URL(res.headers.location);
+    expect(loc.origin + loc.pathname).toBe("http://127.0.0.1:5000/callback");
+    expect(loc.searchParams.get("code")).toBe("auth-code-xyz");
+    expect(loc.searchParams.get("state")).toBe("orig-state");
+  });
+
+  it("TC-MCPGW-068: /oauth/callback with a bad state → 400 invalid_state", async () => {
+    const q = new URLSearchParams({
+      code: "c",
+      state: "garbage.state",
+    }).toString();
+    const res = await route(ev("/oauth/callback", "GET", { query: q }), cfg());
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toBe("invalid_state");
+  });
+
+  it("TC-MCPGW-069: /oauth/token replaces redirect_uri before forwarding to Cognito", async () => {
+    let captured: { url: string; body: string } | undefined;
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      async (url: string | URL | Request, init?: RequestInit) => {
+        captured = { url: String(url), body: String(init?.body ?? "") };
+        return new Response(JSON.stringify({ access_token: "tok" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      },
+    );
+    const form = new URLSearchParams({
+      grant_type: "authorization_code",
+      code: "c",
+      redirect_uri: "http://127.0.0.1:5000/callback",
+      code_verifier: "v",
+    }).toString();
+    const res = await route(
+      ev("/oauth/token", "POST", {
+        body: form,
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+      }),
+      cfg(),
+    );
+    expect(res.statusCode).toBe(200);
+    expect(captured!.url).toBe(cfg().token);
+    const fwd = new URLSearchParams(captured!.body);
+    expect(fwd.get("redirect_uri")).toBe(`${BASE}/oauth/callback`);
+    expect(fwd.get("code")).toBe("c");
+  });
+
+  it("TC-MCPGW-070: empty HMAC key → /oauth/authorize 503", async () => {
+    const q = new URLSearchParams({
+      redirect_uri: "http://localhost:5000/cb",
+      code_challenge: "x",
+    }).toString();
+    const res = await route(
+      ev("/oauth/authorize", "GET", { query: q }),
+      cfg({ hmacKey: "" }),
+    );
+    expect(res.statusCode).toBe(503);
+    expect(JSON.parse(res.body).error).toBe("server_misconfigured");
+  });
+
+  it("TC-MCPGW-071: empty HMAC key → /oauth/callback 503", async () => {
+    const res = await route(
+      ev("/oauth/callback", "GET", { query: "state=x" }),
+      cfg({ hmacKey: "" }),
+    );
+    expect(res.statusCode).toBe(503);
+    expect(JSON.parse(res.body).error).toBe("server_misconfigured");
+  });
+
+  it("TC-MCPGW-072: /register returns the reader client creds (RFC 7591 DCR)", async () => {
+    const res = await route(
+      ev("/register", "POST", { body: JSON.stringify({ redirect_uris: ["http://127.0.0.1:9/cb"] }) }),
+      cfg(),
+    );
+    expect(res.statusCode).toBe(201);
+    const b = JSON.parse(res.body);
+    expect(b.client_id).toBe("reader-client-id");
+    expect(b.client_secret).toBe("reader-client-secret");
+    expect(b.redirect_uris).toEqual(["http://127.0.0.1:9/cb"]);
+    // DCR scope must match the reader client (no profile/write).
+    expect(b.scope).toBe("openid email llm-wiki/query/read");
+    expect(b.scope).not.toMatch(/profile/);
+    expect(b.scope).not.toMatch(/write/);
+  });
+
+  it("TC-MCPGW-073: isAllowedClientRedirect only accepts loopback http URLs", () => {
+    expect(isAllowedClientRedirect("http://localhost:1/cb")).toBe(true);
+    expect(isAllowedClientRedirect("http://127.0.0.1:65535/cb")).toBe(true);
+    expect(isAllowedClientRedirect("https://localhost/cb")).toBe(false);
+    expect(isAllowedClientRedirect("http://evil.example/cb")).toBe(false);
+    expect(isAllowedClientRedirect("not a url")).toBe(false);
+  });
+});

--- a/infra/src/oauth-facade/handler.ts
+++ b/infra/src/oauth-facade/handler.ts
@@ -1,0 +1,459 @@
+/**
+ * OAuth2 façade for the mem9 MCP surface (§6).
+ *
+ * Adapted from a proven OAuth2-façade router. One adaptation:
+ *
+ *   - Config is injected (`route(event, cfg)`) and resolved at runtime from
+ *     env + SSM (`./config.ts`) — see that file for the SSM-at-runtime config.
+ *     The routing logic below is unchanged and fully unit-testable without AWS.
+ *
+ * The façade is fronted by an `ApiGatewayV2` HTTP API (NOT a Lambda Function
+ * URL — that would expose an open `Principal: "*"` resource policy). The event
+ * payload is API-GW-v2 format 2.0
+ * (`rawPath`, `requestContext.http.method`, `rawQueryString`), which is what
+ * this handler reads — identical to the Function-URL payload shape, so the
+ * routing logic is independent of the entry resource.
+ *
+ * Why a façade at all (verbatim rationale from the reference):
+ * - Claude Code's OAuth client needs RFC 8414 / RFC 9728 metadata + RFC 7591
+ *   DCR, none of which Cognito serves at the discovery path the Gateway
+ *   advertises.
+ * - Claude Code's local callback listener picks a random ephemeral port;
+ *   Cognito requires exact-match `callbackUrls`. The façade is the single
+ *   registered redirect target and 302-redirects to the client's loopback
+ *   port. State + the original client redirect_uri ride through Cognito as an
+ *   HMAC-signed opaque blob so the proxy stays stateless.
+ *
+ * Routes: `/.well-known/*` metadata, `/oauth/authorize|callback|token|logout`,
+ * `/register`, and a catch-all proxy to the AgentCore Gateway (`/mcp`).
+ */
+
+import { loadConfig, type FacadeConfig } from "./config.js";
+import { signState, verifyState } from "./state.js";
+
+interface ApiGwEvent {
+  rawPath?: string;
+  path?: string;
+  rawQueryString?: string;
+  headers?: Record<string, string>;
+  body?: string;
+  isBase64Encoded?: boolean;
+  requestContext?: {
+    http?: { method?: string };
+    domainName?: string;
+  };
+  httpMethod?: string;
+}
+
+interface ApiGwResponse {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: string;
+}
+
+function json(
+  status: number,
+  body: unknown,
+  extraHeaders: Record<string, string> = {},
+): ApiGwResponse {
+  return {
+    statusCode: status,
+    headers: { "content-type": "application/json", ...extraHeaders },
+    body: JSON.stringify(body),
+  };
+}
+
+function redirect(location: string): ApiGwResponse {
+  return {
+    statusCode: 302,
+    headers: { location, "cache-control": "no-store" },
+    body: "",
+  };
+}
+
+function selfBaseUrl(event: ApiGwEvent): string {
+  const host = event.headers?.host ?? event.requestContext?.domainName;
+  return `https://${host}`;
+}
+
+function logEvent(name: string, fields: Record<string, unknown>): void {
+  // One structured line per OAuth step. No token bodies — only grant_type /
+  // outcome / non-secret query params.
+  console.log(JSON.stringify({ event: name, ...fields }));
+}
+
+function ensureHmacConfigured(cfg: FacadeConfig): ApiGwResponse | null {
+  if (!cfg.hmacKey) {
+    return json(503, {
+      error: "server_misconfigured",
+      error_description:
+        "OAUTH_STATE_HMAC_KEY is not set; the OAuth2 redirect proxy is unavailable.",
+    });
+  }
+  return null;
+}
+
+/**
+ * Native-app loopback redirect_uri validation (RFC 8252 §7.3). Without this
+ * the façade would be an open redirector leaking auth codes to attacker URLs.
+ * Claude Code's MCP transport uses a loopback address with an arbitrary port.
+ */
+export function isAllowedClientRedirect(uri: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(uri);
+  } catch {
+    return false;
+  }
+  if (url.protocol !== "http:") return false;
+  return (
+    url.hostname === "localhost" ||
+    url.hostname === "127.0.0.1" ||
+    url.hostname === "[::1]" ||
+    url.hostname === "::1"
+  );
+}
+
+/** Pure router — all façade logic; config injected so tests need no AWS. */
+export async function route(
+  event: ApiGwEvent,
+  cfg: FacadeConfig,
+): Promise<ApiGwResponse> {
+  const path = event.rawPath ?? event.path ?? "/";
+  const method =
+    event.requestContext?.http?.method ?? event.httpMethod ?? "GET";
+  const base = selfBaseUrl(event);
+
+  // RFC 9728 — Protected Resource Metadata.
+  if (path === "/.well-known/oauth-protected-resource") {
+    return json(200, {
+      resource: `${base}/mcp`,
+      authorization_servers: [base],
+      scopes_supported: cfg.resourceScopes,
+      bearer_methods_supported: ["header"],
+    });
+  }
+
+  // RFC 8414 — Authorization Server Metadata. authorize/token point at the
+  // façade so clients hit the redirect proxy; the rest pass through to Cognito.
+  if (path === "/.well-known/oauth-authorization-server") {
+    return json(200, {
+      issuer: cfg.issuer,
+      authorization_endpoint: `${base}/oauth/authorize`,
+      token_endpoint: `${base}/oauth/token`,
+      userinfo_endpoint: cfg.userinfo,
+      revocation_endpoint: cfg.revocation,
+      jwks_uri: cfg.jwks,
+      registration_endpoint: `${base}/register`,
+      response_types_supported: ["code"],
+      response_modes_supported: ["query"],
+      grant_types_supported: ["authorization_code", "refresh_token"],
+      code_challenge_methods_supported: ["S256"],
+      token_endpoint_auth_methods_supported: [
+        "client_secret_basic",
+        "client_secret_post",
+      ],
+      // Advertise only what the reader client actually allows: openid + email
+      // + the read resource scope. `profile` and the `write` scope are NOT in
+      // the reader client's allowedOauthScopes, so advertising them here would
+      // make a client that requests the full set fail Cognito's authorize step
+      // with `invalid_scope`.
+      scopes_supported: ["openid", "email", ...cfg.resourceScopes],
+    });
+  }
+
+  // OIDC discovery (some clients only know this path).
+  if (path === "/.well-known/openid-configuration") {
+    return json(200, {
+      issuer: cfg.issuer,
+      authorization_endpoint: `${base}/oauth/authorize`,
+      token_endpoint: `${base}/oauth/token`,
+      userinfo_endpoint: cfg.userinfo,
+      revocation_endpoint: cfg.revocation,
+      jwks_uri: cfg.jwks,
+      registration_endpoint: `${base}/register`,
+      response_types_supported: ["code"],
+      subject_types_supported: ["public"],
+      id_token_signing_alg_values_supported: ["RS256"],
+      code_challenge_methods_supported: ["S256"],
+      grant_types_supported: ["authorization_code", "refresh_token"],
+      // Aligned with the reader client's allowedOauthScopes (no `profile`, no
+      // `write`) — see the oauth-authorization-server metadata above.
+      scopes_supported: ["openid", "email", ...cfg.resourceScopes],
+    });
+  }
+
+  // GET /oauth/authorize — wrap state + client redirect_uri into an
+  // HMAC-signed token, then 302 to Cognito Hosted UI.
+  if (path === "/oauth/authorize" && method === "GET") {
+    const misconfigured = ensureHmacConfigured(cfg);
+    if (misconfigured) return misconfigured;
+
+    const inParams = new URLSearchParams(event.rawQueryString ?? "");
+    const clientRedirect = inParams.get("redirect_uri");
+    const clientState = inParams.get("state") ?? "";
+    if (!clientRedirect) {
+      return json(400, {
+        error: "invalid_request",
+        error_description: "missing redirect_uri",
+      });
+    }
+    if (!isAllowedClientRedirect(clientRedirect)) {
+      return json(400, {
+        error: "invalid_request",
+        error_description:
+          "redirect_uri must be a loopback (http://localhost or http://127.0.0.1) URL",
+      });
+    }
+    // Require PKCE so the auth code is useless without the code_verifier.
+    if (!inParams.get("code_challenge")) {
+      return json(400, {
+        error: "invalid_request",
+        error_description: "code_challenge is required (PKCE)",
+      });
+    }
+    // Enforce S256 explicitly. A missing `code_challenge_method` defaults to
+    // `plain` per RFC 7636 §4.3, so silently accepting it would let the flow
+    // fall back to non-S256 PKCE even though our discovery metadata advertises
+    // `code_challenge_methods_supported: ["S256"]`. Reject anything that is not
+    // exactly `S256` (missing, `plain`, or any other value).
+    const challengeMethod = inParams.get("code_challenge_method");
+    if (challengeMethod !== "S256") {
+      return json(400, {
+        error: "invalid_request",
+        error_description: "code_challenge_method must be S256",
+      });
+    }
+
+    const facadeState = signState(
+      { cs: clientState, r: clientRedirect },
+      cfg.hmacKey,
+      Date.now(),
+    );
+
+    const out = new URLSearchParams();
+    for (const [k, v] of inParams.entries()) {
+      if (k === "redirect_uri" || k === "state") continue;
+      out.append(k, v);
+    }
+    out.set("redirect_uri", `${base}/oauth/callback`);
+    out.set("state", facadeState);
+
+    logEvent("oauth.authorize", {
+      client_id: inParams.get("client_id") ?? null,
+      has_pkce: inParams.get("code_challenge") !== null,
+    });
+    return redirect(`${cfg.authorize}?${out.toString()}`);
+  }
+
+  // GET /oauth/callback — verify HMAC, decode original client state +
+  // redirect_uri, then 302 back to that client URL with the upstream code.
+  if (path === "/oauth/callback" && method === "GET") {
+    const misconfigured = ensureHmacConfigured(cfg);
+    if (misconfigured) return misconfigured;
+
+    const params = new URLSearchParams(event.rawQueryString ?? "");
+    const code = params.get("code");
+    const facadeState = params.get("state");
+    const error = params.get("error");
+
+    if (!facadeState) {
+      return json(400, {
+        error: "invalid_request",
+        error_description: "missing state",
+      });
+    }
+
+    const decoded = verifyState(facadeState, cfg.hmacKey, Date.now());
+    if (!decoded) {
+      logEvent("oauth.callback.bad_state", {});
+      return json(400, {
+        error: "invalid_state",
+        error_description: "state HMAC failed or token expired",
+      });
+    }
+    // Defense-in-depth: re-enforce loopback at the redirect step.
+    if (!isAllowedClientRedirect(decoded.r)) {
+      logEvent("oauth.callback.non_loopback_redirect", {});
+      return json(400, {
+        error: "invalid_state",
+        error_description: "decoded redirect_uri is not a loopback URL",
+      });
+    }
+
+    const out = new URLSearchParams();
+    if (code) out.set("code", code);
+    if (error) {
+      out.set("error", error);
+      const errDesc = params.get("error_description");
+      if (errDesc) out.set("error_description", errDesc);
+    }
+    out.set("state", decoded.cs);
+
+    logEvent("oauth.callback", { ok: !error, error: error ?? null });
+    return redirect(`${decoded.r}?${out.toString()}`);
+  }
+
+  // POST /oauth/token — replace the client redirect_uri with the façade's so
+  // Cognito's redirect_uri-replay check matches the single registered URL.
+  if (path === "/oauth/token" && method === "POST") {
+    const rawBody = event.isBase64Encoded
+      ? Buffer.from(event.body ?? "", "base64").toString("utf8")
+      : (event.body ?? "");
+    const inForm = new URLSearchParams(rawBody);
+
+    const clientRedirect = inForm.get("redirect_uri");
+    if (clientRedirect && !isAllowedClientRedirect(clientRedirect)) {
+      return json(400, {
+        error: "invalid_request",
+        error_description: "redirect_uri must be a loopback URL",
+      });
+    }
+
+    if (
+      inForm.has("redirect_uri") ||
+      inForm.get("grant_type") === "authorization_code"
+    ) {
+      inForm.set("redirect_uri", `${base}/oauth/callback`);
+    }
+
+    const fwdHeaders: Record<string, string> = {
+      "content-type": "application/x-www-form-urlencoded",
+    };
+    const incomingAuth =
+      event.headers?.authorization ?? event.headers?.Authorization;
+    if (incomingAuth) fwdHeaders["authorization"] = incomingAuth;
+
+    let upstream: Response;
+    try {
+      upstream = await fetch(cfg.token, {
+        method: "POST",
+        headers: fwdHeaders,
+        body: inForm.toString(),
+      });
+    } catch (err) {
+      logEvent("oauth.token.upstream_error", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return json(502, {
+        error: "upstream_unreachable",
+        error_description: "Failed to reach Cognito token endpoint",
+      });
+    }
+    const respBody = await upstream.text();
+    const respHeaders: Record<string, string> = {};
+    upstream.headers.forEach((v, k) => {
+      const lk = k.toLowerCase();
+      if (lk === "content-length" || lk === "transfer-encoding") return;
+      respHeaders[k] = v;
+    });
+
+    const clientAuth = incomingAuth
+      ? "basic"
+      : inForm.has("client_secret")
+        ? "post"
+        : "none";
+    logEvent("oauth.token", {
+      grant_type: inForm.get("grant_type") ?? null,
+      client_auth: clientAuth,
+      status: upstream.status,
+    });
+
+    return { statusCode: upstream.status, headers: respHeaders, body: respBody };
+  }
+
+  // Cognito Hosted-UI sign-out landing.
+  if (path === "/oauth/logout" && method === "GET") {
+    logEvent("oauth.logout", {});
+    return {
+      statusCode: 200,
+      headers: { "content-type": "text/plain", "cache-control": "no-store" },
+      body: "Signed out.",
+    };
+  }
+
+  // RFC 7591 — Dynamic Client Registration (returns the pre-provisioned
+  // reader client to every caller).
+  if (path === "/register" && method === "POST") {
+    let req: { redirect_uris?: string[] } = {};
+    try {
+      req = JSON.parse(event.body ?? "{}");
+    } catch {
+      // minimal payloads are fine
+    }
+    return json(201, {
+      client_id: cfg.userClientId,
+      client_secret: cfg.userClientSecret,
+      client_id_issued_at: Math.floor(Date.now() / 1000),
+      client_secret_expires_at: 0,
+      redirect_uris: req.redirect_uris ?? ["http://localhost:8080/callback"],
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+      token_endpoint_auth_method: "client_secret_post",
+      scope: ["openid", "email", ...cfg.resourceScopes].join(" "),
+    });
+  }
+
+  // Catch-all proxy to the upstream AgentCore Gateway (`/mcp` + the rest).
+  const upstreamUrl = new URL(cfg.upstream);
+  upstreamUrl.pathname = path;
+  if (event.rawQueryString) upstreamUrl.search = `?${event.rawQueryString}`;
+
+  const fwdHeaders: Record<string, string> = {};
+  for (const [k, v] of Object.entries(event.headers ?? {})) {
+    const lk = k.toLowerCase();
+    if (lk === "host" || lk === "content-length" || lk === "x-forwarded-for")
+      continue;
+    fwdHeaders[k] = v;
+  }
+
+  const reqBody = event.isBase64Encoded
+    ? Buffer.from(event.body ?? "", "base64")
+    : event.body;
+
+  const upstreamResp = await fetch(upstreamUrl.toString(), {
+    method,
+    headers: fwdHeaders,
+    body: method === "GET" || method === "HEAD" ? undefined : reqBody,
+  });
+
+  const respHeaders: Record<string, string> = {};
+  upstreamResp.headers.forEach((value, key) => {
+    respHeaders[key] = value;
+  });
+  const respBody = await upstreamResp.text();
+
+  // Rewrite WWW-Authenticate so resource_metadata points back at the façade.
+  if (respHeaders["www-authenticate"]) {
+    respHeaders["www-authenticate"] =
+      `Bearer resource_metadata="${base}/.well-known/oauth-protected-resource"`;
+  }
+
+  return {
+    statusCode: upstreamResp.status,
+    headers: respHeaders,
+    body: respBody,
+  };
+}
+
+/** Lambda handler — resolve config (env + SSM) once per cold start, then route. */
+let configPromise: Promise<FacadeConfig> | undefined;
+
+function getConfig(): Promise<FacadeConfig> {
+  if (!configPromise) {
+    configPromise = loadConfig().catch((err) => {
+      configPromise = undefined;
+      throw err;
+    });
+  }
+  return configPromise;
+}
+
+export async function handler(event: ApiGwEvent): Promise<ApiGwResponse> {
+  return route(event, await getConfig());
+}
+
+/** Test-only: drop the cold-start config singleton between cases. */
+export function __resetForTests(): void {
+  configPromise = undefined;
+}

--- a/infra/src/oauth-facade/state.test.ts
+++ b/infra/src/oauth-facade/state.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Unit tests for the façade HMAC state utility (TC-MCPGW-040..046).
+ * See `docs/test-cases/wiki-mcp-gateway.md`.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { signState, verifyState } from "./state.js";
+
+const KEY = "test-hmac-key-do-not-use-in-prod";
+const REDIRECT = "http://127.0.0.1:54321/callback";
+
+describe("façade state (TC-MCPGW-040..046)", () => {
+  it("TC-MCPGW-040: signState → verifyState round-trips {cs, r}", () => {
+    const now = Date.now();
+    const token = signState({ cs: "client-state", r: REDIRECT }, KEY, now);
+    const out = verifyState(token, KEY, now);
+    expect(out).not.toBeNull();
+    expect(out!.cs).toBe("client-state");
+    expect(out!.r).toBe(REDIRECT);
+  });
+
+  it("TC-MCPGW-041: a different key fails verification", () => {
+    const now = Date.now();
+    const token = signState({ cs: "s", r: REDIRECT }, KEY, now);
+    expect(verifyState(token, "another-key", now)).toBeNull();
+  });
+
+  it("TC-MCPGW-042: tampered payload fails verification", () => {
+    const now = Date.now();
+    const token = signState({ cs: "s", r: REDIRECT }, KEY, now);
+    const [payload, sig] = token.split(".");
+    const tampered = `${payload}x.${sig}`;
+    expect(verifyState(tampered, KEY, now)).toBeNull();
+  });
+
+  it("TC-MCPGW-043: past the TTL fails verification", () => {
+    const signedAt = Date.now();
+    const token = signState({ cs: "s", r: REDIRECT }, KEY, signedAt);
+    const later = signedAt + 11 * 60 * 1000; // 11 min > 10 min TTL
+    expect(verifyState(token, KEY, later)).toBeNull();
+  });
+
+  it("TC-MCPGW-044: future-dated by >60s fails verification", () => {
+    const future = Date.now() + 5 * 60 * 1000;
+    const token = signState({ cs: "s", r: REDIRECT }, KEY, future);
+    expect(verifyState(token, KEY, Date.now())).toBeNull();
+  });
+
+  it("TC-MCPGW-045: malformed token returns null (no throw)", () => {
+    const now = Date.now();
+    expect(verifyState("not-a-token", KEY, now)).toBeNull();
+    expect(verifyState("a.b.c", KEY, now)).toBeNull();
+    expect(verifyState("@@@.@@@", KEY, now)).toBeNull();
+  });
+
+  it("TC-MCPGW-046: token stays under Cognito's 1024-char state limit", () => {
+    const token = signState({ cs: "x".repeat(64), r: REDIRECT }, KEY, Date.now());
+    expect(token.length).toBeLessThan(1024);
+  });
+});

--- a/infra/src/oauth-facade/state.ts
+++ b/infra/src/oauth-facade/state.ts
@@ -1,0 +1,96 @@
+/**
+ * HMAC-signed state utility for the OAuth2 redirect proxy (design §6.4).
+ *
+ * State format (URL-safe, ASCII): `<base64url(payload)>.<base64url(sig)>`
+ *
+ * Payload is JSON `{ cs: <client_state>, r: <client_redirect_uri>,
+ * ts: <ms epoch> }`. We HMAC-SHA-256 the payload's base64url form (not the
+ * raw bytes) so verification compares the recomputed b64-form signature
+ * byte-for-byte with `crypto.timingSafeEqual`.
+ *
+ * Stateless by design — no DDB / no TTL store / no extra IAM. A typical token
+ * is ~150-200 bytes, well under Cognito's 1024-char `state` limit.
+ *
+ * Forked verbatim from the proven mem9 MCP surface façade
+ * (`src/lambdas/oauth2-facade/state.ts`).
+ */
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+const STATE_TTL_MS = 10 * 60 * 1000;
+
+export interface StatePayload {
+  cs: string;
+  r: string;
+  ts: number;
+}
+
+function b64urlEncode(buf: Buffer | string): string {
+  return Buffer.from(buf as Buffer | string)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function b64urlDecode(s: string): Buffer {
+  const pad = (4 - (s.length % 4)) % 4;
+  const b64 = s.replace(/-/g, "+").replace(/_/g, "/") + "=".repeat(pad);
+  return Buffer.from(b64, "base64");
+}
+
+function hmac(key: string, payload: string): Buffer {
+  return createHmac("sha256", key).update(payload).digest();
+}
+
+export function signState(
+  input: { cs: string; r: string },
+  key: string,
+  now: number,
+): string {
+  const payload: StatePayload = { cs: input.cs, r: input.r, ts: now };
+  const payloadB64 = b64urlEncode(JSON.stringify(payload));
+  const sigB64 = b64urlEncode(hmac(key, payloadB64));
+  return `${payloadB64}.${sigB64}`;
+}
+
+export function verifyState(
+  token: string,
+  key: string,
+  now: number,
+  ttlMs: number = STATE_TTL_MS,
+): StatePayload | null {
+  const parts = token.split(".");
+  if (parts.length !== 2) return null;
+  const [payloadB64, sigB64] = parts;
+  if (!payloadB64 || !sigB64) return null;
+
+  const expectedSig = hmac(key, payloadB64);
+  let providedSig: Buffer;
+  try {
+    providedSig = b64urlDecode(sigB64);
+  } catch {
+    return null;
+  }
+  if (providedSig.length !== expectedSig.length) return null;
+  if (!timingSafeEqual(providedSig, expectedSig)) return null;
+
+  let payload: StatePayload;
+  try {
+    payload = JSON.parse(b64urlDecode(payloadB64).toString("utf8"));
+  } catch {
+    return null;
+  }
+  if (
+    typeof payload.cs !== "string" ||
+    typeof payload.r !== "string" ||
+    typeof payload.ts !== "number"
+  ) {
+    return null;
+  }
+
+  if (now - payload.ts > ttlMs) return null;
+  if (payload.ts > now + 60_000) return null; // future-dated by >60s, reject
+
+  return payload;
+}

--- a/infra/sst-types.d.ts
+++ b/infra/sst-types.d.ts
@@ -58,6 +58,57 @@ declare namespace aws {
   }
   function getCallerIdentityOutput(): GetCallerIdentityResult;
 
+  // Region lookup — infra/oauth-facade.ts composes the Cognito domain / issuer
+  // URLs from the deploy region.
+  interface GetRegionResult {
+    readonly name: Output<string>;
+  }
+  function getRegionOutput(): GetRegionResult;
+
+  // Cognito user pool + M2M/OAuth client (infra/cognito.ts + infra/oauth-facade.ts).
+  namespace cognito {
+    interface UserPoolArgs {
+      name?: Input<string>;
+      schema?: { name: string; attributeDataType: string; mutable?: boolean; required?: boolean }[];
+      userAttributeUpdateSettings?: { attributesRequireVerificationBeforeUpdate: string[] };
+      autoVerifiedAttributes?: string[];
+      tags?: Record<string, Input<string>>;
+      [k: string]: unknown;
+    }
+    class UserPool {
+      constructor(name: string, args: UserPoolArgs, opts?: unknown);
+      readonly id: Output<string>;
+    }
+    class UserPoolDomain {
+      constructor(name: string, args: Record<string, unknown>, opts?: unknown);
+      readonly domain: Output<string>;
+    }
+    class ResourceServer {
+      constructor(name: string, args: Record<string, unknown>);
+      readonly identifier: Output<string>;
+    }
+    interface UserPoolClientArgs {
+      name?: Input<string>;
+      userPoolId: Input<string>;
+      generateSecret?: Input<boolean>;
+      explicitAuthFlows?: Input<string>[];
+      allowedOauthFlows?: Input<string>[];
+      allowedOauthScopes?: Input<Input<string>[]>;
+      allowedOauthFlowsUserPoolClient?: Input<boolean>;
+      callbackUrls?: Input<Input<string>[]>;
+      logoutUrls?: Input<Input<string>[]>;
+      supportedIdentityProviders?: Input<string>[];
+      preventUserExistenceErrors?: Input<string>;
+      enableTokenRevocation?: Input<boolean>;
+      [k: string]: unknown;
+    }
+    class UserPoolClient {
+      constructor(name: string, args: UserPoolClientArgs, opts?: unknown);
+      readonly id: Output<string>;
+      readonly clientSecret: Output<string>;
+    }
+  }
+
   namespace lambda {
     // Only referenced as the $transform target + its arg shape.
     interface FunctionArgs {
@@ -334,6 +385,8 @@ declare namespace sst {
       handler: Input<string>;
       runtime?: Input<string>;
       timeout?: Input<string>;
+      architecture?: Input<"x86_64" | "arm64">;
+      memory?: Input<string>;
       vpc?: FunctionVpc;
       environment?: Input<Record<string, Input<string>>>;
       permissions?: { actions: string[]; resources: Input<string>[] }[];
@@ -345,5 +398,27 @@ declare namespace sst {
       readonly name: Output<string>;
       readonly nodes: { function: { name: Output<string>; arn: Output<string> } };
     }
+
+    // ── ApiGatewayV2 (infra/oauth-facade.ts — the OAuth login facade API) ─────
+    interface ApiGatewayV2Cors {
+      allowOrigins?: Input<string>[];
+      allowMethods?: Input<string>[];
+      allowHeaders?: Input<string>[];
+      maxAge?: Input<string>;
+    }
+    interface ApiGatewayV2Args {
+      cors?: ApiGatewayV2Cors;
+    }
+    class ApiGatewayV2 {
+      constructor(name: string, args?: ApiGatewayV2Args);
+      readonly url: Output<string>;
+      route(route: string, handler: Input<string>, args?: unknown): void;
+    }
+  }
+
+  // ── sst.Secret (infra/oauth-facade.ts — OAuth client secret / signing key) ──
+  class Secret {
+    constructor(name: string, defaultValue?: string);
+    readonly value: Output<string>;
   }
 }

--- a/scripts/run-oauth-facade-smoke.sh
+++ b/scripts/run-oauth-facade-smoke.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# run-oauth-facade-smoke.sh — verify the OAuth façade metadata endpoints are live.
+# The full browser authorization-code flow can't run headless (needs a human at a
+# browser), so CI validates the RFC 8414/9728 metadata + registration endpoint.
+set -euo pipefail
+STAGE="${STAGE:?STAGE is required}"
+REGION="${AWS_REGION:-ap-northeast-1}"
+PREFIX="/mem9-on-aws/${STAGE}"
+ssm() { aws ssm get-parameter --name "$1" --region "$REGION" --query Parameter.Value --output text; }
+
+echo "run-oauth-facade-smoke: reading façade URL from SSM ${PREFIX}/facade/url"
+FACADE=$(ssm "${PREFIX}/facade/url")
+if [[ -z "$FACADE" ]]; then
+  echo "::warning::no facade/url SSM param — OAuth façade not deployed on this stage (skipping)"
+  exit 0
+fi
+echo "run-oauth-facade-smoke: façade=${FACADE}"
+
+echo "run-oauth-facade-smoke: checking /.well-known/oauth-authorization-server"
+AS=$(curl -fsS "${FACADE}/.well-known/oauth-authorization-server")
+echo "$AS" | jq -e '.authorization_endpoint | endswith("/oauth/authorize")' >/dev/null || { echo "::error::authorization_endpoint does not point at the façade"; exit 1; }
+echo "$AS" | jq -e '.token_endpoint | endswith("/oauth/token")' >/dev/null || { echo "::error::token_endpoint does not point at the façade"; exit 1; }
+echo "$AS" | jq -e '.code_challenge_methods_supported == ["S256"]' >/dev/null || { echo "::error::S256 not advertised"; exit 1; }
+echo "$AS" | jq -e '.registration_endpoint | endswith("/register")' >/dev/null || { echo "::error::no registration_endpoint"; exit 1; }
+
+echo "run-oauth-facade-smoke: checking /.well-known/oauth-protected-resource"
+PR=$(curl -fsS "${FACADE}/.well-known/oauth-protected-resource")
+echo "$PR" | jq -e '.resource | endswith("/mcp")' >/dev/null || { echo "::error::protected-resource.resource does not end with /mcp"; exit 1; }
+
+echo "run-oauth-facade-smoke: OK — façade metadata valid for stage ${STAGE}"

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -6,7 +6,7 @@
  * Self-hosted deployment of mem9 (`mnemo-server`) on AWS. `run()` wires the full
  * stack (see docs/ARCHITECTURE.md): meta (SSM) → Aurora → ECS Fargate
  * (mnemo-server + qwen3-embed + llm-proxy) → schema bootstrap → the MCP surface
- * (ACM cert → Cognito M2M → internal ALB → AgentCore Gateway).
+ * (Cognito M2M + OAuth2 façade → AgentCore Gateway → Lambda-proxy target).
  *
  * Mirrors the shape of the sister SST v4 projects so a single operator can
  * context-switch without re-learning constructs:
@@ -16,9 +16,8 @@
  *
  * TWO STANDING RULES enforced here (see ~/.claude/CLAUDE-AWS.md):
  *   1. Every ZIP Lambda runs `nodejs24.x` (forced via `$transform` below).
- *   2. NO Lambda Function URL — ever. When the AgentCore interceptor Lambda
- *      lands, it is invoked by the Gateway (service-scoped resource policy),
- *      never via a Function URL.
+ *   2. NO Lambda Function URL — the OAuth façade is fronted by ApiGatewayV2, the
+ *      MCP proxy Lambda by the AgentCore Gateway (service-scoped invoke).
  */
 
 export default $config({
@@ -106,8 +105,14 @@ export default $config({
     // id (bootstrapOut) for the outbound X-API-Key.
     const { cognito } = await import("./infra/cognito");
     const cognitoOut = cognito();
+    // OAuth2 browser-login façade (§6): ApiGatewayV2 + reader client + façade
+    // Lambda. Built BEFORE gateway() because it produces the reader client id the
+    // gateway must trust. The façade reads gateway/url from SSM at RUNTIME, so it
+    // takes only cognitoOut (no gateway dep) — keeping the graph acyclic.
+    const { oauthFacade } = await import("./infra/oauth-facade");
+    const facadeOut = oauthFacade(cognitoOut);
     const { gateway } = await import("./infra/gateway");
-    gateway(cognitoOut, ecsOut, bootstrapOut);
+    gateway(cognitoOut, ecsOut, bootstrapOut, facadeOut.readerClientId);
 
     return {};
   },


### PR DESCRIPTION
## Summary
Add an interactive **OAuth2 authorization-code + PKCE** (browser login) flow to the mem9 MCP surface, **alongside** the existing Cognito M2M auth.

- **OAuth façade Lambda** (lifted from llm-wiki, nodejs24.x/arm64) fronted by ApiGatewayV2 — serves RFC 8414/9728 metadata, RFC 7591 DCR, and proxies the auth-code+PKCE flow to Cognito Hosted-UI (loopback redirect via HMAC-signed state).
- **Reader `UserPoolClient`** (`authorization_code` + PKCE S256, Hosted-UI login) — gateway trusts both M2M + reader. Scopes: `openid`, `email`, `mem9-mcp/read`.
- Existing M2M E2E (`scripts/run-mcp-e2e.sh`) and prod ingest are **unchanged** (no regression).
- **Deploy-role IAM** updated + redeployed out-of-band (ApiGatewayV2 grants live).

Architecture: the façade sits IN FRONT of the AgentCore Gateway — the existing Lambda-proxy target → Cloud Map → mnemo-server chain is completely untouched.

## Design
- Design spec: `docs/superpowers/specs/2026-07-15-oauth2-mcp-browser-login-design.md`
- LLM-team reviewed (3 independent reviewers: cycle/Pulumi, AWS/security, completeness-vs-llm-wiki)

## Test Plan
- [x] Design canvas / spec created + LLM-team reviewed
- [x] Build passes (infra tsc clean)
- [x] Unit tests pass (82 infra + 14 root; includes 29 façade-specific tests)
- [x] Deploy-role IAM redeployed out-of-band
- [ ] CI checks pass (preview deploy + MCP E2E + façade smoke)
- [ ] Manual browser-login verification (one-time, post-deploy)

## One-time setup (post-merge, per stage)
```bash
# 1. Seed the HMAC key
pnpm -C infra exec sst secret set OauthStateHmacKey "$(openssl rand -base64 32)" --stage prod
# 2. Create the operator user
aws cognito-idp admin-create-user --user-pool-id <pool-id> --username <email> --region ap-northeast-1
# 3. Point Claude Code at the façade endpoint
# SSM: /mem9-on-aws/prod/facade/mcp-endpoint
```

## Checklist
- [x] New unit tests (29 façade + 2 cognito + 2 gateway)
- [x] Code review (3-agent LLM review + per-task spec-compliance reviews)
- [x] No Lambda Function URL (ApiGatewayV2)
- [x] No committed secrets / account IDs
- [x] ARCHITECTURE.md updated (§6b: two inbound-auth modes)