### PR TITLE
feat(cognito): email auto-verify for ForgotPassword + lock self-signup

### DIFF
--- a/infra/cognito.test.ts
+++ b/infra/cognito.test.ts
@@ -153,7 +153,26 @@ describe("cognito stack", () => {
       attributesRequireVerificationBeforeUpdate: unknown[];
     };
     expect(updateSettings.attributesRequireVerificationBeforeUpdate).toEqual([]);
-    expect(poolArgs.autoVerifiedAttributes).toEqual([]);
+  });
+
+  it("auto-verifies email so ForgotPassword recovery works", async () => {
+    installGlobals("prod");
+    const cognito = await loadCognito();
+    cognito();
+    const poolArgs = byKind("UserPool")[0].args;
+    // email must be auto-verifiable for the Hosted-UI ForgotPassword flow to send
+    // a recovery code (AccountRecovery is verified_email). Without this, reset 503s.
+    expect(poolArgs.autoVerifiedAttributes).toEqual(["email"]);
+  });
+
+  it("locks self-service sign-up (admin-create-user only)", async () => {
+    installGlobals("prod");
+    const cognito = await loadCognito();
+    cognito();
+    const poolArgs = byKind("UserPool")[0].args;
+    const adminCfg = poolArgs.adminCreateUserConfig as { allowAdminCreateUserOnly?: boolean };
+    // Single-operator: no public sign-up. Only an admin creates users.
+    expect(adminCfg.allowAdminCreateUserOnly).toBe(true);
   });
 
   it("exports the Hosted-UI endpoint URLs the façade needs", async () => {

--- a/infra/cognito.ts
+++ b/infra/cognito.ts
@@ -53,12 +53,22 @@ export function cognito(): CognitoOutputs {
     "Mem9McpPool",
     {
       name: `${stage}-mem9-mcp`,
-      // Hosted-UI minimal config (llm-wiki's exact set): an `email` attribute for
-      // the login form, no forced re-verification on update, and nothing
-      // auto-verified (the OAuth2 façade owns the flow, not Cognito email/SMS).
+      // Hosted-UI config: an `email` attribute for the login form, no forced
+      // re-verification on attribute update.
       schema: [{ name: "email", attributeDataType: "String", mutable: true, required: false }],
       userAttributeUpdateSettings: { attributesRequireVerificationBeforeUpdate: [] },
-      autoVerifiedAttributes: [],
+      // Auto-verify email so the Hosted-UI ForgotPassword flow can send a
+      // recovery code (AccountRecovery defaults to verified_email). Without this,
+      // the operator can't reset their password via the browser — reset 503s
+      // because no verified recovery channel exists. Cognito's own /oauth login
+      // + this recovery path are separate from the OAuth2 FAÇADE, which brokers
+      // the authorization-code flow but not password management. Email sending
+      // uses the pool's COGNITO_DEFAULT sender (50/day — ample for one operator).
+      autoVerifiedAttributes: ["email"],
+      // Single-operator: NO self-service sign-up. Only an admin (admin-create-user)
+      // provisions users; enabling email auto-verify above must NOT open public
+      // registration. This flag locks the Hosted-UI sign-up path.
+      adminCreateUserConfig: { allowAdminCreateUserOnly: true },
       tags,
     },
     { deleteBeforeReplace: nonProd },


### PR DESCRIPTION
## Summary
Make the Cognito Hosted-UI **ForgotPassword** password-recovery flow work for the operator user, while keeping the deployment single-operator (no self-service sign-up).

- `autoVerifiedAttributes: ["email"]` — so `AccountRecovery`'s `verified_email` channel can send a reset code. Without it the browser password-reset 503s (no verified recovery channel). Email sending uses the existing `COGNITO_DEFAULT` sender (50/day, ample for one operator — no SES change).
- `adminCreateUserConfig: { allowAdminCreateUserOnly: true }` — locks the Hosted-UI sign-up path so enabling email verification does NOT open public registration. Stays admin-create-user only.

Both fields are AWS-documented **`Update requires: No interruption`** → **no pool replacement**; existing users + the M2M/reader clients are preserved.

## Post-merge (one-time, operator/me)
1. Manual `workflow_dispatch` prod redeploy (local `sst` is unusable — bundled bun deadlocks; CI is the deploy path).
2. Mark the existing `<email>` user's email verified via admin API (pool change doesn't retro-verify existing users) — I'll do this after the deploy.
3. Then ForgotPassword works from the Hosted-UI.

## Test Plan
- [x] Build passes (infra tsc clean)
- [x] Unit tests pass (84 infra; 2 new cognito assertions, TDD-proven to fail on old code)
- [ ] CI preview deploy (verifies the pool update applies with no interruption)

## Checklist
- [x] No pool replacement (AWS-verified no-interruption fields)
- [x] Single-operator preserved (self-signup locked)
- [x] No secrets / account ids committed