### PR TITLE
feat(mcp): add ingest_messages gateway tool for transcript smart-ingest

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -172,7 +172,10 @@ VPC-internal endpoint if the embedding shim is in-VPC).
 >   `mnemo.mem9-<stage>.local`; the Lambda (in the same private subnets + task SG)
 >   resolves it and calls HTTP :8080.
 > - **v1 has NO interceptor Lambda** (single-operator, single-tenant → per-tool
->   scoping deferred). Tools exposed: `add_memory`, `search_memories`.
+>   scoping deferred). Tools exposed: `add_memory`, `search_memories`,
+>   `ingest_messages` (transcript smart-ingest — same mnemo-server
+>   `POST /memories` endpoint as `add_memory`, but a `messages[]` body triggers
+>   LLM extraction; used by the Claude Code ingest hooks).
 
 Mirror podcast-curation `gateway.ts` + `cognito.ts` + `api.ts`:
 
@@ -240,9 +243,10 @@ Design rules:
   `lambda:InvokeFunction` on the one function (least privilege).
 - **The proxy Lambda** (`infra/gateway/proxy-handler.mjs`) receives the tool name in
   `context.clientContext.Custom.bedrockAgentCoreToolName` (`${target}___${tool}`) and
-  the tool inputs as a flat event map; it maps `add_memory`/`search_memories` to
-  mnemo-server's REST (`POST`/`GET /v1alpha2/mem9s/memories`), injecting `X-API-Key`
-  (= tenant id). It's VPC-attached (private subnets + the task SG, so a self-ingress
+  the tool inputs as a flat event map; it maps `add_memory`/`search_memories`/
+  `ingest_messages` to mnemo-server's REST (`POST`/`GET /v1alpha2/mem9s/memories`;
+  `ingest_messages` POSTs a `messages[]` body for smart-ingest), injecting
+  `X-API-Key` (= tenant id). It's VPC-attached (private subnets + the task SG, so a self-ingress
   :8080 rule lets it reach the server) and nodejs24.x. The tool inputSchemas live
   inline in `infra/gateway.ts`.
 - **Cloud Map** (`infra/ecs.ts`): a `PrivateDnsNamespace` (`mem9-<stage>.local`) + a

--- a/infra/gateway.test.ts
+++ b/infra/gateway.test.ts
@@ -215,6 +215,7 @@ describe("gateway stack", () => {
     expect(env.MEM9_TGT_LAMBDA_ARN).toBeDefined();
     expect(String(env.MEM9_TGT_TOOL_SCHEMA)).toContain("add_memory");
     expect(String(env.MEM9_TGT_TOOL_SCHEMA)).toContain("search_memories");
+    expect(String(env.MEM9_TGT_TOOL_SCHEMA)).toContain("ingest_messages");
     // The removed privateEndpoint/API-key/OpenAPI-schema inputs are gone.
     expect(env.MEM9_TGT_SCHEMA).toBeUndefined();
     expect(env.MEM9_TGT_APIKEY_PROVIDER_ARN).toBeUndefined();

--- a/infra/gateway.ts
+++ b/infra/gateway.ts
@@ -84,6 +84,47 @@ const TOOL_SCHEMA = [
       required: ["q"],
     },
   },
+  {
+    // Transcript ingest. Hits the SAME mnemo-server endpoint as add_memory
+    // (POST /v1alpha2/mem9s/memories); mnemo-server branches on the presence of
+    // `messages` — a messages[] body triggers smart-ingest (LLM extraction +
+    // reconciliation) instead of storing one raw string. Used by the Claude Code
+    // ingest hooks (Stop/PreCompact/SessionEnd) to upload a bounded conversation
+    // window. See infra/gateway/proxy-handler.mjs `ingestMessages`.
+    name: "ingest_messages",
+    description:
+      "Ingest a conversation window (messages[]) for smart extraction into memories. Writes are async; returns {status:'accepted'}.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        messages: {
+          type: "array",
+          description: "Ordered conversation turns to extract memories from.",
+          items: {
+            type: "object",
+            properties: {
+              role: { type: "string", description: "'user' or 'assistant'." },
+              content: { type: "string", description: "The message text." },
+            },
+            required: ["role", "content"],
+          },
+        },
+        session_id: {
+          type: "string",
+          description: "Optional session id to group the ingested turns.",
+        },
+        agent_id: {
+          type: "string",
+          description: "Optional agent id to attribute the write to (per-agent scoping).",
+        },
+        mode: {
+          type: "string",
+          description: "Ingest mode: 'smart' (LLM extraction, default) or 'raw'.",
+        },
+      },
+      required: ["messages"],
+    },
+  },
 ];
 
 export interface GatewayOutputs {
@@ -220,7 +261,8 @@ export function gateway(
         MEM9_TGT_REGION: region,
         MEM9_TGT_GATEWAY_ID: bedrockGateway.gatewayId,
         MEM9_TGT_NAME: targetName,
-        MEM9_TGT_DESCRIPTION: "mnemo-server MCP tools (add_memory, search_memories) via a proxy Lambda",
+        MEM9_TGT_DESCRIPTION:
+          "mnemo-server MCP tools (add_memory, search_memories, ingest_messages) via a proxy Lambda",
         MEM9_TGT_LAMBDA_ARN: proxyFn.arn,
         MEM9_TGT_TOOL_SCHEMA: toolSchemaJson,
       },

--- a/infra/gateway/proxy-handler.mjs
+++ b/infra/gateway/proxy-handler.mjs
@@ -146,6 +146,26 @@ async function searchMemories(input) {
   return mem9Fetch(`${MEMORIES_PATH}?${params.toString()}`, { method: "GET" });
 }
 
+async function ingestMessages(input) {
+  // Same endpoint as add_memory; mnemo-server smart-ingests when the body carries
+  // messages[] (LLM extraction) rather than a single content string. Default
+  // mode=smart matches the upstream Claude Code plugin's transcript ingest.
+  const { messages, session_id, agent_id, mode } = input ?? {};
+  if (!Array.isArray(messages) || messages.length === 0) {
+    throw new Error("ingest_messages requires a non-empty 'messages' array");
+  }
+  const headers = { "Content-Type": "application/json" };
+  if (agent_id) headers["X-Mnemo-Agent-Id"] = String(agent_id);
+  const payload = { mode: mode ?? "smart", messages };
+  if (session_id) payload.session_id = session_id;
+  if (agent_id) payload.agent_id = agent_id;
+  return mem9Fetch(MEMORIES_PATH, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(payload),
+  });
+}
+
 export const handler = async (event, context) => {
   const tool = resolveToolName(context);
   switch (tool) {
@@ -153,6 +173,8 @@ export const handler = async (event, context) => {
       return addMemory(event);
     case "search_memories":
       return searchMemories(event);
+    case "ingest_messages":
+      return ingestMessages(event);
     default:
       throw new Error(`unknown tool: ${tool}`);
   }

--- a/infra/gateway/proxy-handler.test.mjs
+++ b/infra/gateway/proxy-handler.test.mjs
@@ -1,0 +1,113 @@
+// Unit tests for the AgentCore Gateway → mnemo-server proxy Lambda handler.
+//
+// The handler reads MEM9_SERVER_BASE_URL / MEM9_API_KEY at module load, so we set
+// them before a dynamic import, then drive the exported `handler` with a mocked
+// global `fetch` and a fake Lambda context (clientContext.Custom carries the
+// AgentCore `${target}___${tool}` name). We assert the outbound request shape for
+// each tool WITHOUT touching AWS, DNS, or a live mnemo-server.
+
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+process.env.MEM9_SERVER_BASE_URL = "http://mnemo.mem9-test.local:8080";
+process.env.MEM9_API_KEY = "test-tenant-id";
+
+let handler;
+beforeAll(async () => {
+  ({ handler } = await import("./proxy-handler.mjs"));
+});
+
+// Capture the single fetch call and return an OK JSON response.
+function mockFetchOk(body = { status: "accepted" }) {
+  const spy = vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    text: async () => JSON.stringify(body),
+  }));
+  vi.stubGlobal("fetch", spy);
+  return spy;
+}
+
+// Build a fake Lambda context naming the tool the way AgentCore does.
+const ctx = (tool) => ({
+  clientContext: { Custom: { bedrockAgentCoreToolName: `test-mem9-rest___${tool}` } },
+});
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("proxy-handler ingest_messages", () => {
+  it("POSTs a smart-ingest body (mode defaults to smart, messages passed through)", async () => {
+    const spy = mockFetchOk();
+    const messages = [
+      { role: "user", content: "remember I prefer arm64" },
+      { role: "assistant", content: "noted" },
+    ];
+    const res = await handler(
+      { messages, session_id: "sess-1", agent_id: "claude-code-x" },
+      ctx("ingest_messages"),
+    );
+
+    expect(res).toEqual({ status: "accepted" });
+    expect(spy).toHaveBeenCalledTimes(1);
+    const [url, init] = spy.mock.calls[0];
+    expect(url).toBe("http://mnemo.mem9-test.local:8080/v1alpha2/mem9s/memories");
+    expect(init.method).toBe("POST");
+    expect(init.headers["X-API-Key"]).toBe("test-tenant-id");
+    expect(init.headers["X-Mnemo-Agent-Id"]).toBe("claude-code-x");
+    const sent = JSON.parse(init.body);
+    expect(sent).toEqual({
+      mode: "smart",
+      messages,
+      session_id: "sess-1",
+      agent_id: "claude-code-x",
+    });
+  });
+
+  it("honors an explicit mode and omits absent optional fields", async () => {
+    const spy = mockFetchOk();
+    await handler(
+      { messages: [{ role: "user", content: "hi" }], mode: "raw" },
+      ctx("ingest_messages"),
+    );
+    const sent = JSON.parse(spy.mock.calls[0][1].body);
+    expect(sent.mode).toBe("raw");
+    expect(sent).not.toHaveProperty("session_id");
+    expect(sent).not.toHaveProperty("agent_id");
+    // No agent_id → no per-agent header.
+    expect(spy.mock.calls[0][1].headers).not.toHaveProperty("X-Mnemo-Agent-Id");
+  });
+
+  it("rejects an empty or missing messages array without calling the backend", async () => {
+    const spy = mockFetchOk();
+    await expect(handler({ messages: [] }, ctx("ingest_messages"))).rejects.toThrow(
+      /non-empty 'messages'/,
+    );
+    await expect(handler({}, ctx("ingest_messages"))).rejects.toThrow(/non-empty 'messages'/);
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+describe("proxy-handler routing (regression)", () => {
+  it("add_memory still POSTs a single content body", async () => {
+    const spy = mockFetchOk();
+    await handler({ content: "one fact", agent_id: "a" }, ctx("add_memory"));
+    const [url, init] = spy.mock.calls[0];
+    expect(url).toBe("http://mnemo.mem9-test.local:8080/v1alpha2/mem9s/memories");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body)).toEqual({ content: "one fact", agent_id: "a" });
+  });
+
+  it("search_memories GETs with the query string", async () => {
+    const spy = mockFetchOk({ memories: [], total: 0 });
+    await handler({ q: "arm64", limit: 5 }, ctx("search_memories"));
+    const [url, init] = spy.mock.calls[0];
+    expect(init.method).toBe("GET");
+    expect(url).toContain("/v1alpha2/mem9s/memories?");
+    expect(url).toContain("q=arm64");
+    expect(url).toContain("limit=5");
+  });
+
+  it("throws on an unknown tool", async () => {
+    mockFetchOk();
+    await expect(handler({}, ctx("delete_everything"))).rejects.toThrow(/unknown tool/);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,12 +1,14 @@
 import { defineConfig } from "vitest/config";
 
 // Root vitest project. The SST app + its unit tests live under `infra/` (see
-// `infra/vitest.config.ts`); this config covers the repo-root/sidecar tests:
+// `infra/vitest.config.ts`, which globs `*.test.ts`); this config covers the
+// repo-root/sidecar tests plus the plain-ESM (`.mjs`) Lambda/sidecar handlers:
 //   - scripts/**/*.test.ts    (any shell-wrapper helpers gaining tests)
 //   - docker/**/*.test.mjs    (the ECS sidecar servers, e.g. llm-proxy)
+//   - infra/**/*.test.mjs     (the .mjs Lambda handlers, e.g. gateway proxy-handler)
 // Runs with `--passWithNoTests` so CI's `npm test` never fails on an empty glob.
 export default defineConfig({
   test: {
-    include: ["scripts/**/*.test.ts", "docker/**/*.test.mjs"],
+    include: ["scripts/**/*.test.ts", "docker/**/*.test.mjs", "infra/**/*.test.mjs"],
   },
 });


### PR DESCRIPTION
## Summary

Adds a third AgentCore Gateway MCP tool, `ingest_messages`, so clients can upload a **conversation window** (`messages[]`) for LLM smart-extraction instead of a single raw string. This is what the Claude Code global memory hooks (recall + auto transcript ingest) call to auto-upload session transcripts to mem9.

It hits the **same** mnemo-server endpoint as `add_memory` (`POST /v1alpha2/mem9s/memories`); mnemo-server branches on the presence of a `messages[]` body to smart-ingest vs. store one string. No mnemo-server change — only the gateway tool schema + proxy handler.

## Changes

- **infra/gateway.ts** — `ingest_messages` `inputSchema` (`messages[]` of `{role, content}`, optional `session_id`/`agent_id`/`mode`). Preserves the shape-sensitive SDK contract (`properties` map, `required` array).
- **infra/gateway/proxy-handler.mjs** — `ingestMessages()` maps the tool to the `messages[]` POST, defaulting `mode=smart` and forwarding `X-Mnemo-Agent-Id`.
- **infra/gateway/proxy-handler.test.mjs** — new handler unit test (mocks `fetch`) covering all three tools; root `vitest.config.ts` `include` extended to `infra/**/*.test.mjs`.
- **docs/ARCHITECTURE.md** — tool list updated.

## Verification

- Unit tests green: root 20, infra 84; typecheck clean.
- **Verified live against prod**: an M2M `client_credentials` bearer + a **stateless** `tools/call` works over the raw gateway (no `initialize` handshake needed); `ingest_messages` returns `Unknown tool` until this deploys — proving the transport + auth path are correct and only the tool registration is pending.
- Confirmed against upstream `server/internal/handler/memory.go` (@ pinned SHA d4638c8): the memories POST decoder is a plain `json.NewDecoder().Decode()` (no `DisallowUnknownFields`), `messages`/`session_id`/`agent_id`/`mode` are first-class fields, and `content`+`messages` are mutually exclusive — the tool sends only `messages[]`, so it's contract-correct.

## Dependencies

None — additive change; the two existing tools are unchanged.

## Testing Requirements

- `npm test` (root, incl. new proxy-handler.test.mjs) + `vitest` (infra) must pass.
- Post-deploy: the existing gateway E2E should exercise `ingest_messages` end-to-end.