### PR TITLE
fix(mcp): gateway target wiped on tool-schema change (deleteBeforeReplace + tool reconcile)

### DIFF
--- a/infra/gateway.test.ts
+++ b/infra/gateway.test.ts
@@ -17,6 +17,7 @@ function out<T>(value: T): { value: T; apply: (fn: (v: T) => unknown) => unknown
 interface Rec {
   kind: string;
   args: Record<string, unknown>;
+  opts?: Record<string, unknown>;
 }
 let created: Rec[];
 let params: { name: string }[];
@@ -58,8 +59,8 @@ function makeCtor(kind: string) {
     id = out(`${kind}-id`);
     gatewayId = out("gw-123");
     gatewayUrl = out("https://gw-123.gateway.bedrock-agentcore.ap-northeast-1.amazonaws.com/mcp");
-    constructor(_n: string, args: Record<string, unknown>) {
-      created.push({ kind, args });
+    constructor(_n: string, args: Record<string, unknown>, opts?: Record<string, unknown>) {
+      created.push({ kind, args, opts });
     }
   };
 }
@@ -226,5 +227,9 @@ describe("gateway stack", () => {
     expect(created.filter((r) => r.kind === "AgentcoreApiKeyCredentialProvider")).toHaveLength(0);
     // Gateway url/id exported to SSM.
     expect(params.map((p) => p.name)).toContain("/mem9-on-aws/prod/gateway/url");
+    // deleteBeforeReplace guards against the create-then-delete replace order that
+    // wiped the target on a tool-schema change (PR #16 prod outage).
+    const cmdRec = created.find((r) => r.kind === "LocalCommand");
+    expect(cmdRec?.opts?.deleteBeforeReplace).toBe(true);
   });
 });

--- a/infra/gateway.ts
+++ b/infra/gateway.ts
@@ -267,7 +267,18 @@ export function gateway(
         MEM9_TGT_TOOL_SCHEMA: toolSchemaJson,
       },
     },
-    { dependsOn: [bedrockGateway, proxyFn] },
+    {
+      dependsOn: [bedrockGateway, proxyFn],
+      // A `triggers` change (e.g. the tool schema) REPLACES this Command. Pulumi's
+      // default replace order is create-new-THEN-delete-old — and because the create
+      // step reuses an existing READY target, the new create was a no-op and the
+      // trailing delete then WIPED the target, leaving the gateway with ZERO tools
+      // (prod outage on PR #16's deploy). `deleteBeforeReplace` flips the order: the
+      // old Command's delete removes the target FIRST, so the new create finds nothing
+      // and provisions a fresh target carrying the new schema. (provision-target.mjs
+      // also now reconciles the tool set on reuse — belt and suspenders.)
+      deleteBeforeReplace: true,
+    },
   );
 
   const gatewayId = bedrockGateway.gatewayId;

--- a/infra/gateway/provision-target.mjs
+++ b/infra/gateway/provision-target.mjs
@@ -141,23 +141,47 @@ async function createOnce(input) {
   return targetId;
 }
 
+/** Names of the tools an existing target exposes, for a schema-drift check on reuse. */
+async function existingToolNames(targetId) {
+  const res = await client.send(
+    new GetGatewayTargetCommand({ gatewayIdentifier: GATEWAY_ID, targetId }),
+  );
+  const inline = res?.targetConfiguration?.mcp?.lambda?.toolSchema?.inlinePayload ?? [];
+  return new Set(inline.map((t) => t.name));
+}
+
 async function create() {
   const lambdaArn = env("MEM9_TGT_LAMBDA_ARN");
   const toolSchema = JSON.parse(env("MEM9_TGT_TOOL_SCHEMA"));
   const description = env("MEM9_TGT_DESCRIPTION", false) ?? "";
 
-  // Idempotency: a same-named target may already exist (retry/re-run). Reuse if
-  // READY; otherwise delete the stale/failed one and recreate cleanly.
+  // Idempotency: a same-named target may already exist (retry/re-run). Reuse ONLY
+  // if READY *and* its tool set matches the desired schema — otherwise delete and
+  // recreate. Reusing a READY-but-stale target is exactly what silently kept the
+  // old 2-tool schema on a tool-schema change (and, combined with a create-then-
+  // delete replace, wiped the target entirely — see gateway.ts deleteBeforeReplace).
   const existing = await findTargetByName(NAME);
   if (existing) {
+    const wantNames = new Set(toolSchema.map((t) => t.name));
+    let sameTools = false;
     if (existing.status === "READY") {
-      console.error(`target ${NAME} already READY (${existing.targetId}); reusing`);
+      try {
+        const haveNames = await existingToolNames(existing.targetId);
+        sameTools =
+          haveNames.size === wantNames.size && [...wantNames].every((n) => haveNames.has(n));
+      } catch (e) {
+        console.error(`  (could not read existing tools, will recreate: ${e?.message ?? e})`);
+      }
+    }
+    if (existing.status === "READY" && sameTools) {
+      console.error(
+        `target ${NAME} already READY with matching tools (${existing.targetId}); reusing`,
+      );
       console.log(existing.targetId);
       return;
     }
-    console.error(
-      `target ${NAME} exists in status ${existing.status}; deleting to recreate`,
-    );
+    const why = existing.status === "READY" ? "tool schema changed" : `status ${existing.status}`;
+    console.error(`target ${NAME} exists (${why}); deleting to recreate`);
     await deleteTarget(existing.targetId);
   }
 


### PR DESCRIPTION
## Summary

PR #16's prod deploy left the AgentCore gateway with **zero tools** (prod outage — all MCP calls returned an empty tool list; the prod hard E2E correctly failed).

**Root cause:** a tool-schema change bumps the `Mem9GatewayTarget` Command's `triggers`, so Pulumi **replaces** the Command. The default replace order is **create-new → then delete-old**. The create step found the old target still `READY` and *reused* it (a no-op that kept the stale 2-tool schema); the trailing delete of the old Command then removed the target entirely → no target left → `tools/list` returns `[]`.

## Fix (two parts)

- **infra/gateway.ts** — `deleteBeforeReplace: true` on the Command. The old Command's delete now runs **before** the new create, so create finds no target and provisions a fresh one carrying the new schema.
- **infra/gateway/provision-target.mjs** — on reuse, compare the existing target's tool-name set to the desired schema; reuse only if `READY` **and** tools match, else delete+recreate. Belt-and-suspenders against any future replace-order regression or out-of-band schema drift.
- **infra/gateway.test.ts** — assert `deleteBeforeReplace` is set (regression guard); the mock ctor now also captures resource opts.

## Prod status

**Already restored out-of-band** — ran `provision-target.mjs create` directly against the prod gateway: target recreated `READY` with all 3 tools; live `ingest_messages` smoke test returned `{status:accepted}`. This PR makes the codebase correct so the next schema change deploys cleanly.

## Verification

- Unit tests green (infra 84); typecheck clean; `provision-target.mjs` syntax-checks.
- `tools/list` against prod now shows `add_memory`, `search_memories`, `ingest_messages`.

## Dependencies

None. Follows PR #16 (merged).

## Testing Requirements

- `vitest` (infra) incl. the new `deleteBeforeReplace` assertion must pass.
- Post-merge: the prod hard E2E (`tools/list` exposes the tools) must pass — the check that caught the original outage.