### PR TITLE
fix(oauth): serve façade metadata on resource-suffixed well-known paths

### DIFF
--- a/infra/src/oauth-facade/handler.test.ts
+++ b/infra/src/oauth-facade/handler.test.ts
@@ -82,6 +82,29 @@ describe("façade routing (TC-MCPGW-060..073)", () => {
     expect(b.scopes_supported).not.toContain("example-mcp/query/write");
   });
 
+  it("TC-MCPGW-061c: resource-suffixed well-known paths (/.well-known/<doc>/mcp) return the FAÇADE metadata, not the raw Gateway", async () => {
+    // A spec-compliant MCP client (RFC 9728/8414) queries the resource-suffixed
+    // path first. Without normalization these fell through to the catch-all proxy
+    // and returned the raw AgentCore Gateway's Cognito metadata (no /register DCR),
+    // breaking discovery. All three must resolve to the façade's own metadata.
+    const pr = JSON.parse(
+      (await route(ev("/.well-known/oauth-protected-resource/mcp"), cfg())).body,
+    );
+    expect(pr.resource).toBe(`${BASE}/mcp`);
+    expect(pr.authorization_servers).toEqual([BASE]);
+
+    const as = JSON.parse(
+      (await route(ev("/.well-known/oauth-authorization-server/mcp"), cfg())).body,
+    );
+    expect(as.authorization_endpoint).toBe(`${BASE}/oauth/authorize`);
+    expect(as.registration_endpoint).toBe(`${BASE}/register`);
+
+    const oidc = JSON.parse(
+      (await route(ev("/.well-known/openid-configuration/mcp"), cfg())).body,
+    );
+    expect(oidc.registration_endpoint).toBe(`${BASE}/register`);
+  });
+
   it("TC-MCPGW-062: /oauth/authorize 302s to Cognito with replaced redirect_uri + HMAC state", async () => {
     const q = new URLSearchParams({
       client_id: "c",

--- a/infra/src/oauth-facade/handler.ts
+++ b/infra/src/oauth-facade/handler.ts
@@ -124,8 +124,21 @@ export async function route(
     event.requestContext?.http?.method ?? event.httpMethod ?? "GET";
   const base = selfBaseUrl(event);
 
+  // Per RFC 9728 §3.1 / RFC 8414 §3.1, a client that found the resource at
+  // `<base>/mcp` queries the metadata at the resource-suffixed well-known path
+  // (`/.well-known/<doc>/mcp`), then falls back to the bare path. Our API
+  // Gateway sends every path to this handler via `ANY /{proxy+}`, so a suffixed
+  // well-known path that we don't match here would fall through to the catch-all
+  // proxy and return the RAW AgentCore Gateway's Cognito metadata (no `/register`
+  // DCR) — which is exactly what broke a spec-compliant MCP client. Normalize by
+  // stripping a trailing `/mcp` from any well-known path so the bare and
+  // resource-suffixed variants both resolve to the façade's own metadata.
+  const wellKnown = path.startsWith("/.well-known/")
+    ? path.replace(/\/mcp$/, "")
+    : path;
+
   // RFC 9728 — Protected Resource Metadata.
-  if (path === "/.well-known/oauth-protected-resource") {
+  if (wellKnown === "/.well-known/oauth-protected-resource") {
     return json(200, {
       resource: `${base}/mcp`,
       authorization_servers: [base],
@@ -136,7 +149,7 @@ export async function route(
 
   // RFC 8414 — Authorization Server Metadata. authorize/token point at the
   // façade so clients hit the redirect proxy; the rest pass through to Cognito.
-  if (path === "/.well-known/oauth-authorization-server") {
+  if (wellKnown === "/.well-known/oauth-authorization-server") {
     return json(200, {
       issuer: cfg.issuer,
       authorization_endpoint: `${base}/oauth/authorize`,
@@ -163,7 +176,7 @@ export async function route(
   }
 
   // OIDC discovery (some clients only know this path).
-  if (path === "/.well-known/openid-configuration") {
+  if (wellKnown === "/.well-known/openid-configuration") {
     return json(200, {
       issuer: cfg.issuer,
       authorization_endpoint: `${base}/oauth/authorize`,


### PR DESCRIPTION
## Summary

A spec-compliant MCP client (per [RFC 9728 §3.1](https://datatracker.ietf.org/doc/html/rfc9728#section-3) / RFC 8414 §3.1 / the [MCP Authorization spec](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization)) queries OAuth discovery metadata at the **resource-suffixed** well-known path first — `/.well-known/<doc>/mcp` — before falling back to the bare path.

The API Gateway routes every path to the façade Lambda via `ANY /{proxy+}`, and the handler only matched the **bare** well-known paths. So the `/mcp`-suffixed variants fell through to the catch-all proxy and returned the **raw AgentCore Gateway's Cognito metadata** — which advertises no `/register` DCR endpoint. A discovery-following MCP client (found via a codex MCP-login attempt) therefore bypassed the façade's `/register` and failed with *'Cognito does not support DCR'*.

**Verified live** against prod: all three suffixed paths (`oauth-protected-resource/mcp`, `oauth-authorization-server/mcp`, `openid-configuration/mcp`) leaked the raw Gateway metadata.

## Fix

Normalize any `/.well-known/*` path by stripping a trailing `/mcp` before matching, so the bare and resource-suffixed variants both resolve to the façade's own metadata. Scoped to well-known paths only — the catch-all proxy still forwards the real `POST /mcp` JSON-RPC tool calls on the raw `path`, untouched. **This is a discovery-routing fix only; MCP tools / JSON-RPC are unchanged, and M2M + bare-path (Claude Code) behavior is unchanged.**

Adds TC-MCPGW-061c covering all three suffixed discovery paths returning façade metadata (asserts `registration_endpoint` = `<base>/register`, i.e. the façade, not the raw Gateway).

## Verification

- 85 infra tests pass (was 84 + the new case); typecheck clean.
- Post-deploy: re-probe the three `/.well-known/<doc>/mcp` paths against prod — each must return the façade metadata (`registration_endpoint` present).

## Dependencies

None.

## Testing Requirements

- `vitest` (infra) incl. TC-MCPGW-061c must pass.
- Manual post-deploy: `curl <facade>/.well-known/oauth-authorization-server/mcp` returns the façade's `registration_endpoint`, and a spec-compliant MCP client (e.g. codex) completes DCR + browser login.