### PR TITLE
fix(oauth): present public client in DCR, inject secret server-side for Codex

### DIFF
--- a/infra/src/oauth-facade/handler.test.ts
+++ b/infra/src/oauth-facade/handler.test.ts
@@ -1,5 +1,5 @@
 /**
- * Unit tests for the façade routing (TC-MCPGW-060..073).
+ * Unit tests for the façade routing (TC-MCPGW-060..078).
  * Exercised through the injected `route(event, cfg)` seam — no AWS/SSM.
  */
 
@@ -67,6 +67,14 @@ describe("façade routing (TC-MCPGW-060..073)", () => {
     expect(b.authorization_endpoint).toBe(`${BASE}/oauth/authorize`);
     expect(b.token_endpoint).toBe(`${BASE}/oauth/token`);
     expect(b.code_challenge_methods_supported).toContain("S256");
+    // Public-client support ("none") plus the legacy secret methods during
+    // migration — clients that registered before the public-client change
+    // still authenticate with Basic/Post.
+    expect(b.token_endpoint_auth_methods_supported).toEqual([
+      "none",
+      "client_secret_basic",
+      "client_secret_post",
+    ]);
     // Advertised scopes must match the reader client's allowed scopes exactly
     // — no `profile`, no `write`.
     expect(b.scopes_supported).toEqual(["openid", "email", "example-mcp/query/read"]);
@@ -233,6 +241,7 @@ describe("façade routing (TC-MCPGW-060..073)", () => {
       code: "c",
       redirect_uri: "http://127.0.0.1:5000/callback",
       code_verifier: "v",
+      client_id: "reader-client-id",
     }).toString();
     const res = await route(
       ev("/oauth/token", "POST", {
@@ -246,6 +255,128 @@ describe("façade routing (TC-MCPGW-060..073)", () => {
     const fwd = new URLSearchParams(captured!.body);
     expect(fwd.get("redirect_uri")).toBe(`${BASE}/oauth/callback`);
     expect(fwd.get("code")).toBe("c");
+  });
+
+  // --- Public-client secret injection at /oauth/token (TC-MCPGW-074..078) ---
+  // Codex-style public clients authenticate with `none`: client_id only, no
+  // Authorization header, no client_secret. The façade injects the Cognito
+  // reader secret before forwarding — the secret must never be required from,
+  // nor returned to, the MCP client.
+
+  function mockTokenUpstream() {
+    const captured: { headers?: Record<string, string>; body?: string } = {};
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      async (_url: string | URL | Request, init?: RequestInit) => {
+        captured.headers = (init?.headers ?? {}) as Record<string, string>;
+        captured.body = String(init?.body ?? "");
+        return new Response(JSON.stringify({ access_token: "tok" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      },
+    );
+    return captured;
+  }
+
+  it("TC-MCPGW-074: secretless refresh with the known client_id → façade injects the Cognito secret", async () => {
+    const captured = mockTokenUpstream();
+    const form = new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: "rt",
+      client_id: "reader-client-id",
+    }).toString();
+    const res = await route(
+      ev("/oauth/token", "POST", { body: form }),
+      cfg(),
+    );
+    expect(res.statusCode).toBe(200);
+    const fwd = new URLSearchParams(captured.body!);
+    expect(fwd.get("client_secret")).toBe("reader-client-secret");
+    expect(fwd.get("client_id")).toBe("reader-client-id");
+    expect(fwd.get("refresh_token")).toBe("rt");
+  });
+
+  it("TC-MCPGW-075: secretless request with an UNKNOWN client_id → 401, no injection", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const form = new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: "rt",
+      client_id: "attacker-client-id",
+    }).toString();
+    const res = await route(
+      ev("/oauth/token", "POST", { body: form }),
+      cfg(),
+    );
+    expect(res.statusCode).toBe(401);
+    expect(JSON.parse(res.body).error).toBe("invalid_client");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("TC-MCPGW-076: secretless request with NO client_id → 401, no injection", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const form = new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: "rt",
+    }).toString();
+    const res = await route(
+      ev("/oauth/token", "POST", { body: form }),
+      cfg(),
+    );
+    expect(res.statusCode).toBe(401);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("TC-MCPGW-077: Basic-auth refresh (legacy Claude Code) passes through untouched — no injection", async () => {
+    const captured = mockTokenUpstream();
+    const basic = "Basic " + Buffer.from("reader-client-id:reader-client-secret").toString("base64");
+    const form = new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: "rt",
+    }).toString();
+    const res = await route(
+      ev("/oauth/token", "POST", { body: form, headers: { authorization: basic } }),
+      cfg(),
+    );
+    expect(res.statusCode).toBe(200);
+    expect(captured.headers!["authorization"]).toBe(basic);
+    const fwd = new URLSearchParams(captured.body!);
+    expect(fwd.get("client_secret")).toBeNull();
+  });
+
+  it("TC-MCPGW-078: client_secret_post refresh (legacy) passes through untouched — no overwrite", async () => {
+    const captured = mockTokenUpstream();
+    const form = new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: "rt",
+      client_id: "reader-client-id",
+      client_secret: "caller-supplied-secret",
+    }).toString();
+    const res = await route(
+      ev("/oauth/token", "POST", { body: form }),
+      cfg(),
+    );
+    expect(res.statusCode).toBe(200);
+    const fwd = new URLSearchParams(captured.body!);
+    expect(fwd.get("client_secret")).toBe("caller-supplied-secret");
+  });
+
+  it("TC-MCPGW-078b: secretless authorization_code exchange also gets the injected secret (PKCE public client)", async () => {
+    const captured = mockTokenUpstream();
+    const form = new URLSearchParams({
+      grant_type: "authorization_code",
+      code: "c",
+      redirect_uri: "http://127.0.0.1:5000/callback",
+      code_verifier: "v",
+      client_id: "reader-client-id",
+    }).toString();
+    const res = await route(
+      ev("/oauth/token", "POST", { body: form }),
+      cfg(),
+    );
+    expect(res.statusCode).toBe(200);
+    const fwd = new URLSearchParams(captured.body!);
+    expect(fwd.get("client_secret")).toBe("reader-client-secret");
+    expect(fwd.get("redirect_uri")).toBe(`${BASE}/oauth/callback`);
   });
 
   it("TC-MCPGW-070: empty HMAC key → /oauth/authorize 503", async () => {
@@ -270,7 +401,7 @@ describe("façade routing (TC-MCPGW-060..073)", () => {
     expect(JSON.parse(res.body).error).toBe("server_misconfigured");
   });
 
-  it("TC-MCPGW-072: /register returns the reader client creds (RFC 7591 DCR)", async () => {
+  it("TC-MCPGW-072: /register returns a PUBLIC client — no secret, auth method none (RFC 7591 DCR)", async () => {
     const res = await route(
       ev("/register", "POST", { body: JSON.stringify({ redirect_uris: ["http://127.0.0.1:9/cb"] }) }),
       cfg(),
@@ -278,12 +409,31 @@ describe("façade routing (TC-MCPGW-060..073)", () => {
     expect(res.statusCode).toBe(201);
     const b = JSON.parse(res.body);
     expect(b.client_id).toBe("reader-client-id");
-    expect(b.client_secret).toBe("reader-client-secret");
+    // The Cognito client secret must NEVER leave the façade: a public MCP
+    // client (Codex) can't durably hold it, and handing it out means any
+    // registrant gets a confidential credential.
+    expect(b.client_secret).toBeUndefined();
+    expect(b.client_secret_expires_at).toBeUndefined();
+    expect(b.token_endpoint_auth_method).toBe("none");
     expect(b.redirect_uris).toEqual(["http://127.0.0.1:9/cb"]);
     // DCR scope must match the reader client (no profile/write).
     expect(b.scope).toBe("openid email example-mcp/query/read");
     expect(b.scope).not.toMatch(/profile/);
     expect(b.scope).not.toMatch(/write/);
+  });
+
+  it("TC-MCPGW-072b: /register rejects a request for a secret-based auth method", async () => {
+    const res = await route(
+      ev("/register", "POST", {
+        body: JSON.stringify({
+          redirect_uris: ["http://127.0.0.1:9/cb"],
+          token_endpoint_auth_method: "client_secret_basic",
+        }),
+      }),
+      cfg(),
+    );
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toBe("invalid_client_metadata");
   });
 
   it("TC-MCPGW-073: isAllowedClientRedirect only accepts loopback http URLs", () => {

--- a/infra/src/oauth-facade/handler.ts
+++ b/infra/src/oauth-facade/handler.ts
@@ -163,6 +163,7 @@ export async function route(
       grant_types_supported: ["authorization_code", "refresh_token"],
       code_challenge_methods_supported: ["S256"],
       token_endpoint_auth_methods_supported: [
+        "none",
         "client_secret_basic",
         "client_secret_post",
       ],
@@ -309,6 +310,9 @@ export async function route(
 
   // POST /oauth/token — replace the client redirect_uri with the façade's so
   // Cognito's redirect_uri-replay check matches the single registered URL.
+  // Public-client support: when no Authorization header AND no client_secret in
+  // the form body, the façade injects the Cognito confidential-client secret
+  // server-side — so PKCE-only clients (Codex) work without holding a secret.
   if (path === "/oauth/token" && method === "POST") {
     const rawBody = event.isBase64Encoded
       ? Buffer.from(event.body ?? "", "base64").toString("utf8")
@@ -337,6 +341,35 @@ export async function route(
       event.headers?.authorization ?? event.headers?.Authorization;
     if (incomingAuth) fwdHeaders["authorization"] = incomingAuth;
 
+    // Classify how the CLIENT authenticated, read before any server-side
+    // mutation. The public-client injection below sets client_secret, so
+    // deriving this afterward would mislabel a secretless client as "post".
+    let clientAuth: "basic" | "post" | "none";
+    if (incomingAuth) clientAuth = "basic";
+    else if (inForm.has("client_secret")) clientAuth = "post";
+    else clientAuth = "none";
+
+    // Public-client secret injection: when the client sent no authentication at
+    // all (clientAuth === "none"), verify its client_id matches the known reader
+    // client and inject the Cognito confidential-client secret so Cognito's token
+    // endpoint accepts the request — PKCE-only clients (Codex) never hold it.
+    let injectedSecret = false;
+    if (clientAuth === "none") {
+      const formClientId = inForm.get("client_id");
+      if (formClientId !== cfg.userClientId) {
+        logEvent("oauth.token.public_client_rejected", {
+          client_id: formClientId ?? null,
+        });
+        return json(401, {
+          error: "invalid_client",
+          error_description:
+            "Unknown client_id for unauthenticated token request.",
+        });
+      }
+      inForm.set("client_secret", cfg.userClientSecret);
+      injectedSecret = true;
+    }
+
     let upstream: Response;
     try {
       upstream = await fetch(cfg.token, {
@@ -361,14 +394,10 @@ export async function route(
       respHeaders[k] = v;
     });
 
-    const clientAuth = incomingAuth
-      ? "basic"
-      : inForm.has("client_secret")
-        ? "post"
-        : "none";
     logEvent("oauth.token", {
       grant_type: inForm.get("grant_type") ?? null,
       client_auth: clientAuth,
+      secret_injected: injectedSecret,
       status: upstream.status,
     });
 
@@ -385,24 +414,38 @@ export async function route(
     };
   }
 
-  // RFC 7591 — Dynamic Client Registration (returns the pre-provisioned
-  // reader client to every caller).
+  // RFC 7591 — Dynamic Client Registration. The façade presents a PUBLIC
+  // client: no secret is returned, auth method is "none". The Cognito
+  // confidential-client secret is held server-side and injected at /oauth/token
+  // for secretless requests — clients (Codex) that can't durably hold secrets
+  // work with PKCE + refresh_token alone.
   if (path === "/register" && method === "POST") {
-    let req: { redirect_uris?: string[] } = {};
+    let req: { redirect_uris?: string[]; token_endpoint_auth_method?: string } =
+      {};
     try {
       req = JSON.parse(event.body ?? "{}");
     } catch {
       // minimal payloads are fine
     }
+    // Reject requests that explicitly ask for secret-based authentication:
+    // this endpoint only issues public-client registrations.
+    if (
+      req.token_endpoint_auth_method &&
+      req.token_endpoint_auth_method !== "none"
+    ) {
+      return json(400, {
+        error: "invalid_client_metadata",
+        error_description:
+          "Only token_endpoint_auth_method 'none' is supported (public client).",
+      });
+    }
     return json(201, {
       client_id: cfg.userClientId,
-      client_secret: cfg.userClientSecret,
       client_id_issued_at: Math.floor(Date.now() / 1000),
-      client_secret_expires_at: 0,
       redirect_uris: req.redirect_uris ?? ["http://localhost:8080/callback"],
       grant_types: ["authorization_code", "refresh_token"],
       response_types: ["code"],
-      token_endpoint_auth_method: "client_secret_post",
+      token_endpoint_auth_method: "none",
       scope: ["openid", "email", ...cfg.resourceScopes].join(" "),
     });
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,12 +6,301 @@
     "": {
       "name": "mem9-on-aws",
       "devDependencies": {
+        "@aws-sdk/client-ssm": "^3.1092.0",
         "@types/node": "^24.0.0",
         "typescript": "^5.7.2",
         "vitest": "^2.1.8"
       },
       "engines": {
         "node": ">=24"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm": {
+      "version": "3.1092.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1092.0.tgz",
+      "integrity": "sha512-3Mr8wLayhrDrqb99RK66AQQdkxh89JpkdW8L28NXh4sONMgnkXm+6oe/5f1zE+x8EUrJrXkKW08TOHeul9fcLw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/credential-provider-node": "^3.972.71",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.976.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.976.0.tgz",
+      "integrity": "sha512-0cjRaEdlVoOrsNb9pP5q1Syyc8pXw5xSj2Np2ryReRTr9FppIIRVSdZK4lbnfmc2Hvgux/xBOUU6baB7z8//uA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/xml-builder": "^3.972.36",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.29.4",
+        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/types": "^4.16.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.60",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.60.tgz",
+      "integrity": "sha512-BAkxdoe7tpDDqCghGpuOeHQRbm/2znVvOQm0AvpQbA2tbfMN46doN4zx65fv85ImP3KADwc2zQPmbrlI9MPfMg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.62",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.62.tgz",
+      "integrity": "sha512-g/0fGqKTb9xpKdd9AtpmV5Eo3DFKbnkpA2+w0peISSlu7NfAoWOuYBFxsu+yWBtxU89ka55ezoZBCbFaS8pjYQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.5.tgz",
+      "integrity": "sha512-ylubazcRfq2TVus/qXucSXeC42Qdjp5HQxTu68K/BsdMiZlcSLD1zkpoCgApXZX1Y6YJhtGGs7ZHhO/GuIgBlw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/credential-provider-env": "^3.972.60",
+        "@aws-sdk/credential-provider-http": "^3.972.62",
+        "@aws-sdk/credential-provider-login": "^3.972.67",
+        "@aws-sdk/credential-provider-process": "^3.972.60",
+        "@aws-sdk/credential-provider-sso": "^3.973.4",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.66",
+        "@aws-sdk/nested-clients": "^3.997.34",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/credential-provider-imds": "^4.4.9",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.67.tgz",
+      "integrity": "sha512-CCygIKJ9YbI3n84OClSaSppkgKKHVj2TGT33c6FRORZrYNZQ1POmD+ip0FLYokiJAK7sSdc3YVkOsBm90oxWMQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/nested-clients": "^3.997.34",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.71",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.71.tgz",
+      "integrity": "sha512-HIg7Q2osBzajQwL+1Vkyh2E7Gim3eTNb9RHIsOxDGjW0eZg4oEKtRs5sioCnc73ilhaOm4gX2lHVF8J7+nt2rg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.60",
+        "@aws-sdk/credential-provider-http": "^3.972.62",
+        "@aws-sdk/credential-provider-ini": "^3.973.5",
+        "@aws-sdk/credential-provider-process": "^3.972.60",
+        "@aws-sdk/credential-provider-sso": "^3.973.4",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.66",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/credential-provider-imds": "^4.4.9",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.60",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.60.tgz",
+      "integrity": "sha512-YIo3f99hM43QdYG8hDzwGemnR/pU95b0kramqSJUTleCqaB7+HwKf7YZFHqvOgTqZTPx/mRmNIqoDRr3U0Z3Tw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.4.tgz",
+      "integrity": "sha512-BPdmL8sSBOCv4ngZ+3LHxyc3CNqDCEK37CHioCk7zGrTMY5sUtkH8q+o6qA80nn6w3/fyBPGNE7OIRlmoOxRQA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/nested-clients": "^3.997.34",
+        "@aws-sdk/token-providers": "3.1092.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.66",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.66.tgz",
+      "integrity": "sha512-kSAziJboOmZmsR9/MTbiNjowl2BPes1bQuJpne4qAZ62ubi8fjfr/aupJSQje6udBoYxXTQbsL0e0kby2la3ng==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/nested-clients": "^3.997.34",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.34.tgz",
+      "integrity": "sha512-Y9REVrSwmLM+Qy6sZJ7ofMC2S3Hr3tPP/4CzL5U1olPP7OGoF+6+Px0E49cVQBtSxJtyeLJMf0UaBErfeSahAA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.41.tgz",
+      "integrity": "sha512-QMUytg+FQMGouc8gHS00KoYih3+N6cqmVI/pQGOIo7Nr7OpQaiXjSYOuL+vsPZ1tymY4LAQ8MYcHJmws5LRxng==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1092.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1092.0.tgz",
+      "integrity": "sha512-hBYUAr6iBLNFcsiWTgtBb0stdSw39VOUq4Sp4A5caCNf66BAZplWN4FleKrVpJx5li2YgdnK2DqoFSMWC642FQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/nested-clients": "^3.997.34",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.36.tgz",
+      "integrity": "sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -801,6 +1090,93 @@
         "win32"
       ]
     },
+    "node_modules/@smithy/core": {
+      "version": "3.29.7",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.7.tgz",
+      "integrity": "sha512-BiEE2bnnGoPKdlGe3L+gOYORDHFGPuYVRLP7iUow/Sflm0B4hC4XY3FC1MRuc7ltzpW2xNnXopKi34TTkULlKQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.4.12",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.12.tgz",
+      "integrity": "sha512-ZZPDbl/aRp77aycuoMlo3BTayT4CE2a3uoqETYZU5ySnVbhpl5IJiY7dCZedn+ZusyDLqVv44IvKBiXd2/nK0Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.7",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.6.9",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.9.tgz",
+      "integrity": "sha512-EJktha5m5MXCwzdXrlWyqb9UCNHNFKlg+PmTpRsdX3dncJPTiqYleM9OKj2mLgdVJHR01d2tU4alG+z2NdH5rQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.7",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.9.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.9.tgz",
+      "integrity": "sha512-xVBZ3hptB99iNO9XyWqEhC7KD9bP9UPXhuy3h5Y2ItCfBv160D9IIC/Fmmp3EbnWwit4C+KVqlSE+E29Nk/pPg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.7",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.6.8",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.8.tgz",
+      "integrity": "sha512-iGBm6hIwD2MGvVRSgrjVWa4FXtXDq3akxu0DCpnkmBo0xtEHZ/siMRt7ycfZAefYr2UdywUgmGtoRLaq5u56pg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.7",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -940,6 +1316,13 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cac": {
       "version": "6.7.14",
@@ -1302,6 +1685,13 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "vitest run --passWithNoTests"
   },
   "devDependencies": {
+    "@aws-sdk/client-ssm": "^3.1092.0",
     "@types/node": "^24.0.0",
     "typescript": "^5.7.2",
     "vitest": "^2.1.8"

--- a/scripts/run-oauth-facade-smoke.sh
+++ b/scripts/run-oauth-facade-smoke.sh
@@ -22,9 +22,16 @@ echo "$AS" | jq -e '.authorization_endpoint | endswith("/oauth/authorize")' >/de
 echo "$AS" | jq -e '.token_endpoint | endswith("/oauth/token")' >/dev/null || { echo "::error::token_endpoint does not point at the façade"; exit 1; }
 echo "$AS" | jq -e '.code_challenge_methods_supported == ["S256"]' >/dev/null || { echo "::error::S256 not advertised"; exit 1; }
 echo "$AS" | jq -e '.registration_endpoint | endswith("/register")' >/dev/null || { echo "::error::no registration_endpoint"; exit 1; }
+echo "$AS" | jq -e '.token_endpoint_auth_methods_supported | index("none")' >/dev/null || { echo "::error::public-client auth method \"none\" not in token_endpoint_auth_methods_supported"; exit 1; }
 
 echo "run-oauth-facade-smoke: checking /.well-known/oauth-protected-resource"
 PR=$(curl -fsS "${FACADE}/.well-known/oauth-protected-resource")
 echo "$PR" | jq -e '.resource | endswith("/mcp")' >/dev/null || { echo "::error::protected-resource.resource does not end with /mcp"; exit 1; }
+
+echo "run-oauth-facade-smoke: checking /register returns a public client (no secret)"
+DCR=$(curl -fsS -X POST -H 'Content-Type: application/json' -d '{"redirect_uris":["http://localhost:8080/cb"]}' "${FACADE}/register")
+echo "$DCR" | jq -e '.client_id | length > 0' >/dev/null || { echo "::error::DCR did not return client_id"; exit 1; }
+echo "$DCR" | jq -e 'has("client_secret") | not' >/dev/null || { echo "::error::DCR must NOT return client_secret (public client)"; exit 1; }
+echo "$DCR" | jq -e '.token_endpoint_auth_method == "none"' >/dev/null || { echo "::error::DCR token_endpoint_auth_method must be \"none\""; exit 1; }
 
 echo "run-oauth-facade-smoke: OK — façade metadata valid for stage ${STAGE}"


### PR DESCRIPTION
## Summary

- **DCR (`/register`) no longer returns `client_secret`** — advertises `token_endpoint_auth_method: "none"` (public client). Rejects requests that explicitly ask for secret-based auth.
- **`/oauth/token` injects the Cognito confidential-client secret server-side** when no Authorization header and no `client_secret` are present, after verifying the `client_id` matches the known reader client. Unknown IDs get 401.
- **Backward-compatible**: existing Claude Code sessions using Basic or `client_secret_post` continue to work (the injection only activates for unauthenticated requests).
- **Metadata** advertises `["none", "client_secret_basic", "client_secret_post"]` during the migration period.

Fixes the Codex MCP client token-refresh failure caused by the client not durably retaining the `client_secret` obtained at DCR time.

## Test Plan

- [x] 7 new unit tests (TC-MCPGW-074..078b) covering secret injection, unknown-ID rejection, and backward-compat paths
- [x] Updated TC-MCPGW-061 (metadata auth methods), TC-MCPGW-069 (added client_id), TC-MCPGW-072 (public client assertions)
- [x] All 24 handler tests pass, 92 total infra tests pass
- [x] Smoke script (`run-oauth-facade-smoke.sh`) updated with live DCR assertions
- [x] Code simplification review passed
- [x] PR review (code-reviewer agent) — no Critical/High/Medium findings
- [ ] CI checks pass
- [ ] Deploy to preview stage and verify with Codex client