### PR TITLE
fix(recall): env-tunable min-confidence + zero-result fallback (#23)

### DIFF
--- a/docker/mnemo-server/Dockerfile
+++ b/docker/mnemo-server/Dockerfile
@@ -45,10 +45,20 @@ RUN git init -q . \
     && git fetch -q --depth 1 origin "${MEM9_REF}" \
     && git checkout -q FETCH_HEAD
 
+# Local patches on top of the pin (docs/designs/recall-min-confidence.md).
+# `git apply` hard-fails the build if a future MEM9_REF bump drifts under a
+# patch — the loud failure forces a conscious re-verify instead of silently
+# shipping unpatched behavior.
+COPY docker/mnemo-server/patches/ /tmp/mem9-patches/
+RUN git apply --verbose /tmp/mem9-patches/*.patch
+
 # Build the server. go.mod + the whole module live under server/. GOARCH targets
 # the requested arch while the compiler itself runs on the native BUILDPLATFORM.
+# The handler-package tests gate the build: they cover the patched recall
+# selection (TC-RECALL-001…009), and run natively on BUILDPLATFORM (no QEMU).
 WORKDIR /src/server
 RUN go mod download \
+    && go test ./internal/handler/ \
     && CGO_ENABLED=0 GOOS=linux GOARCH="${TARGETARCH}" \
        go build -trimpath -ldflags="-s -w" -o /out/mnemo-server ./cmd/mnemo-server
 

--- a/docker/mnemo-server/patches/0001-recall-min-confidence-tunables-and-zero-result-fallback.patch
+++ b/docker/mnemo-server/patches/0001-recall-min-confidence-tunables-and-zero-result-fallback.patch
@@ -1,0 +1,355 @@
+diff --git a/server/internal/handler/recall.go b/server/internal/handler/recall.go
+index a241081..5ab7797 100644
+--- a/server/internal/handler/recall.go
++++ b/server/internal/handler/recall.go
+@@ -213,6 +213,10 @@ func (s *Server) defaultConfidenceRecallSearch(
+ 	selectionDuration := time.Since(selectionStart)
+ 
+ 	memories := append(pinned, mixed...)
++	// mem9-on-aws patch (issue #23): best-effort fallback when the confidence
++	// cutoff rejected every candidate — see recall_config.go.
++	allCandidates := append(append(append([]service.RecallCandidate{}, pinnedCandidates...), insightCandidates...), sessionCandidates...)
++	memories, cutoffReason = applyZeroResultFallback(profile.shape, budget, allCandidates, memories, cutoffReason)
+ 	slog.InfoContext(ctx, "confidence recall search",
+ 		"cluster_id", auth.ClusterID,
+ 		"query_len", len(filter.Query),
+@@ -254,7 +258,7 @@ func (s *Server) singlePoolConfidenceRecallSearch(
+ 	var (
+ 		candidates     []service.RecallCandidate
+ 		err            error
+-		minConfidence  = defaultMixedMinConfidence
++		minConfidence  = mixedMinConfidence
+ 		applyGapCutoff = true
+ 	)
+ 
+@@ -268,7 +272,7 @@ func (s *Server) singlePoolConfidenceRecallSearch(
+ 		candidates, err = svc.session.SearchCandidates(ctx, effectiveFilter, service.RecallSourceSession, recallCandidateOptions(profile.shape, false))
+ 	case string(domain.TypePinned):
+ 		candidates, err = svc.memory.SearchCandidates(ctx, effectiveFilter, service.RecallSourcePinned, recallCandidateOptions(profile.shape, false))
+-		minConfidence = defaultPinnedMinConfidence
++		minConfidence = pinnedMinConfidence
+ 		applyGapCutoff = false
+ 	case string(domain.TypeInsight):
+ 		candidates, err = svc.memory.SearchCandidates(ctx, effectiveFilter, service.RecallSourceInsight, recallCandidateOptions(profile.shape, true))
+@@ -293,6 +297,7 @@ func (s *Server) singlePoolConfidenceRecallSearch(
+ 		memories, cutoffReason = selectTopRecallCandidates(profile.shape, effectiveFilter.Limit, minConfidence, applyGapCutoff, candidates, nil)
+ 		stats.mode = "top"
+ 	}
++	memories, cutoffReason = applyZeroResultFallback(profile.shape, effectiveFilter.Limit, candidates, memories, cutoffReason)
+ 	selectionDuration := time.Since(selectionStart)
+ 
+ 	pinnedSelected := 0
+@@ -498,7 +503,7 @@ func selectPinnedRecallCandidates(
+ 	if isRecallIdentifierLiteral(profile.lower) {
+ 		keepMax = budget
+ 	}
+-	selected, _ := selectTopRecallCandidates(profile.shape, minInt(keepMax, budget), defaultPinnedMinConfidence, false, candidates, nil)
++	selected, _ := selectTopRecallCandidates(profile.shape, minInt(keepMax, budget), pinnedMinConfidence, false, candidates, nil)
+ 	seen := make(map[string]struct{}, len(selected))
+ 	for _, mem := range selected {
+ 		seen[recallMemoryKey(mem)] = struct{}{}
+@@ -518,7 +523,7 @@ func selectMixedRecallCandidates(
+ 	if shouldUseBalancedTopSelection(profile.shape) {
+ 		return selectBalancedRecallCandidates(profile, budget, candidates, seen)
+ 	}
+-	memories, cutoffReason := selectTopRecallCandidates(profile.shape, budget, defaultMixedMinConfidence, true, candidates, seen)
++	memories, cutoffReason := selectTopRecallCandidates(profile.shape, budget, mixedMinConfidence, true, candidates, seen)
+ 	return memories, cutoffReason, recallSelectionStats{mode: "top"}
+ }
+ 
+@@ -632,7 +637,7 @@ func selectBalancedRecallCandidates(
+ 	for round := 0; round < balancedSelectionRounds && len(selected) < budget; round++ {
+ 		progress := false
+ 		for i := range buckets {
+-			candidate, tokens, ok := nextEnumerationCandidate(&buckets[i].index, buckets[i].candidates, seen, defaultMixedMinConfidence, queryTokens, coverageSeen, nil, false, false, true)
++			candidate, tokens, ok := nextEnumerationCandidate(&buckets[i].index, buckets[i].candidates, seen, mixedMinConfidence, queryTokens, coverageSeen, nil, false, false, true)
+ 			if !ok {
+ 				continue
+ 			}
+@@ -661,7 +666,7 @@ func selectBalancedRecallCandidates(
+ 		}
+ 
+ 		confidence := recallConfidenceValue(candidate.Memory)
+-		if confidence < defaultMixedMinConfidence {
++		if confidence < mixedMinConfidence {
+ 			cutoffReason = "min_confidence"
+ 			break
+ 		}
+@@ -715,7 +720,7 @@ func selectEnumerationRecallCandidates(
+ 	for len(selected) < budget && progress {
+ 		progress = false
+ 		for i := range buckets {
+-			candidate, tokens, ok := nextEnumerationCandidate(&buckets[i].index, buckets[i].candidates, seen, enumerationMinConfidence, queryTokens, coverageSeen, profile.focusTokens, true, profile.repeatCountQuery, true)
++			candidate, tokens, ok := nextEnumerationCandidate(&buckets[i].index, buckets[i].candidates, seen, enumMinConfidence, queryTokens, coverageSeen, profile.focusTokens, true, profile.repeatCountQuery, true)
+ 			if !ok {
+ 				continue
+ 			}
+@@ -739,7 +744,7 @@ func selectEnumerationRecallCandidates(
+ 			continue
+ 		}
+ 		confidence := recallConfidenceValue(candidate.Memory)
+-		if confidence < enumerationMinConfidence {
++		if confidence < enumMinConfidence {
+ 			cutoffReason = "min_confidence"
+ 			break
+ 		}
+diff --git a/server/internal/handler/recall_config.go b/server/internal/handler/recall_config.go
+new file mode 100644
+index 0000000..2483894
+--- /dev/null
++++ b/server/internal/handler/recall_config.go
+@@ -0,0 +1,87 @@
++package handler
++
++// Recall selection tunables (mem9-on-aws patch, issue #23).
++//
++// Upstream hard-codes the selection min-confidence thresholds; in production
++// long natural-language queries score below defaultMixedMinConfidence and the
++// whole result set is cut off (cutoff_reason=min_confidence, 88% zero-hit).
++// This file makes the thresholds env-tunable and adds an opt-in zero-result
++// fallback. All defaults equal upstream behavior, so with no env set the
++// patch is a no-op.
++
++import (
++	"os"
++	"strconv"
++
++	"github.com/qiffang/mnemos/server/internal/domain"
++	"github.com/qiffang/mnemos/server/internal/service"
++)
++
++const (
++	cutoffReasonZeroResultFallback = "zero_result_fallback"
++)
++
++var (
++	mixedMinConfidence    = envConfidence("MNEMO_RECALL_MIN_CONFIDENCE", defaultMixedMinConfidence)
++	pinnedMinConfidence   = envConfidence("MNEMO_RECALL_PINNED_MIN_CONFIDENCE", defaultPinnedMinConfidence)
++	enumMinConfidence     = envConfidence("MNEMO_RECALL_ENUM_MIN_CONFIDENCE", enumerationMinConfidence)
++	zeroResultFallback    = envBool("MNEMO_RECALL_ZERO_RESULT_FALLBACK")
++	fallbackMinConfidence = envConfidence("MNEMO_RECALL_FALLBACK_MIN_CONFIDENCE", 25)
++)
++
++// envConfidence parses an int in [0,100] from env; anything else → def.
++func envConfidence(key string, def int) int {
++	raw := os.Getenv(key)
++	if raw == "" {
++		return def
++	}
++	v, err := strconv.Atoi(raw)
++	if err != nil || v < 0 || v > 100 {
++		return def
++	}
++	return v
++}
++
++func envBool(key string) bool {
++	switch os.Getenv(key) {
++	case "1", "true", "TRUE", "True", "yes", "on":
++		return true
++	}
++	return false
++}
++
++// applyZeroResultFallback returns the top-`budget` candidates by confidence
++// (≥ fallbackMinConfidence) when the primary selection produced nothing but
++// candidates exist. Returns the input unchanged when disabled, when the
++// primary selection already returned results, or when nothing clears the
++// floor. The returned cutoff reason replaces the primary one only when the
++// fallback actually fires, so the log line stays attributable.
++func applyZeroResultFallback(
++	shape recallQueryShape,
++	budget int,
++	candidates []service.RecallCandidate,
++	memories []domain.Memory,
++	cutoffReason string,
++) ([]domain.Memory, string) {
++	if !zeroResultFallback || len(memories) > 0 || budget <= 0 || len(candidates) == 0 {
++		return memories, cutoffReason
++	}
++
++	// dedupeRecallCandidates returns candidates ordered confidence-desc
++	// (recallCandidateLess), so walking it in order yields the top-N.
++	eligible := dedupeRecallCandidates(shape, candidates)
++	selected := make([]domain.Memory, 0, minInt(budget, len(eligible)))
++	for _, candidate := range eligible {
++		if recallConfidenceValue(candidate.Memory) < fallbackMinConfidence {
++			continue
++		}
++		selected = append(selected, candidate.Memory)
++		if len(selected) >= budget {
++			break
++		}
++	}
++	if len(selected) == 0 {
++		return memories, cutoffReason
++	}
++	return selected, cutoffReasonZeroResultFallback
++}
+diff --git a/server/internal/handler/recall_config_test.go b/server/internal/handler/recall_config_test.go
+new file mode 100644
+index 0000000..630ced2
+--- /dev/null
++++ b/server/internal/handler/recall_config_test.go
+@@ -0,0 +1,161 @@
++package handler
++
++// Tests for the mem9-on-aws recall patch (issue #23). IDs reference
++// docs/test-cases/recall-min-confidence.md in the mem9-on-aws repo.
++
++import (
++	"testing"
++	"time"
++
++	"github.com/qiffang/mnemos/server/internal/domain"
++	"github.com/qiffang/mnemos/server/internal/service"
++)
++
++func confCandidate(id string, confidence int) service.RecallCandidate {
++	c := confidence
++	return service.RecallCandidate{
++		Memory: domain.Memory{
++			ID:         id,
++			Content:    "content-" + id,
++			Confidence: &c,
++			UpdatedAt:  time.Now(),
++		},
++		SourcePool: service.RecallSourceInsight,
++	}
++}
++
++// TC-RECALL-001: defaults equal upstream constants; fallback off.
++func TestRecallConfigDefaults(t *testing.T) {
++	if got := envConfidence("MNEMO_RECALL_TEST_UNSET_KEY", defaultMixedMinConfidence); got != defaultMixedMinConfidence {
++		t.Fatalf("unset env: got %d, want %d", got, defaultMixedMinConfidence)
++	}
++	if envBool("MNEMO_RECALL_TEST_UNSET_KEY") {
++		t.Fatal("unset env bool: want false")
++	}
++}
++
++// TC-RECALL-002: a valid env value overrides the default.
++func TestEnvConfidenceOverride(t *testing.T) {
++	t.Setenv("MNEMO_RECALL_TEST_KEY", "40")
++	if got := envConfidence("MNEMO_RECALL_TEST_KEY", 65); got != 40 {
++		t.Fatalf("got %d, want 40", got)
++	}
++	t.Setenv("MNEMO_RECALL_TEST_BOOL", "1")
++	if !envBool("MNEMO_RECALL_TEST_BOOL") {
++		t.Fatal("env bool '1': want true")
++	}
++}
++
++// TC-RECALL-003: invalid values fall back to the default; no panic.
++func TestEnvConfidenceInvalid(t *testing.T) {
++	for _, raw := range []string{"abc", "-5", "150", "6.5", " 40"} {
++		t.Setenv("MNEMO_RECALL_TEST_KEY", raw)
++		if got := envConfidence("MNEMO_RECALL_TEST_KEY", 65); got != 65 {
++			t.Fatalf("raw %q: got %d, want default 65", raw, got)
++		}
++	}
++}
++
++// TC-RECALL-004 (regression — fails on unpatched upstream): all candidates
++// below the mixed threshold + fallback on → non-empty best-effort result.
++func TestZeroResultFallbackReturnsBestEffort(t *testing.T) {
++	restore := zeroResultFallback
++	zeroResultFallback = true
++	defer func() { zeroResultFallback = restore }()
++
++	candidates := []service.RecallCandidate{
++		confCandidate("a", 45), confCandidate("b", 38), confCandidate("c", 30),
++	}
++	// Primary selection with upstream threshold 65 rejects everything.
++	memories, cutoff := selectTopRecallCandidates(recallQueryShapeGeneral, 8, 65, true, candidates, nil)
++	if len(memories) != 0 || cutoff != "min_confidence" {
++		t.Fatalf("precondition: primary selection should cut off, got %d/%s", len(memories), cutoff)
++	}
++
++	memories, cutoff = applyZeroResultFallback(recallQueryShapeGeneral, 8, candidates, memories, cutoff)
++	if len(memories) != 3 {
++		t.Fatalf("fallback returned %d memories, want 3", len(memories))
++	}
++	if cutoff != cutoffReasonZeroResultFallback {
++		t.Fatalf("cutoff = %q, want %q", cutoff, cutoffReasonZeroResultFallback)
++	}
++	if recallConfidenceValue(memories[0]) != 45 {
++		t.Fatalf("fallback not ordered by confidence desc: first = %d", recallConfidenceValue(memories[0]))
++	}
++}
++
++// TC-RECALL-005: no candidates at all → fallback stays empty, reason untouched.
++func TestZeroResultFallbackNoCandidates(t *testing.T) {
++	restore := zeroResultFallback
++	zeroResultFallback = true
++	defer func() { zeroResultFallback = restore }()
++
++	memories, cutoff := applyZeroResultFallback(recallQueryShapeGeneral, 8, nil, []domain.Memory{}, "no_candidates")
++	if len(memories) != 0 || cutoff != "no_candidates" {
++		t.Fatalf("got %d/%s, want 0/no_candidates", len(memories), cutoff)
++	}
++}
++
++// TC-RECALL-006: everything below the fallback floor → still empty.
++func TestZeroResultFallbackFloorHolds(t *testing.T) {
++	restoreOn, restoreFloor := zeroResultFallback, fallbackMinConfidence
++	zeroResultFallback, fallbackMinConfidence = true, 25
++	defer func() { zeroResultFallback, fallbackMinConfidence = restoreOn, restoreFloor }()
++
++	candidates := []service.RecallCandidate{confCandidate("a", 10), confCandidate("b", 24)}
++	memories, cutoff := applyZeroResultFallback(recallQueryShapeGeneral, 8, candidates, []domain.Memory{}, "min_confidence")
++	if len(memories) != 0 || cutoff != "min_confidence" {
++		t.Fatalf("got %d/%s, want 0/min_confidence", len(memories), cutoff)
++	}
++}
++
++// TC-RECALL-007: fallback disabled (default) → upstream behavior preserved.
++func TestZeroResultFallbackDisabled(t *testing.T) {
++	restore := zeroResultFallback
++	zeroResultFallback = false
++	defer func() { zeroResultFallback = restore }()
++
++	candidates := []service.RecallCandidate{confCandidate("a", 45)}
++	memories, cutoff := applyZeroResultFallback(recallQueryShapeGeneral, 8, candidates, []domain.Memory{}, "min_confidence")
++	if len(memories) != 0 || cutoff != "min_confidence" {
++		t.Fatalf("got %d/%s, want 0/min_confidence", len(memories), cutoff)
++	}
++}
++
++// TC-RECALL-008: primary selection already returned results → fallback no-op.
++func TestZeroResultFallbackNotTriggeredOnResults(t *testing.T) {
++	restore := zeroResultFallback
++	zeroResultFallback = true
++	defer func() { zeroResultFallback = restore }()
++
++	primary := []domain.Memory{{ID: "kept"}}
++	candidates := []service.RecallCandidate{confCandidate("a", 45)}
++	memories, cutoff := applyZeroResultFallback(recallQueryShapeGeneral, 8, candidates, primary, "budget_exhausted")
++	if len(memories) != 1 || memories[0].ID != "kept" || cutoff != "budget_exhausted" {
++		t.Fatalf("fallback altered a non-empty primary result: %d/%s", len(memories), cutoff)
++	}
++}
++
++// TC-RECALL-009: fallback respects the budget and orders by confidence desc.
++func TestZeroResultFallbackBudget(t *testing.T) {
++	restore := zeroResultFallback
++	zeroResultFallback = true
++	defer func() { zeroResultFallback = restore }()
++
++	candidates := make([]service.RecallCandidate, 0, 10)
++	for i := 0; i < 10; i++ {
++		candidates = append(candidates, confCandidate(string(rune('a'+i)), 30+i))
++	}
++	memories, cutoff := applyZeroResultFallback(recallQueryShapeGeneral, 3, candidates, []domain.Memory{}, "min_confidence")
++	if len(memories) != 3 {
++		t.Fatalf("got %d memories, want 3", len(memories))
++	}
++	if cutoff != cutoffReasonZeroResultFallback {
++		t.Fatalf("cutoff = %q", cutoff)
++	}
++	for i := 1; i < len(memories); i++ {
++		if recallConfidenceValue(memories[i-1]) < recallConfidenceValue(memories[i]) {
++			t.Fatalf("not ordered by confidence desc at %d", i)
++		}
++	}
++}

--- a/docs/designs/recall-min-confidence.md
+++ b/docs/designs/recall-min-confidence.md
@@ -1,0 +1,96 @@
+# Design: recall min_confidence tunables + zero-result fallback (issue #23)
+
+## Problem
+
+Production recall is effectively broken: over 2026-07-16 → 2026-07-23, 88% of
+`search_memories` calls (117/133) returned **zero results**. Every zero-result
+search had candidates (avg ~37 insight candidates); all were rejected by the
+selection stage with `cutoff_reason: "min_confidence"`. Long natural-language
+queries (≥25 chars, what the recall hooks tell every agent to send) averaged
+0.11 results vs 5.5 for short keyword queries.
+
+Root cause: the upstream selection thresholds are **hard-coded consts** in
+`server/internal/handler/recall.go` at the pinned commit:
+
+| const | value | used by |
+|---|---|---|
+| `defaultPinnedMinConfidence` | 70 | pinned pool + single-pool pinned |
+| `defaultMixedMinConfidence` | 65 | balanced/top selection (the main path) |
+| `enumerationMinConfidence` | 55 | enumeration-shape queries |
+
+The confidence score (`buildRecallConfidence`) is dominated by
+`0.55*rrfNorm + 0.20*vecNorm + bonuses`. Long natural-language queries dilute
+RRF/vector agreement, so real hits routinely score below 65 and the whole
+result set is cut off.
+
+## Decision
+
+Patch the vendored upstream build (we already build from a pinned commit —
+`docker/mnemo-server/Dockerfile`) with two orthogonal changes, both
+behavior-neutral by default:
+
+1. **Env-tunable thresholds.** A new `recall_config.go` in the handler package
+   reads at process start:
+   - `MNEMO_RECALL_MIN_CONFIDENCE` (default 65 — upstream value)
+   - `MNEMO_RECALL_PINNED_MIN_CONFIDENCE` (default 70)
+   - `MNEMO_RECALL_ENUM_MIN_CONFIDENCE` (default 55)
+   The three const references in `recall.go` switch to these vars.
+   Invalid/empty values fall back to defaults (never crash the server).
+
+2. **Zero-result fallback.** Gated by `MNEMO_RECALL_ZERO_RESULT_FALLBACK`
+   (default off). When the normal selection returns 0 memories but candidates
+   exist, return the top-`budget` candidates by confidence that clear a low
+   floor (`MNEMO_RECALL_FALLBACK_MIN_CONFIDENCE`, default 25), and log
+   `cutoff_reason: "zero_result_fallback"` so occurrences are countable
+   (feeds the #26 metric work). Applied at the tail of BOTH search entry
+   points (`defaultConfidenceRecallSearch`, `singlePoolConfidenceRecallSearch`).
+
+Deployment config (`infra/ecs.ts`, same values on prod and previews):
+
+```
+MNEMO_RECALL_MIN_CONFIDENCE:        "40"
+MNEMO_RECALL_ZERO_RESULT_FALLBACK:  "1"
+```
+
+Belt and suspenders: even if 40 is still too high for some query shapes, the
+fallback guarantees a non-empty best-effort answer whenever candidates exist.
+
+## Patch mechanism
+
+`docker/mnemo-server/patches/*.patch` (git `diff` format), applied in the
+Dockerfile builder stage right after the pinned checkout:
+
+```dockerfile
+COPY docker/mnemo-server/patches/ /tmp/mem9-patches/
+RUN git apply --verbose /tmp/mem9-patches/*.patch
+```
+
+`git apply` hard-fails the image build if the pinned tree drifts (e.g. a
+future `MEM9_REF` bump), forcing a conscious re-verify of the patch — exactly
+the failure mode we want. The patch includes its own Go unit tests
+(the new `recall_config_test.go`, covering both the config parsing and the
+fallback) so upstream's `go test ./internal/handler/` exercises the new paths;
+CI's docker build runs `go test` for the handler package in the builder stage.
+
+## Alternatives considered
+
+- **Config-only (no fallback):** smaller patch, but the confidence
+  distribution of real NL queries is unknown; if mass sits below 40 the
+  zero-hit behavior persists and needs a second PR. Rejected as sole fix.
+- **Fallback-only:** normal path keeps rejecting; every NL query rides the
+  fallback, losing the gap-cutoff/coverage logic of the primary selection.
+  Rejected as sole fix.
+- **Fork upstream:** heavyweight; the patch-in-Dockerfile approach keeps the
+  pin + reproducibility story intact.
+
+## Observability
+
+No new log lines; the existing `confidence recall search` /
+`single-pool confidence recall` lines carry the new
+`cutoff_reason=zero_result_fallback` value. Alarming on zero-hit rate is
+issue #26 (out of scope here).
+
+## Rollback
+
+Unset the two env vars in `infra/ecs.ts` (defaults are upstream behavior) or
+drop the patch files; no data migration involved.

--- a/docs/test-cases/recall-min-confidence.md
+++ b/docs/test-cases/recall-min-confidence.md
@@ -1,0 +1,37 @@
+# Test cases: recall min_confidence tunables + zero-result fallback (issue #23)
+
+Design: [`docs/designs/recall-min-confidence.md`](../designs/recall-min-confidence.md)
+
+## Go unit tests (inside the patched upstream tree; run by the Docker builder stage)
+
+| ID | Scenario | Expected |
+|---|---|---|
+| TC-RECALL-001 | No `MNEMO_RECALL_*` env set | Thresholds equal upstream defaults (65/70/55); fallback disabled — behavior identical to unpatched upstream |
+| TC-RECALL-002 | `MNEMO_RECALL_MIN_CONFIDENCE=40` | Mixed selection admits candidates with confidence ≥40 that upstream (65) rejected |
+| TC-RECALL-003 | Invalid values (`abc`, `-5`, `150`, empty) | Fall back to defaults; no panic |
+| TC-RECALL-004 | **Regression (fails before fix):** all candidates score below the mixed threshold, fallback enabled | Non-empty result: top-budget candidates ≥ fallback floor, `cutoff_reason="zero_result_fallback"`; upstream behavior returns 0 |
+| TC-RECALL-005 | Fallback enabled, zero candidates at all | Empty result, cutoff_reason unchanged (`no_candidates`) — fallback never fabricates |
+| TC-RECALL-006 | Fallback enabled, all candidates below fallback floor (25) | Empty result — the floor holds |
+| TC-RECALL-007 | Fallback disabled (default), all candidates below threshold | Empty result with `cutoff_reason="min_confidence"` (upstream behavior preserved) |
+| TC-RECALL-008 | Normal selection returns ≥1 result, fallback enabled | Fallback does NOT trigger; results and cutoff_reason are those of the primary selection |
+| TC-RECALL-009 | Fallback respects budget | With budget=3 and 10 eligible candidates, exactly 3 returned, ordered by confidence desc |
+
+## Infra unit tests (`infra/ecs.test.ts`)
+
+| ID | Scenario | Expected |
+|---|---|---|
+| TC-RECALL-020 | mnemo-server container env | `MNEMO_RECALL_MIN_CONFIDENCE="40"` and `MNEMO_RECALL_ZERO_RESULT_FALLBACK="1"` present |
+
+## E2E (`scripts/run-mcp-e2e.sh`, preview soft / prod hard)
+
+| ID | Scenario | Expected |
+|---|---|---|
+| TC-RECALL-030 | Existing keyword probe (marker string) | Unchanged; still passes |
+| TC-RECALL-031 | **Natural-language probe:** after the keyword search finds the marker, search with a ≥25-char natural-language query describing the marker fact (not containing the raw marker token verbatim-only) | ≥1 result containing the marker within the retry window |
+
+## Build-time guards
+
+| ID | Scenario | Expected |
+|---|---|---|
+| TC-RECALL-040 | `git apply` of patches against the pinned `MEM9_REF` | Applies cleanly; a future pin bump that breaks the patch fails the image build loudly |
+| TC-RECALL-041 | Builder-stage `go test ./internal/handler/` in the patched tree | Passes (includes TC-RECALL-001…009) |

--- a/infra/ecs.test.ts
+++ b/infra/ecs.test.ts
@@ -360,6 +360,10 @@ describe("ecs stack", () => {
     expect(String(env.MNEMO_LLM_BASE_URL)).toBe("http://localhost:8082/v1");
     expect(env.MNEMO_LLM_MODEL).toBe("zai.glm-5");
     expect(String(env.MNEMO_LLM_API_KEY ?? "")).not.toBe(""); // dummy, but non-empty
+    // Recall tuning (TC-RECALL-020, issue #23): threshold lowered + zero-result
+    // fallback on — both consumed by the patched mnemo-server image.
+    expect(env.MNEMO_RECALL_MIN_CONFIDENCE).toBe("40");
+    expect(env.MNEMO_RECALL_ZERO_RESULT_FALLBACK).toBe("1");
     // Secret via ssm (== ECS secrets valueFrom), never environment.
     const ssm = mnemo.ssm as Record<string, unknown>;
     expect(ssm.MEM9_DB_SECRET).toBeDefined();

--- a/infra/ecs.ts
+++ b/infra/ecs.ts
@@ -306,6 +306,13 @@ export function ecs(dbOut: DbOutputs): EcsOutputs {
           MNEMO_LLM_BASE_URL: `http://localhost:${LLM_PROXY_PORT}/v1`,
           MNEMO_LLM_MODEL: LLM_MODEL,
           MNEMO_LLM_API_KEY: "local", // dummy; the proxy holds the real bearer
+          // Recall tuning (issue #23, docker/mnemo-server/patches/): upstream's
+          // hard-coded min-confidence 65 rejected ~88% of prod searches
+          // (natural-language queries score low). 40 admits them; the
+          // zero-result fallback guarantees a best-effort answer whenever
+          // candidates exist (cutoff_reason=zero_result_fallback in the logs).
+          MNEMO_RECALL_MIN_CONFIDENCE: "40",
+          MNEMO_RECALL_ZERO_RESULT_FALLBACK: "1",
         },
         // Secret injection (== ECS `secrets: valueFrom`): the DB secret lands as an
         // env var from Secrets Manager at task start. Never a literal in git.

--- a/scripts/run-mcp-e2e.sh
+++ b/scripts/run-mcp-e2e.sh
@@ -157,12 +157,45 @@ while [[ $SECONDS -lt $DEADLINE ]]; do
   sleep 15
 done
 
-if [[ "$FOUND" == "1" ]]; then
-  echo "run-mcp-e2e: OK — write→search round-trip verified (marker found) for stage ${STAGE}"
+if [[ "$FOUND" != "1" ]]; then
+  MSG="search_memories did not surface the marker within ~5 min (async ingest may be slow or the chain is broken). Last response: $(printf '%s' "${SEARCH_RESP:-}" | head -c 400)"
+  if [[ "$SOFT" == "1" ]]; then
+    echo "::warning::${MSG}"
+    exit 0
+  fi
+  echo "::error::${MSG}"
+  exit 1
+fi
+echo "run-mcp-e2e: OK — write→search round-trip verified (marker found) for stage ${STAGE}"
+
+# 5. Natural-language recall probe (TC-RECALL-031, issue #23). The keyword
+# search above proves the memory is indexed; now assert that a long (≥25 char)
+# natural-language query — the style the recall hooks instruct agents to use —
+# also surfaces it. Before the recall-threshold fix these scored below the
+# hard-coded min_confidence and returned 0 results (the cutoff rejected ALL
+# candidates regardless of rank, so an anchored sentence still regresses).
+# The run id anchors the query to THIS run's memory: probe memories from past
+# deploys accumulate in the tenant, and an unanchored query would compete with
+# them for the top-N. The memory is already searchable, so the short retry
+# loop only absorbs transient gateway errors.
+NL_QUERY="what secret marker did the e2e probe store for run ${GITHUB_RUN_ID:-local}"
+echo "run-mcp-e2e: natural-language recall probe (query: ${NL_QUERY})"
+NL_FOUND=0
+for attempt in 1 2 3; do
+  tools_call "$SEARCH_TOOL" "$(jq -nc --arg q "$NL_QUERY" '{q:$q, limit:10}')"
+  if printf '%s' "$MCP_RESP" | grep -qF "$MARKER"; then
+    NL_FOUND=1
+    break
+  fi
+  sleep 10
+done
+
+if [[ "$NL_FOUND" == "1" ]]; then
+  echo "run-mcp-e2e: OK — natural-language recall verified for stage ${STAGE}"
   exit 0
 fi
 
-MSG="search_memories did not surface the marker within ~5 min (async ingest may be slow or the chain is broken). Last response: $(printf '%s' "${SEARCH_RESP:-}" | head -c 400)"
+MSG="natural-language recall probe failed: an indexed memory was not returned for a NL query (recall min_confidence regression? see issue #23). Last response: $(printf '%s' "${MCP_RESP:-}" | head -c 400)"
 if [[ "$SOFT" == "1" ]]; then
   echo "::warning::${MSG}"
   exit 0


### PR DESCRIPTION
## Summary
- Fixes #23 — prod recall returned **0 results for 88% of searches**: every zero-hit had candidates (avg ~37), all rejected by upstream's hard-coded min-confidence 65; natural-language queries averaged 0.11 results vs 5.5 for short keywords
- Patches the pinned upstream tree at image build (`docker/mnemo-server/patches/`): the three selection thresholds become env-tunable (defaults = upstream values, so no env ⇒ no behavior change) + an opt-in zero-result fallback that returns top-budget candidates over a low floor, logged as `cutoff_reason=zero_result_fallback`
- `infra/ecs.ts` sets `MNEMO_RECALL_MIN_CONFIDENCE=40` + `MNEMO_RECALL_ZERO_RESULT_FALLBACK=1`; E2E gains a natural-language recall probe (soft on previews, hard on prod)

## Design
- [x] Design canvas created (`docs/designs/recall-min-confidence.md`)
- [x] Design approved (interactive session)

## Test Plan
- [x] Test cases documented (`docs/test-cases/recall-min-confidence.md`, TC-RECALL-001…041)
- [x] Build passes (patched builder stage builds green incl. `go test ./internal/handler/`)
- [x] Unit tests pass (Go patch tests ×9; infra 92; root 20 — all green locally)
- [x] CI checks pass
- [x] Code simplification review passed
- [x] PR review agent review passed (1 Medium finding fixed: NL probe anchored with run id + limit 10)
- [ ] Reviewer bot findings addressed (REVIEW_BOTS empty — N/A)
- [x] E2E tests pass (pr-27 preview: keyword probe + NL recall probe both passed — NL probe found the marker on first attempt)

## Checklist
- [x] New unit tests written for new functionality
- [x] E2E test cases updated (natural-language recall probe, TC-RECALL-031)
- [x] Documentation updated (design + test-cases docs)
