### PR TITLE
fix(llm-proxy): re-mint bearer and retry once on upstream 401/403 (#24)

### DIFF
--- a/docker/llm-proxy/server.mjs
+++ b/docker/llm-proxy/server.mjs
@@ -129,8 +129,7 @@ export function createProxyServer(cfg, deps = {}) {
     return state.firstMint;
   }
 
-  async function forwardToMantle(bodyBuf) {
-    const token = await ensureToken();
+  async function postToMantle(bodyBuf, token) {
     const headers = {
       Authorization: `Bearer ${token}`,
       "Content-Type": "application/json",
@@ -149,6 +148,21 @@ export function createProxyServer(cfg, deps = {}) {
     } finally {
       clearTimeout(timer);
     }
+  }
+
+  async function forwardToMantle(bodyBuf) {
+    const upstream = await postToMantle(bodyBuf, await ensureToken());
+    // 401/403 means the bearer is dead (typical cause: it was presigned from
+    // task-role session credentials that have since rotated — the 2026-07-22
+    // incident). The timer won't fix it for up to an hour; re-mint NOW (a
+    // local presign, no network) and retry ONCE. A second auth failure passes
+    // through — mem9 handles non-2xx itself.
+    if (upstream.status !== 401 && upstream.status !== 403) return upstream;
+    // Canonical, countable log line — the #26 metric filter matches this
+    // prefix verbatim; TC-PROXY401-006 pins it. Change both together.
+    console.warn(`llm-proxy re-minted bearer after upstream ${upstream.status}`);
+    const fresh = await refresh();
+    return postToMantle(bodyBuf, fresh);
   }
 
   const server = createServer(async (req, res) => {
@@ -226,20 +240,30 @@ export function createProxyServer(cfg, deps = {}) {
   return { server, start, state };
 }
 
+// ── Default minter factory ────────────────────────────────────────────────────
+// Presigns a Bedrock bearer from the task role. Resolves credentials via a NEW
+// provider chain on EVERY mint: a shared fromNodeProviderChain() memoizes, and
+// a bearer presigned from an expired session dies with that session no matter
+// the requested TTL — the mint "succeeds" but every call 401s (issue #24).
+// Minting is at most hourly + rare 401 retries, so per-mint resolution is
+// cheap. Deps are injectable for tests (TC-PROXY401-007).
+export function makeDefaultMintToken(cfg, deps) {
+  const { createProvider, getToken } = deps;
+  return async () => {
+    const credentials = await createProvider()();
+    return getToken({ credentials, region: cfg.region, expiresInSeconds: cfg.tokenTtlSeconds });
+  };
+}
+
 // ── Direct-run entrypoint (node server.mjs) ────────────────────────────────────
 // Only wires the real AWS deps + listens when executed as the main module, so
 // importing this file in a test does not require AWS credentials.
 const isMain = import.meta.url === `file://${process.argv[1]}`;
 if (isMain) {
   const cfg = readConfig();
-  // Real minter: presign a Bedrock bearer from the task role. Local (no network).
   const { getToken } = await import("@aws/bedrock-token-generator");
   const { fromNodeProviderChain } = await import("@aws-sdk/credential-providers");
-  const credentialProvider = fromNodeProviderChain();
-  const mintToken = async () => {
-    const credentials = await credentialProvider();
-    return getToken({ credentials, region: cfg.region, expiresInSeconds: cfg.tokenTtlSeconds });
-  };
+  const mintToken = makeDefaultMintToken(cfg, { createProvider: fromNodeProviderChain, getToken });
 
   const { server, start } = createProxyServer(cfg, { mintToken });
   server.listen(cfg.port, () => {

--- a/docker/llm-proxy/server.test.mjs
+++ b/docker/llm-proxy/server.test.mjs
@@ -6,7 +6,7 @@
 // health gating, and error mapping without touching AWS or Bedrock Mantle.
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createProxyServer, readConfig } from "./server.mjs";
+import { createProxyServer, makeDefaultMintToken, readConfig } from "./server.mjs";
 
 // Start `server` on an ephemeral port; return {url, close}.
 async function listen(server) {
@@ -121,6 +121,143 @@ describe("createProxyServer", () => {
     await start();
     await fetch(`${url}/v1/chat/completions`, { method: "POST", body: "{}" });
     expect(captured.headers["OpenAI-Project"]).toBeUndefined();
+  });
+
+  // 401-reactive re-mint (issue #24, TC-PROXY401-001…006): a bearer presigned
+  // from expired task-role session credentials 401s until the hourly refresh
+  // tick — the proxy must re-mint + retry once instead of serving the dead
+  // bearer for up to an hour (2026-07-22 incident: 32 ingests lost).
+  describe("401-reactive re-mint", () => {
+    const authFailure = (status) =>
+      new Response(JSON.stringify({ error: { code: "invalid_api_key", message: "The security token included in the request is invalid" } }), {
+        status,
+        headers: { "content-type": "application/json" },
+      });
+    const ok = () =>
+      new Response(JSON.stringify({ choices: [{ message: { content: "PONG" } }] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+
+    it("TC-PROXY401-001: re-mints once and retries with the fresh bearer on upstream 401", async () => {
+      const mintToken = vi
+        .fn()
+        .mockResolvedValueOnce("stale-bearer")
+        .mockResolvedValueOnce("fresh-bearer");
+      const seenAuth = [];
+      const fetchImpl = vi.fn(async (_u, opts) => {
+        seenAuth.push(opts.headers.Authorization);
+        return seenAuth.length === 1 ? authFailure(401) : ok();
+      });
+      const { url, start } = await boot(baseCfg, { mintToken, fetchImpl });
+      await start();
+
+      const res = await fetch(`${url}/v1/chat/completions`, { method: "POST", body: "{}" });
+      expect(res.status).toBe(200);
+      expect((await res.json()).choices[0].message.content).toBe("PONG");
+      expect(mintToken).toHaveBeenCalledTimes(2); // initial + 401-triggered re-mint
+      expect(seenAuth).toEqual(["Bearer stale-bearer", "Bearer fresh-bearer"]);
+    });
+
+    it("TC-PROXY401-002: a 401 on the retry passes through — no retry loop", async () => {
+      const mintToken = vi.fn().mockResolvedValue("t");
+      const fetchImpl = vi.fn(async () => authFailure(401));
+      const { url, start } = await boot(baseCfg, { mintToken, fetchImpl });
+      await start();
+
+      const res = await fetch(`${url}/v1/chat/completions`, { method: "POST", body: "{}" });
+      expect(res.status).toBe(401); // mem9 sees the real upstream status
+      expect((await res.json()).error.code).toBe("invalid_api_key");
+      expect(fetchImpl).toHaveBeenCalledTimes(2); // original + exactly one retry
+      expect(mintToken).toHaveBeenCalledTimes(2); // initial + one re-mint
+    });
+
+    it("TC-PROXY401-003: 403 takes the same re-mint+retry path", async () => {
+      const mintToken = vi.fn().mockResolvedValue("t");
+      const fetchImpl = vi
+        .fn()
+        .mockResolvedValueOnce(authFailure(403))
+        .mockResolvedValueOnce(ok());
+      const { url, start } = await boot(baseCfg, { mintToken, fetchImpl });
+      await start();
+
+      const res = await fetch(`${url}/v1/chat/completions`, { method: "POST", body: "{}" });
+      expect(res.status).toBe(200);
+      expect(mintToken).toHaveBeenCalledTimes(2);
+    });
+
+    it("TC-PROXY401-004: non-auth statuses (400/429/500) do NOT re-mint", async () => {
+      for (const status of [400, 429, 500]) {
+        const mintToken = vi.fn().mockResolvedValue("t");
+        const fetchImpl = vi.fn(
+          async () => new Response("{}", { status, headers: { "content-type": "application/json" } }),
+        );
+        const { url, start } = await boot(baseCfg, { mintToken, fetchImpl });
+        await start();
+
+        const res = await fetch(`${url}/v1/chat/completions`, { method: "POST", body: "{}" });
+        expect(res.status).toBe(status);
+        expect(fetchImpl).toHaveBeenCalledTimes(1); // no retry
+        expect(mintToken).toHaveBeenCalledTimes(1); // no re-mint
+      }
+    });
+
+    it("TC-PROXY401-005: a re-mint failure maps to the existing 502 shape", async () => {
+      const mintToken = vi
+        .fn()
+        .mockResolvedValueOnce("stale-bearer")
+        .mockRejectedValueOnce(new Error("provider chain empty"));
+      const fetchImpl = vi.fn(async () => authFailure(401));
+      const { url, start } = await boot(baseCfg, { mintToken, fetchImpl });
+      await start();
+
+      const res = await fetch(`${url}/v1/chat/completions`, { method: "POST", body: "{}" });
+      expect(res.status).toBe(502);
+      expect((await res.json()).error.type).toBe("server_error");
+    });
+
+    it("TC-PROXY401-006: logs a distinct, countable line on the re-mint path", async () => {
+      const logSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const mintToken = vi.fn().mockResolvedValue("t");
+      const fetchImpl = vi
+        .fn()
+        .mockResolvedValueOnce(authFailure(401))
+        .mockResolvedValueOnce(ok());
+      const { url, start } = await boot(baseCfg, { mintToken, fetchImpl });
+      await start();
+
+      await fetch(`${url}/v1/chat/completions`, { method: "POST", body: "{}" });
+      // The full prefix is a stable contract — the #26 CloudWatch metric
+      // filter matches it verbatim. Do not loosen this assertion.
+      const line = logSpy.mock.calls.map((c) => c.join(" ")).find((m) => /re-mint/.test(m));
+      expect(line).toBe("llm-proxy re-minted bearer after upstream 401");
+    });
+  });
+
+  // TC-PROXY401-007: the default minter must resolve credentials FRESH per
+  // mint. A shared fromNodeProviderChain() memoizes; a bearer re-signed from
+  // the same dead session after a 401 would 401 again (the incident's root
+  // cause). The factory takes injectable deps so this is testable without AWS.
+  it("TC-PROXY401-007: default minter resolves fresh credentials on every mint", async () => {
+    const resolved = [];
+    const createProvider = vi.fn(() => {
+      const creds = { accessKeyId: `AK${createProvider.mock.calls.length}`, secretAccessKey: "s" };
+      return async () => {
+        resolved.push(creds.accessKeyId);
+        return creds;
+      };
+    });
+    const getToken = vi.fn(async ({ credentials }) => `bearer-for-${credentials.accessKeyId}`);
+    const mintToken = makeDefaultMintToken(
+      { region: "ap-northeast-1", tokenTtlSeconds: 43200 },
+      { createProvider, getToken },
+    );
+
+    expect(await mintToken()).toBe("bearer-for-AK1");
+    expect(await mintToken()).toBe("bearer-for-AK2");
+    // A NEW provider chain per mint — never a memoized instance.
+    expect(createProvider).toHaveBeenCalledTimes(2);
+    expect(resolved).toEqual(["AK1", "AK2"]);
   });
 
   it("passes the upstream status + body straight through on a Mantle 4xx", async () => {

--- a/docs/designs/llm-proxy-401-remint.md
+++ b/docs/designs/llm-proxy-401-remint.md
@@ -1,0 +1,60 @@
+# Design: llm-proxy 401-reactive bearer re-mint (issue #24)
+
+## Problem
+
+On 2026-07-22 ~14:59–15:04 UTC, Bedrock Mantle returned `401 invalid_api_key`
+("The security token included in the request is ...") for ~5 minutes; 32
+smart-ingest extractions failed permanently (mnemo-server's ingest is
+fire-and-forget). The proxy only re-mints its bearer on a fixed 1h timer, so a
+bearer invalidated mid-interval keeps being served until the next tick.
+
+Root cause is twofold (`docker/llm-proxy/server.mjs`):
+
+1. **Stale session credentials in the mint.** The direct-run entrypoint
+   creates `fromNodeProviderChain()` once and calls it per mint. That provider
+   memoizes; a bearer presigned from an expired ECS task-role session dies
+   with the session regardless of the requested 12h TTL — and the mint
+   "succeeds", so the proxy believes it holds a good token.
+2. **No 401 reaction.** `forwardToMantle` passes any upstream status straight
+   through. A 401 is treated like a business response, not an auth failure.
+
+## Decision
+
+Two changes, both inside the proxy (no mnemo-server / upstream change):
+
+1. **401/403-reactive re-mint + single retry.** In the request path: if the
+   upstream responds 401 or 403, re-mint the bearer once (minting is a local
+   SigV4 presign — cheap, no network), retry the request with the fresh
+   bearer, and pass through whatever the retry returns. No retry loop: a
+   second auth failure passes through (mem9 already handles non-2xx). Log a
+   distinct line — exactly `llm-proxy re-minted bearer after upstream <status>`
+   — so occurrences are countable; the #26 metric filter matches this prefix
+   verbatim and TC-PROXY401-006 pins it as a contract.
+2. **Fresh credentials per mint.** The default minter resolves credentials
+   via a NEW `fromNodeProviderChain()` per mint call instead of a shared
+   memoized provider. Mint happens at most hourly (plus rare 401 retries), so
+   the extra provider-chain resolution cost is negligible against the
+   guarantee that a re-mint after 401 can't re-sign with the same dead
+   session. The minter stays injectable for tests.
+
+The refresh timer, health semantics, non-auth status passthrough, and error
+mapping (502/504) are unchanged.
+
+## Alternatives considered
+
+- **Shorter refresh interval:** narrows but doesn't close the window; the
+  memoized-credentials bug would persist (re-mint with dead session).
+- **Ingest retry/DLQ in mnemo-server:** requires forking upstream; the proxy
+  fix removes the failure class at its source.
+- **expireTime-aware provider cache:** subtler and still trusts the provider's
+  view of expiry; per-mint resolution is simpler and provably fresh.
+
+## Concurrency note
+
+Concurrent requests hitting 401 may each trigger a re-mint; mints are cheap,
+local, and idempotent (last writer wins on `state.token`), so no locking is
+added — matching the existing refresh-timer behavior.
+
+## Rollback
+
+Revert the commit; behavior returns to timer-only refresh.

--- a/docs/test-cases/llm-proxy-401-remint.md
+++ b/docs/test-cases/llm-proxy-401-remint.md
@@ -1,0 +1,17 @@
+# Test cases: llm-proxy 401-reactive re-mint (issue #24)
+
+Design: [`docs/designs/llm-proxy-401-remint.md`](../designs/llm-proxy-401-remint.md)
+
+All run in `docker/llm-proxy/server.test.mjs` (vitest, injected minter+fetch,
+real HTTP server on loopback).
+
+| ID | Scenario | Expected |
+|---|---|---|
+| TC-PROXY401-001 | **Regression (fails before fix):** upstream returns 401 once, then 200 | Proxy re-mints (mintToken called 2×), retries with the NEW bearer, client sees 200; retry request carries `Bearer <new-token>` |
+| TC-PROXY401-002 | Upstream returns 401 on the original AND the retry | Client sees the 401 body passed through; mintToken called exactly 2× (initial + one re-mint — no loop) |
+| TC-PROXY401-003 | Upstream returns 403 | Same re-mint+retry path as 401 |
+| TC-PROXY401-004 | Upstream returns 400/429/500 | NO re-mint (mintToken called 1×), status passes straight through (upstream-error passthrough preserved) |
+| TC-PROXY401-005 | Re-mint itself throws | Mapped to the existing 502 error shape; no crash |
+| TC-PROXY401-006 | Distinct log line on the re-mint path | `console.log/error` spy sees a message containing `re-mint` and `401` |
+| TC-PROXY401-007 | Fresh credentials per mint (direct-run minter) | The default minter constructs a new provider chain per call — asserted via the exported `makeDefaultMintToken` factory taking an injectable `createProvider`, called once per mint |
+| TC-PROXY401-008 | Existing suite | All pre-existing tests still pass unchanged (timer refresh keep-old-token-on-failure, health gating, header injection, 404 routing, timeout→504) |


### PR DESCRIPTION
## Summary
- Fixes #24 — the 2026-07-22 ~5-min Mantle `401 invalid_api_key` window lost 32 fire-and-forget smart-ingests: the sidecar re-mints only on a 1h timer and the memoized credential provider could re-sign with a dead session
- `forwardToMantle` now re-mints once + retries on upstream 401/403; second auth failure passes through unchanged. Log line `llm-proxy re-minted bearer after upstream <status>` is a pinned contract for the #26 metric filter
- `makeDefaultMintToken` factory resolves a NEW provider chain per mint (injectable deps, TC-PROXY401-007); timer/health/passthrough semantics untouched

## Design
- [x] Design canvas created (`docs/designs/llm-proxy-401-remint.md`)
- [x] Design approved (interactive session)

## Test Plan
- [x] Test cases documented (`docs/test-cases/llm-proxy-401-remint.md`, TC-PROXY401-001…008)
- [x] Build passes (root typecheck green)
- [x] Unit tests pass (27/27; TDD red→green: 6 new tests failed before the fix)
- [x] CI checks pass
- [x] Code simplification review passed (reviewed within PR review)
- [x] PR review agent review passed (1 Important finding fixed: log-line/doc contract mismatch — canonical line now pinned by test)
- [ ] Reviewer bot findings addressed (REVIEW_BOTS empty — N/A)
- [x] E2E tests pass (pr-28 preview deploy green — full E2E incl. smart-ingest chain through the rebuilt llm-proxy)

## Checklist
- [x] New unit tests written for new functionality
- [x] E2E test cases updated if needed (N/A — covered by existing ingest chain; log-scan hardening tracked in #26)
- [x] Documentation updated (design + test-cases docs)
