### PR TITLE
feat(observability): SNS → Slack alarm delivery (conditional on webhook secret)

### DIFF
--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -799,6 +799,10 @@ jobs:
           # (infra/ecs.ts BEDROCK_PROJECT). Repo variable set out-of-band by
           # scripts/deploy-bedrock-mantle-project.sh.
           MEM9_BEDROCK_PROJECT: ${{ vars.MEM9_BEDROCK_PROJECT }}
+          # Slack incoming webhook for prod alarm delivery (infra/observability.ts).
+          # OPTIONAL: unset → alarms stay console-only (no SNS topic / Lambda).
+          # Set the SLACK_WEBHOOK_URL repo secret to enable.
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
           set +e
           pnpm -C infra exec sst deploy --stage prod --print-logs 2>&1 | tee sst-deploy.log

--- a/infra/ecs.ts
+++ b/infra/ecs.ts
@@ -435,7 +435,11 @@ export function ecs(dbOut: DbOutputs): EcsOutputs {
   });
 
   // Observability (issue #26): metric filters + alarms for prod only.
-  observability({ stage: $app.stage, logGroupName: mnemoLogGroupName });
+  // Slack delivery is conditional: only wired when the SlackWebhookUrl secret
+  // is set (GitHub Actions secret → `sst secret set` during deploy, or manual).
+  // When absent, alarms still fire (console-visible) but have no actions.
+  const slackWebhookUrl = process.env.SLACK_WEBHOOK_URL || undefined;
+  observability({ stage: $app.stage, logGroupName: mnemoLogGroupName, slackWebhookUrl });
 
   return {
     ssmPrefix: prefix,

--- a/infra/observability.ts
+++ b/infra/observability.ts
@@ -1,6 +1,11 @@
-// Observability: CloudWatch metric filters + alarms for the mnemo-server
-// container (issue #26). Only created for the `prod` stage; PR-preview
-// crash-loops must not page.
+// Observability: CloudWatch metric filters + alarms + Slack alerting for the
+// mnemo-server container (issues #26, follow-up). Only created for the `prod`
+// stage; PR-preview crash-loops must not page.
+//
+// Slack delivery is conditional on the `SlackWebhookUrl` SST secret being
+// configured (set via `npx sst secret set SlackWebhookUrl <url> --stage prod`
+// or via `SLACK_WEBHOOK_URL` GitHub secret). When absent, the alarms still fire
+// (visible in the CloudWatch console) but have no action — no Lambda, no topic.
 //
 // Metrics extracted from the mnemo-server structured log lines:
 //   1. recall_zero_hit — `confidence recall search` with `returned = 0`
@@ -9,20 +14,21 @@
 //   4. ingest_dropped — `async ingest failed`
 //
 // Alarms:
-//   - RecallZeroHitRate: metric math `zero/total > 0.7` over 1h, min 10 samples
+//   - RecallZeroHitRate: metric math `zero/total > 0.7` over 1h
 //   - IngestAuthFailure: ≥3 ingest_llm_auth_failure in 15 min
 //
-// The log group name is set explicitly in ecs.ts (`logging.name`) so it's a
-// stable, predictable string this module can reference without coupling to
-// SST's random physical-name suffix.
+// When SlackWebhookUrl is set:
+//   - SNS topic → alert-router Lambda → Slack webhook (Block Kit, #C0BKH5LPAJW
+//     in the opentuna workspace)
 
 export interface ObservabilityInputs {
   stage: string;
   logGroupName: string;
+  slackWebhookUrl?: string;
 }
 
 export function observability(inputs: ObservabilityInputs) {
-  const { stage, logGroupName } = inputs;
+  const { stage, logGroupName, slackWebhookUrl } = inputs;
   if (stage !== "prod") return;
 
   const namespace = "mem9-on-aws";
@@ -73,6 +79,41 @@ export function observability(inputs: ObservabilityInputs) {
     },
   });
 
+  // ─── SNS topic + alert-router Lambda (conditional on webhook) ────────────
+
+  // alarmActions is either [topicArn] (Slack delivery enabled) or [] (console-only).
+  let alarmActions: any[] = [];
+
+  if (slackWebhookUrl) {
+    const topic = new aws.sns.Topic("Mem9AlertsTopic", {
+      name: `mem9-on-aws-${stage}-alerts`,
+    });
+
+    const alertRouter = new sst.aws.Function("Mem9AlertRouter", {
+      handler: "infra/src/alert-router/handler.handler",
+      runtime: "nodejs24.x",
+      architecture: "arm64",
+      timeout: "30 seconds",
+      memory: "256 MB",
+      environment: { SLACK_WEBHOOK_URL: slackWebhookUrl },
+    });
+
+    new aws.sns.TopicSubscription("Mem9AlertRouterSubscription", {
+      topic: topic.arn,
+      protocol: "lambda",
+      endpoint: alertRouter.arn,
+    });
+
+    new aws.lambda.Permission("Mem9AlertRouterSnsInvoke", {
+      action: "lambda:InvokeFunction",
+      function: alertRouter.name,
+      principal: "sns.amazonaws.com",
+      sourceArn: topic.arn,
+    });
+
+    alarmActions = [topic.arn];
+  }
+
   // ─── Alarms ──────────────────────────────────────────────────────────────
 
   new aws.cloudwatch.MetricAlarm("RecallZeroHitRateAlarm", {
@@ -111,6 +152,7 @@ export function observability(inputs: ObservabilityInputs) {
     threshold: 0.7,
     evaluationPeriods: 1,
     treatMissingData: "notBreaching",
+    alarmActions,
   });
 
   new aws.cloudwatch.MetricAlarm("IngestAuthFailureAlarm", {
@@ -126,5 +168,6 @@ export function observability(inputs: ObservabilityInputs) {
     threshold: 3,
     comparisonOperator: "GreaterThanOrEqualToThreshold",
     treatMissingData: "notBreaching",
+    alarmActions,
   });
 }

--- a/infra/src/alert-router/handler.test.ts
+++ b/infra/src/alert-router/handler.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { handler } from "./handler";
+
+const snsEvent = (message: string) => ({
+  Records: [{ Sns: { Message: message } }],
+});
+
+describe("alert-router handler", () => {
+  beforeEach(() => {
+    process.env.SLACK_WEBHOOK_URL = "https://hooks.slack.example/T000/B000/xxx";
+  });
+  afterEach(() => {
+    delete process.env.SLACK_WEBHOOK_URL;
+    vi.restoreAllMocks();
+  });
+
+  it("POSTs the formatted alarm to the webhook", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("ok", { status: 200 }));
+
+    await handler(snsEvent(JSON.stringify({ AlarmName: "IngestAuthFailureAlarm", NewStateValue: "ALARM" })));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://hooks.slack.example/T000/B000/xxx");
+    expect(String(init?.body)).toContain("IngestAuthFailureAlarm");
+  });
+
+  it("does not throw on a non-2xx Slack response (no SNS redelivery flood)", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("no_service", { status: 404 }));
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(handler(snsEvent("{}"))).resolves.toBeUndefined();
+    expect(errSpy).toHaveBeenCalled();
+  });
+
+  it("does not throw when fetch rejects (network failure)", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("ECONNREFUSED"));
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(handler(snsEvent("{}"))).resolves.toBeUndefined();
+    expect(errSpy).toHaveBeenCalled();
+  });
+
+  it("drops events silently when SLACK_WEBHOOK_URL is unset (wiring bug guard)", async () => {
+    delete process.env.SLACK_WEBHOOK_URL;
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await handler(snsEvent("{}"));
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(errSpy).toHaveBeenCalled();
+  });
+
+  it("skips records without an SNS message", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    await handler({ Records: [{}] });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/infra/src/alert-router/handler.ts
+++ b/infra/src/alert-router/handler.ts
@@ -46,9 +46,7 @@ export async function handler(event: SnsEvent): Promise<void> {
         body,
       });
       if (!res.ok) {
-        console.error(
-          `alert-router: Slack webhook returned ${res.status}: ${(await res.text()).slice(0, 200)}`,
-        );
+        console.error(`alert-router: Slack webhook returned ${res.status}`);
       } else {
         console.log("alert-router: delivered alarm notification to Slack");
       }

--- a/infra/src/alert-router/handler.ts
+++ b/infra/src/alert-router/handler.ts
@@ -1,0 +1,61 @@
+/**
+ * AlertRouter Lambda — SNS → Slack webhook bridge (mem9 observability).
+ *
+ * Subscribed directly to the `Mem9AlertsTopic` SNS topic (created in
+ * `infra/observability.ts` only when the Slack webhook secret is configured).
+ * POSTs Block-Kit messages to the Slack incoming webhook URL in
+ * `SLACK_WEBHOOK_URL`.
+ *
+ * Direct SNS→Lambda (no delay queue): mem9's alarms carry everything needed
+ * in the alarm payload itself — no CloudWatch Logs Insights enrichment, so
+ * there is no log-indexing lag to outrun.
+ *
+ * Best-effort delivery: a non-2xx from Slack is logged but NOT thrown. The
+ * CloudWatch alarm stays visible in the AWS console, and throwing would make
+ * SNS redeliver — alert flooding once Slack recovers is worse than one
+ * missed message.
+ */
+
+import { formatAlarmMessage } from "./slack-formatter";
+
+interface SnsRecord {
+  Sns?: { Message?: string };
+}
+
+interface SnsEvent {
+  Records?: SnsRecord[];
+}
+
+export async function handler(event: SnsEvent): Promise<void> {
+  const webhookUrl = process.env.SLACK_WEBHOOK_URL ?? "";
+  if (!webhookUrl) {
+    // Deploy wiring bug — the Lambda only exists when the secret was set.
+    console.error("alert-router: SLACK_WEBHOOK_URL is empty; dropping event");
+    return;
+  }
+
+  for (const record of event.Records ?? []) {
+    const message = record.Sns?.Message;
+    if (!message) continue;
+
+    const body = formatAlarmMessage(message);
+    try {
+      const res = await fetch(webhookUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body,
+      });
+      if (!res.ok) {
+        console.error(
+          `alert-router: Slack webhook returned ${res.status}: ${(await res.text()).slice(0, 200)}`,
+        );
+      } else {
+        console.log("alert-router: delivered alarm notification to Slack");
+      }
+    } catch (err) {
+      console.error(
+        `alert-router: Slack webhook POST failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+}

--- a/infra/src/alert-router/slack-formatter.test.ts
+++ b/infra/src/alert-router/slack-formatter.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { formatAlarmMessage } from "./slack-formatter";
+
+const alarmPayload = (overrides: Record<string, unknown> = {}) =>
+  JSON.stringify({
+    AlarmName: "RecallZeroHitRateAlarm",
+    NewStateValue: "ALARM",
+    NewStateReason: "Threshold Crossed: 1 datapoint [0.85] was greater than 0.7.",
+    StateChangeTime: "2026-07-24T03:00:00.000+0000",
+    Region: "Asia Pacific (Tokyo)",
+    AlarmDescription: "Recall zero-hit rate > 70% over 1h",
+    ...overrides,
+  });
+
+describe("formatAlarmMessage", () => {
+  it("formats an ALARM transition with rotating_light + all fields", () => {
+    const body = JSON.parse(formatAlarmMessage(alarmPayload()));
+    expect(body.text).toBe("ALARM: RecallZeroHitRateAlarm (ALARM)");
+    const flat = JSON.stringify(body.blocks);
+    expect(flat).toContain(":rotating_light:");
+    expect(flat).toContain("RecallZeroHitRateAlarm");
+    expect(flat).toContain("Threshold Crossed");
+    expect(flat).toContain("Recall zero-hit rate");
+    expect(flat).toContain("Tokyo");
+  });
+
+  it("formats an OK transition as RESOLVED with white_check_mark", () => {
+    const body = JSON.parse(formatAlarmMessage(alarmPayload({ NewStateValue: "OK" })));
+    expect(body.text).toContain("RESOLVED");
+    expect(JSON.stringify(body.blocks)).toContain(":white_check_mark:");
+  });
+
+  it("falls back to a warning text for unparseable payloads", () => {
+    const body = JSON.parse(formatAlarmMessage("not-json-at-all"));
+    expect(body.text).toContain(":warning:");
+    expect(body.text).toContain("not-json-at-all");
+    expect(body.blocks).toBeUndefined();
+  });
+
+  it("tolerates missing optional fields", () => {
+    const body = JSON.parse(formatAlarmMessage(JSON.stringify({ AlarmName: "X" })));
+    expect(body.text).toContain("X");
+    // No Region/Time fields when absent; no crash.
+    expect(JSON.stringify(body.blocks)).not.toContain("*Time:*");
+  });
+
+  it("truncates very long reasons", () => {
+    const long = "y".repeat(1000);
+    const body = JSON.parse(formatAlarmMessage(alarmPayload({ NewStateReason: long })));
+    const reason = JSON.stringify(body.blocks);
+    expect(reason.length).toBeLessThan(1200);
+  });
+});

--- a/infra/src/alert-router/slack-formatter.ts
+++ b/infra/src/alert-router/slack-formatter.ts
@@ -1,0 +1,82 @@
+/**
+ * Slack Block-Kit formatter for CloudWatch alarm SNS payloads.
+ *
+ * Pure functions only — no `process.env` reads, no I/O. The handler in
+ * `./handler.ts` owns transport and env wiring.
+ *
+ * Pattern lifted from a sibling project's alert router (SNS-delivered
+ * CloudWatch alarm JSON → Block Kit). mem9's two alarms are plain metric
+ * alarms (no composites), so the formatter handles just that shape plus an
+ * unparseable-input fallback — silent dropping is the failure mode this
+ * channel exists to prevent.
+ */
+
+interface AlarmPayload {
+  AlarmName?: string;
+  NewStateValue?: string;
+  NewStateReason?: string;
+  StateChangeTime?: string;
+  Region?: string;
+  AlarmDescription?: string;
+}
+
+const REASON_MAX = 300;
+
+/**
+ * Build the Slack webhook body for an SNS-delivered CloudWatch alarm
+ * notification. Returns a JSON string ready for `body:` on the POST.
+ */
+export function formatAlarmMessage(snsMessage: string): string {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(snsMessage);
+  } catch {
+    return JSON.stringify({
+      text: `:warning: mem9 unparseable alarm payload: ${snsMessage.slice(0, REASON_MAX)}`,
+    });
+  }
+
+  const alarm = parsed as AlarmPayload;
+  const name = alarm.AlarmName ?? "Unknown Alarm";
+  const state = alarm.NewStateValue ?? "UNKNOWN";
+  const time = alarm.StateChangeTime ?? "";
+  const region = alarm.Region ?? "";
+
+  const isOk = state === "OK";
+  const emoji = isOk ? ":white_check_mark:" : ":rotating_light:";
+  const label = isOk ? "RESOLVED" : "ALARM";
+
+  const blocks: Record<string, unknown>[] = [
+    {
+      type: "section",
+      text: { type: "mrkdwn", text: `${emoji} *[${label}] mem9: ${name}*` },
+    },
+    {
+      type: "section",
+      fields: [
+        { type: "mrkdwn", text: `*State:* ${state}` },
+        ...(region ? [{ type: "mrkdwn", text: `*Region:* ${region}` }] : []),
+        ...(time ? [{ type: "mrkdwn", text: `*Time:* ${time}` }] : []),
+      ],
+    },
+  ];
+
+  if (alarm.AlarmDescription) {
+    blocks.push({
+      type: "section",
+      text: { type: "mrkdwn", text: `*About:* ${alarm.AlarmDescription}` },
+    });
+  }
+  if (alarm.NewStateReason) {
+    blocks.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `*Reason:* ${alarm.NewStateReason.slice(0, REASON_MAX)}`,
+      },
+    });
+  }
+
+  // `text` is the notification-preview fallback; `blocks` is the rendered body.
+  return JSON.stringify({ text: `${label}: ${name} (${state})`, blocks });
+}

--- a/infra/sst-types.d.ts
+++ b/infra/sst-types.d.ts
@@ -116,6 +116,15 @@ declare namespace aws {
       packageType?: Input<string>;
     }
     class Function {}
+    interface PermissionArgs {
+      action: Input<string>;
+      function: Input<string>;
+      principal: Input<string>;
+      sourceArn?: Input<string>;
+    }
+    class Permission {
+      constructor(name: string, args: PermissionArgs);
+    }
   }
 
   namespace ec2 {
@@ -226,11 +235,31 @@ declare namespace aws {
       comparisonOperator: Input<string>;
       treatMissingData?: Input<string>;
       metricQueries?: MetricAlarmMetricQuery[];
-      alarmActions?: Input<string>[];
+      alarmActions?: Input<Input<string>[]>;
     }
     class MetricAlarm {
       constructor(name: string, args: MetricAlarmArgs);
       readonly arn: Output<string>;
+    }
+  }
+
+  // SNS (infra/observability.ts — Slack alerting).
+  namespace sns {
+    interface TopicArgs {
+      name?: Input<string>;
+      tags?: Record<string, Input<string>>;
+    }
+    class Topic {
+      constructor(name: string, args?: TopicArgs);
+      readonly arn: Output<string>;
+    }
+    interface TopicSubscriptionArgs {
+      topic: Input<string>;
+      protocol: Input<string>;
+      endpoint: Input<string>;
+    }
+    class TopicSubscription {
+      constructor(name: string, args: TopicSubscriptionArgs);
     }
   }
 


### PR DESCRIPTION
## Summary
- Follow-up to #26 — wires the 2 prod alarms (RecallZeroHitRate, IngestAuthFailure) to Slack channel [#C0BKH5LPAJW](https://opentunaworkspace.slack.com/archives/C0BKH5LPAJW) in the opentuna workspace
- **Conditional deployment**: SNS topic + alert-router Lambda + alarmActions only provisioned when `SLACK_WEBHOOK_URL` GitHub secret is configured. Without it = current behavior (console-only alarms, no actions)
- Pattern matches sibling project (podcast-curation): SNS → Lambda → incoming webhook (Block Kit), best-effort delivery (non-2xx logged, not thrown — no alert flood on Slack recovery)

## To enable after merge
1. Create a Slack incoming webhook for the `#C0BKH5LPAJW` channel in the opentuna workspace
2. Set `SLACK_WEBHOOK_URL` as a GitHub Actions repo secret
3. Add to the `deploy-prod` step env in `.github/workflows/infra-ci.yml`:
   ```yaml
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   ```
4. Next push to main auto-deploys with the webhook wired

## Test Plan
- [x] Unit tests (10 new: 5 formatter + 5 handler — delivery paths, non-2xx resilience, missing URL guard, unparseable payload)
- [x] Build passes (typecheck clean; 104 infra + 27 root tests green)
- [x] CI checks pass
- [x] E2E tests pass (pr-32 preview green; no webhook in CI so alert-router not provisioned — correct conditional behavior)

## Checklist
- [x] New unit tests written (handler.test.ts, slack-formatter.test.ts)
- [x] No secrets in committed files (webhook URL read from env at deploy time)
- [x] sst-types.d.ts extended (SNS, Lambda.Permission)
