### PR TITLE
fix(observability): metric filters depend on ECS service; SNS deploy-role grants

### DIFF
--- a/infra/cloudformation/github-actions-role.yaml
+++ b/infra/cloudformation/github-actions-role.yaml
@@ -593,6 +593,35 @@ Resources:
               - application-autoscaling:TagResource
               - application-autoscaling:UntagResource
             Resource: "*"
+          - Sid: SnsAlerting
+            # infra/observability.ts (Slack alerting): SNS topic + Lambda
+            # subscription for prod alarm delivery. Scoped to this project's
+            # topic naming scheme.
+            Effect: Allow
+            Action:
+              - sns:CreateTopic
+              - sns:DeleteTopic
+              - sns:GetTopicAttributes
+              - sns:SetTopicAttributes
+              - sns:Subscribe
+              - sns:Unsubscribe
+              - sns:GetSubscriptionAttributes
+              - sns:ListSubscriptionsByTopic
+              - sns:TagResource
+              - sns:UntagResource
+              - sns:ListTagsForResource
+            Resource:
+              - !Sub arn:${AWS::Partition}:sns:*:${AWS::AccountId}:mem9-on-aws-*
+          - Sid: SnsSubscriptionRead
+            # GetSubscriptionAttributes on refresh addresses the subscription ARN
+            # (arn:...:mem9-on-aws-prod-alerts:<uuid>), covered above; Unsubscribe
+            # during teardown can be called with just the subscription ARN too.
+            Effect: Allow
+            Action:
+              - sns:GetSubscriptionAttributes
+              - sns:Unsubscribe
+            Resource:
+              - !Sub arn:${AWS::Partition}:sns:*:${AWS::AccountId}:mem9-on-aws-*:*
           - Sid: CloudWatchAlarmsForScaling
             # Target-tracking scaling policies auto-provision CloudWatch alarms.
             Effect: Allow

--- a/infra/ecs.ts
+++ b/infra/ecs.ts
@@ -439,7 +439,7 @@ export function ecs(dbOut: DbOutputs): EcsOutputs {
   // is set (GitHub Actions secret → `sst secret set` during deploy, or manual).
   // When absent, alarms still fire (console-visible) but have no actions.
   const slackWebhookUrl = process.env.SLACK_WEBHOOK_URL || undefined;
-  observability({ stage: $app.stage, logGroupName: mnemoLogGroupName, slackWebhookUrl });
+  observability({ stage: $app.stage, logGroupName: mnemoLogGroupName, service, slackWebhookUrl });
 
   return {
     ssmPrefix: prefix,

--- a/infra/observability.ts
+++ b/infra/observability.ts
@@ -24,60 +24,82 @@
 export interface ObservabilityInputs {
   stage: string;
   logGroupName: string;
+  // The ECS service whose container logging creates the log group above. The
+  // metric filters MUST depend on it: they reference the log group by name
+  // (a plain string, no implicit Pulumi edge), and on a fresh deploy a filter
+  // racing ahead of the Service fails with ResourceNotFoundException.
+  service: unknown;
   slackWebhookUrl?: string;
 }
 
 export function observability(inputs: ObservabilityInputs) {
-  const { stage, logGroupName, slackWebhookUrl } = inputs;
+  const { stage, logGroupName, service, slackWebhookUrl } = inputs;
   if (stage !== "prod") return;
 
   const namespace = "mem9-on-aws";
+  const afterService = { dependsOn: [service] };
 
   // ─── Metric filters ──────────────────────────────────────────────────────
 
-  new aws.cloudwatch.LogMetricFilter("RecallZeroHitFilter", {
-    logGroupName,
-    pattern: '{ $.msg = "confidence recall search" && $.returned = 0 }',
-    metricTransformation: {
-      name: "recall_zero_hit",
-      namespace,
-      value: "1",
-      defaultValue: "0",
+  new aws.cloudwatch.LogMetricFilter(
+    "RecallZeroHitFilter",
+    {
+      logGroupName,
+      pattern: '{ $.msg = "confidence recall search" && $.returned = 0 }',
+      metricTransformation: {
+        name: "recall_zero_hit",
+        namespace,
+        value: "1",
+        defaultValue: "0",
+      },
     },
-  });
+    afterService,
+  );
 
-  new aws.cloudwatch.LogMetricFilter("RecallTotalFilter", {
-    logGroupName,
-    pattern: '{ $.msg = "confidence recall search" }',
-    metricTransformation: {
-      name: "recall_total",
-      namespace,
-      value: "1",
-      defaultValue: "0",
+  new aws.cloudwatch.LogMetricFilter(
+    "RecallTotalFilter",
+    {
+      logGroupName,
+      pattern: '{ $.msg = "confidence recall search" }',
+      metricTransformation: {
+        name: "recall_total",
+        namespace,
+        value: "1",
+        defaultValue: "0",
+      },
     },
-  });
+    afterService,
+  );
 
-  new aws.cloudwatch.LogMetricFilter("IngestAuthFailureFilter", {
-    logGroupName,
-    pattern: '{ $.msg = "extraction LLM call failed" && $.err = "*401*" }',
-    metricTransformation: {
-      name: "ingest_llm_auth_failure",
-      namespace,
-      value: "1",
-      defaultValue: "0",
+  new aws.cloudwatch.LogMetricFilter(
+    "IngestAuthFailureFilter",
+    {
+      logGroupName,
+      pattern: '{ $.msg = "extraction LLM call failed" && $.err = "*401*" }',
+      metricTransformation: {
+        name: "ingest_llm_auth_failure",
+        namespace,
+        value: "1",
+        defaultValue: "0",
+      },
     },
-  });
+    afterService,
+  );
 
-  new aws.cloudwatch.LogMetricFilter("IngestDroppedFilter", {
-    logGroupName,
-    pattern: '{ $.msg = "async ingest failed" }',
-    metricTransformation: {
-      name: "ingest_dropped",
-      namespace,
-      value: "1",
-      defaultValue: "0",
+  new aws.cloudwatch.LogMetricFilter(
+    "IngestDroppedFilter",
+    {
+      logGroupName,
+      pattern: '{ $.msg = "async ingest failed" }',
+      metricTransformation: {
+        name: "ingest_dropped",
+        namespace,
+        value: "1",
+        defaultValue: "0",
+      },
     },
-  });
+    afterService,
+  );
 
   // ─── SNS topic + alert-router Lambda (conditional on webhook) ────────────
 

--- a/infra/sst-types.d.ts
+++ b/infra/sst-types.d.ts
@@ -209,7 +209,7 @@ declare namespace aws {
       metricTransformation: LogMetricFilterMetricTransformation;
     }
     class LogMetricFilter {
-      constructor(name: string, args: LogMetricFilterArgs);
+      constructor(name: string, args: LogMetricFilterArgs, opts?: { dependsOn?: unknown[] });
     }
     interface MetricAlarmMetricQuery {
       id: Input<string>;


### PR DESCRIPTION
## Summary
- Fixes the two prod-deploy failures after #32 (auto-filed as #31 / #33):
  1. **AccessDenied** on `logs:PutMetricFilter` + `SNS:GetTopicAttributes` — role template gains an `SnsAlerting` Sid (scoped to `mem9-on-aws-*` topics); the role STACK was re-deployed out-of-band (`deploy-github-role.sh --update`, done)
  2. **ResourceNotFoundException** on all 4 metric filters — they reference the log group by plain-string name (no implicit Pulumi edge) and raced ahead of the ECS service creating it on a fresh deploy; filters now take explicit `dependsOn: [service]`

## Test Plan
- [x] Typecheck + 104 infra tests green
- [ ] CI checks pass
- [ ] Prod deploy succeeds after merge (the real fix validation)

Closes #31, closes #33