### PR TITLE
fix(iam): cloudwatch tag actions for alarm refresh in deploy role

### DIFF
--- a/infra/cloudformation/github-actions-role.yaml
+++ b/infra/cloudformation/github-actions-role.yaml
@@ -623,12 +623,19 @@ Resources:
             Resource:
               - !Sub arn:${AWS::Partition}:sns:*:${AWS::AccountId}:mem9-on-aws-*:*
           - Sid: CloudWatchAlarmsForScaling
-            # Target-tracking scaling policies auto-provision CloudWatch alarms.
+            # Target-tracking scaling policies auto-provision CloudWatch alarms;
+            # infra/observability.ts creates its own metric alarms too. The
+            # Pulumi provider reads tags on every alarm refresh, so the tag
+            # actions ride along (ListTagsForResource 403s the whole deploy
+            # otherwise — the alarm CREATES fine, then the read-back fails).
             Effect: Allow
             Action:
               - cloudwatch:PutMetricAlarm
               - cloudwatch:DeleteAlarms
               - cloudwatch:DescribeAlarms
+              - cloudwatch:ListTagsForResource
+              - cloudwatch:TagResource
+              - cloudwatch:UntagResource
             Resource: "*"
           - Sid: AppAutoScalingSLR
             # First app-autoscaling use in the account needs its service-linked

--- a/infra/ecs.test.ts
+++ b/infra/ecs.test.ts
@@ -10,7 +10,18 @@ import type { DbOutputs } from "./db";
  */
 
 function out<T>(value: T): { value: T; apply: (fn: (v: T) => unknown) => unknown } {
-  return { value, apply: (fn) => out(fn(value) as never) };
+  return {
+    value,
+    // Mirror Pulumi's Output.apply: when fn returns another Output, FLATTEN it
+    // (Output<Output<U>> → Output<U>) instead of double-wrapping — the ecs()
+    // taskDefinition→containerDefinitions chain relies on this.
+    apply: (fn) => {
+      const result = fn(value);
+      return result && typeof result === "object" && "apply" in result
+        ? result
+        : out(result as never);
+    },
+  };
 }
 
 interface ClusterRecord {
@@ -138,7 +149,23 @@ function installGlobals(stage: string) {
         }
       },
       Service: class {
-        nodes = { service: { name: out("mem9-service"), arn: out("arn:service") } };
+        nodes = {
+          service: { name: out("mem9-service"), arn: out("arn:service") },
+          // observability wiring parses containerDefinitions JSON from the task
+          // def to find the mnemo-server awslogs-group.
+          taskDefinition: out({
+            containerDefinitions: out(
+              JSON.stringify([
+                {
+                  name: "mnemo-server",
+                  logConfiguration: {
+                    options: { "awslogs-group": "/sst/cluster/test/svc-hash/mnemo-server" },
+                  },
+                },
+              ]),
+            ),
+          }),
+        };
         service = out("mem9.svc.local");
         constructor(_logicalName: string, args: Record<string, unknown>) {
           services.push({ args });

--- a/infra/ecs.ts
+++ b/infra/ecs.ts
@@ -114,10 +114,6 @@ export interface EcsOutputs {
  */
 export function ecs(dbOut: DbOutputs): EcsOutputs {
   const prefix = `/mem9-on-aws/${$app.stage}`;
-  // Stable log group name for the mnemo-server container — used by
-  // observability.ts metric filters. SST's auto-name includes a random hash;
-  // pinning it makes the filters deterministic and survives service recreates.
-  const mnemoLogGroupName = `/sst/cluster/mem9-on-aws-${$app.stage}/mnemo-server`;
   const { vpcId, privateSubnetIds } = resolveVpc();
 
   const tags = {
@@ -331,9 +327,12 @@ export function ecs(dbOut: DbOutputs): EcsOutputs {
         },
         // Per-container logging: with `containers[]`, top-level `logging` is
         // forbidden (SST rejects it alongside containers) — each container sets
-        // its own. The mnemo-server log group name is set explicitly so
-        // observability.ts can reference it deterministically for metric filters.
-        logging: { retention: "1 month", name: mnemoLogGroupName },
+        // its own. Do NOT pin `logging.name`: SST creates the LogGroup with
+        // `ignoreChanges: ["name"]`, so on a stack whose group already exists
+        // a rename is silently ignored — the pinned name never materializes
+        // (prod incident: metric filters 400'd ResourceNotFoundException
+        // forever). observability.ts reads the REAL name from the task def.
+        logging: { retention: "1 month" },
       },
       {
         name: "qwen3-embed",
@@ -438,8 +437,28 @@ export function ecs(dbOut: DbOutputs): EcsOutputs {
   // Slack delivery is conditional: only wired when the SlackWebhookUrl secret
   // is set (GitHub Actions secret → `sst secret set` during deploy, or manual).
   // When absent, alarms still fire (console-visible) but have no actions.
+  //
+  // The mnemo-server log group name comes from the TASK DEFINITION (the
+  // awslogs-group option of the mnemo-server container) — the only reliable
+  // source: SST auto-names the group with a random hash and ignores renames
+  // (`ignoreChanges: ["name"]`), so a hand-computed name silently diverges on
+  // stacks whose group already exists. Reading it also gives the metric
+  // filters a real Pulumi dependency on the log group's creator.
   const slackWebhookUrl = process.env.SLACK_WEBHOOK_URL || undefined;
-  observability({ stage: $app.stage, logGroupName: mnemoLogGroupName, service, slackWebhookUrl });
+  const mnemoLogGroupName = service.nodes.taskDefinition
+    .apply((td) => (td as { containerDefinitions: Output<string> }).containerDefinitions)
+    .apply((raw: string) => {
+      const defs = JSON.parse(raw) as {
+        name: string;
+        logConfiguration?: { options?: Record<string, string> };
+      }[];
+      const group = defs.find((c) => c.name === "mnemo-server")?.logConfiguration?.options?.[
+        "awslogs-group"
+      ];
+      if (!group) throw new Error("mnemo-server awslogs-group not found in task definition");
+      return group;
+    });
+  observability({ stage: $app.stage, logGroupName: mnemoLogGroupName, slackWebhookUrl });
 
   return {
     ssmPrefix: prefix,

--- a/infra/observability.ts
+++ b/infra/observability.ts
@@ -23,21 +23,23 @@
 
 export interface ObservabilityInputs {
   stage: string;
-  logGroupName: string;
-  // The ECS service whose container logging creates the log group above. The
-  // metric filters MUST depend on it: they reference the log group by name
-  // (a plain string, no implicit Pulumi edge), and on a fresh deploy a filter
-  // racing ahead of the Service fails with ResourceNotFoundException.
-  service: unknown;
+  // The mnemo-server log group name, read from the SERVICE'S TASK DEFINITION
+  // (an Output<string>) — never a hand-computed string. SST names container
+  // log groups with a random physical-name hash AND creates them with
+  // `ignoreChanges: ["name"]`, so a pinned `logging.name` silently never
+  // materializes on a stack whose group already exists (prod incident:
+  // metric filters 400'd ResourceNotFoundException on a name that would
+  // never exist). Deriving from the task def both yields the REAL name and
+  // threads a Pulumi dependency edge through the log group's creator.
+  logGroupName: Output<string>;
   slackWebhookUrl?: string;
 }
 
 export function observability(inputs: ObservabilityInputs) {
-  const { stage, logGroupName, service, slackWebhookUrl } = inputs;
+  const { stage, logGroupName, slackWebhookUrl } = inputs;
   if (stage !== "prod") return;
 
   const namespace = "mem9-on-aws";
-  const afterService = { dependsOn: [service] };
 
   // ─── Metric filters ──────────────────────────────────────────────────────
 
@@ -53,7 +55,6 @@ export function observability(inputs: ObservabilityInputs) {
         defaultValue: "0",
       },
     },
-    afterService,
   );
 
   new aws.cloudwatch.LogMetricFilter(
@@ -68,7 +69,6 @@ export function observability(inputs: ObservabilityInputs) {
         defaultValue: "0",
       },
     },
-    afterService,
   );
 
   new aws.cloudwatch.LogMetricFilter(
@@ -83,7 +83,6 @@ export function observability(inputs: ObservabilityInputs) {
         defaultValue: "0",
       },
     },
-    afterService,
   );
 
   new aws.cloudwatch.LogMetricFilter(
@@ -98,7 +97,6 @@ export function observability(inputs: ObservabilityInputs) {
         defaultValue: "0",
       },
     },
-    afterService,
   );
 
   // ─── SNS topic + alert-router Lambda (conditional on webhook) ────────────

--- a/infra/sst-types.d.ts
+++ b/infra/sst-types.d.ts
@@ -207,6 +207,7 @@ declare namespace aws {
       logGroupName: Input<string>;
       pattern: Input<string>;
       metricTransformation: LogMetricFilterMetricTransformation;
+      [k: string]: unknown;
     }
     class LogMetricFilter {
       constructor(name: string, args: LogMetricFilterArgs, opts?: { dependsOn?: unknown[] });
@@ -431,7 +432,12 @@ declare namespace sst {
     }
     class Service {
       constructor(name: string, args: ServiceArgs);
-      readonly nodes: { service: { name: Output<string>; arn: Output<string> } };
+      readonly nodes: {
+        service: { name: Output<string>; arn: Output<string> };
+        // Output<ecs.TaskDefinition>; observability wiring reads the
+        // containerDefinitions JSON to find the real awslogs-group.
+        taskDefinition: Output<unknown>;
+      };
       readonly service: Output<string>;
     }
 


### PR DESCRIPTION
## Summary
- Third and final grant for the alarm chain: the Pulumi provider calls `cloudwatch:ListTagsForResource` on every MetricAlarm read-back — the alarm CREATED fine but the refresh 403'd the deploy (auto-filed as #35)
- `TagResource`/`UntagResource` ride along for tagged-alarm updates
- Role stack already re-deployed out-of-band (`deploy-github-role.sh --update`) — this PR records the template change; CI does not deploy on `infra/cloudformation/**` paths

Closes #35

---

**Second commit (46fee58)** — the deeper root cause of the metric-filter `ResourceNotFoundException`: pinning `logging.name` never takes effect on an existing stack (SST creates the LogGroup with `ignoreChanges: ["name"]`, silently keeping the old auto-generated name). The filters now derive the REAL `awslogs-group` from the service's task definition — correct on any stack and a genuine Pulumi dependency edge.
