### PR TITLE
chore(skills): onboard autonomous pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,9 @@ infra/sst-env.d.ts
 .worktrees/
 
 # Autonomous-dev-team scaffolding (machine-local; recreated by `npx skills add`).
-# .agents/skills → symlink into the user-scope install; .agents/state → hook state.
+# .agents/skills contains project-scoped skill bodies; .agents/state is hook state.
 .agents/
+.codex/
 .pulumi/
 
 # Symlink scaffolding pointing into .agents/ (machine-local, recreated on install)
@@ -33,6 +34,7 @@ scripts/adt-gc.sh
 scripts/autonomous-dev.sh
 scripts/autonomous-review.sh
 scripts/check-provider-cutover.sh
+scripts/check-shell-idioms.sh
 scripts/check-spec-drift.sh
 scripts/dispatch-local.sh
 scripts/dispatcher-multi-tick.sh
@@ -51,6 +53,8 @@ scripts/resolve-threads.sh
 scripts/setup-labels.sh
 scripts/status.sh
 scripts/upload-screenshot.sh
+scripts/write-verdict-artifact.sh
+scripts/write-verdict-body.sh
 
 # OS
 .DS_Store

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,40 @@
+{
+  "version": 1,
+  "skills": {
+    "autonomous-common": {
+      "source": "zxkane/autonomous-dev-team",
+      "ref": "main",
+      "sourceType": "github",
+      "skillPath": "skills/autonomous-common/SKILL.md",
+      "computedHash": "c4b38d67e95f82070681efe4d55766da0fd1a79067d79379baf074ff70086177"
+    },
+    "autonomous-dev": {
+      "source": "zxkane/autonomous-dev-team",
+      "ref": "main",
+      "sourceType": "github",
+      "skillPath": "skills/autonomous-dev/SKILL.md",
+      "computedHash": "28ce578720bb850a68954051265cd384224a6dbd93ec71e77812ad1906aa4933"
+    },
+    "autonomous-dispatcher": {
+      "source": "zxkane/autonomous-dev-team",
+      "ref": "main",
+      "sourceType": "github",
+      "skillPath": "skills/autonomous-dispatcher/SKILL.md",
+      "computedHash": "6d552c4a19c2f58472920b03df79930f83aa9aec5ef30ab25319bdd84f8b5d53"
+    },
+    "autonomous-review": {
+      "source": "zxkane/autonomous-dev-team",
+      "ref": "main",
+      "sourceType": "github",
+      "skillPath": "skills/autonomous-review/SKILL.md",
+      "computedHash": "bbc18fbaa935e757c9ac1d786670c504ad3a28a10521739a293d6e30c5c10316"
+    },
+    "create-issue": {
+      "source": "zxkane/autonomous-dev-team",
+      "ref": "main",
+      "sourceType": "github",
+      "skillPath": "skills/create-issue/SKILL.md",
+      "computedHash": "5dd0729285e33266d02f9fb6432508b5e6306063c9241fe0710009e605a9a629"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- pin the autonomous pipeline skills in the project lock
- keep project-scoped skill bodies and generated hook scaffolding untracked

## Verification
- installed with Node 24 and skills CLI 1.5.20
- verified all five skill directories match upstream
- validated shell syntax, hook JSON/TOML, autonomous config, and dispatcher cron