### PR TITLE
fix(iam): avoid SQS tag propagation race

### DIFF
--- a/infra/cloudformation/github-actions-role.yaml
+++ b/infra/cloudformation/github-actions-role.yaml
@@ -1031,7 +1031,8 @@ Resources:
             Action:
               - sqs:CreateQueue
             Resource:
-              - !Sub arn:${AWS::Partition}:sqs:*:${AWS::AccountId}:*
+              - !Sub arn:${AWS::Partition}:sqs:*:${AWS::AccountId}:AlertTransportFailureQueue-*
+              - !Sub arn:${AWS::Partition}:sqs:*:${AWS::AccountId}:AlertExecutionFailureQueue-*
             Condition:
               StringEquals:
                 aws:RequestTag/Project: !Ref ProjectName
@@ -1046,12 +1047,12 @@ Resources:
               - sqs:SetQueueAttributes
               - sqs:TagQueue
               - sqs:UntagQueue
+            # Resource tags can lag immediately after CreateQueue. Scope by the
+            # two Pulumi-generated queue-name prefixes so the first read works
+            # without granting control-plane access to unrelated queues.
             Resource:
-              - !Sub arn:${AWS::Partition}:sqs:*:${AWS::AccountId}:*
-            Condition:
-              StringEquals:
-                aws:ResourceTag/Project: !Ref ProjectName
-                aws:ResourceTag/ManagedBy: sst
+              - !Sub arn:${AWS::Partition}:sqs:*:${AWS::AccountId}:AlertTransportFailureQueue-*
+              - !Sub arn:${AWS::Partition}:sqs:*:${AWS::AccountId}:AlertExecutionFailureQueue-*
           - Sid: LambdaAlertAsyncConfig
             Effect: Allow
             Action:

--- a/infra/observability.test.ts
+++ b/infra/observability.test.ts
@@ -315,7 +315,14 @@ describe("observability alert delivery", () => {
           Effect: "Allow",
           Action: ["sqs:CreateQueue"],
           Resource: [
-            { "Fn::Sub": "arn:${AWS::Partition}:sqs:*:${AWS::AccountId}:*" },
+            {
+              "Fn::Sub":
+                "arn:${AWS::Partition}:sqs:*:${AWS::AccountId}:AlertTransportFailureQueue-*",
+            },
+            {
+              "Fn::Sub":
+                "arn:${AWS::Partition}:sqs:*:${AWS::AccountId}:AlertExecutionFailureQueue-*",
+            },
           ],
           Condition: {
             StringEquals: {
@@ -337,14 +344,15 @@ describe("observability alert delivery", () => {
             "sqs:UntagQueue",
           ],
           Resource: [
-            { "Fn::Sub": "arn:${AWS::Partition}:sqs:*:${AWS::AccountId}:*" },
-          ],
-          Condition: {
-            StringEquals: {
-              "aws:ResourceTag/Project": { Ref: "ProjectName" },
-              "aws:ResourceTag/ManagedBy": "sst",
+            {
+              "Fn::Sub":
+                "arn:${AWS::Partition}:sqs:*:${AWS::AccountId}:AlertTransportFailureQueue-*",
             },
-          },
+            {
+              "Fn::Sub":
+                "arn:${AWS::Partition}:sqs:*:${AWS::AccountId}:AlertExecutionFailureQueue-*",
+            },
+          ],
         },
         {
           Sid: "LambdaAlertAsyncConfig",


### PR DESCRIPTION
## Summary
- scope alert-failure SQS control-plane access to the two generated queue-name prefixes
- remove the resource-tag condition that races the provider read immediately after queue creation
- retain request-tag requirements for queue creation

## Verification
- infra typecheck
- 134 infra tests
- IAM simulation allows the matching failure queue and denies an unrelated queue

Closes #67