### PR TITLE
fix(iam): allow API Gateway log delivery cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,5 +21,6 @@ AWS_PROFILE=your-aws-profile
 # already exist; the default is a timestamped, gitignored repo-root file.
 # ECR_SCAN_BACKUP_FILE=/path/to/ecr-registry-scanning-rollback.local.json
 # PROJECT_REGION=ap-northeast-1
+# MEM9_VPC_ID=vpc-xxxxxxxxxxxxxxxxx
 # CloudFormation stack names (override only if you run multiple copies).
 # STACK_NAME=

--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -46,9 +46,10 @@ on:
       - "vitest.config.ts"
       # The OIDC role + ECR repositories are bootstrapped out-of-band via
       # scripts/deploy-github-role.sh / deploy-ecr-repositories.sh — NOT part of
-      # the per-PR SST deploy. Skip the workflow when a PR only touches those
-      # CloudFormation templates.
+      # the per-PR SST deploy. Re-include templates whose regression tests run
+      # in this workflow.
       - "!infra/cloudformation/**"
+      - "infra/cloudformation/github-actions-role.yaml"
       - "infra/cloudformation/ecr-registry-scanning.yaml"
   push:
     branches: [main]
@@ -63,6 +64,7 @@ on:
       - "tsconfig.json"
       - "vitest.config.ts"
       - "!infra/cloudformation/**"
+      - "infra/cloudformation/github-actions-role.yaml"
       - "infra/cloudformation/ecr-registry-scanning.yaml"
 
 # Per-PR concurrency for PR events (cancel superseded runs so repeated

--- a/infra/cloudformation/github-actions-role.yaml
+++ b/infra/cloudformation/github-actions-role.yaml
@@ -799,11 +799,13 @@ Resources:
   # Map's service-discovery and Route53 private-zone grants remain in ComputePolicy.
   # Its own ManagedPolicy stays under IAM's 6144-byte per-policy cap.
   #
-  # The Lambda's VPC ENIs are created by the LAMBDA SERVICE via the Lambda EXEC role
-  # (granted in infra/gateway.ts), NOT this deploy role — so no ec2:CreateNetworkInterface
-  # here (ec2:Describe* is already in ScaffoldPolicy.EC2VpcReadOnly). PassRole to
-  # lambda.amazonaws.com is already covered by ScaffoldPolicy.PassRoleConstrained, and
-  # the mem9-on-aws-* exec-role lifecycle by ComputePolicy.EcsTaskRoles. The Cloud Map
+  # The Lambda service creates VPC ENIs via the Lambda execution role (granted in
+  # infra/gateway.ts), so this deploy role does not need CreateNetworkInterface.
+  # During teardown Pulumi deletes detached Lambda ENIs before deleting the shared
+  # task security group, which requires the narrowly-scoped delete grant below.
+  # ec2:Describe* is already in ScaffoldPolicy.EC2VpcReadOnly. PassRole to
+  # lambda.amazonaws.com is covered by ScaffoldPolicy.PassRoleConstrained, and the
+  # mem9-on-aws-* exec-role lifecycle by ComputePolicy.EcsTaskRoles. The Cloud Map
   # + Route53-for-Cloud-Map grants live in ComputePolicy (near the ECS service).
   #
   # OUT-OF-BAND DEPLOY REQUIREMENT: apply this policy with
@@ -847,6 +849,12 @@ Resources:
               - lambda:DeleteFunctionConcurrency
             Resource:
               - !Sub arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:${ProjectName}-*
+          - Sid: LambdaVpcEniCleanup
+            Effect: Allow
+            Action:
+              - ec2:DeleteNetworkInterface
+            Resource:
+              - !Sub arn:${AWS::Partition}:ec2:ap-northeast-1:${AWS::AccountId}:network-interface/*
           - Sid: LambdaFunctionLogs
             # sst.aws.Function creates a CloudWatch log group at /aws/lambda/<fn>.
             # The CorePolicy/ComputePolicy Logs Sid only covers /sst/* groups, so the

--- a/infra/cloudformation/github-actions-role.yaml
+++ b/infra/cloudformation/github-actions-role.yaml
@@ -43,6 +43,16 @@ Parameters:
       arn:aws:iam::<account-id>:oidc-provider/token.actions.githubusercontent.com
       — pass it so no duplicate is created (only one provider per URL per
       account is allowed).
+  ApplicationRegion:
+    Type: String
+    Default: ap-northeast-1
+    Description: AWS Region where the SST application and its Lambda VPC ENIs run.
+  ApplicationVpcArn:
+    Type: String
+    Description: ARN of the existing VPC used by the SST application.
+  ApplicationPrivateSubnetArns:
+    Type: CommaDelimitedList
+    Description: ARNs of the private subnets used by the proxy Lambda.
 
 Conditions:
   CreateOIDCProvider: !Equals [!Ref OIDCProviderArn, ""]
@@ -854,7 +864,11 @@ Resources:
             Action:
               - ec2:DeleteNetworkInterface
             Resource:
-              - !Sub arn:${AWS::Partition}:ec2:ap-northeast-1:${AWS::AccountId}:network-interface/*
+              - !Sub arn:${AWS::Partition}:ec2:${ApplicationRegion}:${AWS::AccountId}:network-interface/*
+            Condition:
+              ArnEquals:
+                ec2:Vpc: !Ref ApplicationVpcArn
+                ec2:Subnet: !Ref ApplicationPrivateSubnetArns
           - Sid: LambdaFunctionLogs
             # sst.aws.Function creates a CloudWatch log group at /aws/lambda/<fn>.
             # The CorePolicy/ComputePolicy Logs Sid only covers /sst/* groups, so the

--- a/infra/cloudformation/github-actions-role.yaml
+++ b/infra/cloudformation/github-actions-role.yaml
@@ -1049,10 +1049,12 @@ Resources:
               - logs:UntagResource
               - logs:ListTagsForResource
               - logs:DescribeLogGroups
-              # Delivery API actions needed by CreateStage's access-logging setup.
+              # Delivery API actions needed by the CreateStage/DeleteStage
+              # access-logging lifecycle.
               - logs:CreateLogDelivery
               - logs:DeleteLogDelivery
               - logs:GetLogDelivery
+              - logs:ListLogDeliveries
               - logs:UpdateLogDelivery
               - logs:PutDeliverySource
               - logs:PutDeliveryDestination

--- a/scripts/deploy-github-role.sh
+++ b/scripts/deploy-github-role.sh
@@ -33,6 +33,10 @@ TEMPLATE_FILE="infra/cloudformation/github-actions-role.yaml"
 # in different regions (EntityAlreadyExists rollback). Keep all GitHub Actions
 # role stacks in one region so they share one OIDC provider collision-free.
 REGION="${AWS_REGION:-us-west-2}"
+# The application remains regional even though the IAM stack is pinned elsewhere.
+# Match infra/vpc.ts: use MEM9_VPC_ID when configured, otherwise the default VPC,
+# and authorize only the NAT-routed private-1* subnets selected by the app.
+APPLICATION_REGION="${PROJECT_REGION:-ap-northeast-1}"
 
 MODE=""
 for arg in "$@"; do
@@ -108,7 +112,71 @@ if [[ "$OIDC_PROVIDER_ARN" == "None" ]]; then
 else
   echo "OIDC ARN: $OIDC_PROVIDER_ARN"
 fi
-PARAMS=("ParameterKey=OIDCProviderArn,ParameterValue=$OIDC_PROVIDER_ARN")
+
+APPLICATION_VPC_ID="${MEM9_VPC_ID:-}"
+if [[ -z "$APPLICATION_VPC_ID" ]]; then
+  if ! APPLICATION_VPC_ID=$(aws ec2 describe-vpcs \
+      --region "$APPLICATION_REGION" \
+      --filters Name=is-default,Values=true \
+      --query "Vpcs[0].VpcId" \
+      --output text); then
+    echo "Error: failed to resolve the default VPC in $APPLICATION_REGION." >&2
+    exit 1
+  fi
+else
+  if ! aws ec2 describe-vpcs \
+      --region "$APPLICATION_REGION" \
+      --vpc-ids "$APPLICATION_VPC_ID" \
+      --query "Vpcs[0].VpcId" \
+      --output text >/dev/null; then
+    echo "Error: MEM9_VPC_ID does not resolve in $APPLICATION_REGION." >&2
+    exit 1
+  fi
+fi
+if [[ -z "$APPLICATION_VPC_ID" || "$APPLICATION_VPC_ID" == "None" ]]; then
+  echo "Error: no application VPC resolved in $APPLICATION_REGION." >&2
+  exit 1
+fi
+
+if ! PRIVATE_SUBNET_TEXT=$(aws ec2 describe-subnets \
+    --region "$APPLICATION_REGION" \
+    --filters \
+      "Name=vpc-id,Values=$APPLICATION_VPC_ID" \
+      "Name=tag:Name,Values=private-1*" \
+    --query "sort_by(Subnets, &SubnetId)[].SubnetId" \
+    --output text); then
+  echo "Error: failed to resolve application private subnets in $APPLICATION_REGION." >&2
+  exit 1
+fi
+read -r -a PRIVATE_SUBNET_IDS <<< "$PRIVATE_SUBNET_TEXT"
+if [[ ${#PRIVATE_SUBNET_IDS[@]} -eq 0 || "$PRIVATE_SUBNET_TEXT" == "None" ]]; then
+  echo "Error: no private-1* subnets found in the application VPC." >&2
+  exit 1
+fi
+for subnet_id in "${PRIVATE_SUBNET_IDS[@]}"; do
+  if [[ ! "$subnet_id" =~ ^subnet-[0-9a-f]+$ ]]; then
+    echo "Error: invalid private subnet id returned by EC2." >&2
+    exit 1
+  fi
+done
+
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+CALLER_ARN=$(aws sts get-caller-identity --query Arn --output text)
+PARTITION=$(cut -d: -f2 <<< "$CALLER_ARN")
+APPLICATION_VPC_ARN="arn:${PARTITION}:ec2:${APPLICATION_REGION}:${ACCOUNT_ID}:vpc/${APPLICATION_VPC_ID}"
+APPLICATION_SUBNET_ARNS=""
+for subnet_id in "${PRIVATE_SUBNET_IDS[@]}"; do
+  [[ -n "$APPLICATION_SUBNET_ARNS" ]] && APPLICATION_SUBNET_ARNS+=","
+  APPLICATION_SUBNET_ARNS+="arn:${PARTITION}:ec2:${APPLICATION_REGION}:${ACCOUNT_ID}:subnet/${subnet_id}"
+done
+
+PARAMS_JSON=$(printf \
+  '[{"ParameterKey":"OIDCProviderArn","ParameterValue":"%s"},{"ParameterKey":"ApplicationRegion","ParameterValue":"%s"},{"ParameterKey":"ApplicationVpcArn","ParameterValue":"%s"},{"ParameterKey":"ApplicationPrivateSubnetArns","ParameterValue":"%s"}]' \
+  "$OIDC_PROVIDER_ARN" \
+  "$APPLICATION_REGION" \
+  "$APPLICATION_VPC_ARN" \
+  "$APPLICATION_SUBNET_ARNS")
+echo "ENI scope: $APPLICATION_REGION, one VPC, ${#PRIVATE_SUBNET_IDS[@]} private subnet(s)"
 
 # Auto-detect create vs update when the caller did not pass --create / --update.
 if [[ -z "$MODE" ]]; then
@@ -128,7 +196,7 @@ case "$MODE" in
     aws cloudformation create-stack \
       --stack-name "$STACK_NAME" \
       "${TEMPLATE_ARG[@]}" \
-      --parameters "${PARAMS[@]}" \
+      --parameters "$PARAMS_JSON" \
       --capabilities CAPABILITY_NAMED_IAM \
       --region "$REGION" \
       --tags Key=Project,Value=mem9-on-aws Key=ManagedBy,Value=cli
@@ -145,7 +213,7 @@ case "$MODE" in
     UPDATE_OUTPUT=$(aws cloudformation update-stack \
       --stack-name "$STACK_NAME" \
       "${TEMPLATE_ARG[@]}" \
-      --parameters "${PARAMS[@]}" \
+      --parameters "$PARAMS_JSON" \
       --capabilities CAPABILITY_NAMED_IAM \
       --region "$REGION" 2>&1)
     UPDATE_EXIT=$?

--- a/scripts/deployment-workflow.test.mjs
+++ b/scripts/deployment-workflow.test.mjs
@@ -4,6 +4,7 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
 import { afterEach, describe, expect, it } from "vitest";
+import { parse } from "yaml";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const root = resolve(here, "..");
@@ -50,6 +51,21 @@ function actionSetForSid(source, sid) {
 }
 
 describe("workflow integration", () => {
+  it("runs IAM regression tests when the GitHub Actions role template changes", () => {
+    const workflow = parse(readFileSync(workflowPath, "utf8"));
+
+    for (const trigger of ["pull_request", "push"]) {
+      const paths = workflow.on[trigger].paths;
+      const exclusion = paths.indexOf("!infra/cloudformation/**");
+      const roleTemplate = paths.indexOf(
+        "infra/cloudformation/github-actions-role.yaml",
+      );
+
+      expect(exclusion).toBeGreaterThanOrEqual(0);
+      expect(roleTemplate).toBeGreaterThan(exclusion);
+    }
+  });
+
   it("runs the PostgreSQL durable-ingest integration suite in CI", () => {
     const workflow = readFileSync(workflowPath, "utf8");
     expect(workflow).toContain("bash scripts/run-ingest-queue-integration.sh");

--- a/scripts/deployment-workflow.test.mjs
+++ b/scripts/deployment-workflow.test.mjs
@@ -4,12 +4,13 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
 import { afterEach, describe, expect, it } from "vitest";
-import { parse } from "yaml";
+import { parse, parseDocument } from "yaml";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const root = resolve(here, "..");
 const workflowPath = resolve(root, ".github/workflows/infra-ci.yml");
 const rolePath = resolve(root, "infra/cloudformation/github-actions-role.yaml");
+const deployRolePath = resolve(here, "deploy-github-role.sh");
 const reconcilePath = resolve(here, "reconcile-ecs-deployment.mjs");
 const fakeAwsPath = resolve(here, "fixtures/fake-aws.mjs");
 const tempDirs = [];
@@ -147,16 +148,47 @@ describe("OAuth2 facade IAM", () => {
 });
 
 describe("Lambda VPC IAM", () => {
-  it("scopes ENI cleanup to this account and application region", () => {
-    const role = readFileSync(rolePath, "utf8");
-    const block = blockForSid(role, "LambdaVpcEniCleanup");
+  it("discovers the same application VPC and private subnets used by SST", () => {
+    const script = readFileSync(deployRolePath, "utf8");
 
-    expect(actionSetForSid(role, "LambdaVpcEniCleanup")).toEqual([
-      "ec2:DeleteNetworkInterface",
-    ]);
-    expect(block).toContain(
-      "!Sub arn:${AWS::Partition}:ec2:ap-northeast-1:${AWS::AccountId}:network-interface/*",
+    expect(script).toContain(
+      'APPLICATION_REGION="${PROJECT_REGION:-ap-northeast-1}"',
     );
+    expect(script).toContain('APPLICATION_VPC_ID="${MEM9_VPC_ID:-}"');
+    expect(script).toContain('"Name=tag:Name,Values=private-1*"');
+    for (const parameter of [
+      "OIDCProviderArn",
+      "ApplicationRegion",
+      "ApplicationVpcArn",
+      "ApplicationPrivateSubnetArns",
+    ]) {
+      expect(script).toContain(`"ParameterKey":"${parameter}"`);
+    }
+  });
+
+  it("scopes ENI cleanup to the application account, region, VPC, and subnets", () => {
+    const document = parseDocument(readFileSync(rolePath, "utf8"));
+    expect(document.errors).toEqual([]);
+    const template = document.toJS();
+    const statement =
+      template.Resources.LambdaProxyPolicy.Properties.PolicyDocument.Statement.find(
+        ({ Sid }) => Sid === "LambdaVpcEniCleanup",
+      );
+
+    expect(statement).toEqual({
+      Sid: "LambdaVpcEniCleanup",
+      Effect: "Allow",
+      Action: ["ec2:DeleteNetworkInterface"],
+      Resource: [
+        "arn:${AWS::Partition}:ec2:${ApplicationRegion}:${AWS::AccountId}:network-interface/*",
+      ],
+      Condition: {
+        ArnEquals: {
+          "ec2:Vpc": "ApplicationVpcArn",
+          "ec2:Subnet": "ApplicationPrivateSubnetArns",
+        },
+      },
+    });
   });
 });
 

--- a/scripts/deployment-workflow.test.mjs
+++ b/scripts/deployment-workflow.test.mjs
@@ -44,7 +44,9 @@ function actionSetForSid(source, sid) {
   const tail = source.slice(start);
   const next = tail.slice(1).search(/\n\s+- Sid: /);
   const block = next >= 0 ? tail.slice(0, next + 1) : tail;
-  return [...block.matchAll(/^\s+- ((?:ecs|ssm):[A-Za-z]+)$/gm)].map((m) => m[1]);
+  return [...block.matchAll(/^\s+- ((?:ecs|logs|ssm):[A-Za-z]+)$/gm)].map(
+    (m) => m[1],
+  );
 }
 
 describe("workflow integration", () => {
@@ -97,6 +99,26 @@ describe("reconciliation IAM", () => {
         "ecs:ListTasks",
         "ssm:GetParameters",
       ].sort(),
+    );
+  });
+});
+
+describe("OAuth2 facade IAM", () => {
+  it("grants the documented CloudWatch Logs delivery lifecycle actions", () => {
+    const role = readFileSync(rolePath, "utf8");
+    const actions = actionSetForSid(role, "ApiGatewayV2AccessLogs");
+
+    expect(actions).toEqual(
+      expect.arrayContaining([
+        "logs:CreateLogDelivery",
+        "logs:PutResourcePolicy",
+        "logs:UpdateLogDelivery",
+        "logs:DeleteLogDelivery",
+        "logs:CreateLogGroup",
+        "logs:DescribeResourcePolicies",
+        "logs:GetLogDelivery",
+        "logs:ListLogDeliveries",
+      ]),
     );
   });
 });

--- a/scripts/deployment-workflow.test.mjs
+++ b/scripts/deployment-workflow.test.mjs
@@ -39,13 +39,20 @@ function runFixture(name) {
   return { result, callRecords };
 }
 
-function actionSetForSid(source, sid) {
+function blockForSid(source, sid) {
   const start = source.indexOf(`- Sid: ${sid}`);
   expect(start, `missing IAM Sid ${sid}`).toBeGreaterThanOrEqual(0);
   const tail = source.slice(start);
   const next = tail.slice(1).search(/\n\s+- Sid: /);
-  const block = next >= 0 ? tail.slice(0, next + 1) : tail;
-  return [...block.matchAll(/^\s+- ((?:ecs|logs|ssm):[A-Za-z]+)$/gm)].map(
+  return next >= 0 ? tail.slice(0, next + 1) : tail;
+}
+
+function actionSetForSid(source, sid) {
+  return [
+    ...blockForSid(source, sid).matchAll(
+      /^\s+- ((?:ec2|ecs|logs|ssm):[A-Za-z]+)$/gm,
+    ),
+  ].map(
     (m) => m[1],
   );
 }
@@ -135,6 +142,20 @@ describe("OAuth2 facade IAM", () => {
         "logs:GetLogDelivery",
         "logs:ListLogDeliveries",
       ]),
+    );
+  });
+});
+
+describe("Lambda VPC IAM", () => {
+  it("scopes ENI cleanup to this account and application region", () => {
+    const role = readFileSync(rolePath, "utf8");
+    const block = blockForSid(role, "LambdaVpcEniCleanup");
+
+    expect(actionSetForSid(role, "LambdaVpcEniCleanup")).toEqual([
+      "ec2:DeleteNetworkInterface",
+    ]);
+    expect(block).toContain(
+      "!Sub arn:${AWS::Partition}:ec2:ap-northeast-1:${AWS::AccountId}:network-interface/*",
     );
   });
 });


### PR DESCRIPTION
## Summary

- allow API Gateway v2 preview teardown to enumerate CloudWatch Logs deliveries
- allow deletion of detached Lambda ENIs that block security-group cleanup
- scope ENI deletion to the application account, region, VPC, and selected private subnets
- resolve the VPC and subnets in the out-of-band role deployment script using the same inputs as SST
- run IAM role regression tests whenever the out-of-band role template changes

## Verification

- Node.js 24: 205 tests passed
- TypeScript typecheck passed
- shell syntax check passed
- IAM Access Analyzer: no finding for the ENI cleanup statement
- IAM custom-policy simulation: expected VPC/subnet allowed; wrong VPC, subnet, and region denied
- out-of-band IAM role stack updated successfully