### PR TITLE
fix(ci): mask AWS account IDs in Actions logs

### DIFF
--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -251,6 +251,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
+          mask-aws-account-id: true
 
       - name: Preflight — verify role is assumable
         if: steps.gate.outputs.skip != 'true'
@@ -488,6 +489,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
+          mask-aws-account-id: true
 
       - name: Check if stage was ever deployed
         id: check-state
@@ -670,6 +672,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
+          mask-aws-account-id: true
 
       - name: Log in to Amazon ECR
         id: ecr-login
@@ -829,6 +832,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
+          mask-aws-account-id: true
 
       - name: Preflight — verify role is assumable
         shell: bash

--- a/scripts/deployment-workflow.test.mjs
+++ b/scripts/deployment-workflow.test.mjs
@@ -4,6 +4,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readdirSync,
   rmSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -15,6 +16,7 @@ import { parse, parseDocument } from "yaml";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const root = resolve(here, "..");
+const workflowsDirectory = resolve(root, ".github/workflows");
 const workflowPath = resolve(root, ".github/workflows/infra-ci.yml");
 const rolePath = resolve(root, "infra/cloudformation/github-actions-role.yaml");
 const deployRolePath = resolve(here, "deploy-github-role.sh");
@@ -118,6 +120,45 @@ function actionSetForSid(source, sid) {
 }
 
 describe("workflow integration", () => {
+  it("masks the AWS account ID in every credential configuration", () => {
+    const workflowFiles = readdirSync(workflowsDirectory).filter((name) =>
+      /\.ya?ml$/u.test(name),
+    );
+    const credentialJobs = [];
+
+    for (const workflowFile of workflowFiles) {
+      const workflow = parse(
+        readFileSync(resolve(workflowsDirectory, workflowFile), "utf8"),
+      );
+      for (const [jobName, job] of Object.entries(workflow.jobs ?? {})) {
+        for (const step of job.steps ?? []) {
+          if (
+            typeof step.uses !== "string" ||
+            !step.uses.startsWith("aws-actions/configure-aws-credentials@")
+          ) {
+            continue;
+          }
+          credentialJobs.push(`${workflowFile}:${jobName}`);
+          expect(
+            step.with?.["mask-aws-account-id"],
+            `${workflowFile}:${jobName}:${step.name ?? step.uses}`,
+          ).toBe(true);
+        }
+      }
+    }
+
+    expect(credentialJobs.sort()).toEqual(
+      [
+        "infra-ci.yml:build-and-push-image",
+        "infra-ci.yml:cleanup-preview",
+        "infra-ci.yml:deploy-preview",
+        "infra-ci.yml:deploy-prod",
+        "reconcile-previews.yml:apply",
+        "reconcile-previews.yml:report",
+      ].sort(),
+    );
+  });
+
   it("runs IAM regression tests when the GitHub Actions role template changes", () => {
     const workflow = parse(readFileSync(workflowPath, "utf8"));
 

--- a/scripts/workload-permissions-boundary-contract.json
+++ b/scripts/workload-permissions-boundary-contract.json
@@ -13,7 +13,7 @@
     {
       "id": "infra-ci.yml",
       "path": ".github/workflows/infra-ci.yml",
-      "reviewedBlob": "66f490e1ccc4746f08a972cc0b299893b8d3a0a4"
+      "reviewedBlob": "ebb8a153e0e56fad6411af77a34ad076355cc452"
     },
     {
       "id": "reconcile-previews.yml",


### PR DESCRIPTION
## Summary

- Enable `mask-aws-account-id` on every AWS credential configuration step in Infra CI.
- Add a regression test that scans every workflow and requires masking for the exact set of credential-bearing jobs.
- Update the guarded rollout workflow hash for the reviewed Infra CI definition.

This prevents AWS account IDs from appearing in future Actions logs. Existing workflow logs must be deleted separately if they already contain an account ID.

## Test Coverage

All changed behavior is covered by the workflow integration test. The audit found all 6 credential-bearing jobs masked, with no uncovered paths.

## Pre-Landing Review

No issues found.

## Design Review

No frontend files changed; design review skipped.

## Eval Results

No prompt-related files changed; evals skipped.

## Plan Completion

No plan file detected.

## Verification Results

- Root test suite: 595 tests passed.
- Infrastructure test suite: 185 tests passed.
- Root and infrastructure typechecks passed on Node.js 24.18.0.
- Sensitive-content and public-artifact scans passed.
- Workflow blob hash matches the guarded rollout contract.

## Test Plan

- [x] Verify all workflow credential steps set `mask-aws-account-id: true`.
- [x] Verify the expected credential-bearing job inventory is unchanged.
- [x] Run root and infrastructure tests and typechecks.
