### PR TITLE
feat(infra): support Cloudflare facade custom domain

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,7 +29,7 @@ AWS_PROFILE=your-aws-profile
 # PROJECT_REGION=ap-northeast-1
 # MEM9_VPC_ID=vpc-xxxxxxxxxxxxxxxxx
 # Optional production OAuth façade hostname. For local SST deploys only; GitHub
-# Actions reads the domain and token from secrets and the zone ID from a variable.
+# Actions reads the domain, token, and zone ID from repository secrets.
 # The token needs Zone:Read + DNS:Edit for only the matching Cloudflare zone.
 # MEM9_FACADE_CUSTOM_DOMAIN=memory.example.com
 # CLOUDFLARE_API_TOKEN=

--- a/.env.example
+++ b/.env.example
@@ -28,5 +28,9 @@ AWS_PROFILE=your-aws-profile
 # Application VPC discovery remains independently configurable.
 # PROJECT_REGION=ap-northeast-1
 # MEM9_VPC_ID=vpc-xxxxxxxxxxxxxxxxx
+# Optional production OAuth façade hostname. For local SST deploys only; GitHub
+# Actions reads the same setting from the MEM9_FACADE_CUSTOM_DOMAIN secret.
+# The matching public Route 53 hosted zone must exist in the same AWS account.
+# MEM9_FACADE_CUSTOM_DOMAIN=memory.example.com
 # CloudFormation stack names (override only if you run multiple copies).
 # STACK_NAME=

--- a/.env.example
+++ b/.env.example
@@ -29,8 +29,10 @@ AWS_PROFILE=your-aws-profile
 # PROJECT_REGION=ap-northeast-1
 # MEM9_VPC_ID=vpc-xxxxxxxxxxxxxxxxx
 # Optional production OAuth façade hostname. For local SST deploys only; GitHub
-# Actions reads the same setting from the MEM9_FACADE_CUSTOM_DOMAIN secret.
-# The matching public Route 53 hosted zone must exist in the same AWS account.
+# Actions reads the domain and token from secrets and the zone ID from a variable.
+# The token needs Zone:Read + DNS:Edit for only the matching Cloudflare zone.
 # MEM9_FACADE_CUSTOM_DOMAIN=memory.example.com
+# CLOUDFLARE_API_TOKEN=
+# CLOUDFLARE_ZONE_ID=
 # CloudFormation stack names (override only if you run multiple copies).
 # STACK_NAME=

--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -19,12 +19,12 @@
 #                  memory.example.com. Unset keeps the execute-api URL.
 #   CLOUDFLARE_API_TOKEN — required when the custom hostname is set. Scope it to
 #                  Zone:Read + DNS:Edit for that one Cloudflare zone.
+#   CLOUDFLARE_ZONE_ID — required when the custom hostname is set. The existing
+#                  Cloudflare zone that contains the hostname.
 #
 # Optional GitHub repo variables:
 #   RUNNER_LABEL — JSON array selecting a self-hosted runner, e.g.
 #                  ["self-hosted", "linux", "arm64"]. Unset → ubuntu-latest.
-#   CLOUDFLARE_ZONE_ID — required when the custom hostname is set. The existing
-#                  Cloudflare zone that contains the hostname.
 #   DEPLOYMENT_MAINTENANCE_PAUSED — set to true during the guarded workload-role
 #                  migration. Existing AWS jobs fail before assuming the deploy
 #                  role; the operator also waits for every prior run to finish.
@@ -964,7 +964,7 @@ jobs:
           # Previews intentionally receive none of these three values.
           MEM9_FACADE_CUSTOM_DOMAIN: ${{ secrets.MEM9_FACADE_CUSTOM_DOMAIN }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ZONE_ID: ${{ vars.CLOUDFLARE_ZONE_ID }}
+          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
           # Slack incoming webhook for prod alarm delivery (infra/observability.ts).
           # SST marks this value secret before it enters Pulumi state or Lambda config.
           # Production synthesis fails when the managed sink is unset.

--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -14,6 +14,13 @@
 #                  push to main "succeed" without deploying). Preview/cleanup
 #                  skip gracefully when it's unset.
 #
+# Optional GitHub repo secret:
+#   MEM9_FACADE_CUSTOM_DOMAIN — production OAuth façade hostname, for example
+#                  memory.example.com. The public Route 53 hosted zone must
+#                  already exist in the same AWS account. Unset keeps the
+#                  execute-api URL. It is injected only into the prod deploy so
+#                  preview stages cannot claim the production hostname.
+#
 # Optional GitHub repo variables:
 #   RUNNER_LABEL — JSON array selecting a self-hosted runner, e.g.
 #                  ["self-hosted", "linux", "arm64"]. Unset → ubuntu-latest.
@@ -951,6 +958,10 @@ jobs:
           # flag is read at synth time, so a prod deploy without it strips the
           # authorizer and reopens the Palisade finding.
           MEM9_FACADE_AUTHORIZER_ENABLED: "1"
+          # Optional production hostname. SST creates and DNS-validates the
+          # regional ACM certificate, API mapping, and Route 53 aliases. Keep
+          # this in GitHub Secrets; previews intentionally never receive it.
+          MEM9_FACADE_CUSTOM_DOMAIN: ${{ secrets.MEM9_FACADE_CUSTOM_DOMAIN }}
           # Slack incoming webhook for prod alarm delivery (infra/observability.ts).
           # SST marks this value secret before it enters Pulumi state or Lambda config.
           # Production synthesis fails when the managed sink is unset.

--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -16,14 +16,15 @@
 #
 # Optional GitHub repo secret:
 #   MEM9_FACADE_CUSTOM_DOMAIN — production OAuth façade hostname, for example
-#                  memory.example.com. The public Route 53 hosted zone must
-#                  already exist in the same AWS account. Unset keeps the
-#                  execute-api URL. It is injected only into the prod deploy so
-#                  preview stages cannot claim the production hostname.
+#                  memory.example.com. Unset keeps the execute-api URL.
+#   CLOUDFLARE_API_TOKEN — required when the custom hostname is set. Scope it to
+#                  Zone:Read + DNS:Edit for that one Cloudflare zone.
 #
 # Optional GitHub repo variables:
 #   RUNNER_LABEL — JSON array selecting a self-hosted runner, e.g.
 #                  ["self-hosted", "linux", "arm64"]. Unset → ubuntu-latest.
+#   CLOUDFLARE_ZONE_ID — required when the custom hostname is set. The existing
+#                  Cloudflare zone that contains the hostname.
 #   DEPLOYMENT_MAINTENANCE_PAUSED — set to true during the guarded workload-role
 #                  migration. Existing AWS jobs fail before assuming the deploy
 #                  role; the operator also waits for every prior run to finish.
@@ -958,10 +959,12 @@ jobs:
           # flag is read at synth time, so a prod deploy without it strips the
           # authorizer and reopens the Palisade finding.
           MEM9_FACADE_AUTHORIZER_ENABLED: "1"
-          # Optional production hostname. SST creates and DNS-validates the
-          # regional ACM certificate, API mapping, and Route 53 aliases. Keep
-          # this in GitHub Secrets; previews intentionally never receive it.
+          # Optional production hostname. SST creates the regional ACM
+          # certificate, API mapping, and DNS-only Cloudflare records.
+          # Previews intentionally receive none of these three values.
           MEM9_FACADE_CUSTOM_DOMAIN: ${{ secrets.MEM9_FACADE_CUSTOM_DOMAIN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ZONE_ID: ${{ vars.CLOUDFLARE_ZONE_ID }}
           # Slack incoming webhook for prod alarm delivery (infra/observability.ts).
           # SST marks this value secret before it enters Pulumi state or Lambda config.
           # Production synthesis fails when the managed sink is unset.

--- a/README.md
+++ b/README.md
@@ -118,22 +118,35 @@ The OAuth façade can use a production-only custom hostname. Leave
 `MEM9_FACADE_CUSTOM_DOMAIN` unset to keep the generated API Gateway
 `execute-api` URL. When configured, SST creates a Regional API Gateway domain
 and mapping, requests and DNS-validates an ACM certificate in
-`ap-northeast-1`, and writes alias records into an existing public Route 53
-hosted zone in the same AWS account. Preview stages never receive this setting.
+`ap-northeast-1`, and creates DNS-only validation and API-target CNAME records
+in an existing Cloudflare zone. Preview stages never receive these settings.
 
-Before enabling it, update the out-of-band deploy role, then store the hostname
-as a GitHub secret:
+Before enabling it, update the out-of-band deploy role. Create a
+[Cloudflare API token](https://developers.cloudflare.com/dns/manage-dns-records/how-to/api-tokens/)
+scoped to the target zone with `Zone:Read` and `DNS:Edit`, then configure the
+hostname and token as GitHub secrets and the non-sensitive zone ID as a
+repository variable:
 
 ```bash
 scripts/deploy-github-role.sh
 gh secret set MEM9_FACADE_CUSTOM_DOMAIN --body "memory.example.com"
+gh secret set CLOUDFLARE_API_TOKEN
+gh variable set CLOUDFLARE_ZONE_ID --body "<cloudflare-zone-id>"
 ```
 
 Use a hostname only, without `https://`, a port, or a path. The secret prevents
 the repository and workflow definition from carrying the operator's domain,
 but the hostname is inherently public in DNS and appears in the deployed AWS
 resources. One hostname maps to the production stage; use no production
-hostname for PR previews.
+hostname for PR previews. Keep Cloudflare proxying disabled for these managed
+records.
+
+No certificate-renewal issue is required. ACM automatically renews a
+DNS-validated certificate while it remains attached to API Gateway and every
+ACM validation CNAME remains publicly resolvable. Do not manually remove that
+CNAME while the custom domain is in use; ACM reports renewal failures through
+AWS Health and EventBridge. See
+[ACM DNS renewal](https://docs.aws.amazon.com/acm/latest/userguide/dns-renewal-validation.html).
 
 ## Workload permissions-boundary rollout
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ citations.
 | Database           | **Aurora PostgreSQL Serverless v2** + `pgvector` (mem9 `postgres` backend). `mnemo-server` and bootstrap connect directly to the cluster writer endpoint with a Secrets Manager credential. **RDS Proxy is not deployed.**                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | VPC                | **Reuse the account default VPC** (private subnets with NAT egress)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
 | MCP surface        | **AgentCore Gateway** (MCP → mnemo-server REST API)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| Gateway → server   | **Private** (a [Lambda-proxy GatewayTarget](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-add-target-api-target-config.html)): AgentCore invokes a VPC-attached proxy Lambda with [`lambda:InvokeFunction`](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-prerequisites-permissions.html). The Lambda uses [VPC connectivity](https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc.html) and [AWS Cloud Map private DNS](https://docs.aws.amazon.com/cloud-map/latest/api/API_CreatePrivateDnsNamespace.html) (`mnemo.mem9-<stage>.local:8080`) to reach mnemo-server with the `X-API-Key` (= tenant id). No ALB, ACM certificate, VPC Lattice, public Route 53 zone, or public server endpoint is deployed. |
+| Gateway → server   | **Private** (a [Lambda-proxy GatewayTarget](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-add-target-api-target-config.html)): AgentCore invokes a VPC-attached proxy Lambda with [`lambda:InvokeFunction`](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-prerequisites-permissions.html). The Lambda uses [VPC connectivity](https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc.html) and [AWS Cloud Map private DNS](https://docs.aws.amazon.com/cloud-map/latest/api/API_CreatePrivateDnsNamespace.html) (`mnemo.mem9-<stage>.local:8080`) to reach mnemo-server with the `X-API-Key` (= tenant id). No ALB, VPC Lattice, or public server endpoint is deployed; the optional OAuth façade custom domain is a separate API Gateway concern. |
 | Auth (inbound)     | **Cognito M2M** (`client_credentials`) + an OAuth2 browser-login façade (`authorization_code` + PKCE) for interactive MCP clients                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 | LLM (smart-ingest) | `mnemo-server` calls the **local `llm-proxy` sidecar** at `http://localhost:8082/v1`. The proxy refreshes a short-term Mantle bearer, injects `OpenAI-Project` when `MEM9_BEDROCK_PROJECT` is configured, and calls Bedrock Mantle. Each request has one 110-second deadline and at most two Mantle calls. The task role uses `bedrock-mantle:CreateInference` and `bedrock-mantle:CallWithBearerToken`; `mnemo-server` never calls Mantle directly.                                                                                                                                                                                                                                                                                                                   |
 | Embedding          | qwen3 OpenAI-compatible `/embeddings` as an **ECS sidecar** (localhost, always warm), **dims 1024**. Not Mantle, not a third-party API.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
@@ -111,6 +111,29 @@ The AgentCore Gateway exposes four tools over MCP (Cognito-authenticated):
   application VPC discovery must target a region other than its documented
   default.
 - Agent contributors: see [`AGENTS.md`](AGENTS.md) for repo conventions and hard rules.
+
+### Optional production custom domain
+
+The OAuth façade can use a production-only custom hostname. Leave
+`MEM9_FACADE_CUSTOM_DOMAIN` unset to keep the generated API Gateway
+`execute-api` URL. When configured, SST creates a Regional API Gateway domain
+and mapping, requests and DNS-validates an ACM certificate in
+`ap-northeast-1`, and writes alias records into an existing public Route 53
+hosted zone in the same AWS account. Preview stages never receive this setting.
+
+Before enabling it, update the out-of-band deploy role, then store the hostname
+as a GitHub secret:
+
+```bash
+scripts/deploy-github-role.sh
+gh secret set MEM9_FACADE_CUSTOM_DOMAIN --body "memory.example.com"
+```
+
+Use a hostname only, without `https://`, a port, or a path. The secret prevents
+the repository and workflow definition from carrying the operator's domain,
+but the hostname is inherently public in DNS and appears in the deployed AWS
+resources. One hostname maps to the production stage; use no production
+hostname for PR previews.
 
 ## Workload permissions-boundary rollout
 

--- a/README.md
+++ b/README.md
@@ -124,14 +124,13 @@ in an existing Cloudflare zone. Preview stages never receive these settings.
 Before enabling it, update the out-of-band deploy role. Create a
 [Cloudflare API token](https://developers.cloudflare.com/dns/manage-dns-records/how-to/api-tokens/)
 scoped to the target zone with `Zone:Read` and `DNS:Edit`, then configure the
-hostname and token as GitHub secrets and the non-sensitive zone ID as a
-repository variable:
+hostname, token, and zone ID as GitHub repository secrets:
 
 ```bash
 scripts/deploy-github-role.sh
 gh secret set MEM9_FACADE_CUSTOM_DOMAIN --body "memory.example.com"
 gh secret set CLOUDFLARE_API_TOKEN
-gh variable set CLOUDFLARE_ZONE_ID --body "<cloudflare-zone-id>"
+gh secret set CLOUDFLARE_ZONE_ID
 ```
 
 Use a hostname only, without `https://`, a port, or a path. The secret prevents

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -219,8 +219,8 @@ The gateway trusts both implemented Cognito clients:
 The OAuth facade optionally uses a production custom hostname from
 `MEM9_FACADE_CUSTOM_DOMAIN`. GitHub Actions supplies it only from the repository
 secret of the same name. The deploy also receives `CLOUDFLARE_API_TOKEN` from a
-repository secret and `CLOUDFLARE_ZONE_ID` from a repository variable. When the
-hostname is absent, the facade keeps its generated `execute-api` URL. When
+repository secret and `CLOUDFLARE_ZONE_ID` from another repository secret. When
+the hostname is absent, the facade keeps its generated `execute-api` URL. When
 present, SST creates the Regional API Gateway domain and root API mapping,
 requests a same-region ACM certificate, and uses the Cloudflare provider to
 create DNS-only validation and API-target CNAME records in the existing zone.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -206,14 +206,27 @@ Cognito-authenticated MCP request
 
 `infra/ecs.ts` creates an AWS Cloud Map private DNS namespace and service. The
 proxy Lambda and ECS task share the task security group, whose self-referencing
-port 8080 rule permits the private hop. There is no ALB, ACM certificate, VPC
-Lattice target, public Route 53 zone, or public mnemo-server endpoint.
+port 8080 rule permits the private hop. The private backend path has no ALB,
+certificate, VPC Lattice target, public Route 53 zone, or public mnemo-server
+endpoint.
 
 The gateway trusts both implemented Cognito clients:
 
 - M2M `client_credentials` for CI and headless clients.
 - Authorization code with PKCE through the API Gateway v2 OAuth facade for
   interactive clients.
+
+The OAuth facade optionally uses a production custom hostname from
+`MEM9_FACADE_CUSTOM_DOMAIN`. GitHub Actions supplies it only from the repository
+secret of the same name; when it is absent, the facade keeps its generated
+`execute-api` URL. When present, SST creates the Regional API Gateway domain and
+root API mapping, requests a same-region ACM certificate, validates it through
+DNS, and creates aliases in an existing public Route 53 hosted zone in the same
+AWS account. Preview stages never claim the production hostname. AWS documents
+the [HTTP API custom-domain flow](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-custom-domain-names.html)
+and requires a same-region certificate for a
+[Regional custom domain](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-regional-api-custom-domain-create.html).
+These public facade resources do not expose `mnemo-server`.
 
 ### Schema bootstrap and data
 
@@ -572,7 +585,7 @@ to the GitHub Actions deploy role.
 | Ingest observability   | Content-free EMF metrics, CloudWatch dashboard, and production alarms                                | `docker/mnemo-server/patches/0006-durable-ingest-telemetry.patch`, `infra/observability.ts`                   |
 | MCP surface            | AgentCore Gateway Lambda target                                                                      | `infra/gateway.ts`                                                                                            |
 | Private service lookup | AWS Cloud Map                                                                                        | `infra/ecs.ts`                                                                                                |
-| Inbound auth           | Cognito M2M plus OAuth2 PKCE facade                                                                  | `infra/cognito.ts`, `infra/oauth-facade.ts`                                                                   |
+| Inbound auth           | Cognito M2M plus OAuth2 PKCE facade; optional production API Gateway custom domain                  | `infra/cognito.ts`, `infra/oauth-facade.ts`                                                                   |
 | Schema setup           | Startup atomic-ingest migration plus one-shot ECS bootstrap for the complete schema and tenant seed  | `docker/mnemo-server/entrypoint.sh`, `infra/bootstrap.ts`, `docker/bootstrap/migrations/`                     |
 
 ## Locked decisions
@@ -593,6 +606,8 @@ to the GitHub Actions deploy role.
 - The AgentCore Gateway uses a Lambda target and Cloud Map private DNS.
 - The public OAuth facade uses API Gateway v2 plus Lambda, never a Lambda
   Function URL.
+- The OAuth facade custom domain is optional, production-only, and uses an
+  existing same-account public Route 53 hosted zone; previews use `execute-api`.
 - Schema bootstrap is a separate one-shot ECS task.
 - ECR scan-on-push is a guarded out-of-band registry singleton, separate from
   the retained repository stack.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -218,14 +218,24 @@ The gateway trusts both implemented Cognito clients:
 
 The OAuth facade optionally uses a production custom hostname from
 `MEM9_FACADE_CUSTOM_DOMAIN`. GitHub Actions supplies it only from the repository
-secret of the same name; when it is absent, the facade keeps its generated
-`execute-api` URL. When present, SST creates the Regional API Gateway domain and
-root API mapping, requests a same-region ACM certificate, validates it through
-DNS, and creates aliases in an existing public Route 53 hosted zone in the same
-AWS account. Preview stages never claim the production hostname. AWS documents
-the [HTTP API custom-domain flow](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-custom-domain-names.html)
+secret of the same name. The deploy also receives `CLOUDFLARE_API_TOKEN` from a
+repository secret and `CLOUDFLARE_ZONE_ID` from a repository variable. When the
+hostname is absent, the facade keeps its generated `execute-api` URL. When
+present, SST creates the Regional API Gateway domain and root API mapping,
+requests a same-region ACM certificate, and uses the Cloudflare provider to
+create DNS-only validation and API-target CNAME records in the existing zone.
+The token is limited to `Zone:Read` and `DNS:Edit` on that zone. Preview stages
+never receive the three settings or claim the production hostname.
+
+AWS documents the
+[HTTP API custom-domain flow](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-custom-domain-names.html)
 and requires a same-region certificate for a
 [Regional custom domain](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-regional-api-custom-domain-create.html).
+ACM automatically renews the DNS-validated certificate while it remains in use
+by API Gateway and every validation CNAME remains publicly resolvable; no
+operator renewal issue is required. The Cloudflare records therefore remain
+DNS-only and under SST ownership. See
+[ACM DNS renewal](https://docs.aws.amazon.com/acm/latest/userguide/dns-renewal-validation.html).
 These public facade resources do not expose `mnemo-server`.
 
 ### Schema bootstrap and data
@@ -607,7 +617,7 @@ to the GitHub Actions deploy role.
 - The public OAuth facade uses API Gateway v2 plus Lambda, never a Lambda
   Function URL.
 - The OAuth facade custom domain is optional, production-only, and uses an
-  existing same-account public Route 53 hosted zone; previews use `execute-api`.
+  existing Cloudflare zone with DNS-only records; previews use `execute-api`.
 - Schema bootstrap is a separate one-shot ECS task.
 - ECR scan-on-push is a guarded out-of-band registry singleton, separate from
   the retained repository stack.

--- a/docs/mem9-facts.md
+++ b/docs/mem9-facts.md
@@ -400,10 +400,10 @@ proxy Lambda (`targetConfiguration.mcp.lambda.{lambdaArn, toolSchema}`) that rea
 mnemo-server over **AWS Cloud Map** private DNS (`mnemo.mem9-<stage>.local:8080`),
 injecting `X-API-Key` (= tenant id). This private backend path has no ALB, ACM
 certificate, VPC Lattice, public Route 53 zone, or public server endpoint. The
-optional ACM certificate and existing-zone records for the public OAuth facade
-custom domain are separate from this path. The Cloud Map private DNS namespace
-creates a VPC-associated Route 53 private hosted zone, as documented by
-[CreatePrivateDnsNamespace](https://docs.aws.amazon.com/cloud-map/latest/api/API_CreatePrivateDnsNamespace.html).
+optional ACM certificate and DNS-only Cloudflare records for the public OAuth
+facade custom domain are separate from this path. The Cloud Map private DNS
+namespace creates a VPC-associated Route 53 private hosted zone, as documented
+by [CreatePrivateDnsNamespace](https://docs.aws.amazon.com/cloud-map/latest/api/API_CreatePrivateDnsNamespace.html).
 The target shape follows the
 [AgentCore Lambda target documentation](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-add-target-api-target-config.html).
 The gateway service role grants only `lambda:InvokeFunction` on that target, as

--- a/docs/mem9-facts.md
+++ b/docs/mem9-facts.md
@@ -398,9 +398,11 @@ this repo — **empirically live 2026-07-12** (ap-northeast-1):
 **Current implementation:** a **Lambda target**. AgentCore invokes a VPC-attached
 proxy Lambda (`targetConfiguration.mcp.lambda.{lambdaArn, toolSchema}`) that reaches
 mnemo-server over **AWS Cloud Map** private DNS (`mnemo.mem9-<stage>.local:8080`),
-injecting `X-API-Key` (= tenant id). No ALB, no ACM cert, no VPC Lattice, no Route53
-public zone. The Cloud Map private DNS namespace creates a VPC-associated Route 53
-private hosted zone, as documented by
+injecting `X-API-Key` (= tenant id). This private backend path has no ALB, ACM
+certificate, VPC Lattice, public Route 53 zone, or public server endpoint. The
+optional ACM certificate and existing-zone records for the public OAuth facade
+custom domain are separate from this path. The Cloud Map private DNS namespace
+creates a VPC-associated Route 53 private hosted zone, as documented by
 [CreatePrivateDnsNamespace](https://docs.aws.amazon.com/cloud-map/latest/api/API_CreatePrivateDnsNamespace.html).
 The target shape follows the
 [AgentCore Lambda target documentation](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-add-target-api-target-config.html).

--- a/infra/cloudformation/github-actions-role.yaml
+++ b/infra/cloudformation/github-actions-role.yaml
@@ -895,15 +895,12 @@ Resources:
               - servicediscovery:UntagResource
               - servicediscovery:ListTagsForResource
             Resource: "*"
-          - Sid: Route53ForCloudMapAndFacadeDomain
+          - Sid: Route53ForCloudMap
             # A servicediscovery PrivateDnsNamespace creates + manages a Route53
             # PRIVATE hosted zone under the hood (and its record sets). Cloud Map
             # owns the record writes at runtime, but the deploy role must be able to
-            # create/delete the zone + associate it with the VPC. The optional
-            # OAuth façade custom domain reuses the read/change actions to find an
-            # existing same-account PUBLIC hosted zone and manage certificate
-            # validation plus API Gateway alias records; it never creates that
-            # public zone.
+            # create/delete the zone + associate it with the VPC. This is the only
+            # Route53 need; the OAuth façade uses Cloudflare for public DNS.
             Effect: Allow
             Action:
               - route53:CreateHostedZone
@@ -1186,9 +1183,8 @@ Resources:
   # UserPoolClient is covered by GatewayMcpPolicy.Cognito (cognito-idp:*Client),
   # and the sst.Secret's /sst/* SSM parameter by ScaffoldPolicy.SSM{Read,Write}
   # — so this policy carries the API Gateway, ACM, and service-linked-role
-  # control-plane surface. Route 53 record access is shared with ComputePolicy's
-  # Cloud Map lifecycle. Its own ManagedPolicy keeps the OAuth2-façade footprint
-  # auditable in one place and below IAM's 6144-byte per-policy cap.
+  # control-plane surface. Its own ManagedPolicy keeps the OAuth2-façade
+  # footprint auditable in one place and below IAM's 6144-byte per-policy cap.
   #
   # API Gateway ARNs have an EMPTY account field (arn:aws:apigateway:<region>::/…)
   # — the /apis (create), /apis/* (per-API ops), /domainnames (create),

--- a/infra/cloudformation/github-actions-role.yaml
+++ b/infra/cloudformation/github-actions-role.yaml
@@ -895,12 +895,15 @@ Resources:
               - servicediscovery:UntagResource
               - servicediscovery:ListTagsForResource
             Resource: "*"
-          - Sid: Route53ForCloudMap
+          - Sid: Route53ForCloudMapAndFacadeDomain
             # A servicediscovery PrivateDnsNamespace creates + manages a Route53
             # PRIVATE hosted zone under the hood (and its record sets). Cloud Map
             # owns the record writes at runtime, but the deploy role must be able to
-            # create/delete the zone + associate it with the VPC. (This is the ONLY
-            # remaining Route53 need — the ACM cert + ALB private zone are gone.)
+            # create/delete the zone + associate it with the VPC. The optional
+            # OAuth façade custom domain reuses the read/change actions to find an
+            # existing same-account PUBLIC hosted zone and manage certificate
+            # validation plus API Gateway alias records; it never creates that
+            # public zone.
             Effect: Allow
             Action:
               - route53:CreateHostedZone
@@ -1182,14 +1185,17 @@ Resources:
   # covered by LambdaProxyPolicy.LambdaManage (mem9-on-aws-* scope). The reader
   # UserPoolClient is covered by GatewayMcpPolicy.Cognito (cognito-idp:*Client),
   # and the sst.Secret's /sst/* SSM parameter by ScaffoldPolicy.SSM{Read,Write}
-  # — so this policy carries ONLY the genuinely-new apigateway control-plane
-  # surface. Its own ManagedPolicy to stay under IAM's 6144-byte per-policy cap
-  # and keep the OAuth2-façade footprint auditable in one place.
+  # — so this policy carries the API Gateway, ACM, and service-linked-role
+  # control-plane surface. Route 53 record access is shared with ComputePolicy's
+  # Cloud Map lifecycle. Its own ManagedPolicy keeps the OAuth2-façade footprint
+  # auditable in one place and below IAM's 6144-byte per-policy cap.
   #
   # API Gateway ARNs have an EMPTY account field (arn:aws:apigateway:<region>::/…)
-  # — the /apis (create), /apis/* (per-API ops), and /tags/* (tagging) resources
-  # cover the HTTP API lifecycle. apigateway:POST/GET/PATCH/PUT/DELETE are the
-  # verb-style actions the API Gateway v2 control plane authorizes against.
+  # — the /apis (create), /apis/* (per-API ops), /domainnames (create),
+  # /domainnames/* (domain + mapping lifecycle), and /tags/* (tagging)
+  # resources cover the HTTP API lifecycle. apigateway:POST/GET/PATCH/PUT/DELETE
+  # are the verb-style actions the API Gateway v2 control plane authorizes
+  # against.
   #
   # TagResource/UntagResource are SEPARATE from the verb-style actions: Api and
   # Stage are taggable v2 resources, and CreateStage carries `tags`, so the stage
@@ -1238,7 +1244,46 @@ Resources:
               # (empty field between the double colons), only the region matters.
               - "arn:aws:apigateway:*::/apis"
               - "arn:aws:apigateway:*::/apis/*"
+              - "arn:aws:apigateway:*::/domainnames"
+              - "arn:aws:apigateway:*::/domainnames/*"
               - "arn:aws:apigateway:*::/tags/*"
+          - Sid: AcmFacadeCertificateCreate
+            # SST requests an Amazon-issued DNS-validated certificate in the
+            # application region. The certificate ARN does not exist yet, so
+            # RequestCertificate requires Resource "*"; request tags and the
+            # validation method keep creation project-scoped.
+            Effect: Allow
+            Action:
+              - acm:RequestCertificate
+              - acm:AddTagsToCertificate
+            Resource: "*"
+            Condition:
+              StringEquals:
+                aws:RequestedRegion: !Ref ApplicationRegion
+                acm:ValidationMethod: DNS
+                aws:RequestTag/Project: !Ref ProjectName
+                aws:RequestTag/ManagedBy: sst
+          - Sid: AcmFacadeCertificateManage
+            Effect: Allow
+            Action:
+              - acm:AddTagsToCertificate
+              - acm:DeleteCertificate
+              - acm:DescribeCertificate
+              - acm:ListTagsForCertificate
+              - acm:RemoveTagsFromCertificate
+            Resource:
+              - !Sub arn:${AWS::Partition}:acm:${ApplicationRegion}:${AWS::AccountId}:certificate/*
+          - Sid: ApiGatewayServiceLinkedRole
+            # A Regional custom domain can cause API Gateway to create
+            # AWSServiceRoleForAPIGateway on first use. API Gateway owns the
+            # role; the explicit deny above still prevents its deletion.
+            Effect: Allow
+            Action:
+              - iam:CreateServiceLinkedRole
+            Resource: "*"
+            Condition:
+              StringEquals:
+                iam:AWSServiceName: ops.apigateway.amazonaws.com
           # SST's sst.aws.ApiGatewayV2 creates an access-log LogGroup under
           # /aws/vendedlogs/apis/<app>-<stage>-<id> AND creates a log delivery
           # via the CloudWatch Logs Delivery API (CreateStage enables access logging).

--- a/infra/config.test.ts
+++ b/infra/config.test.ts
@@ -47,6 +47,15 @@ describe("sst.config.ts locked facts", () => {
     expect(src).toMatch(/packageType === ["']Image["']/);
   });
 
+  it("initializes Cloudflare only for a configured production custom domain", () => {
+    expect(src).toMatch(
+      /const cloudflareEnabled =\s*input\?\.stage === ["']prod["']\s*&&\s*Boolean\(process\.env\.MEM9_FACADE_CUSTOM_DOMAIN\?\.trim\(\)\)\s*&&\s*Boolean\(process\.env\.CLOUDFLARE_API_TOKEN\?\.trim\(\)\)/u,
+    );
+    expect(src).toMatch(
+      /\.\.\.\(cloudflareEnabled\s*\?\s*\{\s*cloudflare:\s*\{\s*version:\s*["']6\.15\.0["']\s*\}\s*\}\s*:\s*\{\}\)/u,
+    );
+  });
+
   it("wires the meta stack via lazy import", () => {
     expect(src).toMatch(/await import\(["']\.\/infra\/meta["']\)/);
     expect(src).toContain("meta()");

--- a/infra/docs-consistency.test.ts
+++ b/infra/docs-consistency.test.ts
@@ -264,4 +264,15 @@ describe("runtime documentation", () => {
       "**Empirical deployment observation, 2026-07-12:**",
     );
   });
+
+  it("TC-DOCS-009: documents the optional production facade domain boundary", () => {
+    for (const source of [text.readme, text.architecture]) {
+      expect(source).toContain("MEM9_FACADE_CUSTOM_DOMAIN");
+      expect(source).toMatch(/existing public Route 53\s+hosted zone/i);
+      expect(source).toMatch(/Preview stages never/i);
+    }
+    expect(text.facts).toContain(
+      "optional ACM certificate and existing-zone records for the public OAuth facade",
+    );
+  });
 });

--- a/infra/docs-consistency.test.ts
+++ b/infra/docs-consistency.test.ts
@@ -268,11 +268,18 @@ describe("runtime documentation", () => {
   it("TC-DOCS-009: documents the optional production facade domain boundary", () => {
     for (const source of [text.readme, text.architecture]) {
       expect(source).toContain("MEM9_FACADE_CUSTOM_DOMAIN");
-      expect(source).toMatch(/existing public Route 53\s+hosted zone/i);
-      expect(source).toMatch(/Preview stages never/i);
+      expect(source).toContain("CLOUDFLARE_API_TOKEN");
+      expect(source).toContain("CLOUDFLARE_ZONE_ID");
+      expect(source).toMatch(/existing Cloudflare zone/i);
+      expect(source).toMatch(/DNS-only/i);
+      expect(source).toMatch(/Preview stages\s+never/i);
+      expect(source).toMatch(/ACM automatically renews/i);
+      expect(source).toContain(
+        "https://docs.aws.amazon.com/acm/latest/userguide/dns-renewal-validation.html",
+      );
     }
     expect(text.facts).toContain(
-      "optional ACM certificate and existing-zone records for the public OAuth facade",
+      "optional ACM certificate and DNS-only Cloudflare records for the public OAuth",
     );
   });
 });

--- a/infra/oauth-facade.test.ts
+++ b/infra/oauth-facade.test.ts
@@ -32,6 +32,8 @@ let addAuthorizerSpy: ReturnType<typeof vi.fn>;
 let authorizerId: ReturnType<typeof out>;
 let previousFacadeAuthorizerEnabled: string | undefined;
 let previousFacadeCustomDomain: string | undefined;
+let previousCloudflareApiToken: string | undefined;
+let previousCloudflareZoneId: string | undefined;
 
 // Recursively unwrap the loose out<T> mock (and plain values) — env / arg values
 // come through as out<T> or $interpolate results.
@@ -114,6 +116,13 @@ function installGlobals(stage: string) {
         }
       },
     },
+    cloudflare: {
+      dns: (args: Record<string, unknown>) => {
+        const dns = { provider: "cloudflare", args };
+        created.push({ kind: "CloudflareDns", args });
+        return dns;
+      },
+    },
     // sst.Secret — the HMAC signing key (empty default → façade 503 until seeded).
     Secret: class {
       value = out("hmac-secret-value");
@@ -133,8 +142,12 @@ beforeEach(() => {
   previousFacadeAuthorizerEnabled =
     process.env.MEM9_FACADE_AUTHORIZER_ENABLED;
   previousFacadeCustomDomain = process.env.MEM9_FACADE_CUSTOM_DOMAIN;
+  previousCloudflareApiToken = process.env.CLOUDFLARE_API_TOKEN;
+  previousCloudflareZoneId = process.env.CLOUDFLARE_ZONE_ID;
   delete process.env.MEM9_FACADE_AUTHORIZER_ENABLED;
   delete process.env.MEM9_FACADE_CUSTOM_DOMAIN;
+  delete process.env.CLOUDFLARE_API_TOKEN;
+  delete process.env.CLOUDFLARE_ZONE_ID;
 });
 afterEach(() => {
   for (const g of ["$app", "aws", "sst", "$interpolate"])
@@ -149,6 +162,16 @@ afterEach(() => {
     delete process.env.MEM9_FACADE_CUSTOM_DOMAIN;
   } else {
     process.env.MEM9_FACADE_CUSTOM_DOMAIN = previousFacadeCustomDomain;
+  }
+  if (previousCloudflareApiToken === undefined) {
+    delete process.env.CLOUDFLARE_API_TOKEN;
+  } else {
+    process.env.CLOUDFLARE_API_TOKEN = previousCloudflareApiToken;
+  }
+  if (previousCloudflareZoneId === undefined) {
+    delete process.env.CLOUDFLARE_ZONE_ID;
+  } else {
+    process.env.CLOUDFLARE_ZONE_ID = previousCloudflareZoneId;
   }
   vi.resetModules();
 });
@@ -262,11 +285,54 @@ describe("oauthFacade factory", () => {
 
   it("configures the production custom domain from a trimmed hostname", async () => {
     process.env.MEM9_FACADE_CUSTOM_DOMAIN = " Memory.Example.com. ";
+    process.env.CLOUDFLARE_API_TOKEN = "test-token";
+    process.env.CLOUDFLARE_ZONE_ID = "test-zone-id";
     installGlobals("prod");
     const oauthFacade = await loadFacade();
     oauthFacade(fakeCognitoOut());
 
-    expect(only("ApiGatewayV2").domain).toBe("memory.example.com");
+    expect(only("CloudflareDns")).toEqual({
+      zone: "test-zone-id",
+      proxy: false,
+    });
+    expect(only("ApiGatewayV2").domain).toEqual({
+      name: "memory.example.com",
+      dns: {
+        provider: "cloudflare",
+        args: {
+          zone: "test-zone-id",
+          proxy: false,
+        },
+      },
+    });
+    expect(JSON.stringify(only("ApiGatewayV2"))).not.toContain("test-token");
+  });
+
+  it.each([
+    ["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ZONE_ID", "test-zone-id"],
+    ["CLOUDFLARE_ZONE_ID", "CLOUDFLARE_API_TOKEN", "test-token"],
+  ])(
+    "requires %s when the production custom domain is configured",
+    async (_missing, present, value) => {
+      process.env.MEM9_FACADE_CUSTOM_DOMAIN = "memory.example.com";
+      process.env[present] = value;
+      installGlobals("prod");
+      const oauthFacade = await loadFacade();
+
+      expect(() => oauthFacade(fakeCognitoOut())).toThrow(
+        new RegExp(`requires ${_missing} for Cloudflare DNS`, "u"),
+      );
+    },
+  );
+
+  it("reports both missing Cloudflare settings together", async () => {
+    process.env.MEM9_FACADE_CUSTOM_DOMAIN = "memory.example.com";
+    installGlobals("prod");
+    const oauthFacade = await loadFacade();
+
+    expect(() => oauthFacade(fakeCognitoOut())).toThrow(
+      /requires CLOUDFLARE_API_TOKEN and CLOUDFLARE_ZONE_ID for Cloudflare DNS/u,
+    );
   });
 
   it("does not attach the production hostname to a preview stage", async () => {
@@ -276,6 +342,9 @@ describe("oauthFacade factory", () => {
     oauthFacade(fakeCognitoOut());
 
     expect(only("ApiGatewayV2").domain).toBeUndefined();
+    expect(created.filter(({ kind }) => kind === "CloudflareDns")).toHaveLength(
+      0,
+    );
   });
 
   it("rejects a URL instead of accepting it as the custom hostname", async () => {

--- a/infra/oauth-facade.test.ts
+++ b/infra/oauth-facade.test.ts
@@ -31,6 +31,7 @@ let routeSpy: ReturnType<typeof vi.fn>;
 let addAuthorizerSpy: ReturnType<typeof vi.fn>;
 let authorizerId: ReturnType<typeof out>;
 let previousFacadeAuthorizerEnabled: string | undefined;
+let previousFacadeCustomDomain: string | undefined;
 
 // Recursively unwrap the loose out<T> mock (and plain values) — env / arg values
 // come through as out<T> or $interpolate results.
@@ -131,7 +132,9 @@ beforeEach(() => {
   addAuthorizerSpy = vi.fn(() => ({ id: authorizerId }));
   previousFacadeAuthorizerEnabled =
     process.env.MEM9_FACADE_AUTHORIZER_ENABLED;
+  previousFacadeCustomDomain = process.env.MEM9_FACADE_CUSTOM_DOMAIN;
   delete process.env.MEM9_FACADE_AUTHORIZER_ENABLED;
+  delete process.env.MEM9_FACADE_CUSTOM_DOMAIN;
 });
 afterEach(() => {
   for (const g of ["$app", "aws", "sst", "$interpolate"])
@@ -141,6 +144,11 @@ afterEach(() => {
   } else {
     process.env.MEM9_FACADE_AUTHORIZER_ENABLED =
       previousFacadeAuthorizerEnabled;
+  }
+  if (previousFacadeCustomDomain === undefined) {
+    delete process.env.MEM9_FACADE_CUSTOM_DOMAIN;
+  } else {
+    process.env.MEM9_FACADE_CUSTOM_DOMAIN = previousFacadeCustomDomain;
   }
   vi.resetModules();
 });
@@ -249,6 +257,35 @@ describe("oauthFacade factory", () => {
     expect(cors.allowHeaders).toContain("Authorization");
     expect(cors.allowOrigins).toEqual(["*"]);
     expect(cors.allowMethods).toEqual(["*"]);
+    expect(api.domain).toBeUndefined();
+  });
+
+  it("configures the production custom domain from a trimmed hostname", async () => {
+    process.env.MEM9_FACADE_CUSTOM_DOMAIN = " Memory.Example.com. ";
+    installGlobals("prod");
+    const oauthFacade = await loadFacade();
+    oauthFacade(fakeCognitoOut());
+
+    expect(only("ApiGatewayV2").domain).toBe("memory.example.com");
+  });
+
+  it("does not attach the production hostname to a preview stage", async () => {
+    process.env.MEM9_FACADE_CUSTOM_DOMAIN = "memory.example.com";
+    installGlobals("pr-42");
+    const oauthFacade = await loadFacade();
+    oauthFacade(fakeCognitoOut());
+
+    expect(only("ApiGatewayV2").domain).toBeUndefined();
+  });
+
+  it("rejects a URL instead of accepting it as the custom hostname", async () => {
+    process.env.MEM9_FACADE_CUSTOM_DOMAIN = "https://memory.example.com/path";
+    installGlobals("prod");
+    const oauthFacade = await loadFacade();
+
+    expect(() => oauthFacade(fakeCognitoOut())).toThrow(
+      /MEM9_FACADE_CUSTOM_DOMAIN must be a hostname/u,
+    );
   });
 
   it("creates the reader UserPoolClient wired to the facade callback URL (cycle break)", async () => {

--- a/infra/oauth-facade.ts
+++ b/infra/oauth-facade.ts
@@ -29,6 +29,30 @@ import type { CognitoOutputs } from "./cognito";
 const awsAny = aws as unknown as Record<string, any>;
 const FACADE_AUTHORIZER_ENABLED =
   process.env.MEM9_FACADE_AUTHORIZER_ENABLED === "1";
+const FACADE_CUSTOM_DOMAIN_ENV = "MEM9_FACADE_CUSTOM_DOMAIN";
+
+export function facadeCustomDomain(
+  stage: string,
+  raw = process.env[FACADE_CUSTOM_DOMAIN_ENV],
+): string | undefined {
+  // One hostname can map to only one stage. CI intentionally reserves the
+  // optional shared hostname for production and leaves previews on execute-api.
+  if (stage !== "prod" || !raw?.trim()) return undefined;
+
+  const domain = raw.trim().toLowerCase().replace(/\.$/u, "");
+  const labels = domain.split(".");
+  const validLabel = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/u;
+  if (
+    domain.length > 253 ||
+    labels.length < 2 ||
+    labels.some((label) => !validLabel.test(label))
+  ) {
+    throw new Error(
+      `${FACADE_CUSTOM_DOMAIN_ENV} must be a hostname such as memory.example.com (without a scheme, port, or path).`,
+    );
+  }
+  return domain;
+}
 
 export interface OauthFacadeOutputs {
   ssmPrefix: string;
@@ -42,6 +66,7 @@ export function oauthFacade(cognitoOut: CognitoOutputs): OauthFacadeOutputs {
   const tags = { Project: "mem9-on-aws", Stage: stage, ManagedBy: "sst" };
   const region = awsAny.getRegionOutput().name;
   const accountId = awsAny.getCallerIdentityOutput().accountId;
+  const customDomain = facadeCustomDomain(stage);
 
   // Small helper: emit an SSM export under this stage's prefix. `secure` flips the
   // type to SecureString (the reader client secret; the MCP client needs it to
@@ -63,6 +88,7 @@ export function oauthFacade(cognitoOut: CognitoOutputs): OauthFacadeOutputs {
   // CORS scoped to the headers an MCP client sends: the bearer, JSON bodies, the
   // Accept negotiation, and the MCP protocol-version header the transport adds.
   const facadeApi = new sst.aws.ApiGatewayV2("Mem9OauthFacadeApi", {
+    ...(customDomain ? { domain: customDomain } : {}),
     cors: {
       allowHeaders: [
         "Authorization",

--- a/infra/oauth-facade.ts
+++ b/infra/oauth-facade.ts
@@ -30,6 +30,8 @@ const awsAny = aws as unknown as Record<string, any>;
 const FACADE_AUTHORIZER_ENABLED =
   process.env.MEM9_FACADE_AUTHORIZER_ENABLED === "1";
 const FACADE_CUSTOM_DOMAIN_ENV = "MEM9_FACADE_CUSTOM_DOMAIN";
+const CLOUDFLARE_API_TOKEN_ENV = "CLOUDFLARE_API_TOKEN";
+const CLOUDFLARE_ZONE_ID_ENV = "CLOUDFLARE_ZONE_ID";
 
 export function facadeCustomDomain(
   stage: string,
@@ -67,6 +69,27 @@ export function oauthFacade(cognitoOut: CognitoOutputs): OauthFacadeOutputs {
   const region = awsAny.getRegionOutput().name;
   const accountId = awsAny.getCallerIdentityOutput().accountId;
   const customDomain = facadeCustomDomain(stage);
+  const cloudflareToken = process.env[CLOUDFLARE_API_TOKEN_ENV]?.trim();
+  const cloudflareZoneId = process.env[CLOUDFLARE_ZONE_ID_ENV]?.trim();
+  if (customDomain && (!cloudflareToken || !cloudflareZoneId)) {
+    const missing = [
+      !cloudflareToken && CLOUDFLARE_API_TOKEN_ENV,
+      !cloudflareZoneId && CLOUDFLARE_ZONE_ID_ENV,
+    ].filter(Boolean);
+    throw new Error(
+      `${FACADE_CUSTOM_DOMAIN_ENV} requires ${missing.join(" and ")} for Cloudflare DNS.`,
+    );
+  }
+  const customDomainConfig = customDomain
+    ? {
+        name: customDomain,
+        dns: sst.cloudflare.dns({
+          zone: cloudflareZoneId!,
+          // Keep both ACM validation and API Gateway CNAMEs DNS-only.
+          proxy: false,
+        }),
+      }
+    : undefined;
 
   // Small helper: emit an SSM export under this stage's prefix. `secure` flips the
   // type to SecureString (the reader client secret; the MCP client needs it to
@@ -88,7 +111,7 @@ export function oauthFacade(cognitoOut: CognitoOutputs): OauthFacadeOutputs {
   // CORS scoped to the headers an MCP client sends: the bearer, JSON bodies, the
   // Accept negotiation, and the MCP protocol-version header the transport adds.
   const facadeApi = new sst.aws.ApiGatewayV2("Mem9OauthFacadeApi", {
-    ...(customDomain ? { domain: customDomain } : {}),
+    ...(customDomainConfig ? { domain: customDomainConfig } : {}),
     cors: {
       allowHeaders: [
         "Authorization",

--- a/infra/sst-types.d.ts
+++ b/infra/sst-types.d.ts
@@ -613,8 +613,12 @@ declare namespace sst {
       allowHeaders?: Input<string>[];
       maxAge?: Input<string>;
     }
+    interface ApiGatewayV2Domain {
+      name: Input<string>;
+      dns?: unknown;
+    }
     interface ApiGatewayV2Args {
-      domain?: Input<string>;
+      domain?: Input<string | ApiGatewayV2Domain>;
       cors?: ApiGatewayV2Cors;
     }
     interface ApiGatewayV2AuthorizerArgs {
@@ -634,6 +638,14 @@ declare namespace sst {
       };
       route(route: string, handler: Input<string>, args?: unknown): void;
     }
+  }
+
+  namespace cloudflare {
+    interface DnsArgs {
+      zone?: Input<string>;
+      proxy?: Input<boolean>;
+    }
+    function dns(args?: DnsArgs): unknown;
   }
 
   // ── sst.Secret (infra/oauth-facade.ts — OAuth client secret / signing key) ──

--- a/infra/sst-types.d.ts
+++ b/infra/sst-types.d.ts
@@ -614,6 +614,7 @@ declare namespace sst {
       maxAge?: Input<string>;
     }
     interface ApiGatewayV2Args {
+      domain?: Input<string>;
       cors?: ApiGatewayV2Cors;
     }
     interface ApiGatewayV2AuthorizerArgs {

--- a/scripts/deployment-workflow.test.mjs
+++ b/scripts/deployment-workflow.test.mjs
@@ -195,7 +195,7 @@ describe("workflow integration", () => {
       "${{ secrets.CLOUDFLARE_API_TOKEN }}",
     );
     expect(prod.env.CLOUDFLARE_ZONE_ID).toBe(
-      "${{ vars.CLOUDFLARE_ZONE_ID }}",
+      "${{ secrets.CLOUDFLARE_ZONE_ID }}",
     );
     for (const name of [
       "MEM9_FACADE_CUSTOM_DOMAIN",

--- a/scripts/deployment-workflow.test.mjs
+++ b/scripts/deployment-workflow.test.mjs
@@ -179,7 +179,7 @@ describe("workflow integration", () => {
     expect(workflow).toContain("bash scripts/run-ingest-queue-integration.sh");
   });
 
-  it("passes the optional façade domain secret only to the prod deploy", () => {
+  it("passes the optional façade Cloudflare settings only to the prod deploy", () => {
     const workflow = parse(readFileSync(workflowPath, "utf8"));
     const preview = workflow.jobs["deploy-preview"].steps.find(
       ({ name }) => name === "Deploy PR stage",
@@ -191,7 +191,19 @@ describe("workflow integration", () => {
     expect(prod.env.MEM9_FACADE_CUSTOM_DOMAIN).toBe(
       "${{ secrets.MEM9_FACADE_CUSTOM_DOMAIN }}",
     );
-    expect(preview.env.MEM9_FACADE_CUSTOM_DOMAIN).toBeUndefined();
+    expect(prod.env.CLOUDFLARE_API_TOKEN).toBe(
+      "${{ secrets.CLOUDFLARE_API_TOKEN }}",
+    );
+    expect(prod.env.CLOUDFLARE_ZONE_ID).toBe(
+      "${{ vars.CLOUDFLARE_ZONE_ID }}",
+    );
+    for (const name of [
+      "MEM9_FACADE_CUSTOM_DOMAIN",
+      "CLOUDFLARE_API_TOKEN",
+      "CLOUDFLARE_ZONE_ID",
+    ]) {
+      expect(preview.env[name]).toBeUndefined();
+    }
   });
 
   it("TC-EMF-011: smokes non-TTY EMF bytes from the built arm64 image", () => {
@@ -339,10 +351,11 @@ describe("OAuth2 facade IAM", () => {
       "iam:AWSServiceName: ops.apigateway.amazonaws.com",
     );
 
-    const route53 = blockForSid(role, "Route53ForCloudMapAndFacadeDomain");
+    const route53 = blockForSid(role, "Route53ForCloudMap");
     expect(route53).toContain("route53:ChangeResourceRecordSets");
     expect(route53).toContain("route53:ListHostedZonesByName");
-    expect(route53).toContain("it never creates that");
+    expect(route53).toContain("This is the only");
+    expect(route53).toContain("uses Cloudflare for public DNS");
   });
 });
 

--- a/scripts/deployment-workflow.test.mjs
+++ b/scripts/deployment-workflow.test.mjs
@@ -112,7 +112,7 @@ function blockForSid(source, sid) {
 function actionSetForSid(source, sid) {
   return [
     ...blockForSid(source, sid).matchAll(
-      /^\s+- ((?:ec2|ecs|logs|ssm):[A-Za-z]+)$/gm,
+      /^\s+- ([a-z0-9-]+:[A-Za-z*]+)$/gm,
     ),
   ].map(
     (m) => m[1],
@@ -177,6 +177,21 @@ describe("workflow integration", () => {
   it("runs the PostgreSQL durable-ingest integration suite in CI", () => {
     const workflow = readFileSync(workflowPath, "utf8");
     expect(workflow).toContain("bash scripts/run-ingest-queue-integration.sh");
+  });
+
+  it("passes the optional façade domain secret only to the prod deploy", () => {
+    const workflow = parse(readFileSync(workflowPath, "utf8"));
+    const preview = workflow.jobs["deploy-preview"].steps.find(
+      ({ name }) => name === "Deploy PR stage",
+    );
+    const prod = workflow.jobs["deploy-prod"].steps.find(
+      ({ name }) => name === "Deploy prod stage",
+    );
+
+    expect(prod.env.MEM9_FACADE_CUSTOM_DOMAIN).toBe(
+      "${{ secrets.MEM9_FACADE_CUSTOM_DOMAIN }}",
+    );
+    expect(preview.env.MEM9_FACADE_CUSTOM_DOMAIN).toBeUndefined();
   });
 
   it("TC-EMF-011: smokes non-TTY EMF bytes from the built arm64 image", () => {
@@ -289,6 +304,45 @@ describe("OAuth2 facade IAM", () => {
         "logs:ListLogDeliveries",
       ]),
     );
+  });
+
+  it("grants the optional custom-domain lifecycle without creating a public zone", () => {
+    const role = readFileSync(rolePath, "utf8");
+
+    expect(actionSetForSid(role, "ApiGatewayV2")).toEqual(
+      expect.arrayContaining([
+        "apigateway:POST",
+        "apigateway:GET",
+        "apigateway:PATCH",
+        "apigateway:PUT",
+        "apigateway:DELETE",
+      ]),
+    );
+    expect(blockForSid(role, "ApiGatewayV2")).toContain(
+      "arn:aws:apigateway:*::/domainnames/*",
+    );
+    expect(actionSetForSid(role, "AcmFacadeCertificateCreate")).toEqual([
+      "acm:RequestCertificate",
+      "acm:AddTagsToCertificate",
+    ]);
+    expect(actionSetForSid(role, "AcmFacadeCertificateManage")).toEqual(
+      expect.arrayContaining([
+        "acm:DeleteCertificate",
+        "acm:DescribeCertificate",
+        "acm:ListTagsForCertificate",
+      ]),
+    );
+    expect(actionSetForSid(role, "ApiGatewayServiceLinkedRole")).toEqual([
+      "iam:CreateServiceLinkedRole",
+    ]);
+    expect(blockForSid(role, "ApiGatewayServiceLinkedRole")).toContain(
+      "iam:AWSServiceName: ops.apigateway.amazonaws.com",
+    );
+
+    const route53 = blockForSid(role, "Route53ForCloudMapAndFacadeDomain");
+    expect(route53).toContain("route53:ChangeResourceRecordSets");
+    expect(route53).toContain("route53:ListHostedZonesByName");
+    expect(route53).toContain("it never creates that");
   });
 });
 

--- a/scripts/workload-permissions-boundary-contract.json
+++ b/scripts/workload-permissions-boundary-contract.json
@@ -13,7 +13,7 @@
     {
       "id": "infra-ci.yml",
       "path": ".github/workflows/infra-ci.yml",
-      "reviewedBlob": "f3f8602d1f2af0177e4d084c9619ec91ba20fa1c"
+      "reviewedBlob": "6b13689f40befbe6a5e05ebf18836020fadef1e6"
     },
     {
       "id": "reconcile-previews.yml",

--- a/scripts/workload-permissions-boundary-contract.json
+++ b/scripts/workload-permissions-boundary-contract.json
@@ -13,7 +13,7 @@
     {
       "id": "infra-ci.yml",
       "path": ".github/workflows/infra-ci.yml",
-      "reviewedBlob": "6b13689f40befbe6a5e05ebf18836020fadef1e6"
+      "reviewedBlob": "8cc8e91ef7649c130594bad8beb4bb186da6fb7f"
     },
     {
       "id": "reconcile-previews.yml",

--- a/scripts/workload-permissions-boundary-contract.json
+++ b/scripts/workload-permissions-boundary-contract.json
@@ -13,7 +13,7 @@
     {
       "id": "infra-ci.yml",
       "path": ".github/workflows/infra-ci.yml",
-      "reviewedBlob": "ebb8a153e0e56fad6411af77a34ad076355cc452"
+      "reviewedBlob": "f3f8602d1f2af0177e4d084c9619ec91ba20fa1c"
     },
     {
       "id": "reconcile-previews.yml",

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -22,6 +22,11 @@
 
 export default $config({
   app(input) {
+    const cloudflareEnabled =
+      input?.stage === "prod" &&
+      Boolean(process.env.MEM9_FACADE_CUSTOM_DOMAIN?.trim()) &&
+      Boolean(process.env.CLOUDFLARE_API_TOKEN?.trim());
+
     return {
       name: "mem9-on-aws",
       // prod state is retained + protected so a stray `sst remove` can't
@@ -40,10 +45,11 @@ export default $config({
             },
           },
         },
-        // The optional production OAuth façade domain is hosted on Cloudflare.
-        // Authentication comes from CLOUDFLARE_API_TOKEN at deploy time; the
-        // provider is still declared globally so SST injects sst.cloudflare.
-        cloudflare: { version: "6.15.0" },
+        // Avoid initializing the Cloudflare client for preview stages, which
+        // intentionally never receive the production DNS token.
+        ...(cloudflareEnabled
+          ? { cloudflare: { version: "6.15.0" } }
+          : {}),
         // The `random` provider exposes the `random` global (random.RandomId) used
         // by infra/tenant-identity.ts to mint the STABLE tenant id / X-API-Key. It must
         // be declared here for the global to bind at run() (SST only injects a

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -40,6 +40,10 @@ export default $config({
             },
           },
         },
+        // The optional production OAuth façade domain is hosted on Cloudflare.
+        // Authentication comes from CLOUDFLARE_API_TOKEN at deploy time; the
+        // provider is still declared globally so SST injects sst.cloudflare.
+        cloudflare: { version: "6.15.0" },
         // The `random` provider exposes the `random` global (random.RandomId) used
         // by infra/tenant-identity.ts to mint the STABLE tenant id / X-API-Key. It must
         // be declared here for the global to bind at run() (SST only injects a


### PR DESCRIPTION
## Summary

- support an optional production-only OAuth facade custom domain configured through the `MEM9_FACADE_CUSTOM_DOMAIN` GitHub Actions secret
- provision the Regional API Gateway domain and same-region DNS-validated ACM certificate, with DNS-only Cloudflare records managed through a zone-scoped API token
- inject `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ZONE_ID` only into the production deploy; preview stages continue to use the generated `execute-api` URL
- document that ACM renews automatically while the certificate remains attached and its validation CNAME remains publicly resolvable

## Verification

- `npm test` (597 tests passed)
- `pnpm -C infra test` (193 tests passed, including real SST graph and Pulumi lifecycle coverage)
- root and infrastructure TypeScript checks passed
- GitHub Actions workflow and IAM contract tests passed
- YAML parse, `git diff --check`, and public-artifact scans passed

## Deployment note

Before enabling the custom domain:

1. Run `scripts/deploy-github-role.sh` to apply the out-of-band ACM and API Gateway deployment permissions.
2. Configure `CLOUDFLARE_API_TOKEN` as a repository secret with `Zone:Read` and `DNS:Edit` on the target zone.
3. Configure `CLOUDFLARE_ZONE_ID` as a repository secret.

No certificate-renewal follow-up issue is required. No production application deployment was performed as part of this PR.