### PR TITLE
fix(ci): resolve Cloudflare account before deploy

### DIFF
--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -937,6 +937,28 @@ jobs:
           pnpm -C infra exec sst secret set OauthStateHmacKey "$KEY" --stage prod
           echo "::notice::OauthStateHmacKey seeded for prod (re-linked by the deploy below)"
 
+      - name: Resolve Cloudflare account ID
+        shell: bash
+        env:
+          MEM9_FACADE_CUSTOM_DOMAIN: ${{ secrets.MEM9_FACADE_CUSTOM_DOMAIN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$MEM9_FACADE_CUSTOM_DOMAIN" ]]; then
+            echo "::notice::No production custom domain configured; skipping Cloudflare account resolution"
+            exit 0
+          fi
+          : "${CLOUDFLARE_API_TOKEN:?CLOUDFLARE_API_TOKEN is required when MEM9_FACADE_CUSTOM_DOMAIN is set}"
+          : "${CLOUDFLARE_ZONE_ID:?CLOUDFLARE_ZONE_ID is required when MEM9_FACADE_CUSTOM_DOMAIN is set}"
+          ZONE_JSON=$(curl --fail --silent --show-error \
+            --retry 3 --retry-delay 1 --retry-all-errors \
+            --header "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+            "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}")
+          ACCOUNT_ID=$(printf '%s' "$ZONE_JSON" | python3 -c 'import json,re,sys; data=json.load(sys.stdin); value=data.get("result", {}).get("account", {}).get("id", ""); valid=data.get("success") is True and isinstance(value, str) and re.fullmatch(r"[0-9a-f]{32}", value) is not None; print(value) if valid else sys.exit("Cloudflare zone response did not contain a valid account ID")')
+          echo "::add-mask::$ACCOUNT_ID"
+          printf 'CLOUDFLARE_DEFAULT_ACCOUNT_ID=%s\n' "$ACCOUNT_ID" >> "$GITHUB_ENV"
+
       - name: Deploy prod stage
         shell: bash
         # Pin prod to the shared tag built for all workload images in this commit

--- a/docs/test-cases/cloudflare-account-resolution.md
+++ b/docs/test-cases/cloudflare-account-resolution.md
@@ -1,0 +1,39 @@
+# Cloudflare account resolution test cases
+
+## Scope
+
+The production deployment resolves the Cloudflare account that owns the
+configured zone before SST initializes its Cloudflare provider. Pull-request
+preview deployments remain independent of Cloudflare credentials.
+
+## Cases
+
+### TC-CF-ACCOUNT-001: Resolve the account before production deployment
+
+- Given the production custom-domain secrets are configured
+- When the production deployment job runs
+- Then it queries the configured Cloudflare zone before `sst deploy`
+- And exports the owning account as `CLOUDFLARE_DEFAULT_ACCOUNT_ID`
+- And masks the resolved account ID before writing it to the GitHub Actions
+  environment
+
+### TC-CF-ACCOUNT-002: Keep Cloudflare credentials production-only
+
+- Given a pull-request preview deployment
+- When its SST deployment step runs
+- Then it receives no custom-domain, Cloudflare token, zone, or account
+  configuration
+
+### TC-CF-ACCOUNT-003: Fail closed on an unusable zone response
+
+- Given Cloudflare rejects the request or omits a valid account ID
+- When the account-resolution step runs
+- Then the step fails before SST deployment
+- And it does not export an empty or malformed account ID
+
+### TC-CF-ACCOUNT-004: Preserve deployments without a custom domain
+
+- Given no production custom domain is configured
+- When the account-resolution step runs
+- Then it succeeds without calling Cloudflare
+- And it exports no Cloudflare account ID

--- a/scripts/deployment-workflow.test.mjs
+++ b/scripts/deployment-workflow.test.mjs
@@ -6,6 +6,7 @@ import {
   readFileSync,
   readdirSync,
   rmSync,
+  writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { delimiter, dirname, join, resolve } from "node:path";
@@ -96,6 +97,49 @@ function runDeployRoleFixture(args = []) {
   return { result, callRecords };
 }
 
+function runCloudflareResolver({
+  customDomain = "memory.example.com",
+  curlExit = 0,
+  zoneResponse = "",
+} = {}) {
+  const workflow = parse(readFileSync(workflowPath, "utf8"));
+  const resolver = workflow.jobs["deploy-prod"].steps.find(
+    ({ name }) => name === "Resolve Cloudflare account ID",
+  );
+  const dir = mkdtempSync(join(tmpdir(), "mem9-cloudflare-account-"));
+  tempDirs.push(dir);
+  const bin = join(dir, "bin");
+  const githubEnv = join(dir, "github-env");
+  mkdirSync(bin);
+  writeFileSync(
+    join(bin, "curl"),
+    [
+      "#!/usr/bin/env bash",
+      'if [[ "${MOCK_CURL_EXIT:-0}" != "0" ]]; then exit "$MOCK_CURL_EXIT"; fi',
+      "printf '%s' \"$MOCK_ZONE_RESPONSE\"",
+      "",
+    ].join("\n"),
+    { mode: 0o755 },
+  );
+  writeFileSync(githubEnv, "");
+
+  const result = spawnSync("bash", ["-c", resolver.run], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${bin}${delimiter}${process.env.PATH}`,
+      GITHUB_ENV: githubEnv,
+      MEM9_FACADE_CUSTOM_DOMAIN: customDomain,
+      CLOUDFLARE_API_TOKEN: customDomain ? "fixture-token" : "",
+      CLOUDFLARE_ZONE_ID: customDomain ? "a".repeat(32) : "",
+      MOCK_CURL_EXIT: String(curlExit),
+      MOCK_ZONE_RESPONSE: zoneResponse,
+    },
+  });
+
+  return { result, githubEnv: readFileSync(githubEnv, "utf8") };
+}
+
 function optionValue(args, option) {
   const index = args.indexOf(option);
   return index >= 0 ? args[index + 1] : undefined;
@@ -179,15 +223,44 @@ describe("workflow integration", () => {
     expect(workflow).toContain("bash scripts/run-ingest-queue-integration.sh");
   });
 
-  it("passes the optional façade Cloudflare settings only to the prod deploy", () => {
+  it("TC-CF-ACCOUNT-001/002/003: resolves the Cloudflare account only for prod", () => {
     const workflow = parse(readFileSync(workflowPath, "utf8"));
-    const preview = workflow.jobs["deploy-preview"].steps.find(
+    const previewSteps = workflow.jobs["deploy-preview"].steps;
+    const prodSteps = workflow.jobs["deploy-prod"].steps;
+    const preview = previewSteps.find(
       ({ name }) => name === "Deploy PR stage",
     );
-    const prod = workflow.jobs["deploy-prod"].steps.find(
+    const resolverIndex = prodSteps.findIndex(
+      ({ name }) => name === "Resolve Cloudflare account ID",
+    );
+    const deployIndex = prodSteps.findIndex(
       ({ name }) => name === "Deploy prod stage",
     );
+    const resolver = prodSteps[resolverIndex];
+    const prod = prodSteps[deployIndex];
 
+    expect(resolverIndex).toBeGreaterThanOrEqual(0);
+    expect(resolverIndex).toBeLessThan(deployIndex);
+    expect(resolver.env.MEM9_FACADE_CUSTOM_DOMAIN).toBe(
+      "${{ secrets.MEM9_FACADE_CUSTOM_DOMAIN }}",
+    );
+    expect(resolver.env.CLOUDFLARE_API_TOKEN).toBe(
+      "${{ secrets.CLOUDFLARE_API_TOKEN }}",
+    );
+    expect(resolver.env.CLOUDFLARE_ZONE_ID).toBe(
+      "${{ secrets.CLOUDFLARE_ZONE_ID }}",
+    );
+    expect(resolver.run).toContain(
+      "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}",
+    );
+    expect(resolver.run).toContain("curl --fail");
+    expect(resolver.run).toContain('data.get("success") is True');
+    expect(resolver.run).toContain('re.fullmatch(r"[0-9a-f]{32}", value)');
+    expect(resolver.run).toContain("::add-mask::$ACCOUNT_ID");
+    expect(resolver.run).toContain(
+      "CLOUDFLARE_DEFAULT_ACCOUNT_ID=%s\\n",
+    );
+    expect(resolver.run).toContain('>> "$GITHUB_ENV"');
     expect(prod.env.MEM9_FACADE_CUSTOM_DOMAIN).toBe(
       "${{ secrets.MEM9_FACADE_CUSTOM_DOMAIN }}",
     );
@@ -201,8 +274,45 @@ describe("workflow integration", () => {
       "MEM9_FACADE_CUSTOM_DOMAIN",
       "CLOUDFLARE_API_TOKEN",
       "CLOUDFLARE_ZONE_ID",
+      "CLOUDFLARE_DEFAULT_ACCOUNT_ID",
     ]) {
       expect(preview.env[name]).toBeUndefined();
+    }
+    expect(
+      previewSteps.some(({ name }) => name === "Resolve Cloudflare account ID"),
+    ).toBe(false);
+  });
+
+  it("TC-CF-ACCOUNT-003/004: exports only a valid account and skips an unset domain", () => {
+    const accountId = "b".repeat(32);
+    const success = runCloudflareResolver({
+      zoneResponse: JSON.stringify({
+        success: true,
+        result: { account: { id: accountId } },
+      }),
+    });
+    expect(success.result.status).toBe(0);
+    expect(success.result.stdout).toContain(`::add-mask::${accountId}`);
+    expect(success.githubEnv).toBe(
+      `CLOUDFLARE_DEFAULT_ACCOUNT_ID=${accountId}\n`,
+    );
+
+    const noDomain = runCloudflareResolver({ customDomain: "" });
+    expect(noDomain.result.status).toBe(0);
+    expect(noDomain.result.stdout).toContain(
+      "skipping Cloudflare account resolution",
+    );
+    expect(noDomain.githubEnv).toBe("");
+
+    for (const failure of [
+      runCloudflareResolver({ curlExit: 22 }),
+      runCloudflareResolver({ zoneResponse: "not-json" }),
+      runCloudflareResolver({
+        zoneResponse: JSON.stringify({ success: true, result: {} }),
+      }),
+    ]) {
+      expect(failure.result.status).not.toBe(0);
+      expect(failure.githubEnv).toBe("");
     }
   });
 

--- a/scripts/workload-permissions-boundary-contract.json
+++ b/scripts/workload-permissions-boundary-contract.json
@@ -13,7 +13,7 @@
     {
       "id": "infra-ci.yml",
       "path": ".github/workflows/infra-ci.yml",
-      "reviewedBlob": "8cc8e91ef7649c130594bad8beb4bb186da6fb7f"
+      "reviewedBlob": "673fef8b7a4682ac3d4167936541d927247c02c3"
     },
     {
       "id": "reconcile-previews.yml",


### PR DESCRIPTION
## Summary
- resolve the Cloudflare account from the configured zone before SST initializes the provider
- preserve production deployments when the optional custom domain is unset
- fail closed on invalid zone responses and cover success and failure paths with executable workflow tests

## Test Plan
- [x] Root typecheck and tests (598 passed)
- [x] Infra typecheck and tests (193 passed)
- [x] Workflow contract and failure-path tests
- [x] Public-artifact and secret scans
- [x] Independent code simplification review
- [x] Independent PR review
- [x] CI checks pass
- [x] Production deployment and HTTPS smoke pass