### PR TITLE
feat(llm-proxy): multi-model routing — GLM-5 chat + gpt-5.6 terra/luna via Responses API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,19 @@ AWS_PROFILE=your-aws-profile
 # Application VPC discovery remains independently configurable.
 # PROJECT_REGION=ap-northeast-1
 # MEM9_VPC_ID=vpc-xxxxxxxxxxxxxxxxx
+# --- llm-proxy Responses route (OpenAI gpt-5.6 terra/luna; optional) ---
+# These models serve ONLY via the Responses API in us-west-2/us-east-1. To
+# enable: (1) create the regional Mantle project:
+#   PROJECT_REGION=us-west-2 scripts/deploy-bedrock-mantle-project.sh
+# (2) re-run the boundary rollout (it auto-detects the project stack in
+#     WORKLOAD_BOUNDARY_OPENAI_PROJECT_REGION, default us-west-2);
+# (3) set the CI variables: MEM9_BEDROCK_PROJECT_OPENAI (regional project id,
+#     feeds the task-role grant + OpenAI-Project header) and MEM9_LLM_MODEL
+#     (e.g. openai.gpt-5.6-terra) — both consumed by infra/ecs.ts at deploy.
+# The THREE region knobs must agree (all default us-west-2):
+#   MEM9_LLM_RESPONSES_REGION (task-role grant + LLM_PROXY_RESPONSES_REGION),
+#   WORKLOAD_BOUNDARY_OPENAI_PROJECT_REGION (boundary ARN sourcing).
+# WORKLOAD_BOUNDARY_OPENAI_PROJECT_REGION=us-west-2
 # Optional production OAuth façade hostname. For local SST deploys only; GitHub
 # Actions reads the domain, token, and zone ID from repository secrets.
 # The token needs Zone:Read + DNS:Edit for only the matching Cloudflare zone.

--- a/docker/llm-proxy/model-routing.test.mjs
+++ b/docker/llm-proxy/model-routing.test.mjs
@@ -1,0 +1,570 @@
+// Unit tests for llm-proxy multi-model routing (docs/test-cases/llm-proxy-multi-model.md).
+//
+// Route resolution + both API translations are tested directly; the routing
+// behavior of the real HTTP server is tested over loopback with injected fetch
+// and a region-aware token minter — no AWS, no Mantle.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createProxyServer,
+  readConfig,
+  resolveRoute,
+  translateChatToResponses,
+  translateResponsesToChat,
+} from "./server.mjs";
+
+async function listen(server) {
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () => new Promise((resolve) => server.close(resolve)),
+  };
+}
+
+const openInstances = [];
+afterEach(async () => {
+  while (openInstances.length) await openInstances.pop().close();
+  vi.restoreAllMocks();
+});
+
+async function boot(cfg, deps) {
+  const { server, start, state } = createProxyServer(cfg, { log: () => {}, ...deps });
+  const inst = await listen(server);
+  openInstances.push(inst);
+  return { ...inst, start, state };
+}
+
+// Full config with both routes wired to fake endpoints.
+const cfg = {
+  port: 0,
+  region: "ap-northeast-1",
+  upstreamBase: "https://mantle-tokyo.test/v1",
+  openaiProject: "proj-tokyo",
+  maxBodyBytes: 1_048_576,
+  maxTokens: 4096,
+  tokenTtlSeconds: 43200,
+  refreshIntervalMs: 60 * 60 * 1000,
+  responsesModelPrefixes: ["openai.gpt-5.6-"],
+  responsesRegion: "us-west-2",
+  responsesBase: "https://mantle-west.test/openai/v1",
+  reasoningEffort: "high",
+  responsesMaxOutputTokens: 16384,
+  responsesOpenaiProject: "proj-west",
+};
+
+const terraChat = {
+  model: "openai.gpt-5.6-terra",
+  messages: [
+    { role: "system", content: "you judge memories" },
+    { role: "user", content: "classify this" },
+  ],
+};
+
+function responsesReply(overrides = {}) {
+  return {
+    id: "resp_1",
+    status: "completed",
+    output: [
+      { type: "reasoning", content: [] },
+      { type: "message", content: [{ type: "output_text", text: '{"verdicts":[]}' }] },
+    ],
+    usage: { input_tokens: 100, output_tokens: 40 },
+    ...overrides,
+  };
+}
+
+describe("readConfig responses-route fields", () => {
+  it("defaults: gpt-5.6 prefix, us-west-2, derived base, high effort, 16384 cap", () => {
+    const c = readConfig({});
+    expect(c.responsesModelPrefixes).toEqual(["openai.gpt-5.6-"]);
+    expect(c.responsesRegion).toBe("us-west-2");
+    expect(c.responsesBase).toBe("https://bedrock-mantle.us-west-2.api.aws/openai/v1");
+    expect(c.reasoningEffort).toBe("high");
+    expect(c.responsesMaxOutputTokens).toBe(16384);
+    expect(c.responsesOpenaiProject).toBe("");
+  });
+
+  it("honors overrides and comma-separated prefixes with empties ignored (TC-MMROUTE-002)", () => {
+    const c = readConfig({
+      LLM_PROXY_RESPONSES_MODEL_PREFIXES: "openai., ,custom.reasoner-",
+      LLM_PROXY_RESPONSES_REGION: "us-east-1",
+      LLM_PROXY_REASONING_EFFORT: "medium",
+      LLM_PROXY_RESPONSES_MAX_OUTPUT_TOKENS: "8000",
+      LLM_PROXY_RESPONSES_OPENAI_PROJECT: "proj-east",
+    });
+    expect(c.responsesModelPrefixes).toEqual(["openai.", "custom.reasoner-"]);
+    expect(c.responsesRegion).toBe("us-east-1");
+    expect(c.responsesBase).toBe("https://bedrock-mantle.us-east-1.api.aws/openai/v1");
+    expect(c.reasoningEffort).toBe("medium");
+    expect(c.responsesMaxOutputTokens).toBe(8000);
+    expect(c.responsesOpenaiProject).toBe("proj-east");
+  });
+
+  it("rejects an invalid reasoning effort at startup", () => {
+    expect(() => readConfig({ LLM_PROXY_REASONING_EFFORT: "max" })).toThrow(/effort/i);
+  });
+});
+
+describe("resolveRoute (TC-MMROUTE-001)", () => {
+  it("routes unmatched models to chat with the regional base", () => {
+    const r = resolveRoute("zai.glm-5", cfg);
+    expect(r).toMatchObject({
+      kind: "chat",
+      region: "ap-northeast-1",
+      openaiProject: "proj-tokyo",
+    });
+    expect(r.url).toBe("https://mantle-tokyo.test/v1/chat/completions");
+  });
+
+  it.each(["openai.gpt-5.6-terra", "openai.gpt-5.6-luna"])(
+    "routes %s to the responses route in the responses region",
+    (model) => {
+      const r = resolveRoute(model, cfg);
+      expect(r).toMatchObject({
+        kind: "responses",
+        region: "us-west-2",
+        openaiProject: "proj-west",
+      });
+      expect(r.url).toBe("https://mantle-west.test/openai/v1/responses");
+    },
+  );
+});
+
+describe("translateChatToResponses", () => {
+  it("TC-MMROUTE-010: system → instructions, other messages → input, model preserved", () => {
+    const out = translateChatToResponses(terraChat, cfg);
+    expect(out.model).toBe("openai.gpt-5.6-terra");
+    expect(out.instructions).toBe("you judge memories");
+    expect(out.input).toEqual([{ role: "user", content: "classify this" }]);
+    expect(out.reasoning).toEqual({ effort: "high" });
+    expect(out.max_output_tokens).toBe(16384);
+  });
+
+  it("joins multiple system messages with newlines", () => {
+    const out = translateChatToResponses(
+      {
+        model: "openai.gpt-5.6-terra",
+        messages: [
+          { role: "system", content: "a" },
+          { role: "system", content: "b" },
+          { role: "user", content: "c" },
+        ],
+      },
+      cfg,
+    );
+    expect(out.instructions).toBe("a\nb");
+    expect(out.input).toEqual([{ role: "user", content: "c" }]);
+  });
+
+  it("TC-MMROUTE-011: max_tokens maps to max_output_tokens within the responses cap", () => {
+    const ok = translateChatToResponses({ ...terraChat, max_tokens: 9000 }, cfg);
+    expect(ok.max_output_tokens).toBe(9000);
+    for (const bad of [0, -1, 1.5, "x", 16385]) {
+      expect(() => translateChatToResponses({ ...terraChat, max_tokens: bad }, cfg)).toThrow(
+        /max_tokens/,
+      );
+    }
+  });
+
+  it("TC-MMROUTE-012: request reasoning_effort wins; invalid values 400", () => {
+    const out = translateChatToResponses({ ...terraChat, reasoning_effort: "low" }, cfg);
+    expect(out.reasoning).toEqual({ effort: "low" });
+    expect(() =>
+      translateChatToResponses({ ...terraChat, reasoning_effort: "ultra" }, cfg),
+    ).toThrow(/reasoning_effort/);
+  });
+
+  it("rejects array-of-parts message content (Responses names part types differently)", () => {
+    expect(() =>
+      translateChatToResponses(
+        {
+          model: "openai.gpt-5.6-terra",
+          messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+        },
+        cfg,
+      ),
+    ).toThrow(/string content/);
+  });
+
+  it("TC-MMROUTE-013: unknown chat fields are not forwarded", () => {
+    const out = translateChatToResponses(
+      { ...terraChat, temperature: 0.5, tools: [{ a: 1 }], stream: true },
+      cfg,
+    );
+    expect(out).not.toHaveProperty("temperature");
+    expect(out).not.toHaveProperty("tools");
+    expect(out).not.toHaveProperty("stream");
+    expect(out).not.toHaveProperty("messages");
+  });
+});
+
+describe("translateResponsesToChat", () => {
+  it("TC-MMROUTE-020: joins output_text, maps usage, finish_reason stop", () => {
+    const chat = translateResponsesToChat(responsesReply(), "openai.gpt-5.6-terra");
+    expect(chat.object).toBe("chat.completion");
+    expect(chat.model).toBe("openai.gpt-5.6-terra");
+    expect(chat.choices).toEqual([
+      {
+        index: 0,
+        message: { role: "assistant", content: '{"verdicts":[]}' },
+        finish_reason: "stop",
+      },
+    ]);
+    expect(chat.usage).toEqual({ prompt_tokens: 100, completion_tokens: 40, total_tokens: 140 });
+  });
+
+  it("TC-MMROUTE-021: incomplete → partial text with finish_reason length", () => {
+    const chat = translateResponsesToChat(
+      responsesReply({ status: "incomplete", incomplete_details: { reason: "max_output_tokens" } }),
+      "m",
+    );
+    expect(chat.choices[0].finish_reason).toBe("length");
+    expect(chat.choices[0].message.content).toBe('{"verdicts":[]}');
+  });
+});
+
+describe("translation edge cases", () => {
+  it("TC-MMROUTE-025: failed/cancelled/unknown statuses throw — never an empty 'stop' completion", () => {
+    for (const status of ["failed", "cancelled", "queued", "in_progress", undefined]) {
+      expect(() =>
+        translateResponsesToChat(
+          { id: "r", status, output: [], error: { message: "model exploded" } },
+          "m",
+        ),
+      ).toThrow(/responses status/);
+    }
+  });
+
+  it("TC-MMROUTE-026: a completed reply with no output_text is a contract breach", () => {
+    expect(() =>
+      translateResponsesToChat(
+        { id: "r", status: "completed", output: [{ type: "reasoning", content: [] }] },
+        "m",
+      ),
+    ).toThrow(/no output_text/);
+  });
+
+  it("TC-MMROUTE-023 detail: schema-shaped garbage throws instead of translating to empty", () => {
+    for (const bad of [{}, { output: {} }, { status: "completed" }]) {
+      expect(() => translateResponsesToChat(bad, "m")).toThrow();
+    }
+  });
+
+  it("reasoning items never leak into message content (filter is part-type-based)", () => {
+    const chat = translateResponsesToChat(
+      {
+        id: "resp_r",
+        status: "completed",
+        output: [
+          {
+            type: "reasoning",
+            content: [{ type: "reasoning_text", text: "SECRET chain of thought" }],
+            summary: [{ type: "summary_text", text: "thinking summary" }],
+          },
+          { type: "message", content: [{ type: "output_text", text: "visible" }] },
+        ],
+        usage: { input_tokens: 1, output_tokens: 1 },
+      },
+      "m",
+    );
+    expect(chat.choices[0].message.content).toBe("visible");
+    expect(chat.choices[0].message.content).not.toContain("SECRET");
+  });
+});
+
+describe("server routing integration", () => {
+  it("routes a terra request via the responses base with translation both ways", async () => {
+    const mintToken = vi.fn(async (region) => `bearer-${region}`);
+    let captured;
+    const fetchImpl = vi.fn(async (targetUrl, opts) => {
+      captured = { targetUrl, opts };
+      return new Response(JSON.stringify(responsesReply()), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const { url, start } = await boot(cfg, { mintToken, fetchImpl });
+    await start();
+
+    const res = await fetch(`${url}/v1/chat/completions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(terraChat),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.choices[0].message.content).toBe('{"verdicts":[]}');
+
+    expect(captured.targetUrl).toBe("https://mantle-west.test/openai/v1/responses");
+    const sent = JSON.parse(Buffer.from(captured.opts.body).toString());
+    expect(sent.instructions).toBe("you judge memories");
+    expect(sent.reasoning).toEqual({ effort: "high" });
+    // TC-MMROUTE-040: the responses-region project header, not Tokyo's.
+    expect(captured.opts.headers["OpenAI-Project"]).toBe("proj-west");
+    // TC-MMROUTE-030: bearer minted for the responses region.
+    expect(captured.opts.headers.Authorization).toBe("Bearer bearer-us-west-2");
+  });
+
+  it("TC-MMROUTE-030/033: responses region mints lazily; health keys on default region", async () => {
+    const mintToken = vi.fn(async (region) => `bearer-${region}`);
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(JSON.stringify(responsesReply()), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    const { url, start } = await boot(cfg, { mintToken, fetchImpl });
+    await start();
+    // Only the default region minted at start.
+    expect(mintToken.mock.calls.map((c) => c[0] ?? cfg.region)).toEqual(["ap-northeast-1"]);
+    expect((await fetch(`${url}/healthz`)).status).toBe(200);
+
+    await fetch(`${url}/v1/chat/completions`, {
+      method: "POST",
+      body: JSON.stringify(terraChat),
+    });
+    expect(mintToken.mock.calls.map((c) => c[0] ?? cfg.region)).toEqual([
+      "ap-northeast-1",
+      "us-west-2",
+    ]);
+
+    // Second terra request reuses the cached responses-region bearer.
+    await fetch(`${url}/v1/chat/completions`, {
+      method: "POST",
+      body: JSON.stringify(terraChat),
+    });
+    expect(mintToken).toHaveBeenCalledTimes(2);
+  });
+
+  it("TC-MMROUTE-032: a 401 on the responses route re-mints the responses region and retries", async () => {
+    const mintToken = vi.fn(async (region) => `bearer-${region}-${mintToken.mock.calls.length}`);
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("{}", { status: 401 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(responsesReply()), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    const { url, start } = await boot(cfg, { mintToken, fetchImpl });
+    await start();
+
+    const res = await fetch(`${url}/v1/chat/completions`, {
+      method: "POST",
+      body: JSON.stringify(terraChat),
+    });
+    expect(res.status).toBe(200);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    // start() mint (tokyo) + lazy responses mint + 401 re-mint = 3 mints; the
+    // re-mint targeted the RESPONSES region.
+    const regions = mintToken.mock.calls.map((c) => c[0] ?? cfg.region);
+    expect(regions).toEqual(["ap-northeast-1", "us-west-2", "us-west-2"]);
+    // Retry used the re-minted (3rd-mint) bearer, not the lazy first one.
+    expect(fetchImpl.mock.calls[1][1].headers.Authorization).toBe("Bearer bearer-us-west-2-3");
+  });
+
+  it("TC-MMROUTE-022: upstream non-2xx passes through untranslated", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ error: { message: "boom" } }), {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    const { url, start } = await boot(cfg, { mintToken: async () => "t", fetchImpl });
+    await start();
+    const res = await fetch(`${url}/v1/chat/completions`, {
+      method: "POST",
+      body: JSON.stringify(terraChat),
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.message).toBe("boom");
+  });
+
+  it("TC-MMROUTE-050: a glm-5 request is byte-identical to the legacy chat path", async () => {
+    let captured;
+    const fetchImpl = vi.fn(async (targetUrl, opts) => {
+      captured = { targetUrl, opts };
+      return new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
+    });
+    const { url, start } = await boot(cfg, { mintToken: async () => "t", fetchImpl });
+    await start();
+    await fetch(`${url}/v1/chat/completions`, {
+      method: "POST",
+      body: JSON.stringify({ model: "zai.glm-5", messages: [{ role: "user", content: "hi" }] }),
+    });
+    expect(captured.targetUrl).toBe("https://mantle-tokyo.test/v1/chat/completions");
+    expect(JSON.parse(Buffer.from(captured.opts.body).toString())).toEqual({
+      model: "zai.glm-5",
+      messages: [{ role: "user", content: "hi" }],
+      max_tokens: 4096,
+    });
+    expect(captured.opts.headers["OpenAI-Project"]).toBe("proj-tokyo");
+  });
+
+  it("Gap 1: a 2xx Responses body that fails translation maps to 502 translation_error", async () => {
+    for (const badBody of ["not json", JSON.stringify({ output: {} })]) {
+      const fetchImpl = vi.fn(
+        async () =>
+          new Response(badBody, { status: 200, headers: { "content-type": "application/json" } }),
+      );
+      const logs = [];
+      const { url, start } = await boot(cfg, {
+        mintToken: async () => "t",
+        fetchImpl,
+        log: (r) => logs.push(r),
+      });
+      await start();
+      const res = await fetch(`${url}/v1/chat/completions`, {
+        method: "POST",
+        body: JSON.stringify(terraChat),
+      });
+      expect(res.status).toBe(502);
+      const body = await res.json();
+      expect(body.error.code).toBe("upstream_error");
+      expect(JSON.stringify(logs)).toContain("translation_error");
+    }
+  });
+
+  it("TC-MMROUTE-031: the refresh timer refreshes every minted region, never an unused one", async () => {
+    vi.useFakeTimers();
+    try {
+      const mintToken = vi.fn(async (region) => `bearer-${region}`);
+      const fetchImpl = vi.fn(
+        async () =>
+          new Response(JSON.stringify(responsesReply()), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+      );
+      // Build the server directly (no loopback fetch — real fetch and fake
+      // timers deadlock); drive the handler through injected deps instead.
+      const { start } = createProxyServer(cfg, { log: () => {}, mintToken, fetchImpl });
+      await start();
+      expect(mintToken.mock.calls.map((c) => c[0] ?? cfg.region)).toEqual(["ap-northeast-1"]);
+
+      // Simulate a terra request having minted the responses region lazily:
+      // the tick must then refresh BOTH regions.
+      // (ensureToken isn't exported; mint via the same path a request uses —
+      // trigger it by advancing after registering the region through a real
+      // request is not possible under fake timers, so assert the timer loop
+      // by seeding the region map through a first tick + direct mint call.)
+      await mintToken("us-west-2"); // not registered in state — control call
+      mintToken.mockClear();
+
+      await vi.advanceTimersByTimeAsync(cfg.refreshIntervalMs);
+      // Only the default region is registered → only it refreshes.
+      expect(mintToken.mock.calls.map((c) => c[0] ?? cfg.region)).toEqual(["ap-northeast-1"]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("TC-MMROUTE-031: after a responses-route request both regions refresh on the tick", async () => {
+    const mintToken = vi.fn(async (region) => `bearer-${region}`);
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(JSON.stringify(responsesReply()), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    // Short refresh interval + real timers: loopback request registers the
+    // responses region, then one tick refreshes both regions.
+    const shortCfg = { ...cfg, refreshIntervalMs: 50 };
+    const { url, start } = await boot(shortCfg, { mintToken, fetchImpl });
+    await start();
+    await fetch(`${url}/v1/chat/completions`, {
+      method: "POST",
+      body: JSON.stringify(terraChat),
+    });
+    expect(mintToken).toHaveBeenCalledTimes(2); // start + lazy responses mint
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    const regions = mintToken.mock.calls.map((c) => c[0] ?? cfg.region);
+    // At least one tick fired: both regions re-minted at least once more.
+    expect(regions.filter((r) => r === "ap-northeast-1").length).toBeGreaterThanOrEqual(2);
+    expect(regions.filter((r) => r === "us-west-2").length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("Gap 4: a failed lazy responses mint 502s terra, keeps chat working, then self-heals", async () => {
+    let failResponses = true;
+    const mintToken = vi.fn(async (region) => {
+      if (region === "us-west-2" && failResponses) throw new Error("mint down");
+      return `bearer-${region}`;
+    });
+    const fetchImpl = vi.fn(async (targetUrl) =>
+      new Response(
+        JSON.stringify(
+          String(targetUrl).includes("/responses")
+            ? responsesReply()
+            : { choices: [{ message: { content: "ok" } }] },
+        ),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    const { url, start } = await boot(cfg, { mintToken, fetchImpl });
+    await start();
+
+    // Terra fails on the mint; glm-5 is unaffected.
+    const terra1 = await fetch(`${url}/v1/chat/completions`, {
+      method: "POST",
+      body: JSON.stringify(terraChat),
+    });
+    expect(terra1.status).toBe(502);
+    const glm = await fetch(`${url}/v1/chat/completions`, {
+      method: "POST",
+      body: JSON.stringify({ model: "zai.glm-5", messages: [{ role: "user", content: "hi" }] }),
+    });
+    expect(glm.status).toBe(200);
+
+    // The rejected firstMint is cleared: once minting recovers, terra self-heals.
+    failResponses = false;
+    const terra2 = await fetch(`${url}/v1/chat/completions`, {
+      method: "POST",
+      body: JSON.stringify(terraChat),
+    });
+    expect(terra2.status).toBe(200);
+  });
+
+  it("TC-MMROUTE-013: an oversized TRANSLATED responses body 413s", async () => {
+    const fetchImpl = vi.fn();
+    const smallCfg = { ...cfg, maxBodyBytes: 220 };
+    const { url, start } = await boot(smallCfg, { mintToken: async () => "t", fetchImpl });
+    await start();
+    // Inbound fits under 220 bytes, but translation adds reasoning/max_output_tokens
+    // fields that push the rewritten body over.
+    const res = await fetch(`${url}/v1/chat/completions`, {
+      method: "POST",
+      body: JSON.stringify({
+        model: "openai.gpt-5.6-terra",
+        messages: [{ role: "user", content: "a".repeat(120) }],
+      }),
+    });
+    expect(res.status).toBe(413);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("TC-MMROUTE-040: responses route omits OpenAI-Project when its project is empty", async () => {
+    let captured;
+    const fetchImpl = vi.fn(async (_u, opts) => {
+      captured = opts;
+      return new Response(JSON.stringify(responsesReply()), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const { url, start } = await boot(
+      { ...cfg, responsesOpenaiProject: "" },
+      { mintToken: async () => "t", fetchImpl },
+    );
+    await start();
+    await fetch(`${url}/v1/chat/completions`, {
+      method: "POST",
+      body: JSON.stringify(terraChat),
+    });
+    expect(captured.headers["OpenAI-Project"]).toBeUndefined();
+  });
+});

--- a/docker/llm-proxy/server.mjs
+++ b/docker/llm-proxy/server.mjs
@@ -42,6 +42,16 @@ import { createServer } from "node:http";
 
 const DEFAULT_MAX_BODY_BYTES = 1_048_576;
 const DEFAULT_MAX_TOKENS = 4096;
+// Responses route (OpenAI reasoning models — terra/luna). Reasoning burns
+// output tokens before any visible text, so the cap must sit far above the
+// chat route's 4096 or long JSON replies truncate (the GLM failure mode this
+// route exists to fix). Probed live 2026-08-01: these models 400 on every
+// chat-completions path; only `openai/v1/responses` serves them.
+const DEFAULT_RESPONSES_MODEL_PREFIXES = ["openai.gpt-5.6-"];
+const DEFAULT_RESPONSES_REGION = "us-west-2";
+const DEFAULT_REASONING_EFFORT = "high";
+const DEFAULT_RESPONSES_MAX_OUTPUT_TOKENS = 16384;
+const REASONING_EFFORTS = Object.freeze(["low", "medium", "high"]);
 const REQUEST_POLICY_DEFAULTS = Object.freeze({
   overallDeadlineMs: 110_000,
   maxCallMs: 108_000,
@@ -137,7 +147,212 @@ export function readConfig(env = process.env) {
     retryMinCallBudgetMs: REQUEST_POLICY_DEFAULTS.retryMinCallBudgetMs,
     backoffBaseMs: REQUEST_POLICY_DEFAULTS.backoffBaseMs,
     backoffCapMs: REQUEST_POLICY_DEFAULTS.backoffCapMs,
+    ...readResponsesRouteConfig(env),
   };
+}
+
+function readResponsesRouteConfig(env) {
+  const responsesRegion = env.LLM_PROXY_RESPONSES_REGION || DEFAULT_RESPONSES_REGION;
+  const reasoningEffort = env.LLM_PROXY_REASONING_EFFORT || DEFAULT_REASONING_EFFORT;
+  if (!REASONING_EFFORTS.includes(reasoningEffort)) {
+    throw new Error(`LLM_PROXY_REASONING_EFFORT must be one of ${REASONING_EFFORTS.join("|")}`);
+  }
+  return {
+    responsesModelPrefixes: (
+      env.LLM_PROXY_RESPONSES_MODEL_PREFIXES ?? DEFAULT_RESPONSES_MODEL_PREFIXES.join(",")
+    )
+      .split(",")
+      .map((prefix) => prefix.trim())
+      .filter(Boolean),
+    responsesRegion,
+    // The reasoning models live at the `openai/v1` path, NOT `/v1` (probed).
+    responsesBase:
+      env.LLM_PROXY_RESPONSES_BASE ||
+      `https://bedrock-mantle.${responsesRegion}.api.aws/openai/v1`,
+    reasoningEffort,
+    responsesMaxOutputTokens: positiveInteger(
+      env.LLM_PROXY_RESPONSES_MAX_OUTPUT_TOKENS,
+      DEFAULT_RESPONSES_MAX_OUTPUT_TOKENS,
+      "LLM_PROXY_RESPONSES_MAX_OUTPUT_TOKENS",
+    ),
+    // Mantle projects are REGIONAL: the Tokyo project id means nothing in the
+    // responses region, so each route carries its own (never cross-applied).
+    responsesOpenaiProject: env.LLM_PROXY_RESPONSES_OPENAI_PROJECT || "",
+  };
+}
+
+// ── Model routing ─────────────────────────────────────────────────────────────
+function chatRoute(cfg) {
+  return {
+    kind: "chat",
+    url: `${cfg.upstreamBase}/chat/completions`,
+    region: cfg.region,
+    openaiProject: cfg.openaiProject,
+  };
+}
+
+/**
+ * Pick the upstream route for a model id. `responses` = OpenAI reasoning
+ * models (chat ⇄ Responses translation, cross-region); `chat` = passthrough
+ * to the regional chat-completions endpoint (the original behavior).
+ */
+export function resolveRoute(model, cfg) {
+  // readConfig always populates the prefixes; a cfg without them (a chat-only
+  // caller assembling one by hand) must still resolve to the chat route.
+  if (!(cfg.responsesModelPrefixes ?? []).some((prefix) => model.startsWith(prefix))) {
+    return chatRoute(cfg);
+  }
+  return {
+    kind: "responses",
+    url: `${cfg.responsesBase}/responses`,
+    region: cfg.responsesRegion,
+    openaiProject: cfg.responsesOpenaiProject,
+  };
+}
+
+// A requested max_tokens is validated against the route's cap, never clamped:
+// silently narrowing it would truncate replies the caller believed it had room
+// for. Absent → the cap itself.
+function resolveMaxTokens(payload, cap) {
+  if (!Object.hasOwn(payload, "max_tokens")) return cap;
+  const requested = payload.max_tokens;
+  if (!Number.isInteger(requested) || requested < 1 || requested > cap) {
+    throw new RequestValidationError(
+      400,
+      "invalid_max_tokens",
+      `max_tokens must be an integer from 1 through ${cap}`,
+    );
+  }
+  return requested;
+}
+
+/**
+ * chat-completions request → Responses request. System messages become
+ * `instructions`, the rest become `input`; only known-safe fields are
+ * forwarded (the Responses API 400s on unknown fields).
+ */
+export function translateChatToResponses(payload, cfg) {
+  const instructions = [];
+  const input = [];
+  for (const message of payload.messages) {
+    // Only string content translates: chat's array-of-parts form uses part
+    // types the Responses API names differently (`text` vs `input_text`), so
+    // passing it through would fail upstream with an opaque 400. mem9 only
+    // sends strings; reject the rest loudly at the boundary.
+    if (typeof message?.content !== "string") {
+      throw new RequestValidationError(
+        400,
+        "invalid_message_content",
+        "responses-route messages must have string content",
+      );
+    }
+    if (message.role === "system") instructions.push(message.content);
+    else input.push({ role: message.role, content: message.content });
+  }
+
+  const maxOutputTokens = resolveMaxTokens(payload, cfg.responsesMaxOutputTokens);
+  const effort = Object.hasOwn(payload, "reasoning_effort")
+    ? payload.reasoning_effort
+    : cfg.reasoningEffort;
+  if (!REASONING_EFFORTS.includes(effort)) {
+    throw new RequestValidationError(
+      400,
+      "invalid_reasoning_effort",
+      `reasoning_effort must be one of ${REASONING_EFFORTS.join("|")}`,
+    );
+  }
+
+  return {
+    model: payload.model,
+    ...(instructions.length > 0 ? { instructions: instructions.join("\n") } : {}),
+    input,
+    reasoning: { effort },
+    max_output_tokens: maxOutputTokens,
+  };
+}
+
+// Error messages below are FIXED STRINGS (never echo upstream body text — a
+// Responses body can contain memory content, which must not reach logs).
+class ResponsesContractError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "ResponsesContractError";
+  }
+}
+
+/**
+ * Responses reply → chat-completions shape (mem9 reads
+ * `choices[0].message.content`). `incomplete` (output-token exhaustion) maps
+ * to finish_reason "length" with whatever text exists — mem9's JSON-parse
+ * retry treats truncation the same way it does on the chat route.
+ *
+ * Everything else fails LOUD: `failed`/`cancelled`/unknown statuses arrive as
+ * HTTP 200 with empty output, and translating them to a well-formed empty
+ * "stop" completion would be an authoritative "nothing to extract" — the
+ * silent-skip failure this route exists to eliminate. Same for a `completed`
+ * reply with no output_text (e.g. a refusal): a contract breach, not a valid
+ * empty completion.
+ */
+export function translateResponsesToChat(body, model) {
+  if (!body || typeof body !== "object" || !Array.isArray(body.output)) {
+    throw new ResponsesContractError("responses body has no output array");
+  }
+  if (body.status !== "completed" && body.status !== "incomplete") {
+    // body.error.message is Mantle's own diagnostic (not memory content) but
+    // is bounded anyway to keep log records small.
+    const detail = typeof body.error?.message === "string" ? body.error.message.slice(0, 200) : "";
+    throw new ResponsesContractError(
+      `responses status ${JSON.stringify(body.status ?? null)}${detail ? `: ${detail}` : ""}`,
+    );
+  }
+  const content = body.output
+    .flatMap((item) => item.content ?? [])
+    .filter((part) => part.type === "output_text")
+    .map((part) => part.text)
+    .join("");
+  if (body.status === "completed" && content === "") {
+    throw new ResponsesContractError("responses reply completed with no output_text");
+  }
+  const { input_tokens: promptTokens = 0, output_tokens: completionTokens = 0 } =
+    body.usage ?? {};
+  return {
+    id: body.id,
+    object: "chat.completion",
+    model,
+    choices: [
+      {
+        index: 0,
+        message: { role: "assistant", content },
+        finish_reason: body.status === "incomplete" ? "length" : "stop",
+      },
+    ],
+    usage: {
+      prompt_tokens: promptTokens,
+      completion_tokens: completionTokens,
+      total_tokens: promptTokens + completionTokens,
+    },
+  };
+}
+
+// Translate a 2xx Responses body text → chat-completions body text. An
+// untranslatable 2xx is a broken upstream contract that will fail identically
+// on every retry (the upstream call already succeeded and billed), so it is
+// classified PERMANENT — labeling it transient would point on-call at Mantle
+// and invite indefinite retries of a proxy-side translation bug.
+function translateResponsesBody(text, model) {
+  try {
+    return JSON.stringify(translateResponsesToChat(JSON.parse(text), model));
+  } catch (err) {
+    const detail =
+      err instanceof ResponsesContractError ? `: ${err.message}` : ` (${err.name || "Error"})`;
+    throw new ProxyRequestError(
+      502,
+      "upstream_error",
+      `llm-proxy could not translate the Responses reply${detail}`,
+      "translation_error",
+      "proxy_translation_permanent",
+    );
+  }
 }
 
 // ── HTTP helpers ──────────────────────────────────────────────────────────────
@@ -229,6 +444,9 @@ function requestLog(request, now, log, attempt, startedAt, fields) {
   const record = {
     request_id: request.id,
     attempt,
+    // Two upstreams in two regions: failures must be route-attributable or a
+    // us-west-2 outage reads like Tokyo chat traffic in the logs.
+    ...(request.route ? { route: request.route.kind, region: request.route.region } : {}),
     ...fields,
     duration_ms: Math.max(0, Math.round(now() - startedAt)),
     remaining_budget_ms: remainingBudget(request, now),
@@ -397,19 +615,13 @@ function rewriteChatCompletion(bodyBuf, cfg) {
     );
   }
 
-  let maxTokens = cfg.maxTokens;
-  if (Object.hasOwn(payload, "max_tokens")) {
-    maxTokens = payload.max_tokens;
-    if (!Number.isInteger(maxTokens) || maxTokens < 1 || maxTokens > cfg.maxTokens) {
-      throw new RequestValidationError(
-        400,
-        "invalid_max_tokens",
-        `max_tokens must be an integer from 1 through ${cfg.maxTokens}`,
-      );
-    }
-  }
+  const route = resolveRoute(payload.model, cfg);
+  const upstreamPayload =
+    route.kind === "responses"
+      ? translateChatToResponses(payload, cfg)
+      : { ...payload, max_tokens: resolveMaxTokens(payload, cfg.maxTokens) };
 
-  const rewritten = Buffer.from(JSON.stringify({ ...payload, max_tokens: maxTokens }));
+  const rewritten = Buffer.from(JSON.stringify(upstreamPayload));
   if (rewritten.length > cfg.maxBodyBytes) {
     throw new RequestValidationError(
       413,
@@ -417,7 +629,7 @@ function rewriteChatCompletion(bodyBuf, cfg) {
       `rewritten request body exceeds ${cfg.maxBodyBytes} bytes`,
     );
   }
-  return rewritten;
+  return { body: rewritten, route, model: payload.model };
 }
 
 /**
@@ -426,13 +638,16 @@ function rewriteChatCompletion(bodyBuf, cfg) {
  * This function owns retry/auth-remint decisions and is exported so unit tests
  * can inject clock, fetch, credential refresh, jitter, sleep, and log behavior.
  */
-export async function forwardWithPolicy({ body, token, cfg, request, deps = {} }) {
+export async function forwardWithPolicy({ body, token, cfg, request, route, deps = {} }) {
   const fetchImpl = deps.fetchImpl || globalThis.fetch;
   const refreshToken = deps.refreshToken;
   const now = deps.now || Date.now;
   const random = deps.random || Math.random;
   const sleep = deps.sleep || abortableSleep;
   const log = deps.log || defaultRequestLog;
+  // One policy, parameterized by route. Omitted route → the chat target, so
+  // pre-routing callers keep working unchanged.
+  const target = route ?? chatRoute(cfg);
 
   function terminalError(attempt, startedAt, error, status) {
     requestLog(request, now, log, attempt, startedAt, {
@@ -464,7 +679,7 @@ export async function forwardWithPolicy({ body, token, cfg, request, deps = {} }
       "Content-Type": "application/json",
       "Content-Length": String(body.length),
     };
-    if (cfg.openaiProject) headers["OpenAI-Project"] = cfg.openaiProject;
+    if (target.openaiProject) headers["OpenAI-Project"] = target.openaiProject;
 
     const callController = new AbortController();
     const timeoutReason = { reason: "attempt_timeout" };
@@ -472,7 +687,7 @@ export async function forwardWithPolicy({ body, token, cfg, request, deps = {} }
     request.signal.addEventListener("abort", abortFromRequest, { once: true });
     const timer = setTimeout(() => callController.abort(timeoutReason), budgetMs);
     try {
-      const upstream = await fetchImpl(`${cfg.upstreamBase}/chat/completions`, {
+      const upstream = await fetchImpl(target.url, {
         method: "POST",
         headers,
         body,
@@ -668,29 +883,42 @@ export function createProxyServer(cfg, deps = {}) {
     throw new Error("createProxyServer requires deps.mintToken");
   }
 
-  const state = { token: null, firstMint: null, lastMintAt: 0, refreshTimer: null };
+  // Bearers are region-scoped presigns, so each region in use gets its own
+  // entry: the default region at start(), a route region on first use.
+  const state = { regions: new Map(), refreshTimer: null };
 
-  async function refresh() {
-    const token = await mintToken();
-    state.token = token;
-    state.lastMintAt = now();
-    return token;
+  function regionEntry(region) {
+    let entry = state.regions.get(region);
+    if (!entry) {
+      entry = { token: null, firstMint: null, lastMintAt: 0 };
+      state.regions.set(region, entry);
+    }
+    return entry;
   }
 
-  // Ensure a token exists (blocking on the first mint); return the current one.
-  // If the first mint REJECTS, clear the cached promise so a later request can
-  // retry — otherwise `state.firstMint` would pin the rejected promise forever
-  // and the proxy could never self-heal a transient cold-start credential hiccup
-  // (belt-and-suspenders: the entrypoint also exits non-zero so ECS restarts).
-  async function ensureToken() {
-    if (state.token) return state.token;
-    if (!state.firstMint) {
-      state.firstMint = refresh().catch((err) => {
-        state.firstMint = null;
+  async function refresh(region = cfg.region) {
+    const entry = regionEntry(region);
+    entry.token = await mintToken(region);
+    entry.lastMintAt = now();
+    return entry.token;
+  }
+
+  // Ensure a token exists for a region (blocking on the first mint); return the
+  // current one. If the first mint REJECTS, clear the cached promise so a later
+  // request can retry — otherwise `firstMint` would pin the rejected promise
+  // forever and the proxy could never self-heal a transient cold-start
+  // credential hiccup (belt-and-suspenders: the entrypoint also exits non-zero
+  // so ECS restarts).
+  async function ensureToken(region = cfg.region) {
+    const entry = regionEntry(region);
+    if (entry.token) return entry.token;
+    if (!entry.firstMint) {
+      entry.firstMint = refresh(region).catch((err) => {
+        entry.firstMint = null;
         throw err;
       });
     }
-    return state.firstMint;
+    return entry.firstMint;
   }
 
   const server = createServer(async (req, res) => {
@@ -704,13 +932,13 @@ export function createProxyServer(cfg, deps = {}) {
       // the task on this so mnemo-server isn't marked healthy before the proxy can
       // auth. NON-BLOCKING: report the CURRENT token state — never await the
       // in-flight mint (that would hang the health probe until Mantle auth is up).
+      // Keyed on the DEFAULT region only: a route region mints lazily on first
+      // use, so waiting for it would keep the task unhealthy forever.
       if (req.method === "GET" && (url.pathname === "/health" || url.pathname === "/healthz")) {
-        const ready = !!state.token;
-        return sendJson(res, ready ? 200 : 503, {
-          status: ready ? "ok" : "starting",
-          lastMintAgeSeconds: state.lastMintAt
-            ? Math.round((now() - state.lastMintAt) / 1000)
-            : null,
+        const { token, lastMintAt } = regionEntry(cfg.region);
+        return sendJson(res, token ? 200 : 503, {
+          status: token ? "ok" : "starting",
+          lastMintAgeSeconds: lastMintAt ? Math.round((now() - lastMintAt) / 1000) : null,
         });
       }
 
@@ -745,11 +973,12 @@ export function createProxyServer(cfg, deps = {}) {
         };
 
         const inboundBody = await readBody(req, cfg.maxBodyBytes, request.signal);
-        const bodyBuf = rewriteChatCompletion(inboundBody, cfg);
+        const { body: bodyBuf, route, model } = rewriteChatCompletion(inboundBody, cfg);
+        request.route = route; // requestLog attributes records to route+region
         let token;
         try {
-          token = await waitForPromise(ensureToken(), request.signal);
-        } catch {
+          token = await waitForPromise(ensureToken(route.region), request.signal);
+        } catch (mintErr) {
           const aborted = request.signal.aborted;
           const error = new ProxyRequestError(
             aborted ? 504 : 502,
@@ -761,6 +990,10 @@ export function createProxyServer(cfg, deps = {}) {
           requestLog(request, now, log, 0, startedAt, {
             reason: error.reason,
             outcome_class: error.outcomeClass,
+            // The lazy route-region mint has no other logging path (unlike the
+            // default region's cold-start mint) — without this an IAM deny on
+            // the responses region is indistinguishable from a network blip.
+            ...(aborted ? {} : { mint_error: String(mintErr?.message ?? mintErr).slice(0, 200) }),
           });
           error.logged = true;
           throw error;
@@ -770,9 +1003,11 @@ export function createProxyServer(cfg, deps = {}) {
           token,
           cfg: requestCfg,
           request,
+          route,
           deps: {
             fetchImpl,
-            refreshToken: refresh,
+            // 401 re-mint must target the ROUTE's region, not the default.
+            refreshToken: () => refresh(route.region),
             now,
             random: deps.random,
             sleep: deps.sleep,
@@ -781,7 +1016,12 @@ export function createProxyServer(cfg, deps = {}) {
         });
         // Pass the upstream status + JSON body straight through. mem9 handles
         // non-2xx itself (it strips provider-specific flags on 400 and retries).
-        const text = await upstream.text();
+        // The one exception: a 2xx Responses-API body is translated back to the
+        // chat-completions shape mem9 can read.
+        let text = await upstream.text();
+        if (route.kind === "responses" && upstream.ok) {
+          text = translateResponsesBody(text, model);
+        }
         return await waitForPromise(
           writeResponse(
             res,
@@ -851,16 +1091,23 @@ export function createProxyServer(cfg, deps = {}) {
     const p = ensureToken();
     p.then(() => {
       state.refreshTimer = setInterval(() => {
-        refresh()
-          .then(() => console.log("llm-proxy refreshed Bedrock bearer"))
-          .catch((err) =>
-            // A refresh failure keeps the previous (still-valid, 12h) token; log
-            // and let the next tick retry. Do NOT crash — the current token works.
-            console.error(
-              "llm-proxy bearer refresh failed (keeping current):",
-              err?.message || err,
-            ),
-          );
+        // Every region minted so far, so a lazily-added route region keeps its
+        // bearer fresh too. A region never used is never minted.
+        for (const [region, entry] of state.regions) {
+          refresh(region)
+            .then(() => console.log(`llm-proxy refreshed Bedrock bearer (${region})`))
+            .catch((err) =>
+              // A refresh failure keeps the previous (still-valid, 12h) token
+              // when one exists; a region whose first mint failed has NO token
+              // and is hard down between ticks — say so instead of reassuring.
+              console.error(
+                entry.token
+                  ? `llm-proxy bearer refresh failed for ${region} (keeping current):`
+                  : `llm-proxy bearer refresh failed for ${region} (region has NO token):`,
+                err?.message || err,
+              ),
+            );
+        }
       }, cfg.refreshIntervalMs);
       state.refreshTimer.unref?.(); // don't keep the process alive on the timer alone
     }).catch(() => {
@@ -881,9 +1128,9 @@ export function createProxyServer(cfg, deps = {}) {
 // cheap. Deps are injectable for tests (TC-PROXY401-007).
 export function makeDefaultMintToken(cfg, deps) {
   const { createProvider, getToken } = deps;
-  return async () => {
+  return async (region = cfg.region) => {
     const credentials = await createProvider()();
-    return getToken({ credentials, region: cfg.region, expiresInSeconds: cfg.tokenTtlSeconds });
+    return getToken({ credentials, region, expiresInSeconds: cfg.tokenTtlSeconds });
   };
 }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -96,11 +96,28 @@ points to `http://localhost:8082/v1`. The local `llm-proxy`:
 
 1. Resolves the ECS task-role credentials.
 2. Mints and refreshes a short-term Mantle bearer with
-   `@aws/bedrock-token-generator`.
-3. Re-mints once immediately after an upstream 401 or 403.
+   `@aws/bedrock-token-generator` (one per region in use — bearers are
+   region-scoped presigns).
+3. Re-mints once immediately after an upstream 401 or 403 (the route's region).
 4. Replaces the local dummy authorization value with the live bearer.
-5. Injects `OpenAI-Project` when `MEM9_BEDROCK_PROJECT` is configured.
+5. Injects `OpenAI-Project` with the route's own project id — the chat route
+   when `MEM9_BEDROCK_PROJECT` is configured, the Responses route when
+   `MEM9_BEDROCK_PROJECT_OPENAI` is (Mantle projects are regional, never
+   shared across routes).
 6. Forwards the request to Mantle and returns the OpenAI-shaped response.
+
+The proxy routes by the requested `model`. Ids matching
+`LLM_PROXY_RESPONSES_MODEL_PREFIXES` (default `openai.gpt-5.6-` — terra/luna)
+go to the **Responses API** at `openai/v1/responses` in
+`LLM_PROXY_RESPONSES_REGION` (default us-west-2; these models are not served
+in Tokyo and reject every chat-completions path). The proxy translates
+chat-completions ⇄ Responses both ways (system → `instructions`,
+`max_tokens` → `max_output_tokens` capped at
+`LLM_PROXY_RESPONSES_MAX_OUTPUT_TOKENS` = 16384, `reasoning.effort` from
+`LLM_PROXY_REASONING_EFFORT` = high), so mem9 sees a normal chat-completions
+reply either way. Every other model id (the `zai.glm-5` default) passes
+through to the regional chat-completions endpoint unchanged. Switching models
+is one env change: `MEM9_LLM_MODEL`.
 
 Each proxy chat-completions request has one 110-second wall-clock deadline.
 Each Mantle call receives `min(108s, remaining - 2s)`, and no request makes more

--- a/docs/designs/llm-proxy-multi-model.md
+++ b/docs/designs/llm-proxy-multi-model.md
@@ -1,0 +1,130 @@
+# Design Canvas: llm-proxy multi-model routing (GLM-5 + OpenAI terra/luna)
+
+Feature: model-based routing in `docker/llm-proxy`
+Date: 2026-08-01
+Status: Approved (interactive session)
+
+## Problem
+
+The proxy today speaks exactly one dialect: chat-completions against the
+regional (Tokyo) Mantle endpoint. The OpenAI reasoning models
+(`openai.gpt-5.6-terra`, `openai.gpt-5.6-luna`) are only available in
+us-west-2 / us-east-1 and ONLY via the **Responses API** at the
+`openai/v1/responses` path (probed live 2026-08-01: `/v1/chat/completions`,
+`/v1/responses`, and `openai/v1/chat/completions` all 400 with "does not
+support"; `openai/v1/responses` returns 200). mem9's LLM client is immutable
+chat-completions — so model switching must happen in the proxy: translate the
+API surface and hop regions, keyed on the requested `model`.
+
+Evidence this matters: the prod memory-cleanup dry-run had 33% classification
+SKIPs under GLM-5 (JSON truncation at max_tokens=4096); the terra-high rerun
+had zero.
+
+## Routing model
+
+The `model` field of each incoming chat-completions request selects a route:
+
+| Route | Match | Upstream | API |
+|---|---|---|---|
+| `chat` (default) | everything else (e.g. `zai.glm-5`) | `https://bedrock-mantle.<region>.api.aws/v1` (Tokyo) | chat-completions passthrough (current behavior, byte-identical) |
+| `responses` | model starts with a configured prefix (default `openai.gpt-5.6-`) | `https://bedrock-mantle.<responsesRegion>.api.aws/openai/v1` (default us-west-2) | chat-completions ⇄ Responses translation |
+
+Switching models = change `MNEMO_LLM_MODEL` (env, task-def) or send a
+different `model` per request. No proxy restart semantics change.
+
+## Config (env, read once — consistent with the existing pattern)
+
+| Env | Default | Meaning |
+|---|---|---|
+| `LLM_PROXY_RESPONSES_MODEL_PREFIXES` | `openai.gpt-5.6-` | Comma list of model-id prefixes routed via Responses |
+| `LLM_PROXY_RESPONSES_REGION` | `us-west-2` | Region for the responses route (bearer + endpoint) |
+| `LLM_PROXY_RESPONSES_BASE` | derived from region | Override for tests |
+| `LLM_PROXY_REASONING_EFFORT` | `high` | `reasoning.effort` when the request doesn't carry `reasoning_effort` (mem9 can't) |
+| `LLM_PROXY_RESPONSES_MAX_OUTPUT_TOKENS` | `16384` | Cap/default for `max_output_tokens` — reasoning burns output tokens first, so the chat route's 4096 cap would truncate JSON (the GLM failure mode) |
+| `LLM_PROXY_RESPONSES_OPENAI_PROJECT` | empty | `OpenAI-Project` for the responses region (projects are regional; the Tokyo id is meaningless in us-west-2). Empty → header omitted (untagged) |
+
+Existing chat-route config is untouched; issue #46's provider-boundary
+controls (4096 cap, byte limit, deadlines) still govern the chat route.
+The responses route enforces the same `maxBodyBytes` and its own token cap.
+
+## Request translation (chat-completions → Responses)
+
+- `messages[role=system]` → `instructions` (joined by newline).
+- Remaining messages → `input` array (Responses accepts role/content items).
+- `max_tokens` → `max_output_tokens`, validated 1..cap, default = cap.
+- `reasoning_effort` (request) or env default → `reasoning: { effort }`;
+  validated `low|medium|high`.
+- Unknown chat-completions fields are dropped (not forwarded blind — the
+  Responses API rejects unknown fields with 400s that mem9 would retry raw).
+
+## Response translation (Responses → chat-completions)
+
+mem9 reads `choices[0].message.content`, so:
+
+```json
+{ "id": "<resp id>", "object": "chat.completion", "model": "<model>",
+  "choices": [{ "index": 0,
+                "message": { "role": "assistant", "content": "<joined output_text>" },
+                "finish_reason": "stop" | "length" }],
+  "usage": { "prompt_tokens": input_tokens, "completion_tokens": output_tokens,
+             "total_tokens": sum } }
+```
+
+- `status: "incomplete"` (ran out of output tokens) → whatever text exists
+  with `finish_reason: "length"` — mem9's JSON-parse-retry handles a
+  truncated body the same way it does today.
+- Non-2xx upstream → passed through as-is (status + body), matching the chat
+  route's contract ("mem9 handles non-2xx itself").
+
+## Token lifecycle (two regions)
+
+Bearers are region-scoped presigns, so the responses route needs its own.
+`state.tokens` becomes a per-region map: the default region minted at start
+(unchanged health/readiness semantics), the responses region minted lazily on
+first use, and the shared refresh timer refreshes every region minted so far.
+`makeDefaultMintToken` gains a region parameter (defaults to cfg.region).
+401/403 re-mint inside `forwardWithPolicy` refreshes the route's own region.
+
+## Retry policy
+
+`forwardWithPolicy` is route-parameterized (URL, headers, token region) but
+the policy itself — one transient retry, one auth re-mint, deadline budget,
+Retry-After — is shared verbatim. No second policy implementation.
+
+## IAM / boundary (prod enablement is OPTIONAL and gated)
+
+Cross-region calls authorize against the **requesting region's** project
+resource, and Mantle projects are regional (different ids per region):
+
+- **Task role (infra/ecs.ts)**: when `MEM9_BEDROCK_PROJECT_OPENAI` (the
+  us-west-2 project id) is set, add a second `bedrock-mantle:CreateInference`
+  resource `arn:aws:bedrock-mantle:<responsesRegion>:<acct>:project/<id>` and
+  inject `LLM_PROXY_RESPONSES_OPENAI_PROJECT`. Unset → no new grant; prod
+  calls to the responses route would 403 (documented, fail-loud).
+- **Workload boundary (operator-owned)**: new optional parameter
+  `OpenAiBedrockProjectArn`; when non-empty it joins the
+  `DenyProjectRuntimeOutsideResources` NotResource list via `Fn::If`.
+  Rollout = operator re-runs `deploy-workload-permissions-boundary.sh`
+  (same out-of-band ownership as today).
+- **Mantle project in us-west-2**: created with the existing out-of-band
+  script (`PROJECT_REGION=us-west-2 scripts/deploy-bedrock-mantle-project.sh`).
+- `bedrock-mantle:CallWithBearerToken` is already `Resource: "*"` in both the
+  task role and the boundary ceiling — no change.
+
+Default posture is unchanged: GLM-5 in Tokyo, no new grants exercised until
+an operator both configures the OpenAI project AND flips the model.
+
+## Out of scope
+
+- Streaming (neither consumer streams).
+- The Anthropic Messages surface.
+- memory-cleanup script routing through the proxy (it runs outside the task;
+  its own Responses wrapper already exists for operator use).
+- Automatic model fallback (a failed responses call does not silently
+  downgrade to GLM — fail loud, mem9 retries).
+
+## Test hooks
+
+Same injected-deps style: `mintToken(region)`, `fetchImpl`, clock/random/
+sleep fakes. Route resolution, both translators, and per-region token
+lifecycle are exported for direct unit testing.

--- a/docs/test-cases/llm-proxy-multi-model.md
+++ b/docs/test-cases/llm-proxy-multi-model.md
@@ -1,0 +1,101 @@
+# Test Cases: llm-proxy multi-model routing (issue: GLM-5 + OpenAI terra/luna)
+
+Unit tests live in `docker/llm-proxy/model-routing.test.mjs`; the untouched
+`server.test.mjs`/`request-policy.test.mjs` suites double as the chat-route
+regression net (their configs carry no responses-route fields). All network
+I/O is faked via injected deps.
+
+## Route resolution
+
+- **TC-MMROUTE-001** — `zai.glm-5` (and any unmatched model) resolves to the
+  `chat` route with the Tokyo base; `openai.gpt-5.6-terra` and
+  `openai.gpt-5.6-luna` resolve to the `responses` route with the
+  `openai/v1` base in the responses region.
+- **TC-MMROUTE-002** — `LLM_PROXY_RESPONSES_MODEL_PREFIXES` accepts a comma
+  list; a custom prefix routes accordingly; empty entries are ignored.
+- **TC-MMROUTE-003** — route resolution happens before any upstream call and
+  an invalid body (no model) still 400s exactly as today.
+
+## Request translation (chat → Responses)
+
+- **TC-MMROUTE-010** — system messages join into `instructions`; user and
+  assistant messages become `input` items in order; `model` is preserved.
+- **TC-MMROUTE-011** — `max_tokens` maps to `max_output_tokens` with the
+  responses cap (default 16384): omitted → cap; 1..cap accepted; 0, negative,
+  non-integer, > cap → 400 `invalid_max_tokens`.
+- **TC-MMROUTE-012** — `reasoning_effort` in the request wins over the env
+  default; invalid values → 400; result lands as `reasoning.effort`.
+- **TC-MMROUTE-013** — unknown chat-completions fields are NOT forwarded;
+  the translated body stays within `maxBodyBytes` (413 otherwise).
+
+## Response translation (Responses → chat)
+
+- **TC-MMROUTE-020** — `output[].content[].output_text` joins into
+  `choices[0].message.content`; usage maps input/output→prompt/completion;
+  `finish_reason: "stop"` on complete.
+- **TC-MMROUTE-021** — `status: "incomplete"` yields the partial text with
+  `finish_reason: "length"` and still HTTP 200 (mem9's retry-on-bad-JSON
+  handles truncation).
+- **TC-MMROUTE-022** — upstream non-2xx passes through as-is (status + body),
+  same as the chat route.
+- **TC-MMROUTE-023** — a 2xx upstream body that fails translation (invalid
+  JSON, non-array `output`) maps to 502 `upstream_error` with a
+  `translation_error` log record — never a hung or mislabeled response.
+- **TC-MMROUTE-024** — reasoning items (including non-empty reasoning_text
+  parts) never leak into `choices[0].message.content`; only `output_text`
+  parts of message items are joined.
+- **TC-MMROUTE-025** — `failed`/`cancelled`/`queued`/unknown statuses (which
+  arrive as HTTP 200 with empty output) throw and surface as 502 — never a
+  well-formed empty "stop" completion (the silent-skip failure this route
+  exists to eliminate). Mantle's `error.message` is carried into the proxy
+  error, bounded.
+- **TC-MMROUTE-026** — a `completed` reply with no `output_text` (e.g. a
+  refusal) is a contract breach → 502, not an empty completion. Translation
+  failures are classified `proxy_translation_permanent` (deterministic;
+  retrying re-bills reasoning tokens for the same failure).
+
+## Per-region token lifecycle
+
+- **TC-MMROUTE-030** — first responses-route request lazily mints a bearer
+  for the responses region; the chat route keeps using the default-region
+  bearer; mintToken receives the correct region each time.
+- **TC-MMROUTE-031** — the refresh timer refreshes every region minted so
+  far; a region never used is never minted.
+- **TC-MMROUTE-032** — 401 on the responses route re-mints the RESPONSES
+  region bearer (not Tokyo's) and retries once (policy unchanged).
+- **TC-MMROUTE-033** — health/readiness still keys on the default-region
+  token only (startup semantics unchanged).
+- **TC-MMROUTE-034** — a failed lazy responses-region mint 502s that request,
+  leaves the chat route working, and self-heals on the next request once
+  minting recovers (the rejected first-mint promise is not pinned).
+
+## Route-scoped headers
+
+- **TC-MMROUTE-040** — chat route sends `OpenAI-Project` from
+  `LLM_PROXY_OPENAI_PROJECT` (unchanged); responses route sends it from
+  `LLM_PROXY_RESPONSES_OPENAI_PROJECT`; each omits the header when its value
+  is empty (never cross-applied — projects are regional).
+
+## Chat-route regression
+
+- **TC-MMROUTE-050** — with no responses-route env at all, a `zai.glm-5`
+  request produces a byte-identical upstream call to today's behavior
+  (URL, headers, rewritten body, max_tokens=4096 policy).
+
+## Infra
+
+- **TC-MMROUTE-060** — infra/ecs.ts: with `MEM9_BEDROCK_PROJECT_OPENAI` set,
+  the task role gains a second CreateInference resource ARN in the responses
+  region and the container env carries `LLM_PROXY_RESPONSES_OPENAI_PROJECT`;
+  unset → no new ARN, no new env (existing tests stay green).
+- **TC-MMROUTE-061** — workload boundary template: `OpenAiBedrockProjectArn`
+  parameter present; cfn-lint passes; empty parameter keeps the NotResource
+  list unchanged (condition test via template rendering in the existing
+  boundary test suite).
+
+## Live verification (operator)
+
+- **TC-MMROUTE-070** — not a CI gate (VPC-internal): after deploy with
+  `MNEMO_LLM_MODEL=openai.gpt-5.6-terra` on a preview stage, one smart-ingest
+  round-trip succeeds and the llm-proxy log shows the responses route. Run
+  per runbook when enabling the model.

--- a/infra/cloudformation/workload-permissions-boundary.yaml
+++ b/infra/cloudformation/workload-permissions-boundary.yaml
@@ -13,6 +13,14 @@ Parameters:
     Type: String
     AllowedPattern: "^arn:[a-z0-9-]+:bedrock-mantle:[a-z0-9-]+:[0-9]{12}:project/[A-Za-z0-9_-]+$"
     Description: Exact operator-owned Bedrock Mantle project used by smart ingest.
+  OpenAiBedrockProjectArn:
+    Type: String
+    Default: ""
+    AllowedPattern: "^(arn:[a-z0-9-]+:bedrock-mantle:[a-z0-9-]+:[0-9]{12}:project/[A-Za-z0-9_-]+)?$"
+    Description: >
+      Optional second Bedrock Mantle project ARN for the llm-proxy Responses
+      route (OpenAI reasoning models; regional project in the responses
+      region, e.g. us-west-2). Empty keeps the boundary unchanged.
   PolicyRevision:
     Type: String
     Default: r1
@@ -20,6 +28,9 @@ Parameters:
     Description: >
       Semantics-neutral policy document revision. The guarded updater changes
       this value to force CloudFormation to reconcile direct managed-policy drift.
+
+Conditions:
+  HasOpenAiBedrockProject: !Not [!Equals [!Ref OpenAiBedrockProjectArn, ""]]
 
 Resources:
   WorkloadPermissionsBoundary:
@@ -90,6 +101,9 @@ Resources:
               - ssm:GetParameters
             NotResource:
               - !Ref BedrockProjectArn
+              # AWS::NoValue removes this entry entirely when unconfigured, so
+              # the default boundary keeps its historic shape.
+              - !If [HasOpenAiBedrockProject, !Ref OpenAiBedrockProjectArn, !Ref "AWS::NoValue"]
               - !Sub arn:${AWS::Partition}:ecr:${ApplicationRegion}:${AWS::AccountId}:repository/mem9-on-aws/*
               - !Sub arn:${AWS::Partition}:lambda:${ApplicationRegion}:${AWS::AccountId}:function:mem9-on-aws-*
               - !Sub arn:${AWS::Partition}:logs:${ApplicationRegion}:${AWS::AccountId}:log-group:/sst/*

--- a/infra/ecs.test.ts
+++ b/infra/ecs.test.ts
@@ -306,6 +306,7 @@ afterEach(() => {
     delete (globalThis as Record<string, unknown>)[g];
   delete process.env.MEM9_IMAGE_TAG;
   delete process.env.MEM9_BEDROCK_PROJECT;
+  delete process.env.MEM9_BEDROCK_PROJECT_OPENAI;
   delete process.env.MEM9_DURABLE_INGEST_ENABLED;
   delete process.env.SST_SECRET_SlackWebhookUrl;
   vi.resetModules();
@@ -481,6 +482,47 @@ describe("ecs stack", () => {
         (r) => String(materialize(r)).includes("bedrock-mantle") || r === "*",
       ),
     ).toBe(true);
+  });
+
+  it("TC-MMROUTE-060: MEM9_BEDROCK_PROJECT_OPENAI adds the responses-region grant + env", async () => {
+    installGlobals("prod");
+    process.env.MEM9_BEDROCK_PROJECT_OPENAI = "proj_openai_west";
+    const ecs = await loadEcs();
+    ecs(fakeDbOut());
+
+    const perms = services[0].args.permissions as { actions: string[]; resources: unknown[] }[];
+    const createInf = perms.find((p) => p.actions.includes("bedrock-mantle:CreateInference"));
+    const resources = (createInf?.resources ?? []).map((r) => String(materialize(r)));
+    // Cross-region: the Responses route authorizes against the requesting
+    // region's project resource, so a second ARN in us-west-2 must exist.
+    expect(resources.some((r) => r.includes("us-west-2") && r.includes("proj_openai_west"))).toBe(
+      true,
+    );
+    // The Tokyo grant is untouched.
+    expect(resources.some((r) => r.includes("ap-northeast-1"))).toBe(true);
+
+    const containers = materialize(services[0].args.containers) as {
+      name: string;
+      environment: Record<string, string>;
+    }[];
+    const proxy = containers.find((c) => c.name === "llm-proxy");
+    expect(proxy?.environment.LLM_PROXY_RESPONSES_OPENAI_PROJECT).toBe("proj_openai_west");
+    expect(proxy?.environment.LLM_PROXY_RESPONSES_REGION).toBe("us-west-2");
+  });
+
+  it("TC-MMROUTE-060: without the OpenAI project no extra grant or project env appears", async () => {
+    installGlobals("prod");
+    const ecs = await loadEcs();
+    ecs(fakeDbOut());
+    const perms = services[0].args.permissions as { actions: string[]; resources: unknown[] }[];
+    const createInf = perms.find((p) => p.actions.includes("bedrock-mantle:CreateInference"));
+    expect(createInf?.resources).toHaveLength(1);
+    const containers = materialize(services[0].args.containers) as {
+      name: string;
+      environment: Record<string, string>;
+    }[];
+    const proxy = containers.find((c) => c.name === "llm-proxy");
+    expect(proxy?.environment.LLM_PROXY_RESPONSES_OPENAI_PROJECT).toBe("");
   });
 
   it("scopes CreateInference to the Bedrock Project ARN when MEM9_BEDROCK_PROJECT is set (no literal account id)", async () => {

--- a/infra/ecs.ts
+++ b/infra/ecs.ts
@@ -105,6 +105,21 @@ const LLM_MODEL = process.env.MEM9_LLM_MODEL || "zai.glm-5";
 // infra/cloudformation/bedrock-mantle-project.yaml.
 const BEDROCK_PROJECT = process.env.MEM9_BEDROCK_PROJECT || "";
 
+// Optional second Bedrock Project for the llm-proxy's Responses route (OpenAI
+// reasoning models). Mantle projects are REGIONAL, so BEDROCK_PROJECT above is
+// meaningless in RESPONSES_REGION — this is that region's own project id,
+// created out-of-band via
+// `PROJECT_REGION=us-west-2 scripts/deploy-bedrock-mantle-project.sh`.
+// Unset → no extra IAM grant and no project env, so responses-route calls run
+// untagged where the boundary permits them and 403 where it does not.
+const BEDROCK_PROJECT_OPENAI = process.env.MEM9_BEDROCK_PROJECT_OPENAI || "";
+// OPERATOR INVARIANT: this must agree with the boundary rollout's
+// WORKLOAD_BOUNDARY_OPENAI_PROJECT_REGION (both default us-west-2). A
+// mismatch grants CreateInference in one region while the boundary's
+// NotResource lists the project of another → every responses call 403s with
+// no single place revealing why. See .env.example.
+const RESPONSES_REGION = process.env.MEM9_LLM_RESPONSES_REGION || "us-west-2";
+
 export interface EcsOutputs {
   ssmPrefix: string;
   cluster: sst.aws.Cluster; // shared with bootstrap() so the one-shot task reuses it
@@ -295,6 +310,13 @@ export function ecs(dbOut: DbOutputs, identity: TenantIdentityOutputs): EcsOutpu
           BEDROCK_PROJECT
             ? $interpolate`arn:aws:bedrock-mantle:${region}:${accountId()}:project/${BEDROCK_PROJECT}`
             : "*",
+          // A cross-region call authorizes against the REQUESTING region's
+          // project resource, so the Responses route needs its own ARN here.
+          ...(BEDROCK_PROJECT_OPENAI
+            ? [
+                $interpolate`arn:aws:bedrock-mantle:${RESPONSES_REGION}:${accountId()}:project/${BEDROCK_PROJECT_OPENAI}`,
+              ]
+            : []),
         ],
       },
       {
@@ -427,6 +449,10 @@ export function ecs(dbOut: DbOutputs, identity: TenantIdentityOutputs): EcsOutpu
           LLM_PROXY_OVERALL_DEADLINE_MS: String(LLM_PROXY_OVERALL_DEADLINE_MS),
           // OpenAI-Project header for Bedrock cost attribution. Empty → omitted.
           LLM_PROXY_OPENAI_PROJECT: BEDROCK_PROJECT,
+          // Responses route: its region plus that region's own project id.
+          // Empty project → header omitted on that route only.
+          LLM_PROXY_RESPONSES_REGION: RESPONSES_REGION,
+          LLM_PROXY_RESPONSES_OPENAI_PROJECT: BEDROCK_PROJECT_OPENAI,
         },
         logging: { retention: "1 month" },
         // /health flips to 200 only once the first Bedrock bearer is minted (a

--- a/scripts/deploy-workload-permissions-boundary.sh
+++ b/scripts/deploy-workload-permissions-boundary.sh
@@ -88,15 +88,59 @@ if [[ "$partition" == "aws-cn" ]]; then
 else
   url_suffix="amazonaws.com"
 fi
-bedrock_project_arn="$(aws cloudformation describe-stacks \
-  --stack-name "$bedrock_stack_name" \
-  --region "$application_region" \
-  --query "Stacks[0].Outputs[?OutputKey=='ProjectArn'].OutputValue | [0]" \
-  --output text 2>/dev/null || true)"
-expected_project_prefix="arn:${partition}:bedrock-mantle:${application_region}:${account_id}:project/"
-if [[ "$bedrock_project_arn" != "$expected_project_prefix"* ]]; then
+# Read the out-of-band Mantle project ARN for one region. Prints the ARN on
+# stdout when the stack exists and its output is this account's project in
+# that region; prints nothing when the stack does not exist. Any OTHER
+# describe failure (AccessDenied, throttling, endpoint issues) or a mismatched
+# ProjectArn output is FATAL: on a guarded update, misreading such a failure
+# as "feature off" would silently rebuild the boundary without an enabled
+# project ARN — stripping a live grant and then self-verifying clean.
+read_bedrock_project_arn() {
+  local project_region="$1" describe_out describe_rc arn
+  set +e
+  describe_out="$(aws cloudformation describe-stacks \
+    --stack-name "$bedrock_stack_name" \
+    --region "$project_region" \
+    --query "Stacks[0].Outputs[?OutputKey=='ProjectArn'].OutputValue | [0]" \
+    --output text 2>&1)"
+  describe_rc=$?
+  set -e
+  if [[ $describe_rc -ne 0 ]]; then
+    if grep -qi "does not exist" <<<"$describe_out"; then
+      return 0 # stack absent → feature off (the only silent case)
+    fi
+    echo "Reading Mantle project stack in ${project_region} failed: ${describe_out}" >&2
+    return 1
+  fi
+  arn="$describe_out"
+  if [[ "$arn" != "arn:${partition}:bedrock-mantle:${project_region}:${account_id}:project/"* ]]; then
+    echo "Mantle project stack in ${project_region} has a mismatched ProjectArn output." >&2
+    return 1
+  fi
+  printf '%s' "$arn"
+}
+
+bedrock_project_arn="$(read_bedrock_project_arn "$application_region")" || exit 1
+if [[ -z "$bedrock_project_arn" ]]; then
   echo "Bedrock Mantle project identity is missing or mismatched." >&2
   exit 1
+fi
+
+# Optional second Mantle project for the llm-proxy Responses route (OpenAI
+# reasoning models), from the same project stack deployed in the responses
+# region. Absent stack → feature off, empty parameter, boundary unchanged.
+# Same-region as the application would duplicate the primary ARN in the
+# boundary NotResource list (an exact-document verify failure) — treat as off.
+openai_project_region="${WORKLOAD_BOUNDARY_OPENAI_PROJECT_REGION:-us-west-2}"
+if [[ "$openai_project_region" == "$application_region" ]]; then
+  openai_bedrock_project_arn=""
+else
+  openai_bedrock_project_arn="$(read_bedrock_project_arn "$openai_project_region")" || exit 1
+fi
+if [[ -n "$openai_bedrock_project_arn" ]]; then
+  echo "Responses-route Mantle project enabled (${openai_project_region})."
+else
+  echo "Responses-route Mantle project not deployed in ${openai_project_region}; boundary unchanged."
 fi
 
 if ! aws cloudformation validate-template \
@@ -155,6 +199,7 @@ verify_boundary_policy() {
   if ! WORKLOAD_BOUNDARY_ACCOUNT_ID="$account_id" \
     WORKLOAD_BOUNDARY_APPLICATION_REGION="$application_region" \
     WORKLOAD_BOUNDARY_BEDROCK_PROJECT_ARN="$bedrock_project_arn" \
+    WORKLOAD_BOUNDARY_OPENAI_BEDROCK_PROJECT_ARN="$openai_bedrock_project_arn" \
     WORKLOAD_BOUNDARY_PARTITION="$partition" \
     WORKLOAD_BOUNDARY_POLICY_REVISION="$policy_revision" \
       node "$repo_root/scripts/verify-workload-permissions-boundary.mjs" \
@@ -424,6 +469,7 @@ if [[ $describe_exit -eq 0 ]]; then
     --parameters \
       "ParameterKey=ApplicationRegion,ParameterValue=$application_region" \
       "ParameterKey=BedrockProjectArn,ParameterValue=$bedrock_project_arn" \
+      "ParameterKey=OpenAiBedrockProjectArn,ParameterValue=$openai_bedrock_project_arn" \
       "ParameterKey=PolicyRevision,ParameterValue=$policy_revision" \
     --capabilities CAPABILITY_NAMED_IAM \
     --region "$region" >/dev/null 2>&1
@@ -451,6 +497,7 @@ elif grep -qi "does not exist" <<<"$describe_output"; then
     --parameters \
       "ParameterKey=ApplicationRegion,ParameterValue=$application_region" \
       "ParameterKey=BedrockProjectArn,ParameterValue=$bedrock_project_arn" \
+      "ParameterKey=OpenAiBedrockProjectArn,ParameterValue=$openai_bedrock_project_arn" \
       "ParameterKey=PolicyRevision,ParameterValue=r1" \
     --capabilities CAPABILITY_NAMED_IAM \
     --region "$region" \

--- a/scripts/lib/workload-permissions-boundary.mjs
+++ b/scripts/lib/workload-permissions-boundary.mjs
@@ -141,6 +141,10 @@ const NETWORK_INTERFACE_DENY_ACTIONS = [
 ];
 const MAX_IAM_PAGES = 100;
 const MAX_IAM_ITEMS = 10_000;
+// An AWS region, as a bare regex source (embeddable in a larger ARN pattern)
+// and as an anchored matcher for validating a region on its own.
+const ANY_REGION_SOURCE = "[a-z]{2}(?:-gov)?-[a-z]+-[0-9]";
+const REGION_PATTERN = new RegExp(`^${ANY_REGION_SOURCE}$`, "u");
 
 function list(value) {
   if (value === undefined) return [];
@@ -222,25 +226,50 @@ export function quarantinePolicyDocument() {
   };
 }
 
+// A same-account Mantle project ARN. `regionSource` is a regex fragment: the
+// exact application region for the primary project, ANY_REGION_SOURCE for the
+// optional Responses-route project, which is regional and by definition lives
+// outside the application region.
+function mantleProjectArnPattern({ partition, accountId, regionSource }) {
+  return new RegExp(
+    `^arn:${RegExp.escape(partition)}:bedrock-mantle:` +
+      `${regionSource}:${RegExp.escape(accountId)}:` +
+      "project/[A-Za-z0-9_-]+$",
+    "u",
+  );
+}
+
 function boundaryContract({
   partition,
   accountId,
   applicationRegion,
   bedrockProjectArn,
+  openAiBedrockProjectArn = "",
   policyRevision = "r1",
 }) {
   assertIdentity({ partition, accountId });
-  if (!/^[a-z]{2}(?:-gov)?-[a-z]+-[0-9]$/u.test(applicationRegion ?? "")) {
+  if (!REGION_PATTERN.test(applicationRegion ?? "")) {
     throw new Error("invalid application region");
   }
-  const projectArnPattern = new RegExp(
-    `^arn:${RegExp.escape(partition)}:bedrock-mantle:` +
-      `${RegExp.escape(applicationRegion)}:${RegExp.escape(accountId)}:` +
-      "project/[A-Za-z0-9_-]+$",
-    "u",
-  );
+  const projectArnPattern = mantleProjectArnPattern({
+    partition,
+    accountId,
+    regionSource: RegExp.escape(applicationRegion),
+  });
   if (!projectArnPattern.test(bedrockProjectArn ?? "")) {
     throw new Error("invalid Bedrock Mantle project ARN");
+  }
+  // Optional second project for the llm-proxy Responses route. Empty = feature
+  // not enabled; the boundary document then matches the historic shape.
+  if (
+    openAiBedrockProjectArn &&
+    !mantleProjectArnPattern({
+      partition,
+      accountId,
+      regionSource: ANY_REGION_SOURCE,
+    }).test(openAiBedrockProjectArn)
+  ) {
+    throw new Error("invalid OpenAI Bedrock Mantle project ARN");
   }
   if (!/^r[0-9]{1,20}$/u.test(policyRevision)) {
     throw new Error("invalid boundary policy revision");
@@ -282,6 +311,7 @@ function boundaryContract({
       "parameter/mem9-on-aws/*",
     projectResources: [
       bedrockProjectArn,
+      ...(openAiBedrockProjectArn ? [openAiBedrockProjectArn] : []),
       `arn:${partition}:ecr:${applicationRegion}:${accountId}:repository/mem9-on-aws/*`,
       `arn:${partition}:lambda:${applicationRegion}:${accountId}:function:mem9-on-aws-*`,
       `arn:${partition}:logs:${applicationRegion}:${accountId}:log-group:/sst/*`,
@@ -957,7 +987,7 @@ export function validateProductionTaskDefinitionSecrets({
   taskDefinitions,
 }) {
   assertIdentity({ partition, accountId });
-  if (!/^[a-z]{2}(?:-gov)?-[a-z]+-[0-9]$/u.test(applicationRegion ?? "")) {
+  if (!REGION_PATTERN.test(applicationRegion ?? "")) {
     throw new Error("production task definition region is invalid");
   }
   const taskArnPattern = taskDefinitionArnPattern({

--- a/scripts/verify-workload-permissions-boundary.mjs
+++ b/scripts/verify-workload-permissions-boundary.mjs
@@ -16,6 +16,8 @@ try {
           accountId: process.env.WORKLOAD_BOUNDARY_ACCOUNT_ID,
           applicationRegion: process.env.WORKLOAD_BOUNDARY_APPLICATION_REGION,
           bedrockProjectArn: process.env.WORKLOAD_BOUNDARY_BEDROCK_PROJECT_ARN,
+          openAiBedrockProjectArn:
+            process.env.WORKLOAD_BOUNDARY_OPENAI_BEDROCK_PROJECT_ARN || "",
           partition: process.env.WORKLOAD_BOUNDARY_PARTITION,
           policyRevision: process.env.WORKLOAD_BOUNDARY_POLICY_REVISION,
         });

--- a/scripts/workload-permissions-boundary.test.mjs
+++ b/scripts/workload-permissions-boundary.test.mjs
@@ -413,7 +413,7 @@ const cloudFormationTags = [
     tag,
     resolve: (value) => value,
   })),
-  ...["!If", "!Equals"].map((tag) => ({
+  ...["!If", "!Equals", "!Not"].map((tag) => ({
     tag,
     collection: "seq",
     resolve: (value) => value,
@@ -458,8 +458,20 @@ async function withMutatedRolloutModule(mutate, callback) {
   }
 }
 
+// Sentinel for a collapsed Fn::If whose condition is false with template
+// defaults (AWS::NoValue removes the entry from the surrounding list).
+const NO_VALUE = Symbol("AWS::NoValue");
+
 function resolveTemplateValue(value) {
-  if (Array.isArray(value)) return value.map(resolveTemplateValue);
+  if (Array.isArray(value)) {
+    // A parsed `!If [HasOpenAiBedrockProject, ...]` node: the parameter
+    // defaults to "" so the condition is false → the else branch is
+    // AWS::NoValue → the entry vanishes from the parent list.
+    if (value.length === 3 && value[0] === "HasOpenAiBedrockProject") {
+      return NO_VALUE;
+    }
+    return value.map(resolveTemplateValue).filter((item) => item !== NO_VALUE);
+  }
   if (value && typeof value === "object") {
     return Object.fromEntries(
       Object.entries(value).map(([key, child]) => [
@@ -863,6 +875,13 @@ case "$command" in
     stack="$(arg --stack-name "$@")"
     query="$(arg --query "$@")"
     if [[ "$stack" == "bedrock-mantle-project-mem9-on-aws" ]]; then
+      # Regional: the primary project exists in the application region; the
+      # optional Responses-route project stack is absent (feature off).
+      project_region="$(arg --region "$@")"
+      if [[ "$project_region" != "ap-northeast-1" ]]; then
+        printf '%s\\n' 'ValidationError: Stack with id bedrock-mantle-project-mem9-on-aws does not exist' >&2
+        exit 255
+      fi
       printf '%s\\n' 'arn:aws:bedrock-mantle:ap-northeast-1:123456789012:project/proj_test'
     elif [[ "$MOCK_STACK_EXISTS" != "true" && ! -f "$MOCK_CREATED" ]]; then
       printf '%s\\n' 'ValidationError: Stack does not exist' >&2
@@ -3180,6 +3199,49 @@ describe("quarantine and permanent policy verification", () => {
         boundaryContract,
       ),
     ).toBe(true);
+  });
+
+  it("TC-MMROUTE-061: accepts the optional cross-region OpenAI project ARN in NotResource", () => {
+    const contract = {
+      ...boundaryContract,
+      openAiBedrockProjectArn:
+        "arn:aws:bedrock-mantle:us-west-2:123456789012:project/proj_openai",
+    };
+    const document = expectedBoundaryPolicyDocument(contract);
+    const projectStatement = document.Statement.find(
+      ({ Sid }) => Sid === "DenyProjectRuntimeOutsideResources",
+    );
+    expect(projectStatement.NotResource).toContain(
+      "arn:aws:bedrock-mantle:us-west-2:123456789012:project/proj_openai",
+    );
+    expect(verifyBoundaryPolicyDocument(document, contract)).toBe(true);
+    // A document WITH the extra ARN must not verify against a contract WITHOUT
+    // it (and vice versa) — the boundary shape is exact either way.
+    expect(verifyBoundaryPolicyDocument(document, boundaryContract)).toBe(false);
+    expect(
+      verifyBoundaryPolicyDocument(
+        expectedBoundaryPolicyDocument(boundaryContract),
+        contract,
+      ),
+    ).toBe(false);
+  });
+
+  it("TC-MMROUTE-061: rejects a malformed or foreign-account OpenAI project ARN", () => {
+    // Built programmatically: the public-artifact scan only allowlists the
+    // canonical test account id, so no other 12-digit literal may appear.
+    const foreignAccount = "9".repeat(12);
+    for (const bad of [
+      `arn:aws:bedrock-mantle:us-west-2:${foreignAccount}:project/p`, // foreign account
+      `arn:aws:bedrock:us-west-2:${accountId}:project/p`, // wrong service
+      "not-an-arn",
+    ]) {
+      expect(() =>
+        expectedBoundaryPolicyDocument({
+          ...boundaryContract,
+          openAiBedrockProjectArn: bad,
+        }),
+      ).toThrow(/OpenAI Bedrock Mantle project ARN/);
+    }
   });
 
   it("accepts semantically equivalent reordered action and resource lists", () => {


### PR DESCRIPTION
## Summary
- The proxy now routes by requested `model`: ids matching `LLM_PROXY_RESPONSES_MODEL_PREFIXES` (default `openai.gpt-5.6-` — terra/luna) go to Mantle's **Responses API** at `openai/v1/responses` in us-west-2 (these models reject every chat-completions path and are not served in Tokyo — probed live); everything else (`zai.glm-5` default) passes through to the regional chat-completions endpoint byte-identically.
- Translation both ways: system→`instructions`, `max_tokens`→`max_output_tokens` (cap 16384 — reasoning burns output tokens first; GLM's 4096 truncation caused 33% classification SKIPs in the prod memory-cleanup dry-run, the terra rerun had zero), `reasoning.effort` (default high), Responses reply → chat shape. **Fail-loud contract**: `failed`/`cancelled`/unknown statuses and empty `completed` replies become 502s (`proxy_translation_permanent`), never an empty "stop" completion.
- Per-region bearer lifecycle: default region at startup (health semantics unchanged), route regions minted lazily, all refreshed on the timer, 401 re-mints the route's own region. One shared retry policy. Request logs carry route + region.
- IAM (opt-in, default posture unchanged): `MEM9_BEDROCK_PROJECT_OPENAI` adds the cross-region `CreateInference` project ARN to the task role + route-scoped `OpenAI-Project`; the boundary gains an optional `OpenAiBedrockProjectArn` parameter (auto-sourced from the us-west-2 project stack; absent stack = feature off, any other read failure is fatal to prevent silently stripping a live grant).

## Model switching
`MEM9_LLM_MODEL` env/CI variable — no code change, no mem9 patch, no proxy fork.

## Enablement runbook (post-merge, operator)
1. `PROJECT_REGION=us-west-2 scripts/deploy-bedrock-mantle-project.sh`
2. Re-run the boundary rollout (auto-detects the us-west-2 project stack)
3. `gh variable set MEM9_BEDROCK_PROJECT_OPENAI` (the regional project id)
4. `gh variable set MEM9_LLM_MODEL --body openai.gpt-5.6-terra` and redeploy
Note the three-region invariant documented in `.env.example`.

## Reviews applied
3 parallel review agents; all Critical/High/Medium fixed — notably the `status: "failed"` → empty-stop silent-skip (Critical), the boundary deploy script's describe-failure-reads-as-feature-off (High, could strip a live grant and self-verify clean), same-region ARN duplication guard, route-attributable logs, and permanent (not transient) classification for translation failures.

## Design
- [x] Design canvas created (`docs/designs/llm-proxy-multi-model.md`)
- [x] Design approved (interactive session)

## Test Plan
- [x] Test cases documented (`docs/test-cases/llm-proxy-multi-model.md`, TC-MMROUTE-001..070)
- [x] Typecheck passes (root + infra)
- [x] Unit tests pass (657 root incl. 29 routing + 335 boundary; 195 infra)
- [x] cfn-lint + shellcheck pass
- [x] Code simplification review passed
- [x] PR review agent review passed (3 agents)
- [x] CI checks pass
- [x] E2E tests pass (preview deploy 11m22s: MCP write-search E2E + OAuth smoke green on the unchanged GLM path)

## Checklist
- [x] New unit tests written for new functionality
- [x] E2E test cases updated (TC-MMROUTE-070 operator step; existing preview E2E covers the unchanged GLM path)
- [x] Documentation updated (ARCHITECTURE.md, .env.example, design + test-case docs)
