### PR TITLE
fix(ci): wire MEM9_BEDROCK_PROJECT_OPENAI and MEM9_LLM_MODEL into deploys

### DIFF
--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -306,6 +306,11 @@ jobs:
           # scripts/deploy-bedrock-mantle-project.sh; empty → the proxy omits the
           # header (still functional, just untagged).
           MEM9_BEDROCK_PROJECT: ${{ vars.MEM9_BEDROCK_PROJECT }}
+          # llm-proxy Responses route (OpenAI gpt-5.6 terra/luna): the regional
+          # (us-west-2) Mantle project id + the model selector. Unset vars pass
+          # through empty → feature off / GLM-5 default.
+          MEM9_BEDROCK_PROJECT_OPENAI: ${{ vars.MEM9_BEDROCK_PROJECT_OPENAI }}
+          MEM9_LLM_MODEL: ${{ vars.MEM9_LLM_MODEL }}
           # The image applies the repeatable atomic-ingest migration before the
           # server starts, so one enabled rollout is safe.
           MEM9_DURABLE_INGEST_ENABLED: "1"
@@ -970,6 +975,11 @@ jobs:
           # (infra/ecs.ts BEDROCK_PROJECT). Repo variable set out-of-band by
           # scripts/deploy-bedrock-mantle-project.sh.
           MEM9_BEDROCK_PROJECT: ${{ vars.MEM9_BEDROCK_PROJECT }}
+          # llm-proxy Responses route (OpenAI gpt-5.6 terra/luna): the regional
+          # (us-west-2) Mantle project id + the model selector. Unset vars pass
+          # through empty → feature off / GLM-5 default.
+          MEM9_BEDROCK_PROJECT_OPENAI: ${{ vars.MEM9_BEDROCK_PROJECT_OPENAI }}
+          MEM9_LLM_MODEL: ${{ vars.MEM9_LLM_MODEL }}
           # Explicitly false before migration. The guarded migration changes it
           # to true only after every passable role has the exact boundary and
           # permanent enforcement is active. Missing/invalid values fail closed.

--- a/scripts/workload-permissions-boundary-contract.json
+++ b/scripts/workload-permissions-boundary-contract.json
@@ -13,7 +13,7 @@
     {
       "id": "infra-ci.yml",
       "path": ".github/workflows/infra-ci.yml",
-      "reviewedBlob": "76c936f6eb5682fd3f52a12a09bdba1fc05fb996"
+      "reviewedBlob": "c6a2042d429ee17fe70c2268b65c5a6e069a2877"
     },
     {
       "id": "reconcile-previews.yml",


### PR DESCRIPTION
## Summary
- infra/ecs.ts reads `MEM9_BEDROCK_PROJECT_OPENAI` and `MEM9_LLM_MODEL` at synth time, but the deploy jobs never exported the repo variables, so they could not reach the task definition. This wires both into deploy-preview and deploy-prod (unset → empty → feature off / GLM-5 default).
- 11-line workflow change + contract blob re-pin; unblocks the terra/luna enablement runbook from #115.

## Test Plan
- [x] Root suite green (657) with the re-pinned workflow blob
- [x] No behavior change while the variables are unset