### PR TITLE
feat(auth): add second M2M client

### DIFF
--- a/README.md
+++ b/README.md
@@ -675,7 +675,7 @@ Establish a write fence under the incident change window:
    client with the existing read/write scopes. Store its generated ID and secret
    in `/mem9-on-aws/prod/recovery/cognito/{client-id,client-secret}` and make it
    the Gateway's **only** `allowedClients` entry for `prod`.
-3. Deploy the fence, verify both a normal M2M client and normal interactive
+3. Deploy the fence, verify all normal M2M clients and the normal interactive
    client are rejected, and use
    the proxy Lambda's CloudWatch `Invocations` metric to confirm zero backend
    calls during twice the maximum request timeout.
@@ -748,9 +748,10 @@ task start. The bootstrap task is also required: it idempotently updates the
 tenant row's per-request `db_host` and credentials to the selected endpoint.
 Do not probe until both the ECS service and bootstrap task are on the recovery
 configuration. Adopt the restored cluster into long-term IaC ownership only in
-a separate reviewed change after recovery is stable. Restore the normal M2M and
-reader client IDs to the Gateway allowlist, remove the temporary recovery client,
-and resume paused jobs only after the cutover or rollback probe passes.
+a separate reviewed change after recovery is stable. Restore all normal M2M
+client IDs and the reader client ID to the Gateway allowlist, remove the
+temporary recovery client, and resume paused jobs only after the cutover or
+rollback probe passes.
 
 ### 6. Verify and roll back
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -227,9 +227,9 @@ port 8080 rule permits the private hop. The private backend path has no ALB,
 certificate, VPC Lattice target, public Route 53 zone, or public mnemo-server
 endpoint.
 
-The gateway trusts both implemented Cognito clients:
+The gateway trusts three implemented Cognito clients:
 
-- M2M `client_credentials` for CI and headless clients.
+- Two independent M2M clients using `client_credentials`.
 - Authorization code with PKCE through the API Gateway v2 OAuth facade for
   interactive clients.
 

--- a/docs/test-cases/second-m2m-client.md
+++ b/docs/test-cases/second-m2m-client.md
@@ -1,0 +1,11 @@
+# Test cases: second M2M client
+
+The Cognito stack provisions a second confidential client for independent
+machine-to-machine access. Both M2M clients use the same resource server and
+remain explicitly trusted by the AgentCore Gateway.
+
+| ID | Scenario | Expected |
+|---|---|---|
+| TC-M2M2-001 | Synthesize the Cognito stack | Two confidential user-pool clients are created with generated secrets, `client_credentials` as their only OAuth flow, and the existing read/write scopes |
+| TC-M2M2-002 | Inspect the second client's SSM exports | The client ID is a `String` at `cognito/client2/client-id`, and the secret is a `SecureString` at `cognito/client2/client-secret` |
+| TC-M2M2-003 | Synthesize the AgentCore Gateway | `allowedClients` contains both M2M client IDs and the browser-login reader client ID |

--- a/infra/cognito.test.ts
+++ b/infra/cognito.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 /**
  * Unit tests for the `cognito` stack factory. Mocks the SST globals so the
  * factory runs bare; asserts the M2M user pool + domain + resource server +
- * client wiring and the SSM exports (client secret as SecureString, never plain).
+ * client wiring and the SSM exports (client secrets as SecureString, never plain).
  */
 
 function out<T>(value: T): { value: T; apply: (fn: (v: T) => unknown) => unknown } {
@@ -15,7 +15,7 @@ interface Rec {
   args: Record<string, unknown>;
 }
 let created: Rec[];
-let params: { name: string; type: string }[];
+let params: { name: string; type: string; value: unknown }[];
 
 function installInterpolate() {
   (globalThis as Record<string, unknown>).$interpolate = (
@@ -36,11 +36,13 @@ function installInterpolate() {
 
 function makeCtor(kind: string) {
   return class {
-    id = out(`${kind}-id`);
+    id = out(`${kind}-${created.filter((record) => record.kind === kind).length + 1}-id`);
     arn = out(`arn:${kind}`);
     identifier = out("mem9-mcp");
     domain = out("prod-mem9-mcp");
-    clientSecret = out("SECRET-VALUE");
+    clientSecret = out(
+      `SECRET-VALUE-${created.filter((record) => record.kind === kind).length + 1}`,
+    );
     constructor(_n: string, args: Record<string, unknown>) {
       created.push({ kind, args });
     }
@@ -60,12 +62,16 @@ function installGlobals(stage: string) {
     },
     ssm: {
       Parameter: class {
-        constructor(_n: string, args: { name: unknown; type: string }) {
+        constructor(_n: string, args: { name: unknown; type: string; value: unknown }) {
           const name =
             typeof args.name === "object" && args.name && "value" in args.name
               ? (args.name as { value: string }).value
               : (args.name as string);
-          params.push({ name, type: args.type });
+          const value =
+            typeof args.value === "object" && args.value && "value" in args.value
+              ? (args.value as { value: unknown }).value
+              : args.value;
+          params.push({ name, type: args.type, value });
         }
       },
     },
@@ -90,7 +96,7 @@ function byKind(kind: string) {
 }
 
 describe("cognito stack", () => {
-  it("creates a pool, domain, resource server (read+write), and one M2M client", async () => {
+  it("creates a pool, domain, resource server (read+write), and two M2M clients", async () => {
     installGlobals("prod");
     const cognito = await loadCognito();
     const outs = cognito();
@@ -101,24 +107,50 @@ describe("cognito stack", () => {
     const scopeNames = (rs.scopes as { scopeName: string }[]).map((s) => s.scopeName).sort();
     expect(scopeNames).toEqual(["read", "write"]);
     const clients = byKind("UserPoolClient");
-    expect(clients).toHaveLength(1);
-    const c = clients[0].args;
-    expect(c.generateSecret).toBe(true);
-    expect(c.allowedOauthFlows).toEqual(["client_credentials"]);
-    // The gateway consumes the client id in allowedClientIds.
-    expect(outs.allowedClientIds).toHaveLength(1);
-    expect(outs.clientId).toBeDefined();
+    expect(clients).toHaveLength(2);
+    expect(clients.map(({ args }) => args.name)).toEqual([
+      "prod-mem9-mcp-client",
+      "prod-mem9-mcp-client2",
+    ]);
+    for (const { args } of clients) {
+      expect(args.generateSecret).toBe(true);
+      expect(args.allowedOauthFlows).toEqual(["client_credentials"]);
+      expect((args.allowedOauthScopes as { value: string[] }).value).toEqual([
+        "mem9-mcp/read",
+        "mem9-mcp/write",
+      ]);
+    }
+    // The gateway consumes both client ids in allowedClientIds.
+    expect(outs.allowedClientIds).toHaveLength(2);
+    expect(outs.allowedClientIds.map((id) => (id as unknown as { value: string }).value)).toEqual(
+      ["UserPoolClient-1-id", "UserPoolClient-2-id"],
+    );
   });
 
-  it("exports client secret as a SecureString (never plaintext String)", async () => {
+  it("exports both client secrets as SecureString values", async () => {
     installGlobals("prod");
     const cognito = await loadCognito();
     cognito();
-    const secretParam = params.find((p) => p.name.endsWith("/cognito/client-secret"));
-    expect(secretParam?.type).toBe("SecureString");
-    // issuer / token-endpoint / client-id / scope are plain Strings.
+    expect(params.find((p) => p.name.endsWith("/cognito/client-secret"))).toMatchObject({
+      type: "SecureString",
+      value: "SECRET-VALUE-1",
+    });
+    expect(
+      params.find((p) => p.name.endsWith("/cognito/client2/client-secret")),
+    ).toMatchObject({
+      type: "SecureString",
+      value: "SECRET-VALUE-2",
+    });
+    // Issuer, token endpoint, client ids, and scope are plain Strings.
     expect(params.find((p) => p.name.endsWith("/cognito/issuer"))?.type).toBe("String");
-    expect(params.find((p) => p.name.endsWith("/cognito/client-id"))?.type).toBe("String");
+    expect(params.find((p) => p.name.endsWith("/cognito/client-id"))).toMatchObject({
+      type: "String",
+      value: "UserPoolClient-1-id",
+    });
+    expect(params.find((p) => p.name.endsWith("/cognito/client2/client-id"))).toMatchObject({
+      type: "String",
+      value: "UserPoolClient-2-id",
+    });
   });
 
   it("uses deleteBeforeReplace on non-prod, not on prod (pool replacement wipes clients)", async () => {

--- a/infra/cognito.ts
+++ b/infra/cognito.ts
@@ -3,17 +3,16 @@
  *
  * The AgentCore Gateway's inbound authorizer is a CUSTOM_JWT authorizer that
  * validates Cognito `client_credentials` (M2M) JWTs. This stack provisions the
- * pool + domain (OAuth token endpoint) + resource server (scopes) + ONE M2M
- * client (single-operator; a multi-tenant setup would run several clients — we
- * keep one and can add more later without rotating the Gateway URL, since only
- * `name`/`authorizerType` are RequiresReplace on the Gateway).
+ * pool + domain (OAuth token endpoint) + resource server (scopes) + two M2M
+ * clients. Additional clients do not rotate the Gateway URL because only
+ * `name`/`authorizerType` are RequiresReplace on the Gateway.
  *
  * The Gateway matches on `allowedClients` (Cognito client_credentials tokens carry
- * `client_id`, not `aud`), so infra/gateway.ts lists this client's id there.
+ * `client_id`, not `aud`), so infra/gateway.ts lists both client ids there.
  *
- * Exports the issuer + token endpoint (for clients to mint tokens) and the client
- * id + secret ARN via SSM. The client SECRET is a SecureString (needed by the
- * caller — Claude Code — to mint tokens; surfaced to the operator at setup).
+ * Exports the issuer + token endpoint (for clients to mint tokens) and both client
+ * ids + secrets via SSM. Client secrets are SecureString values surfaced only to
+ * the operator.
  */
 
 // @ts-ignore - `aws` injected globally by SST; cognito types declared loosely.
@@ -93,10 +92,8 @@ export function cognito(): CognitoOutputs {
     ],
   });
 
-  // Single M2M client (client_credentials, both scopes). Used as BOTH the caller
-  // and the Gateway's allowedClients entry.
-  const client = new awsAny.cognito.UserPoolClient("Mem9McpClient", {
-    name: `${stage}-mem9-mcp-client`,
+  const m2mClientArgs = (name: string) => ({
+    name,
     userPoolId: pool.id,
     generateSecret: true,
     explicitAuthFlows: [],
@@ -109,6 +106,15 @@ export function cognito(): CognitoOutputs {
     preventUserExistenceErrors: "ENABLED",
     enableTokenRevocation: true,
   });
+
+  const client = new awsAny.cognito.UserPoolClient(
+    "Mem9McpClient",
+    m2mClientArgs(`${stage}-mem9-mcp-client`),
+  );
+  const client2 = new awsAny.cognito.UserPoolClient(
+    "Mem9McpClient2",
+    m2mClientArgs(`${stage}-mem9-mcp-client2`),
+  );
 
   // $interpolate (NOT a template literal) resolves the embedded Output<string>s;
   // a plain literal would stringify them and break CFN/JWT-authorizer validation.
@@ -143,6 +149,18 @@ export function cognito(): CognitoOutputs {
     value: client.clientSecret,
     tags,
   });
+  new awsAny.ssm.Parameter("SsmCognitoClient2Id", {
+    name: `${prefix}/cognito/client2/client-id`,
+    type: "String",
+    value: client2.id,
+    tags,
+  });
+  new awsAny.ssm.Parameter("SsmCognitoClient2Secret", {
+    name: `${prefix}/cognito/client2/client-secret`,
+    type: "SecureString",
+    value: client2.clientSecret,
+    tags,
+  });
   new awsAny.ssm.Parameter("SsmCognitoScope", {
     name: `${prefix}/cognito/scope`,
     type: "String",
@@ -162,6 +180,6 @@ export function cognito(): CognitoOutputs {
     resourceServerId: RESOURCE_SERVER_ID,
     clientId: client.id,
     clientSecret: client.clientSecret,
-    allowedClientIds: [client.id],
+    allowedClientIds: [client.id, client2.id],
   };
 }

--- a/infra/gateway.test.ts
+++ b/infra/gateway.test.ts
@@ -58,7 +58,7 @@ function makeCtor(kind: string) {
     arn = { value: `arn:${kind}`, apply: (fn: (v: string) => unknown) => out(fn(`arn:${kind}`) as never) };
     id = out(`${kind}-id`);
     gatewayId = out("gw-123");
-    gatewayUrl = out("https://gw-123.gateway.bedrock-agentcore.ap-northeast-1.amazonaws.com/mcp");
+    gatewayUrl = out("https://gateway.example.com/mcp");
     constructor(_n: string, args: Record<string, unknown>, opts?: Record<string, unknown>) {
       created.push({ kind, args, opts });
     }
@@ -118,7 +118,7 @@ async function loadGateway() {
 function fakeCognito(): CognitoOutputs {
   return {
     issuer: out("https://cognito-idp.ap-northeast-1.amazonaws.com/pool-1"),
-    allowedClientIds: [out("client-1")],
+    allowedClientIds: [out("client-1"), out("client-2")],
   } as unknown as CognitoOutputs;
 }
 function fakeEcs(): EcsOutputs {
@@ -149,13 +149,13 @@ describe("gateway stack", () => {
     expect(gw.authorizerType).toBe("CUSTOM_JWT");
     const jwt = (gw.authorizerConfiguration as any).customJwtAuthorizer;
     expect(String((jwt.discoveryUrl as { value?: string }).value)).toContain("/.well-known/openid-configuration");
-    // The M2M client plus the browser-login reader client.
-    expect(jwt.allowedClients).toHaveLength(2);
+    // The two M2M clients plus the browser-login reader client.
+    expect(jwt.allowedClients).toHaveLength(3);
     // No interceptor in v1.
     expect(gw.interceptorConfigurations).toBeUndefined();
   });
 
-  it("trusts BOTH the M2M and the reader client in allowedClients", async () => {
+  it("trusts both M2M clients and the reader client in allowedClients", async () => {
     installGlobals("prod");
     const gateway = await loadGateway();
     gateway(fakeCognito(), fakeEcs(), fakeIdentity(), out("reader-client-id-test") as unknown as Output<string>);
@@ -164,8 +164,9 @@ describe("gateway stack", () => {
     // The list is [...cognitoOut.allowedClientIds, readerClientId]; each entry is an
     // out<string> wrapper, so unwrap to compare the underlying client ids.
     const clients = (unwrap(jwt.allowedClients) as string[]);
-    // The M2M client from fakeCognito().allowedClientIds.
+    // Both M2M clients from fakeCognito().allowedClientIds.
     expect(clients).toContain("client-1");
+    expect(clients).toContain("client-2");
     // The browser-login reader client passed as the 4th arg.
     expect(clients).toContain("reader-client-id-test");
   });


### PR DESCRIPTION
## Summary
- provision a second confidential Cognito M2M client with the existing read/write scopes
- export its credentials under `/mem9-on-aws/<stage>/cognito/client2/` and trust its client ID at the Gateway
- update authentication tests, architecture notes, and recovery guidance for both M2M clients

## Test Plan
- [x] Test cases documented (`docs/test-cases/second-m2m-client.md`)
- [x] Infra typecheck passes (`pnpm -C infra typecheck`)
- [x] Infra unit tests pass (195 tests)
- [x] Root typecheck passes (`npm run typecheck`)
- [x] Root unit tests pass (657 tests)
- [x] Public artifact scan passes
- [x] Code simplification and independent review pass
- [x] Documentation Security CI passes
- [x] Infra CI passes
- [x] Preview E2E passes with the second client

## Design
A separate design canvas is not required for this narrow extension of the existing Cognito M2M pattern.