### PR TITLE
feat(auth): support configurable OAuth callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,33 @@ The AgentCore Gateway exposes four tools over MCP (Cognito-authenticated):
   default.
 - Agent contributors: see [`AGENTS.md`](AGENTS.md) for repo conventions and hard rules.
 
+### Optional hosted OAuth callback URLs
+
+Native MCP clients continue to use RFC 8252 loopback callbacks without any
+configuration. For a hosted OAuth client, set the stage-scoped SST secret to a
+JSON array of complete callback URLs, then redeploy so SST propagates the value
+to the stage's OAuth configuration in SSM and refreshes the façade Lambda:
+
+```bash
+pnpm -C infra exec sst secret set OauthAllowedCallbackUrls \
+  '["https://oauth.example.com/callback/app"]' \
+  --stage prod
+gh workflow run "Infra CI"
+```
+
+The array supports at most 20 unique HTTPS URLs and its serialized JSON must
+not exceed 1 KiB. Each URL must be an exact match and cannot contain credentials
+or a fragment; host and path wildcards are intentionally unsupported. Use `[]`
+to remove all hosted callbacks. The façade validates the same list during
+dynamic registration, authorization, callback, and token exchange.
+
+Do not add hosted-client URLs to the Cognito reader app client's callback list.
+Cognito always redirects to the façade's own `/oauth/callback`; the façade
+carries the original client URL in HMAC-signed state and redirects there only
+after exact allowlist validation. It also wraps the Cognito authorization code
+in a short-lived signature so token exchange must present the same client
+redirect URL. The interactive OAuth client remains read-only.
+
 ### Optional production custom domain
 
 The OAuth façade can use a production-only custom hostname. Leave

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -233,6 +233,19 @@ The gateway trusts three implemented Cognito clients:
 - Authorization code with PKCE through the API Gateway v2 OAuth facade for
   interactive clients.
 
+The OAuth facade accepts RFC 8252 loopback redirects by default. Hosted clients
+can be added per stage through the SST `OauthAllowedCallbackUrls` secret, whose
+value is a JSON array of exact HTTPS URLs. SST writes the selected value to the
+stage's existing OAuth SSM prefix, and the facade reads it at cold start with
+the reader client configuration. A SHA-256 configuration version in the Lambda
+environment forces a function update when the SSM value changes, without
+putting callback URLs in the environment. The facade applies the same allowlist
+to dynamic registration, authorization, callback, and token exchange. Cognito
+still sees only the facade's own `/oauth/callback`; external callback URLs are
+never added to the Cognito reader client. A short-lived HMAC wrapper binds the
+Cognito authorization code to the original external redirect URL for token
+exchange.
+
 The OAuth facade optionally uses a production custom hostname from
 `MEM9_FACADE_CUSTOM_DOMAIN`. GitHub Actions supplies it only from the repository
 secret of the same name. The deploy also receives `CLOUDFLARE_API_TOKEN` from a

--- a/docs/test-cases/configurable-oauth-callbacks.md
+++ b/docs/test-cases/configurable-oauth-callbacks.md
@@ -1,0 +1,21 @@
+# Test cases: configurable OAuth callback URLs
+
+The OAuth facade keeps native-app loopback callbacks enabled and can additionally
+allow stage-specific HTTPS callback URLs supplied through the SST
+`OauthAllowedCallbackUrls` secret. The secret value is a JSON array of complete
+URLs. Configured URLs are exact matches; host or path wildcards are not
+supported.
+
+| ID | Scenario | Expected result |
+| --- | --- | --- |
+| TC-OAUTH-CALLBACK-001 | Synthesize the OAuth facade | SST creates `OauthAllowedCallbackUrls` with an empty-list default and writes its value under the stage's OAuth SSM prefix |
+| TC-OAUTH-CALLBACK-002 | Load a valid JSON array containing complete HTTPS callback URLs | The runtime config exposes the validated URLs |
+| TC-OAUTH-CALLBACK-003 | Load malformed JSON, a non-array value, an HTTP remote URL, a URL with credentials or fragment, a URL too long for signed state, more than 20 unique URLs, or more than 1 KiB of JSON | Configuration fails closed before serving OAuth requests |
+| TC-OAUTH-CALLBACK-004 | Authorize with a configured HTTPS callback and S256 PKCE | The facade sends Cognito its own callback URL and preserves the external callback in signed state |
+| TC-OAUTH-CALLBACK-005 | Complete the callback for a configured HTTPS URL | The facade redirects the authorization code and original state to the exact configured URL |
+| TC-OAUTH-CALLBACK-006 | Use an unconfigured URL, sibling path, or sibling host | Authorization, callback, and token exchange reject the redirect |
+| TC-OAUTH-CALLBACK-007 | Exchange a signed code with the same configured HTTPS callback | The facade unwraps the Cognito code and sends Cognito its own callback URL |
+| TC-OAUTH-CALLBACK-008 | Dynamically register only loopback and configured HTTPS redirects | Registration succeeds and echoes the accepted redirects |
+| TC-OAUTH-CALLBACK-009 | Dynamically register any unsupported or intrinsically overlong redirect in a mixed list | The entire registration fails with `invalid_redirect_uri` |
+| TC-OAUTH-CALLBACK-010 | Use an existing localhost, IPv4 loopback, or IPv6 loopback callback | Existing RFC 8252 loopback behavior remains unchanged |
+| TC-OAUTH-CALLBACK-011 | Omit, empty, or change the redirect URI during authorization-code exchange, or exceed Cognito's state limit | The facade rejects the request before contacting Cognito |

--- a/infra/oauth-facade.test.ts
+++ b/infra/oauth-facade.test.ts
@@ -26,7 +26,7 @@ interface Rec {
   args: Record<string, unknown>;
 }
 let created: Rec[];
-let params: { name: string; type: string }[];
+let params: { name: string; type: string; value: unknown }[];
 let routeSpy: ReturnType<typeof vi.fn>;
 let addAuthorizerSpy: ReturnType<typeof vi.fn>;
 let authorizerId: ReturnType<typeof out>;
@@ -86,12 +86,17 @@ function installGlobals(stage: string) {
     },
     ssm: {
       Parameter: class {
-        constructor(_n: string, args: { name: unknown; type: string }) {
+        value: unknown;
+        constructor(
+          _n: string,
+          args: { name: unknown; type: string; value: unknown },
+        ) {
+          this.value = args.value;
           const name =
             typeof args.name === "object" && args.name && "value" in args.name
               ? (args.name as { value: string }).value
               : (args.name as string);
-          params.push({ name, type: args.type });
+          params.push({ name, type: args.type, value: unwrap(args.value) });
         }
       },
     },
@@ -123,11 +128,12 @@ function installGlobals(stage: string) {
         return dns;
       },
     },
-    // sst.Secret — the HMAC signing key (empty default → façade 503 until seeded).
+    // sst.Secret — stage-scoped values linked into the façade environment.
     Secret: class {
-      value = out("hmac-secret-value");
-      constructor(name: string, _default?: string) {
-        created.push({ kind: "Secret", args: { name } });
+      value: ReturnType<typeof out>;
+      constructor(name: string, fallback?: string) {
+        this.value = out(`${name}-value`);
+        created.push({ kind: "Secret", args: { name, fallback } });
       }
     },
   };
@@ -417,12 +423,32 @@ describe("oauthFacade factory", () => {
     ]);
   });
 
-  it("creates the HMAC state-signing Secret", async () => {
+  it("TC-OAUTH-CALLBACK-001: creates and wires the OAuth configuration Secrets", async () => {
     installGlobals("prod");
     const oauthFacade = await loadFacade();
     oauthFacade(fakeCognitoOut());
-    const secret = only("Secret");
-    expect(secret.name).toBe("OauthStateHmacKey");
+    const secrets = created
+      .filter(({ kind }) => kind === "Secret")
+      .map(({ args }) => args);
+    expect(secrets).toEqual([
+      { name: "OauthStateHmacKey", fallback: "" },
+      { name: "OauthAllowedCallbackUrls", fallback: "[]" },
+    ]);
+    const fn = only("SstFunction");
+    const environment = unwrap(fn.environment) as Record<string, string>;
+    expect(environment).toMatchObject({
+      OAUTH_STATE_HMAC_KEY: "OauthStateHmacKey-value",
+    });
+    expect(environment.OAUTH_ALLOWED_CALLBACK_URLS_VERSION).toMatch(
+      /^[0-9a-f]{64}$/u,
+    );
+    expect(environment).not.toHaveProperty("OAUTH_ALLOWED_CALLBACK_URLS");
+    expect(
+      params.find((p) => p.name.endsWith("/oauth/allowed-callback-urls")),
+    ).toMatchObject({
+      type: "String",
+      value: "OauthAllowedCallbackUrls-value",
+    });
   });
 
   it("returns the reader client id + facade url", async () => {
@@ -439,6 +465,7 @@ describe("oauthFacade factory", () => {
     const oauthFacade = await loadFacade();
     oauthFacade(fakeCognitoOut());
     const names = params.map((p) => p.name);
+    expect(names).toContain("/mem9-on-aws/prod/oauth/allowed-callback-urls");
     expect(names).toContain("/mem9-on-aws/prod/cognito/reader/client-id");
     expect(names).toContain("/mem9-on-aws/prod/cognito/reader/client-secret");
     expect(names).toContain("/mem9-on-aws/prod/facade/url");

--- a/infra/oauth-facade.ts
+++ b/infra/oauth-facade.ts
@@ -23,6 +23,8 @@
  * public internet, so a VPC/NAT hop would only add cold-start ENI latency.
  */
 
+import { createHash } from "node:crypto";
+
 import type { CognitoOutputs } from "./cognito";
 
 // @ts-ignore - `aws`/`sst` injected globally by SST; cognito/ssm types loose.
@@ -151,6 +153,22 @@ export function oauthFacade(cognitoOut: CognitoOutputs): OauthFacadeOutputs {
 
   // --- HMAC state-signing key (empty default → façade 503 until seeded) ---
   const hmacKey = new sst.Secret("OauthStateHmacKey", "");
+  // Stage-scoped JSON array of exact HTTPS callbacks for hosted MCP clients.
+  // Loopback callbacks remain built in; an empty array preserves that default.
+  const allowedCallbackUrls = new sst.Secret(
+    "OauthAllowedCallbackUrls",
+    "[]",
+  );
+  const allowedCallbackUrlsParameter = param(
+    "SsmAllowedCallbackUrls",
+    "oauth/allowed-callback-urls",
+    allowedCallbackUrls.value,
+  );
+  // Deriving the version from the Parameter output orders its update before
+  // Lambda replacement, so a new cold start cannot cache the previous value.
+  const allowedCallbackUrlsVersion = allowedCallbackUrlsParameter.value.apply(
+    (value: string) => createHash("sha256").update(value).digest("hex"),
+  );
 
   // --- Façade Function (public, NOT VPC-attached) ---
   // arm64 nodejs24.x. Env carries the SSM prefix (the handler reads the reader
@@ -173,6 +191,7 @@ export function oauthFacade(cognitoOut: CognitoOutputs): OauthFacadeOutputs {
       COGNITO_JWKS_URI: cognitoOut.jwksUri,
       RESOURCE_SCOPES: "mem9-mcp/read",
       OAUTH_STATE_HMAC_KEY: hmacKey.value,
+      OAUTH_ALLOWED_CALLBACK_URLS_VERSION: allowedCallbackUrlsVersion,
     },
     permissions: [
       {

--- a/infra/src/oauth-facade/config.test.ts
+++ b/infra/src/oauth-facade/config.test.ts
@@ -6,7 +6,12 @@
 
 import { describe, expect, it, vi } from "vitest";
 
-import { loadConfig, resolveSsm, type SsmLike } from "./config.js";
+import {
+  loadConfig,
+  parseAllowedCallbackUrls,
+  resolveSsm,
+  type SsmLike,
+} from "./config.js";
 
 const PREFIX = "/example-app/pr-7/mcp";
 
@@ -22,6 +27,8 @@ const fullSsm = {
   [`${PREFIX}/gateway/url`]: "https://gw",
   [`${PREFIX}/cognito/reader/client-id`]: "cid",
   [`${PREFIX}/cognito/reader/client-secret`]: "csecret",
+  [`${PREFIX}/oauth/allowed-callback-urls`]:
+    '["https://oauth.example.com/callback/app"]',
 };
 
 const baseEnv = {
@@ -44,6 +51,8 @@ describe("façade config loader (cycle-break SSM reads)", () => {
       upstream: "https://gw",
       userClientId: "cid",
       userClientSecret: "csecret",
+      allowedCallbackUrls:
+        '["https://oauth.example.com/callback/app"]',
     });
     const cmd = (ssm.send as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(cmd.input.WithDecryption).toBe(true);
@@ -51,6 +60,7 @@ describe("façade config loader (cycle-break SSM reads)", () => {
       `${PREFIX}/gateway/url`,
       `${PREFIX}/cognito/reader/client-id`,
       `${PREFIX}/cognito/reader/client-secret`,
+      `${PREFIX}/oauth/allowed-callback-urls`,
     ]);
   });
 
@@ -72,6 +82,9 @@ describe("façade config loader (cycle-break SSM reads)", () => {
       "example-mcp/query/read",
       "example-mcp/query/write",
     ]);
+    expect(cfg.allowedClientRedirectUris).toEqual([
+      "https://oauth.example.com/callback/app",
+    ]);
   });
 
   it("loadConfig throws when a required env var is missing", async () => {
@@ -91,5 +104,55 @@ describe("façade config loader (cycle-break SSM reads)", () => {
     const env = { ...baseEnv, RESOURCE_SCOPES: "" };
     const cfg = await loadConfig({ ssm: ssmReturning(fullSsm), env });
     expect(cfg.resourceScopes).toEqual([]);
+  });
+
+  it("TC-OAUTH-CALLBACK-002: parses and de-duplicates valid HTTPS callback URLs", () => {
+    expect(
+      parseAllowedCallbackUrls(
+        '["https://oauth.example.com/callback/app","https://oauth.example.com/callback/app"]',
+      ),
+    ).toEqual(["https://oauth.example.com/callback/app"]);
+    expect(
+      parseAllowedCallbackUrls(
+        JSON.stringify(
+          Array.from(
+            { length: 21 },
+            () => "https://x.co/c",
+          ),
+        ),
+      ),
+    ).toEqual(["https://x.co/c"]);
+    expect(parseAllowedCallbackUrls("")).toEqual([]);
+  });
+
+  it.each([
+    ["malformed JSON", "["],
+    ["non-array JSON", '{"url":"https://oauth.example.com/callback"}'],
+    ["non-string entry", '["https://oauth.example.com/callback",7]'],
+    ["remote HTTP", '["http://oauth.example.com/callback"]'],
+    ["credentials", '["https://user:pass@oauth.example.com/callback"]'],
+    ["fragment", '["https://oauth.example.com/callback#fragment"]'],
+    ["oversized whitespace", " ".repeat(1025)],
+    [
+      "callback that cannot fit in signed state",
+      JSON.stringify([`https://oauth.example.com/${"x".repeat(800)}`]),
+    ],
+    [
+      "serialized configuration over 1 KiB",
+      JSON.stringify([`https://oauth.example.com/${"x".repeat(1100)}`]),
+    ],
+    [
+      "too many callbacks",
+      JSON.stringify(
+        Array.from(
+          { length: 21 },
+          (_, i) => `https://x.co/${i}`,
+        ),
+      ),
+    ],
+  ])("TC-OAUTH-CALLBACK-003: rejects %s", (_case, raw) => {
+    expect(() => parseAllowedCallbackUrls(raw)).toThrow(
+      /OauthAllowedCallbackUrls/u,
+    );
   });
 });

--- a/infra/src/oauth-facade/config.ts
+++ b/infra/src/oauth-facade/config.ts
@@ -17,14 +17,16 @@
  *   - `{mcpPrefix}/gateway/url`                    (UPSTREAM gateway)
  *   - `{mcpPrefix}/cognito/reader/client-id`
  *   - `{mcpPrefix}/cognito/reader/client-secret`   (SecureString)
+ *   - `{mcpPrefix}/oauth/allowed-callback-urls`
  *
  * The remaining, non-cyclic values (Cognito endpoint URLs that depend only on
- * the user pool + domain, the HMAC key from the SST Secret, and the resource
+ * the user pool + domain, the HMAC key from an SST Secret, and the resource
  * scopes) are plain env vars. The SSM client is injected (`SsmLike`) so the
  * loader is unit-testable without AWS.
  */
 
 import { GetParametersCommand, SSMClient } from "@aws-sdk/client-ssm";
+import { canEncodeCognitoState } from "./state.js";
 
 export interface FacadeConfig {
   /** AgentCore Gateway URL the façade proxies to (`/mcp` + fallthrough). */
@@ -42,6 +44,8 @@ export interface FacadeConfig {
   /** Reader app client credentials returned by `/register` (DCR). */
   userClientId: string;
   userClientSecret: string;
+  /** Exact HTTPS redirect URIs allowed in addition to RFC 8252 loopback URLs. */
+  allowedClientRedirectUris: string[];
   /** HMAC key for state signing; empty disables the proxy (503). */
   hmacKey: string;
 }
@@ -54,6 +58,10 @@ export interface SsmLike {
 }
 
 type Env = Record<string, string | undefined>;
+const ALLOWED_CALLBACK_URLS_SETTING = "OauthAllowedCallbackUrls";
+const MAX_ALLOWED_CALLBACK_URLS = 20;
+const MAX_CALLBACK_URL_LENGTH = 2048;
+const MAX_CALLBACK_CONFIG_BYTES = 1024;
 
 function reqEnv(env: Env, name: string): string {
   const v = env[name];
@@ -61,15 +69,85 @@ function reqEnv(env: Env, name: string): string {
   return v;
 }
 
-/** Resolve the three cyclic values from SSM (decrypting the client secret). */
+export function parseAllowedCallbackUrls(raw = ""): string[] {
+  if (Buffer.byteLength(raw, "utf8") > MAX_CALLBACK_CONFIG_BYTES) {
+    throw new Error(
+      `${ALLOWED_CALLBACK_URLS_SETTING} must not exceed ${MAX_CALLBACK_CONFIG_BYTES} UTF-8 bytes`,
+    );
+  }
+  if (!raw.trim()) return [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(`${ALLOWED_CALLBACK_URLS_SETTING} must be a JSON array`);
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error(`${ALLOWED_CALLBACK_URLS_SETTING} must be a JSON array`);
+  }
+  const urls = new Set<string>();
+  for (const entry of parsed) {
+    if (
+      typeof entry !== "string" ||
+      !entry ||
+      entry !== entry.trim() ||
+      entry.length > MAX_CALLBACK_URL_LENGTH
+    ) {
+      throw new Error(
+        `${ALLOWED_CALLBACK_URLS_SETTING} entries must be non-empty URL strings`,
+      );
+    }
+
+    let url: URL;
+    try {
+      url = new URL(entry);
+    } catch {
+      throw new Error(
+        `${ALLOWED_CALLBACK_URLS_SETTING} entries must be valid HTTPS URLs`,
+      );
+    }
+    if (
+      url.protocol !== "https:" ||
+      !url.hostname ||
+      url.username ||
+      url.password ||
+      url.hash
+    ) {
+      throw new Error(
+        `${ALLOWED_CALLBACK_URLS_SETTING} entries must be HTTPS URLs without credentials or fragments`,
+      );
+    }
+    if (!canEncodeCognitoState({ cs: "", r: entry })) {
+      throw new Error(
+        `${ALLOWED_CALLBACK_URLS_SETTING} entries must fit in Cognito's signed state limit`,
+      );
+    }
+    urls.add(entry);
+    if (urls.size > MAX_ALLOWED_CALLBACK_URLS) {
+      throw new Error(
+        `${ALLOWED_CALLBACK_URLS_SETTING} supports at most ${MAX_ALLOWED_CALLBACK_URLS} unique URLs`,
+      );
+    }
+  }
+  return [...urls];
+}
+
+/** Resolve runtime values from SSM (decrypting the client secret). */
 export async function resolveSsm(
   prefix: string,
   ssm: SsmLike,
-): Promise<{ upstream: string; userClientId: string; userClientSecret: string }> {
+): Promise<{
+  upstream: string;
+  userClientId: string;
+  userClientSecret: string;
+  allowedCallbackUrls: string;
+}> {
   const names = [
     `${prefix}/gateway/url`,
     `${prefix}/cognito/reader/client-id`,
     `${prefix}/cognito/reader/client-secret`,
+    `${prefix}/oauth/allowed-callback-urls`,
   ];
   const res = await ssm.send(
     new GetParametersCommand({ Names: names, WithDecryption: true }),
@@ -86,6 +164,7 @@ export async function resolveSsm(
     upstream: get(names[0]!),
     userClientId: get(names[1]!),
     userClientSecret: get(names[2]!),
+    allowedCallbackUrls: get(names[3]!),
   };
 }
 
@@ -114,6 +193,9 @@ export async function loadConfig(
       .filter(Boolean),
     userClientId: resolved.userClientId,
     userClientSecret: resolved.userClientSecret,
+    allowedClientRedirectUris: parseAllowedCallbackUrls(
+      resolved.allowedCallbackUrls,
+    ),
     // Empty (not missing) is the intended "proxy disabled" sentinel.
     hmacKey: env.OAUTH_STATE_HMAC_KEY ?? "",
   };

--- a/infra/src/oauth-facade/handler.test.ts
+++ b/infra/src/oauth-facade/handler.test.ts
@@ -6,26 +6,32 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { isAllowedClientRedirect, route } from "./handler.js";
-import { verifyState } from "./state.js";
+import {
+  signAuthorizationCode,
+  verifyAuthorizationCode,
+  verifyState,
+} from "./state.js";
 import type { FacadeConfig } from "./config.js";
 
 const HOST = "abc123.lambda-url.ap-northeast-1.on.aws";
 const BASE = `https://${HOST}`;
 const HMAC = "unit-test-hmac-key";
+const REMOTE_CALLBACK = "https://oauth.example.com/callback/app";
 
 function cfg(overrides: Partial<FacadeConfig> = {}): FacadeConfig {
   return {
     upstream: "https://gateway.example/mcp-prefix",
     issuer: "https://cognito-idp.ap-northeast-1.amazonaws.com/pool",
-    authorize: "https://dom.auth.ap-northeast-1.amazoncognito.com/oauth2/authorize",
-    token: "https://dom.auth.ap-northeast-1.amazoncognito.com/oauth2/token",
-    userinfo: "https://dom.auth.ap-northeast-1.amazoncognito.com/oauth2/userInfo",
-    revocation: "https://dom.auth.ap-northeast-1.amazoncognito.com/oauth2/revoke",
+    authorize: "https://auth.example.com/oauth2/authorize",
+    token: "https://auth.example.com/oauth2/token",
+    userinfo: "https://auth.example.com/oauth2/userInfo",
+    revocation: "https://auth.example.com/oauth2/revoke",
     jwks: "https://cognito-idp.ap-northeast-1.amazonaws.com/pool/.well-known/jwks.json",
     // Reader-client-aligned: openid + email + read only (no write).
     resourceScopes: ["example-mcp/query/read"],
     userClientId: "reader-client-id",
     userClientSecret: "reader-client-secret",
+    allowedClientRedirectUris: [],
     hmacKey: HMAC,
     ...overrides,
   };
@@ -187,6 +193,18 @@ describe("façade routing (TC-MCPGW-060..073)", () => {
     expect(JSON.parse(res.body).error_description).toMatch(/S256/);
   });
 
+  it("rejects authorize requests whose signed state would exceed Cognito's limit", async () => {
+    const q = new URLSearchParams({
+      redirect_uri: "http://localhost:5000/cb",
+      state: "x".repeat(1000),
+      code_challenge: "x",
+      code_challenge_method: "S256",
+    }).toString();
+    const res = await route(ev("/oauth/authorize", "GET", { query: q }), cfg());
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error_description).toMatch(/length/u);
+  });
+
   it("TC-MCPGW-067: /oauth/callback 302s back to the client loopback with code + orig state", async () => {
     // Sign a state the way /oauth/authorize would.
     const authQ = new URLSearchParams({
@@ -211,7 +229,12 @@ describe("façade routing (TC-MCPGW-060..073)", () => {
     expect(res.statusCode).toBe(302);
     const loc = new URL(res.headers.location);
     expect(loc.origin + loc.pathname).toBe("http://127.0.0.1:5000/callback");
-    expect(loc.searchParams.get("code")).toBe("auth-code-xyz");
+    expect(
+      verifyAuthorizationCode(loc.searchParams.get("code")!, HMAC, Date.now()),
+    ).toMatchObject({
+      c: "auth-code-xyz",
+      r: "http://127.0.0.1:5000/callback",
+    });
     expect(loc.searchParams.get("state")).toBe("orig-state");
   });
 
@@ -238,7 +261,14 @@ describe("façade routing (TC-MCPGW-060..073)", () => {
     );
     const form = new URLSearchParams({
       grant_type: "authorization_code",
-      code: "c",
+      code: signAuthorizationCode(
+        {
+          code: "c",
+          redirectUri: "http://127.0.0.1:5000/callback",
+        },
+        HMAC,
+        Date.now(),
+      ),
       redirect_uri: "http://127.0.0.1:5000/callback",
       code_verifier: "v",
       client_id: "reader-client-id",
@@ -364,7 +394,14 @@ describe("façade routing (TC-MCPGW-060..073)", () => {
     const captured = mockTokenUpstream();
     const form = new URLSearchParams({
       grant_type: "authorization_code",
-      code: "c",
+      code: signAuthorizationCode(
+        {
+          code: "c",
+          redirectUri: "http://127.0.0.1:5000/callback",
+        },
+        HMAC,
+        Date.now(),
+      ),
       redirect_uri: "http://127.0.0.1:5000/callback",
       code_verifier: "v",
       client_id: "reader-client-id",
@@ -439,8 +476,228 @@ describe("façade routing (TC-MCPGW-060..073)", () => {
   it("TC-MCPGW-073: isAllowedClientRedirect only accepts loopback http URLs", () => {
     expect(isAllowedClientRedirect("http://localhost:1/cb")).toBe(true);
     expect(isAllowedClientRedirect("http://127.0.0.1:65535/cb")).toBe(true);
+    expect(isAllowedClientRedirect("http://[::1]:54321/cb")).toBe(true);
     expect(isAllowedClientRedirect("https://localhost/cb")).toBe(false);
     expect(isAllowedClientRedirect("http://evil.example/cb")).toBe(false);
     expect(isAllowedClientRedirect("not a url")).toBe(false);
+  });
+
+  it("TC-OAUTH-CALLBACK-004/005: accepts an exact configured HTTPS callback through authorize and callback", async () => {
+    const configuredCallback =
+      `${REMOTE_CALLBACK}?tenant=example&code=stale&error=stale`;
+    const config = cfg({ allowedClientRedirectUris: [configuredCallback] });
+    const authQ = new URLSearchParams({
+      redirect_uri: configuredCallback,
+      state: "remote-state",
+      code_challenge: "challenge",
+      code_challenge_method: "S256",
+    }).toString();
+    const authRes = await route(
+      ev("/oauth/authorize", "GET", { query: authQ }),
+      config,
+    );
+    expect(authRes.statusCode).toBe(302);
+    const cognitoRedirect = new URL(authRes.headers.location);
+    expect(cognitoRedirect.searchParams.get("redirect_uri")).toBe(
+      `${BASE}/oauth/callback`,
+    );
+
+    const callbackQ = new URLSearchParams({
+      code: "remote-code",
+      state: cognitoRedirect.searchParams.get("state")!,
+    }).toString();
+    const callbackRes = await route(
+      ev("/oauth/callback", "GET", { query: callbackQ }),
+      config,
+    );
+    expect(callbackRes.statusCode).toBe(302);
+    const clientRedirect = new URL(callbackRes.headers.location);
+    expect(clientRedirect.origin + clientRedirect.pathname).toBe(
+      REMOTE_CALLBACK,
+    );
+    expect(clientRedirect.searchParams.get("tenant")).toBe("example");
+    expect(
+      verifyAuthorizationCode(
+        clientRedirect.searchParams.get("code")!,
+        HMAC,
+        Date.now(),
+      ),
+    ).toMatchObject({ c: "remote-code", r: configuredCallback });
+    expect(clientRedirect.searchParams.get("error")).toBeNull();
+    expect(clientRedirect.searchParams.get("state")).toBe("remote-state");
+  });
+
+  it.each([
+    "https://oauth.example.com/callback/other",
+    "https://sub.oauth.example.com/callback/app",
+  ])(
+    "TC-OAUTH-CALLBACK-006: rejects an unconfigured sibling redirect %s",
+    async (redirectUri) => {
+      const q = new URLSearchParams({
+        redirect_uri: redirectUri,
+        code_challenge: "challenge",
+        code_challenge_method: "S256",
+      }).toString();
+      const res = await route(
+        ev("/oauth/authorize", "GET", { query: q }),
+        cfg({ allowedClientRedirectUris: [REMOTE_CALLBACK] }),
+      );
+      expect(res.statusCode).toBe(400);
+    },
+  );
+
+  it("TC-OAUTH-CALLBACK-006: rechecks the allowlist before redirecting from callback", async () => {
+    const authQ = new URLSearchParams({
+      redirect_uri: REMOTE_CALLBACK,
+      code_challenge: "challenge",
+      code_challenge_method: "S256",
+    }).toString();
+    const authRes = await route(
+      ev("/oauth/authorize", "GET", { query: authQ }),
+      cfg({ allowedClientRedirectUris: [REMOTE_CALLBACK] }),
+    );
+    const state = new URL(authRes.headers.location).searchParams.get("state")!;
+
+    const res = await route(
+      ev("/oauth/callback", "GET", {
+        query: new URLSearchParams({ code: "c", state }).toString(),
+      }),
+      cfg(),
+    );
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toBe("invalid_state");
+  });
+
+  it("TC-OAUTH-CALLBACK-007: accepts the configured callback during code exchange", async () => {
+    const captured = mockTokenUpstream();
+    const form = new URLSearchParams({
+      grant_type: "authorization_code",
+      code: signAuthorizationCode(
+        { code: "c", redirectUri: REMOTE_CALLBACK },
+        HMAC,
+        Date.now(),
+      ),
+      redirect_uri: REMOTE_CALLBACK,
+      code_verifier: "v",
+      client_id: "reader-client-id",
+    }).toString();
+    const res = await route(
+      ev("/oauth/token", "POST", { body: form }),
+      cfg({ allowedClientRedirectUris: [REMOTE_CALLBACK] }),
+    );
+    expect(res.statusCode).toBe(200);
+    const forwarded = new URLSearchParams(captured.body!);
+    expect(forwarded.get("redirect_uri")).toBe(`${BASE}/oauth/callback`);
+    expect(forwarded.get("code")).toBe("c");
+  });
+
+  it.each([
+    ["omitted", undefined],
+    ["empty", ""],
+  ])(
+    "rejects an authorization-code exchange with an %s redirect_uri",
+    async (_case, redirectUri) => {
+      const form = new URLSearchParams({
+        grant_type: "authorization_code",
+        code: signAuthorizationCode(
+          { code: "c", redirectUri: REMOTE_CALLBACK },
+          HMAC,
+          Date.now(),
+        ),
+        code_verifier: "v",
+        client_id: "reader-client-id",
+      });
+      if (redirectUri !== undefined) form.set("redirect_uri", redirectUri);
+      const res = await route(
+        ev("/oauth/token", "POST", { body: form.toString() }),
+        cfg({ allowedClientRedirectUris: [REMOTE_CALLBACK] }),
+      );
+      expect(res.statusCode).toBe(400);
+      expect(JSON.parse(res.body).error).toBe("invalid_request");
+    },
+  );
+
+  it("rejects a code exchange using a different allowlisted redirect_uri", async () => {
+    const otherCallback = "https://oauth.example.com/callback/other";
+    const res = await route(
+      ev("/oauth/token", "POST", {
+        body: new URLSearchParams({
+          grant_type: "authorization_code",
+          code: signAuthorizationCode(
+            { code: "c", redirectUri: REMOTE_CALLBACK },
+            HMAC,
+            Date.now(),
+          ),
+          redirect_uri: otherCallback,
+          code_verifier: "v",
+          client_id: "reader-client-id",
+        }).toString(),
+      }),
+      cfg({
+        allowedClientRedirectUris: [REMOTE_CALLBACK, otherCallback],
+      }),
+    );
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toBe("invalid_grant");
+  });
+
+  it("TC-OAUTH-CALLBACK-006: rejects an unconfigured callback during code exchange", async () => {
+    const res = await route(
+      ev("/oauth/token", "POST", {
+        body: new URLSearchParams({
+          grant_type: "authorization_code",
+          code: "c",
+          redirect_uri: "https://oauth.example.com/callback/other",
+          code_verifier: "v",
+          client_id: "reader-client-id",
+        }).toString(),
+      }),
+      cfg({ allowedClientRedirectUris: [REMOTE_CALLBACK] }),
+    );
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toBe("invalid_request");
+  });
+
+  it("TC-OAUTH-CALLBACK-008: registers configured HTTPS and loopback callbacks", async () => {
+    const redirects = [REMOTE_CALLBACK, "http://127.0.0.1:54321/callback"];
+    const res = await route(
+      ev("/register", "POST", {
+        body: JSON.stringify({ redirect_uris: redirects }),
+      }),
+      cfg({ allowedClientRedirectUris: [REMOTE_CALLBACK] }),
+    );
+    expect(res.statusCode).toBe(201);
+    expect(JSON.parse(res.body).redirect_uris).toEqual(redirects);
+  });
+
+  it("TC-OAUTH-CALLBACK-009: rejects the entire registration when one redirect is unsupported", async () => {
+    const res = await route(
+      ev("/register", "POST", {
+        body: JSON.stringify({
+          redirect_uris: [
+            REMOTE_CALLBACK,
+            "https://oauth.example.com/callback/other",
+          ],
+        }),
+      }),
+      cfg({ allowedClientRedirectUris: [REMOTE_CALLBACK] }),
+    );
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toBe("invalid_redirect_uri");
+  });
+
+  it("rejects registration of a callback that cannot fit in signed state", async () => {
+    const res = await route(
+      ev("/register", "POST", {
+        body: JSON.stringify({
+          redirect_uris: [
+            `http://localhost:8080/${"x".repeat(800)}`,
+          ],
+        }),
+      }),
+      cfg(),
+    );
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toBe("invalid_redirect_uri");
   });
 });

--- a/infra/src/oauth-facade/handler.ts
+++ b/infra/src/oauth-facade/handler.ts
@@ -18,18 +18,26 @@
  * - Claude Code's OAuth client needs RFC 8414 / RFC 9728 metadata + RFC 7591
  *   DCR, none of which Cognito serves at the discovery path the Gateway
  *   advertises.
- * - Claude Code's local callback listener picks a random ephemeral port;
- *   Cognito requires exact-match `callbackUrls`. The façade is the single
- *   registered redirect target and 302-redirects to the client's loopback
- *   port. State + the original client redirect_uri ride through Cognito as an
- *   HMAC-signed opaque blob so the proxy stays stateless.
+ * - Native clients can pick a random loopback port, while hosted clients use
+ *   stage-configured exact HTTPS callbacks; Cognito requires static
+ *   `callbackUrls`. The façade is the single registered Cognito target and
+ *   302-redirects to the validated client URL. State + the original
+ *   redirect_uri ride through Cognito as an HMAC-signed opaque blob so the
+ *   proxy stays stateless.
  *
  * Routes: `/.well-known/*` metadata, `/oauth/authorize|callback|token|logout`,
  * `/register`, and a catch-all proxy to the AgentCore Gateway (`/mcp`).
  */
 
 import { loadConfig, type FacadeConfig } from "./config.js";
-import { signState, verifyState } from "./state.js";
+import {
+  canEncodeCognitoState,
+  COGNITO_STATE_MAX_LENGTH,
+  signAuthorizationCode,
+  signState,
+  verifyAuthorizationCode,
+  verifyState,
+} from "./state.js";
 
 interface ApiGwEvent {
   rawPath?: string;
@@ -94,24 +102,29 @@ function ensureHmacConfigured(cfg: FacadeConfig): ApiGwResponse | null {
 }
 
 /**
- * Native-app loopback redirect_uri validation (RFC 8252 §7.3). Without this
- * the façade would be an open redirector leaking auth codes to attacker URLs.
- * Claude Code's MCP transport uses a loopback address with an arbitrary port.
+ * Native-app loopback redirect_uri validation (RFC 8252 §7.3) plus exact-match
+ * HTTPS callbacks configured for hosted clients. Without this the façade would
+ * be an open redirector leaking auth codes to attacker URLs.
  */
-export function isAllowedClientRedirect(uri: string): boolean {
+export function isAllowedClientRedirect(
+  uri: string,
+  allowedHttpsUris: readonly string[] = [],
+): boolean {
   let url: URL;
   try {
     url = new URL(uri);
   } catch {
     return false;
   }
-  if (url.protocol !== "http:") return false;
-  return (
-    url.hostname === "localhost" ||
-    url.hostname === "127.0.0.1" ||
-    url.hostname === "[::1]" ||
-    url.hostname === "::1"
-  );
+  if (url.protocol === "http:") {
+    return (
+      url.hostname === "localhost" ||
+      url.hostname === "127.0.0.1" ||
+      url.hostname === "[::1]" ||
+      url.hostname === "::1"
+    );
+  }
+  return url.protocol === "https:" && allowedHttpsUris.includes(uri);
 }
 
 /** Pure router — all façade logic; config injected so tests need no AWS. */
@@ -212,11 +225,16 @@ export async function route(
         error_description: "missing redirect_uri",
       });
     }
-    if (!isAllowedClientRedirect(clientRedirect)) {
+    if (
+      !isAllowedClientRedirect(
+        clientRedirect,
+        cfg.allowedClientRedirectUris,
+      )
+    ) {
       return json(400, {
         error: "invalid_request",
         error_description:
-          "redirect_uri must be a loopback (http://localhost or http://127.0.0.1) URL",
+          "redirect_uri must be an allowed callback URL",
       });
     }
     // Require PKCE so the auth code is useless without the code_verifier.
@@ -244,6 +262,12 @@ export async function route(
       cfg.hmacKey,
       Date.now(),
     );
+    if (facadeState.length > COGNITO_STATE_MAX_LENGTH) {
+      return json(400, {
+        error: "invalid_request",
+        error_description: "redirect_uri and state exceed the supported length",
+      });
+    }
 
     const out = new URLSearchParams();
     for (const [k, v] of inParams.entries()) {
@@ -286,17 +310,28 @@ export async function route(
         error_description: "state HMAC failed or token expired",
       });
     }
-    // Defense-in-depth: re-enforce loopback at the redirect step.
-    if (!isAllowedClientRedirect(decoded.r)) {
-      logEvent("oauth.callback.non_loopback_redirect", {});
+    // Defense-in-depth: re-enforce the current allowlist at the redirect step.
+    if (
+      !isAllowedClientRedirect(decoded.r, cfg.allowedClientRedirectUris)
+    ) {
+      logEvent("oauth.callback.disallowed_redirect", {});
       return json(400, {
         error: "invalid_state",
-        error_description: "decoded redirect_uri is not a loopback URL",
+        error_description: "decoded redirect_uri is not allowed",
       });
     }
 
     const out = new URLSearchParams();
-    if (code) out.set("code", code);
+    if (code) {
+      out.set(
+        "code",
+        signAuthorizationCode(
+          { code, redirectUri: decoded.r },
+          cfg.hmacKey,
+          Date.now(),
+        ),
+      );
+    }
     if (error) {
       out.set("error", error);
       const errDesc = params.get("error_description");
@@ -305,7 +340,12 @@ export async function route(
     out.set("state", decoded.cs);
 
     logEvent("oauth.callback", { ok: !error, error: error ?? null });
-    return redirect(`${decoded.r}?${out.toString()}`);
+    const clientRedirect = new URL(decoded.r);
+    for (const key of ["code", "error", "error_description", "state"]) {
+      clientRedirect.searchParams.delete(key);
+    }
+    for (const [key, value] of out) clientRedirect.searchParams.set(key, value);
+    return redirect(clientRedirect.toString());
   }
 
   // POST /oauth/token — replace the client redirect_uri with the façade's so
@@ -319,18 +359,64 @@ export async function route(
       : (event.body ?? "");
     const inForm = new URLSearchParams(rawBody);
 
+    const grantType = inForm.get("grant_type");
     const clientRedirect = inForm.get("redirect_uri");
-    if (clientRedirect && !isAllowedClientRedirect(clientRedirect)) {
+    if (grantType === "authorization_code") {
+      const misconfigured = ensureHmacConfigured(cfg);
+      if (misconfigured) return misconfigured;
+      if (!clientRedirect) {
+        return json(400, {
+          error: "invalid_request",
+          error_description:
+            "redirect_uri is required for authorization_code exchange",
+        });
+      }
+      if (
+        !isAllowedClientRedirect(
+          clientRedirect,
+          cfg.allowedClientRedirectUris,
+        )
+      ) {
+        return json(400, {
+          error: "invalid_request",
+          error_description: "redirect_uri must be an allowed callback URL",
+        });
+      }
+
+      const clientCode = inForm.get("code");
+      if (!clientCode) {
+        return json(400, {
+          error: "invalid_request",
+          error_description: "code is required for authorization_code exchange",
+        });
+      }
+      const codePayload = verifyAuthorizationCode(
+        clientCode,
+        cfg.hmacKey,
+        Date.now(),
+      );
+      if (!codePayload || codePayload.r !== clientRedirect) {
+        return json(400, {
+          error: "invalid_grant",
+          error_description:
+            "authorization code is invalid or redirect_uri does not match",
+        });
+      }
+      inForm.set("code", codePayload.c);
+    } else if (
+      clientRedirect &&
+      !isAllowedClientRedirect(
+        clientRedirect,
+        cfg.allowedClientRedirectUris,
+      )
+    ) {
       return json(400, {
         error: "invalid_request",
-        error_description: "redirect_uri must be a loopback URL",
+        error_description: "redirect_uri must be an allowed callback URL",
       });
     }
 
-    if (
-      inForm.has("redirect_uri") ||
-      inForm.get("grant_type") === "authorization_code"
-    ) {
+    if (inForm.has("redirect_uri") || grantType === "authorization_code") {
       inForm.set("redirect_uri", `${base}/oauth/callback`);
     }
 
@@ -439,10 +525,29 @@ export async function route(
           "Only token_endpoint_auth_method 'none' is supported (public client).",
       });
     }
+    const redirectUris = req.redirect_uris ?? [
+      "http://localhost:8080/callback",
+    ];
+    if (
+      !Array.isArray(redirectUris) ||
+      redirectUris.length === 0 ||
+      redirectUris.some(
+        (uri) =>
+          typeof uri !== "string" ||
+          !isAllowedClientRedirect(uri, cfg.allowedClientRedirectUris) ||
+          !canEncodeCognitoState({ cs: "", r: uri }),
+      )
+    ) {
+      return json(400, {
+        error: "invalid_redirect_uri",
+        error_description:
+          "redirect_uris must contain only allowed callback URLs",
+      });
+    }
     return json(201, {
       client_id: cfg.userClientId,
       client_id_issued_at: Math.floor(Date.now() / 1000),
-      redirect_uris: req.redirect_uris ?? ["http://localhost:8080/callback"],
+      redirect_uris: redirectUris,
       grant_types: ["authorization_code", "refresh_token"],
       response_types: ["code"],
       token_endpoint_auth_method: "none",

--- a/infra/src/oauth-facade/state.test.ts
+++ b/infra/src/oauth-facade/state.test.ts
@@ -5,7 +5,12 @@
 
 import { describe, expect, it } from "vitest";
 
-import { signState, verifyState } from "./state.js";
+import {
+  signAuthorizationCode,
+  signState,
+  verifyAuthorizationCode,
+  verifyState,
+} from "./state.js";
 
 const KEY = "test-hmac-key-do-not-use-in-prod";
 const REDIRECT = "http://127.0.0.1:54321/callback";
@@ -57,5 +62,19 @@ describe("façade state (TC-MCPGW-040..046)", () => {
   it("TC-MCPGW-046: token stays under Cognito's 1024-char state limit", () => {
     const token = signState({ cs: "x".repeat(64), r: REDIRECT }, KEY, Date.now());
     expect(token.length).toBeLessThan(1024);
+  });
+
+  it("round-trips an authorization code bound to its client redirect URI", () => {
+    const now = Date.now();
+    const token = signAuthorizationCode(
+      { code: "cognito-code", redirectUri: REDIRECT },
+      KEY,
+      now,
+    );
+    expect(verifyAuthorizationCode(token, KEY, now)).toMatchObject({
+      c: "cognito-code",
+      r: REDIRECT,
+    });
+    expect(verifyAuthorizationCode(`${token}x`, KEY, now)).toBeNull();
   });
 });

--- a/infra/src/oauth-facade/state.ts
+++ b/infra/src/oauth-facade/state.ts
@@ -18,9 +18,16 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 
 const STATE_TTL_MS = 10 * 60 * 1000;
+export const COGNITO_STATE_MAX_LENGTH = 1024;
 
 export interface StatePayload {
   cs: string;
+  r: string;
+  ts: number;
+}
+
+export interface AuthorizationCodePayload {
+  c: string;
   r: string;
   ts: number;
 }
@@ -43,23 +50,44 @@ function hmac(key: string, payload: string): Buffer {
   return createHmac("sha256", key).update(payload).digest();
 }
 
-export function signState(
-  input: { cs: string; r: string },
+function signPayload(
+  payload: Record<string, string | number>,
   key: string,
-  now: number,
 ): string {
-  const payload: StatePayload = { cs: input.cs, r: input.r, ts: now };
   const payloadB64 = b64urlEncode(JSON.stringify(payload));
   const sigB64 = b64urlEncode(hmac(key, payloadB64));
   return `${payloadB64}.${sigB64}`;
 }
 
-export function verifyState(
+export function signState(
+  input: { cs: string; r: string },
+  key: string,
+  now: number,
+): string {
+  return signPayload({ cs: input.cs, r: input.r, ts: now }, key);
+}
+
+export function canEncodeCognitoState(
+  input: { cs: string; r: string },
+  now: number = Date.now(),
+): boolean {
+  return signState(input, "", now).length <= COGNITO_STATE_MAX_LENGTH;
+}
+
+export function signAuthorizationCode(
+  input: { code: string; redirectUri: string },
+  key: string,
+  now: number,
+): string {
+  return signPayload({ c: input.code, r: input.redirectUri, ts: now }, key);
+}
+
+function verifyPayload(
   token: string,
   key: string,
   now: number,
   ttlMs: number = STATE_TTL_MS,
-): StatePayload | null {
+): Record<string, unknown> | null {
   const parts = token.split(".");
   if (parts.length !== 2) return null;
   const [payloadB64, sigB64] = parts;
@@ -75,22 +103,57 @@ export function verifyState(
   if (providedSig.length !== expectedSig.length) return null;
   if (!timingSafeEqual(providedSig, expectedSig)) return null;
 
-  let payload: StatePayload;
+  let payload: unknown;
   try {
     payload = JSON.parse(b64urlDecode(payloadB64).toString("utf8"));
   } catch {
     return null;
   }
   if (
-    typeof payload.cs !== "string" ||
-    typeof payload.r !== "string" ||
-    typeof payload.ts !== "number"
+    !payload ||
+    typeof payload !== "object" ||
+    typeof (payload as Record<string, unknown>).ts !== "number"
   ) {
     return null;
   }
 
-  if (now - payload.ts > ttlMs) return null;
-  if (payload.ts > now + 60_000) return null; // future-dated by >60s, reject
+  const parsed = payload as Record<string, unknown> & { ts: number };
+  if (now - parsed.ts > ttlMs) return null;
+  if (parsed.ts > now + 60_000) return null; // future-dated by >60s, reject
 
-  return payload;
+  return parsed;
+}
+
+export function verifyState(
+  token: string,
+  key: string,
+  now: number,
+  ttlMs: number = STATE_TTL_MS,
+): StatePayload | null {
+  const payload = verifyPayload(token, key, now, ttlMs);
+  if (
+    !payload ||
+    typeof payload.cs !== "string" ||
+    typeof payload.r !== "string"
+  ) {
+    return null;
+  }
+  return { cs: payload.cs, r: payload.r, ts: payload.ts as number };
+}
+
+export function verifyAuthorizationCode(
+  token: string,
+  key: string,
+  now: number,
+  ttlMs: number = STATE_TTL_MS,
+): AuthorizationCodePayload | null {
+  const payload = verifyPayload(token, key, now, ttlMs);
+  if (
+    !payload ||
+    typeof payload.c !== "string" ||
+    typeof payload.r !== "string"
+  ) {
+    return null;
+  }
+  return { c: payload.c, r: payload.r, ts: payload.ts as number };
 }


### PR DESCRIPTION
## Summary
- add a stage-scoped SST callback allowlist backed by SSM
- preserve loopback redirects while enforcing exact HTTPS callback matching across OAuth routes
- bind authorization codes to the original redirect URI and enforce state/configuration limits

## Test Plan
- [x] Test cases documented (`docs/test-cases/configurable-oauth-callbacks.md`)
- [x] Root typecheck and tests pass (657 tests)
- [x] Infra typecheck and tests pass (220 tests)
- [x] Code simplification review passed
- [x] Independent PR review passed
- [x] CI checks pass
- [x] Preview E2E tests pass

## Checklist
- [x] New unit tests added
- [x] Documentation updated
- [x] Public artifact security scan passed