### PR TITLE
fix(auth): support large OAuth client state

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,10 +261,22 @@ dynamic registration, authorization, callback, and token exchange.
 
 Do not add hosted-client URLs to the Cognito reader app client's callback list.
 Cognito always redirects to the façade's own `/oauth/callback`; the façade
-carries the original client URL in HMAC-signed state and redirects there only
-after exact allowlist validation. It also wraps the Cognito authorization code
-in a short-lived signature so token exchange must present the same client
-redirect URL. The interactive OAuth client remains read-only.
+sends Cognito only a compact HMAC-signed nonce. The original client URL and
+opaque client state stay in a nonce-bound, HMAC-signed cookie with
+`Secure`, `HttpOnly`, `SameSite=Lax`, a 10-minute lifetime, and
+`Path=/oauth/callback`; the callback clears it after use. This supports hosted
+clients whose state is too large for Cognito's state parameter without adding
+server-side session storage. The complete cookie is limited to 4 KiB. One fixed
+cookie slot prevents pending authorization attempts from accumulating beyond
+API Gateway's
+[10,240-byte request-line and header quota](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-quotas.html);
+starting a new authorization in the same browser replaces an older unfinished
+transaction.
+
+After exact allowlist validation, the façade redirects to the client URL. It
+also wraps the Cognito authorization code in a short-lived signature so token
+exchange must present the same client redirect URL. The interactive OAuth
+client remains read-only.
 
 ### Optional production custom domain
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -242,9 +242,20 @@ environment forces a function update when the SSM value changes, without
 putting callback URLs in the environment. The facade applies the same allowlist
 to dynamic registration, authorization, callback, and token exchange. Cognito
 still sees only the facade's own `/oauth/callback`; external callback URLs are
-never added to the Cognito reader client. A short-lived HMAC wrapper binds the
-Cognito authorization code to the original external redirect URL for token
-exchange.
+never added to the Cognito reader client. The authorization request sends
+Cognito a compact HMAC-signed nonce. The original client state and redirect URL
+remain in a nonce-bound HMAC-signed cookie scoped to `/oauth/callback`, with
+`Secure`, `HttpOnly`, `SameSite=Lax`, a ten-minute lifetime, and a 4 KiB total
+size limit. A fixed cookie name bounds the browser to one pending transaction;
+a new authorization replaces an older unfinished flow, and a stale callback
+cannot clear the newer valid cookie. This avoids accumulating cookies against
+API Gateway's
+[10,240-byte request-line and header quota](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-quotas.html).
+The callback requires both valid signatures, rechecks the current allowlist,
+and clears the matching cookie. This remains free of server-side session storage
+while supporting hosted clients whose opaque state exceeds Cognito's state
+limit. A separate short-lived HMAC wrapper binds the Cognito authorization code
+to the original external redirect URL for token exchange.
 
 The OAuth facade optionally uses a production custom hostname from
 `MEM9_FACADE_CUSTOM_DOMAIN`. GitHub Actions supplies it only from the repository

--- a/docs/test-cases/configurable-oauth-callbacks.md
+++ b/docs/test-cases/configurable-oauth-callbacks.md
@@ -10,12 +10,15 @@ supported.
 | --- | --- | --- |
 | TC-OAUTH-CALLBACK-001 | Synthesize the OAuth facade | SST creates `OauthAllowedCallbackUrls` with an empty-list default and writes its value under the stage's OAuth SSM prefix |
 | TC-OAUTH-CALLBACK-002 | Load a valid JSON array containing complete HTTPS callback URLs | The runtime config exposes the validated URLs |
-| TC-OAUTH-CALLBACK-003 | Load malformed JSON, a non-array value, an HTTP remote URL, a URL with credentials or fragment, a URL too long for signed state, more than 20 unique URLs, or more than 1 KiB of JSON | Configuration fails closed before serving OAuth requests |
-| TC-OAUTH-CALLBACK-004 | Authorize with a configured HTTPS callback and S256 PKCE | The facade sends Cognito its own callback URL and preserves the external callback in signed state |
-| TC-OAUTH-CALLBACK-005 | Complete the callback for a configured HTTPS URL | The facade redirects the authorization code and original state to the exact configured URL |
+| TC-OAUTH-CALLBACK-003 | Load malformed JSON, a non-array value, an HTTP remote URL, a URL with credentials or fragment, more than 20 unique URLs, or more than 1 KiB of JSON | Configuration fails closed before serving OAuth requests |
+| TC-OAUTH-CALLBACK-004 | Authorize with a configured HTTPS callback and S256 PKCE | The facade sends Cognito its own callback URL plus a compact signed nonce and stores the external callback and client state in a signed callback-only cookie |
+| TC-OAUTH-CALLBACK-005 | Complete the callback for a configured HTTPS URL with the matching transaction cookie | The facade verifies both signatures, clears the cookie, and redirects the authorization code and original state to the exact configured URL |
 | TC-OAUTH-CALLBACK-006 | Use an unconfigured URL, sibling path, or sibling host | Authorization, callback, and token exchange reject the redirect |
 | TC-OAUTH-CALLBACK-007 | Exchange a signed code with the same configured HTTPS callback | The facade unwraps the Cognito code and sends Cognito its own callback URL |
 | TC-OAUTH-CALLBACK-008 | Dynamically register only loopback and configured HTTPS redirects | Registration succeeds and echoes the accepted redirects |
-| TC-OAUTH-CALLBACK-009 | Dynamically register any unsupported or intrinsically overlong redirect in a mixed list | The entire registration fails with `invalid_redirect_uri` |
+| TC-OAUTH-CALLBACK-009 | Dynamically register any unsupported redirect or one that cannot fit in the 4 KiB transaction cookie | The entire registration fails with `invalid_redirect_uri` |
 | TC-OAUTH-CALLBACK-010 | Use an existing localhost, IPv4 loopback, or IPv6 loopback callback | Existing RFC 8252 loopback behavior remains unchanged |
-| TC-OAUTH-CALLBACK-011 | Omit, empty, or change the redirect URI during authorization-code exchange, or exceed Cognito's state limit | The facade rejects the request before contacting Cognito |
+| TC-OAUTH-CALLBACK-011 | Omit, empty, or change the redirect URI during authorization-code exchange | The facade rejects the request before contacting Cognito |
+| TC-OAUTH-CALLBACK-012 | Authorize with a long opaque hosted-client state that exceeds Cognito's direct state capacity | The compact Cognito state remains within its limit and the original client state round-trips through the signed transaction cookie |
+| TC-OAUTH-CALLBACK-013 | Complete a callback with a missing, tampered, duplicate, or expired transaction cookie | The facade returns `invalid_state` and does not redirect to the client |
+| TC-OAUTH-CALLBACK-014 | Start a second authorization before the first callback returns | The fixed cookie slot contains only the newer transaction; the stale callback fails without clearing it, and the newer callback still succeeds |

--- a/docs/test-cases/configurable-oauth-callbacks.md
+++ b/docs/test-cases/configurable-oauth-callbacks.md
@@ -8,7 +8,7 @@ supported.
 
 | ID | Scenario | Expected result |
 | --- | --- | --- |
-| TC-OAUTH-CALLBACK-001 | Synthesize the OAuth facade | SST creates `OauthAllowedCallbackUrls` with an empty-list default and writes its value under the stage's OAuth SSM prefix |
+| TC-OAUTH-CALLBACK-001 | Synthesize the OAuth facade | SST creates `OauthAllowedCallbackUrls` with an empty-list default and writes its value under the stage's OAuth SSM prefix; production keeps the operator-set HMAC secret while ephemeral stages receive a stable Pulumi-generated secret output |
 | TC-OAUTH-CALLBACK-002 | Load a valid JSON array containing complete HTTPS callback URLs | The runtime config exposes the validated URLs |
 | TC-OAUTH-CALLBACK-003 | Load malformed JSON, a non-array value, an HTTP remote URL, a URL with credentials or fragment, more than 20 unique URLs, or more than 1 KiB of JSON | Configuration fails closed before serving OAuth requests |
 | TC-OAUTH-CALLBACK-004 | Authorize with a configured HTTPS callback and S256 PKCE | The facade sends Cognito its own callback URL plus a compact signed nonce and stores the external callback and client state in a signed callback-only cookie |

--- a/infra/oauth-facade.test.ts
+++ b/infra/oauth-facade.test.ts
@@ -21,6 +21,10 @@ function out<T>(value: T): {
   return { value, apply: (fn) => out(fn(value) as never) };
 }
 
+function secretOut<T>(value: T) {
+  return { ...out(value), isSecret: true as const };
+}
+
 interface Rec {
   kind: string;
   args: Record<string, unknown>;
@@ -30,6 +34,10 @@ let params: { name: string; type: string; value: unknown }[];
 let routeSpy: ReturnType<typeof vi.fn>;
 let addAuthorizerSpy: ReturnType<typeof vi.fn>;
 let authorizerId: ReturnType<typeof out>;
+let randomPasswords: {
+  name: string;
+  args: Record<string, unknown>;
+}[];
 let previousFacadeAuthorizerEnabled: string | undefined;
 let previousFacadeCustomDomain: string | undefined;
 let previousCloudflareApiToken: string | undefined;
@@ -137,11 +145,20 @@ function installGlobals(stage: string) {
       }
     },
   };
+  (globalThis as Record<string, unknown>).random = {
+    RandomPassword: class {
+      result = secretOut("preview-hmac-key");
+      constructor(name: string, args: Record<string, unknown>) {
+        randomPasswords.push({ name, args });
+      }
+    },
+  };
 }
 
 beforeEach(() => {
   created = [];
   params = [];
+  randomPasswords = [];
   routeSpy = vi.fn();
   authorizerId = out("facade-allow-all-authorizer-id");
   addAuthorizerSpy = vi.fn(() => ({ id: authorizerId }));
@@ -156,7 +173,7 @@ beforeEach(() => {
   delete process.env.CLOUDFLARE_ZONE_ID;
 });
 afterEach(() => {
-  for (const g of ["$app", "aws", "sst", "$interpolate"])
+  for (const g of ["$app", "aws", "sst", "random", "$interpolate"])
     delete (globalThis as Record<string, unknown>)[g];
   if (previousFacadeAuthorizerEnabled === undefined) {
     delete process.env.MEM9_FACADE_AUTHORIZER_ENABLED;
@@ -443,11 +460,38 @@ describe("oauthFacade factory", () => {
       /^[0-9a-f]{64}$/u,
     );
     expect(environment).not.toHaveProperty("OAUTH_ALLOWED_CALLBACK_URLS");
+    expect(randomPasswords).toEqual([]);
     expect(
       params.find((p) => p.name.endsWith("/oauth/allowed-callback-urls")),
     ).toMatchObject({
       type: "String",
       value: "OauthAllowedCallbackUrls-value",
+    });
+  });
+
+  it("generates a stable non-production HMAC key instead of using an empty fallback", async () => {
+    installGlobals("pr-42");
+    const oauthFacade = await loadFacade();
+    oauthFacade(fakeCognitoOut());
+
+    expect(randomPasswords).toEqual([
+      {
+        name: "OauthStateHmacKey",
+        args: { length: 64, special: false },
+      },
+    ]);
+    expect(
+      created
+        .filter(({ kind }) => kind === "Secret")
+        .map(({ args }) => args),
+    ).toEqual([{ name: "OauthAllowedCallbackUrls", fallback: "[]" }]);
+    const environment = only("SstFunction").environment as Record<
+      string,
+      unknown
+    >;
+    expect(environment.OAUTH_STATE_HMAC_KEY).toMatchObject({
+      value: "preview-hmac-key",
+      isSecret: true,
     });
   });
 

--- a/infra/oauth-facade.ts
+++ b/infra/oauth-facade.ts
@@ -15,9 +15,9 @@
  * — it's a public authorization-code client (Hosted-UI), scoped to read-only
  * (`mem9-mcp/read`), returned via `readerClientId` for gateway.ts to trust.
  *
- * The HMAC state-signing key is an `sst.Secret` seeded EMPTY — the handler returns
- * 503 until the operator seeds it (config.ts treats an empty key as unconfigured),
- * so a fresh deploy never runs the flow with a guessable state signature.
+ * Production uses an operator-seeded `sst.Secret` and fails closed while it is
+ * empty. Ephemeral stages use a stable Pulumi RandomPassword secret output so
+ * preview OAuth smoke tests exercise the signed flow without shared credentials.
  *
  * The façade Function is NOT VPC-attached: it only reaches Cognito + SSM over the
  * public internet, so a VPC/NAT hop would only add cold-start ENI latency.
@@ -151,8 +151,16 @@ export function oauthFacade(cognitoOut: CognitoOutputs): OauthFacadeOutputs {
     { dependsOn: [facadeApi] },
   );
 
-  // --- HMAC state-signing key (empty default → façade 503 until seeded) ---
-  const hmacKey = new sst.Secret("OauthStateHmacKey", "");
+  // Production fails closed until its operator-owned key is seeded. Ephemeral
+  // stages get a secret Pulumi output that remains stable across stack updates
+  // and disappears with the stage.
+  const hmacKeyValue =
+    stage === "prod"
+      ? new sst.Secret("OauthStateHmacKey", "").value
+      : new random.RandomPassword("OauthStateHmacKey", {
+          length: 64,
+          special: false,
+        }).result;
   // Stage-scoped JSON array of exact HTTPS callbacks for hosted MCP clients.
   // Loopback callbacks remain built in; an empty array preserves that default.
   const allowedCallbackUrls = new sst.Secret(
@@ -190,7 +198,7 @@ export function oauthFacade(cognitoOut: CognitoOutputs): OauthFacadeOutputs {
       COGNITO_REVOCATION_ENDPOINT: cognitoOut.revocationEndpoint,
       COGNITO_JWKS_URI: cognitoOut.jwksUri,
       RESOURCE_SCOPES: "mem9-mcp/read",
-      OAUTH_STATE_HMAC_KEY: hmacKey.value,
+      OAUTH_STATE_HMAC_KEY: hmacKeyValue,
       OAUTH_ALLOWED_CALLBACK_URLS_VERSION: allowedCallbackUrlsVersion,
     },
     permissions: [

--- a/infra/src/oauth-facade/config.test.ts
+++ b/infra/src/oauth-facade/config.test.ts
@@ -134,10 +134,6 @@ describe("façade config loader (cycle-break SSM reads)", () => {
     ["fragment", '["https://oauth.example.com/callback#fragment"]'],
     ["oversized whitespace", " ".repeat(1025)],
     [
-      "callback that cannot fit in signed state",
-      JSON.stringify([`https://oauth.example.com/${"x".repeat(800)}`]),
-    ],
-    [
       "serialized configuration over 1 KiB",
       JSON.stringify([`https://oauth.example.com/${"x".repeat(1100)}`]),
     ],
@@ -154,5 +150,12 @@ describe("façade config loader (cycle-break SSM reads)", () => {
     expect(() => parseAllowedCallbackUrls(raw)).toThrow(
       /OauthAllowedCallbackUrls/u,
     );
+  });
+
+  it("accepts a callback within the serialized configuration limit", () => {
+    const callback = `https://oauth.example.com/${"x".repeat(800)}`;
+    expect(parseAllowedCallbackUrls(JSON.stringify([callback]))).toEqual([
+      callback,
+    ]);
   });
 });

--- a/infra/src/oauth-facade/config.ts
+++ b/infra/src/oauth-facade/config.ts
@@ -26,7 +26,6 @@
  */
 
 import { GetParametersCommand, SSMClient } from "@aws-sdk/client-ssm";
-import { canEncodeCognitoState } from "./state.js";
 
 export interface FacadeConfig {
   /** AgentCore Gateway URL the façade proxies to (`/mcp` + fallthrough). */
@@ -116,11 +115,6 @@ export function parseAllowedCallbackUrls(raw = ""): string[] {
     ) {
       throw new Error(
         `${ALLOWED_CALLBACK_URLS_SETTING} entries must be HTTPS URLs without credentials or fragments`,
-      );
-    }
-    if (!canEncodeCognitoState({ cs: "", r: entry })) {
-      throw new Error(
-        `${ALLOWED_CALLBACK_URLS_SETTING} entries must fit in Cognito's signed state limit`,
       );
     }
     urls.add(entry);

--- a/infra/src/oauth-facade/config.ts
+++ b/infra/src/oauth-facade/config.ts
@@ -20,9 +20,10 @@
  *   - `{mcpPrefix}/oauth/allowed-callback-urls`
  *
  * The remaining, non-cyclic values (Cognito endpoint URLs that depend only on
- * the user pool + domain, the HMAC key from an SST Secret, and the resource
- * scopes) are plain env vars. The SSM client is injected (`SsmLike`) so the
- * loader is unit-testable without AWS.
+ * the user pool + domain, the stage-specific HMAC key, and the resource scopes)
+ * are plain env vars. Production sources the key from an operator-set SST
+ * secret; ephemeral stages use a Pulumi-generated secret output. The SSM client
+ * is injected (`SsmLike`) so the loader is unit-testable without AWS.
  */
 
 import { GetParametersCommand, SSMClient } from "@aws-sdk/client-ssm";

--- a/infra/src/oauth-facade/handler.test.ts
+++ b/infra/src/oauth-facade/handler.test.ts
@@ -8,7 +8,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { isAllowedClientRedirect, route } from "./handler.js";
 import {
   signAuthorizationCode,
+  signOAuthTransaction,
   verifyAuthorizationCode,
+  verifyOAuthTransaction,
   verifyState,
 } from "./state.js";
 import type { FacadeConfig } from "./config.js";
@@ -40,15 +42,27 @@ function cfg(overrides: Partial<FacadeConfig> = {}): FacadeConfig {
 function ev(
   path: string,
   method = "GET",
-  opts: { query?: string; body?: string; headers?: Record<string, string> } = {},
+  opts: {
+    query?: string;
+    body?: string;
+    headers?: Record<string, string>;
+    cookies?: string[];
+  } = {},
 ) {
   return {
     rawPath: path,
     rawQueryString: opts.query ?? "",
     headers: { host: HOST, ...(opts.headers ?? {}) },
+    cookies: opts.cookies,
     body: opts.body,
     requestContext: { http: { method }, domainName: HOST },
   };
+}
+
+function requestCookies(
+  response: { cookies?: string[] },
+): string[] {
+  return (response.cookies ?? []).map((cookie) => cookie.split(";", 1)[0]!);
 }
 
 afterEach(() => {
@@ -119,7 +133,7 @@ describe("façade routing (TC-MCPGW-060..073)", () => {
     expect(oidc.registration_endpoint).toBe(`${BASE}/register`);
   });
 
-  it("TC-MCPGW-062: /oauth/authorize 302s to Cognito with replaced redirect_uri + HMAC state", async () => {
+  it("TC-MCPGW-062: /oauth/authorize sends Cognito a short signed handle and stores client state in a signed cookie", async () => {
     const q = new URLSearchParams({
       client_id: "c",
       redirect_uri: "http://127.0.0.1:5000/callback",
@@ -138,8 +152,25 @@ describe("façade routing (TC-MCPGW-060..073)", () => {
       HMAC,
       Date.now(),
     );
-    expect(decoded!.r).toBe("http://127.0.0.1:5000/callback");
-    expect(decoded!.cs).toBe("orig-state");
+    expect(decoded).not.toBeNull();
+    expect(decoded!.r).not.toBe("http://127.0.0.1:5000/callback");
+    expect(decoded!.cs).not.toBe("orig-state");
+
+    const setCookie = (res as typeof res & { cookies: string[] }).cookies[0]!;
+    expect(setCookie).toContain("Path=/oauth/callback");
+    expect(setCookie).toContain("Secure");
+    expect(setCookie).toContain("HttpOnly");
+    expect(setCookie).toContain("SameSite=Lax");
+    const transaction = verifyOAuthTransaction(
+      setCookie.split(";", 1)[0]!.split("=", 2)[1]!,
+      HMAC,
+      Date.now(),
+    );
+    expect(transaction).toMatchObject({
+      nonce: decoded!.cs,
+      redirectUri: "http://127.0.0.1:5000/callback",
+      clientState: "orig-state",
+    });
   });
 
   it("TC-MCPGW-063: /oauth/authorize without redirect_uri → 400", async () => {
@@ -193,16 +224,52 @@ describe("façade routing (TC-MCPGW-060..073)", () => {
     expect(JSON.parse(res.body).error_description).toMatch(/S256/);
   });
 
-  it("rejects authorize requests whose signed state would exceed Cognito's limit", async () => {
+  it("TC-OAUTH-CALLBACK-012: preserves a hosted client's long opaque state without exceeding Cognito's limit", async () => {
+    const clientState = "g".repeat(2200);
     const q = new URLSearchParams({
-      redirect_uri: "http://localhost:5000/cb",
-      state: "x".repeat(1000),
+      redirect_uri: REMOTE_CALLBACK,
+      state: clientState,
       code_challenge: "x",
       code_challenge_method: "S256",
     }).toString();
-    const res = await route(ev("/oauth/authorize", "GET", { query: q }), cfg());
-    expect(res.statusCode).toBe(400);
-    expect(JSON.parse(res.body).error_description).toMatch(/length/u);
+    const config = cfg({ allowedClientRedirectUris: [REMOTE_CALLBACK] });
+    const authRes = await route(
+      ev("/oauth/authorize", "GET", { query: q }),
+      config,
+    );
+    expect(authRes.statusCode).toBe(302);
+    const cognitoState = new URL(
+      authRes.headers.location,
+    ).searchParams.get("state");
+    expect(cognitoState).toBeTruthy();
+    expect(cognitoState!.length).toBeLessThanOrEqual(1024);
+
+    const cookies = (authRes as typeof authRes & { cookies: string[] }).cookies;
+    expect(cookies).toHaveLength(1);
+    expect(Buffer.byteLength(cookies[0]!, "utf8")).toBeLessThanOrEqual(4096);
+    expect(cookies[0]).toContain("HttpOnly");
+    expect(cookies[0]).toContain("SameSite=Lax");
+
+    const callbackQ = new URLSearchParams({
+      code: "auth-code-xyz",
+      state: cognitoState!,
+    }).toString();
+    const callbackRes = await route(
+      ev("/oauth/callback", "GET", {
+        query: callbackQ,
+        cookies: requestCookies({ cookies }),
+      }),
+      config,
+    );
+    expect(callbackRes.statusCode).toBe(302);
+    const clientLocation = new URL(callbackRes.headers.location);
+    expect(clientLocation.origin + clientLocation.pathname).toBe(
+      REMOTE_CALLBACK,
+    );
+    expect(clientLocation.searchParams.get("state")).toBe(clientState);
+    expect(
+      (callbackRes as typeof callbackRes & { cookies: string[] }).cookies[0],
+    ).toContain("Max-Age=0");
   });
 
   it("TC-MCPGW-067: /oauth/callback 302s back to the client loopback with code + orig state", async () => {
@@ -225,7 +292,13 @@ describe("façade routing (TC-MCPGW-060..073)", () => {
       code: "auth-code-xyz",
       state: facadeState,
     }).toString();
-    const res = await route(ev("/oauth/callback", "GET", { query: cbQ }), cfg());
+    const res = await route(
+      ev("/oauth/callback", "GET", {
+        query: cbQ,
+        cookies: requestCookies(authRes),
+      }),
+      cfg(),
+    );
     expect(res.statusCode).toBe(302);
     const loc = new URL(res.headers.location);
     expect(loc.origin + loc.pathname).toBe("http://127.0.0.1:5000/callback");
@@ -246,6 +319,156 @@ describe("façade routing (TC-MCPGW-060..073)", () => {
     const res = await route(ev("/oauth/callback", "GET", { query: q }), cfg());
     expect(res.statusCode).toBe(400);
     expect(JSON.parse(res.body).error).toBe("invalid_state");
+  });
+
+  it("TC-OAUTH-CALLBACK-013: rejects a valid Cognito state handle when its transaction cookie is missing", async () => {
+    const authQ = new URLSearchParams({
+      redirect_uri: "http://127.0.0.1:5000/callback",
+      state: "orig-state",
+      code_challenge: "x",
+      code_challenge_method: "S256",
+    }).toString();
+    const authRes = await route(
+      ev("/oauth/authorize", "GET", { query: authQ }),
+      cfg(),
+    );
+    const state = new URL(authRes.headers.location).searchParams.get("state")!;
+
+    const res = await route(
+      ev("/oauth/callback", "GET", {
+        query: new URLSearchParams({ code: "c", state }).toString(),
+      }),
+      cfg(),
+    );
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toBe("invalid_state");
+    expect((res as typeof res & { cookies: string[] }).cookies[0]).toContain(
+      "Max-Age=0",
+    );
+  });
+
+  it("TC-OAUTH-CALLBACK-013: rejects tampered or duplicate transaction cookies", async () => {
+    const authQ = new URLSearchParams({
+      redirect_uri: "http://127.0.0.1:5000/callback",
+      state: "orig-state",
+      code_challenge: "x",
+      code_challenge_method: "S256",
+    }).toString();
+    const authRes = await route(
+      ev("/oauth/authorize", "GET", { query: authQ }),
+      cfg(),
+    );
+    const state = new URL(authRes.headers.location).searchParams.get("state")!;
+    const cookie = requestCookies(authRes)[0]!;
+    const query = new URLSearchParams({ code: "c", state }).toString();
+
+    const tampered = await route(
+      ev("/oauth/callback", "GET", {
+        query,
+        cookies: [`${cookie}x`],
+      }),
+      cfg(),
+    );
+    expect(tampered.statusCode).toBe(400);
+    expect(JSON.parse(tampered.body).error).toBe("invalid_state");
+
+    const duplicate = await route(
+      ev("/oauth/callback", "GET", {
+        query,
+        cookies: [cookie, cookie],
+      }),
+      cfg(),
+    );
+    expect(duplicate.statusCode).toBe(400);
+    expect(JSON.parse(duplicate.body).error).toBe("invalid_state");
+  });
+
+  it("TC-OAUTH-CALLBACK-013: rejects an expired transaction cookie", async () => {
+    const authQ = new URLSearchParams({
+      redirect_uri: "http://127.0.0.1:5000/callback",
+      state: "orig-state",
+      code_challenge: "x",
+      code_challenge_method: "S256",
+    }).toString();
+    const authRes = await route(
+      ev("/oauth/authorize", "GET", { query: authQ }),
+      cfg(),
+    );
+    const state = new URL(authRes.headers.location).searchParams.get("state")!;
+    const handle = verifyState(state, HMAC, Date.now())!;
+    const cookie = requestCookies(authRes)[0]!;
+    const cookieName = cookie.slice(0, cookie.indexOf("="));
+    const expiredTransaction = signOAuthTransaction(
+      {
+        nonce: handle.cs,
+        clientState: "orig-state",
+        redirectUri: "http://127.0.0.1:5000/callback",
+      },
+      HMAC,
+      Date.now() - 11 * 60 * 1000,
+    );
+
+    const res = await route(
+      ev("/oauth/callback", "GET", {
+        query: new URLSearchParams({ code: "c", state }).toString(),
+        cookies: [`${cookieName}=${expiredTransaction}`],
+      }),
+      cfg(),
+    );
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toBe("invalid_state");
+  });
+
+  it("binds one fixed transaction-cookie slot and preserves a newer transaction from a stale callback", async () => {
+    const authorize = async (clientState: string) => {
+      const query = new URLSearchParams({
+        redirect_uri: "http://127.0.0.1:5000/callback",
+        state: clientState,
+        code_challenge: "x",
+        code_challenge_method: "S256",
+      }).toString();
+      return route(ev("/oauth/authorize", "GET", { query }), cfg());
+    };
+    const first = await authorize("first-state");
+    const second = await authorize("second-state");
+    const firstCookie = requestCookies(first)[0]!;
+    const secondCookie = requestCookies(second)[0]!;
+    const firstCookieName = firstCookie.slice(0, firstCookie.indexOf("="));
+    const secondCookieName = secondCookie.slice(0, secondCookie.indexOf("="));
+    expect(secondCookieName).toBe(firstCookieName);
+    const firstState = new URL(first.headers.location).searchParams.get("state")!;
+    const secondState = new URL(second.headers.location).searchParams.get(
+      "state",
+    )!;
+
+    const stale = await route(
+      ev("/oauth/callback", "GET", {
+        query: new URLSearchParams({
+          code: "c",
+          state: firstState,
+        }).toString(),
+        cookies: [secondCookie],
+      }),
+      cfg(),
+    );
+    expect(stale.statusCode).toBe(400);
+    expect(JSON.parse(stale.body).error).toBe("invalid_state");
+    expect(stale.cookies).toBeUndefined();
+
+    const current = await route(
+      ev("/oauth/callback", "GET", {
+        query: new URLSearchParams({
+          code: "c",
+          state: secondState,
+        }).toString(),
+        cookies: [secondCookie],
+      }),
+      cfg(),
+    );
+    expect(current.statusCode).toBe(302);
+    expect(new URL(current.headers.location).searchParams.get("state")).toBe(
+      "second-state",
+    );
   });
 
   it("TC-MCPGW-069: /oauth/token replaces redirect_uri before forwarding to Cognito", async () => {
@@ -507,7 +730,10 @@ describe("façade routing (TC-MCPGW-060..073)", () => {
       state: cognitoRedirect.searchParams.get("state")!,
     }).toString();
     const callbackRes = await route(
-      ev("/oauth/callback", "GET", { query: callbackQ }),
+      ev("/oauth/callback", "GET", {
+        query: callbackQ,
+        cookies: requestCookies(authRes),
+      }),
       config,
     );
     expect(callbackRes.statusCode).toBe(302);
@@ -561,6 +787,7 @@ describe("façade routing (TC-MCPGW-060..073)", () => {
     const res = await route(
       ev("/oauth/callback", "GET", {
         query: new URLSearchParams({ code: "c", state }).toString(),
+        cookies: requestCookies(authRes),
       }),
       cfg(),
     );
@@ -686,12 +913,26 @@ describe("façade routing (TC-MCPGW-060..073)", () => {
     expect(JSON.parse(res.body).error).toBe("invalid_redirect_uri");
   });
 
-  it("rejects registration of a callback that cannot fit in signed state", async () => {
+  it("accepts registration of a callback that fits the transaction cookie", async () => {
+    const redirectUri = `http://localhost:8080/${"x".repeat(800)}`;
+    const res = await route(
+      ev("/register", "POST", {
+        body: JSON.stringify({
+          redirect_uris: [redirectUri],
+        }),
+      }),
+      cfg(),
+    );
+    expect(res.statusCode).toBe(201);
+    expect(JSON.parse(res.body).redirect_uris).toEqual([redirectUri]);
+  });
+
+  it("rejects registration of a callback that cannot fit in the transaction cookie", async () => {
     const res = await route(
       ev("/register", "POST", {
         body: JSON.stringify({
           redirect_uris: [
-            `http://localhost:8080/${"x".repeat(800)}`,
+            `http://localhost:8080/${"x".repeat(4000)}`,
           ],
         }),
       }),

--- a/infra/src/oauth-facade/handler.ts
+++ b/infra/src/oauth-facade/handler.ts
@@ -1,11 +1,11 @@
 /**
  * OAuth2 façade for the mem9 MCP surface (§6).
  *
- * Adapted from a proven OAuth2-façade router. One adaptation:
+ * Adapted from a proven OAuth2-façade router:
  *
  *   - Config is injected (`route(event, cfg)`) and resolved at runtime from
  *     env + SSM (`./config.ts`) — see that file for the SSM-at-runtime config.
- *     The routing logic below is unchanged and fully unit-testable without AWS.
+ *     The router remains fully unit-testable without AWS.
  *
  * The façade is fronted by an `ApiGatewayV2` HTTP API (NOT a Lambda Function
  * URL — that would expose an open `Principal: "*"` resource policy). The event
@@ -22,20 +22,26 @@
  *   stage-configured exact HTTPS callbacks; Cognito requires static
  *   `callbackUrls`. The façade is the single registered Cognito target and
  *   302-redirects to the validated client URL. State + the original
- *   redirect_uri ride through Cognito as an HMAC-signed opaque blob so the
- *   proxy stays stateless.
+ *   redirect_uri are held in a short-lived HMAC-signed HttpOnly cookie while a
+ *   compact signed nonce rides through Cognito. This keeps third-party client
+ *   state out of Cognito's bounded `state` parameter without adding server-side
+ *   session storage.
  *
  * Routes: `/.well-known/*` metadata, `/oauth/authorize|callback|token|logout`,
  * `/register`, and a catch-all proxy to the AgentCore Gateway (`/mcp`).
  */
 
+import { randomBytes } from "node:crypto";
+
 import { loadConfig, type FacadeConfig } from "./config.js";
 import {
-  canEncodeCognitoState,
   COGNITO_STATE_MAX_LENGTH,
+  SIGNED_PAYLOAD_TTL_SECONDS,
   signAuthorizationCode,
+  signOAuthTransaction,
   signState,
   verifyAuthorizationCode,
+  verifyOAuthTransaction,
   verifyState,
 } from "./state.js";
 
@@ -44,6 +50,7 @@ interface ApiGwEvent {
   path?: string;
   rawQueryString?: string;
   headers?: Record<string, string>;
+  cookies?: string[];
   body?: string;
   isBase64Encoded?: boolean;
   requestContext?: {
@@ -57,7 +64,19 @@ interface ApiGwResponse {
   statusCode: number;
   headers: Record<string, string>;
   body: string;
+  cookies?: string[];
 }
+
+const OAUTH_STATE_COOKIE_NAME = "__Secure-mem9-oauth";
+const OAUTH_STATE_COOKIE_PATH = "/oauth/callback";
+const OAUTH_STATE_COOKIE_MAX_BYTES = 4096;
+const OAUTH_STATE_HANDLE_MARKER = "cookie-v1";
+const OAUTH_STATE_NONCE_BYTES = 16;
+const OAUTH_STATE_NONCE_LENGTH = Math.ceil((OAUTH_STATE_NONCE_BYTES * 4) / 3);
+const OAUTH_STATE_NONCE_PATTERN = new RegExp(
+  `^[A-Za-z0-9_-]{${OAUTH_STATE_NONCE_LENGTH}}$`,
+  "u",
+);
 
 function json(
   status: number,
@@ -71,12 +90,75 @@ function json(
   };
 }
 
-function redirect(location: string): ApiGwResponse {
+function redirect(location: string, cookies?: string[]): ApiGwResponse {
   return {
     statusCode: 302,
     headers: { location, "cache-control": "no-store" },
     body: "",
+    ...(cookies?.length ? { cookies } : {}),
   };
+}
+
+function stateCookie(name: string, value: string, maxAge: number): string {
+  return [
+    `${name}=${value}`,
+    `Max-Age=${maxAge}`,
+    `Path=${OAUTH_STATE_COOKIE_PATH}`,
+    "Secure",
+    "HttpOnly",
+    "SameSite=Lax",
+  ].join("; ");
+}
+
+function createTransactionCookie(
+  clientState: string,
+  clientRedirect: string,
+  hmacKey: string,
+  now: number,
+  nonce: string,
+): string | null {
+  const transaction = signOAuthTransaction(
+    {
+      nonce,
+      clientState,
+      redirectUri: clientRedirect,
+    },
+    hmacKey,
+    now,
+  );
+  const cookie = stateCookie(
+    OAUTH_STATE_COOKIE_NAME,
+    transaction,
+    SIGNED_PAYLOAD_TTL_SECONDS,
+  );
+  return Buffer.byteLength(cookie, "utf8") <= OAUTH_STATE_COOKIE_MAX_BYTES
+    ? cookie
+    : null;
+}
+
+function canFitTransactionCookie(clientRedirect: string): boolean {
+  return (
+    createTransactionCookie(
+      "",
+      clientRedirect,
+      "",
+      1_000_000_000_000,
+      "n".repeat(OAUTH_STATE_NONCE_LENGTH),
+    ) !== null
+  );
+}
+
+function readCookie(event: ApiGwEvent, name: string): string | null {
+  const values: string[] = [];
+  for (const header of event.cookies ?? []) {
+    for (const pair of header.split(";")) {
+      const separator = pair.indexOf("=");
+      if (separator < 0) continue;
+      if (pair.slice(0, separator).trim() !== name) continue;
+      values.push(pair.slice(separator + 1).trim());
+    }
+  }
+  return values.length === 1 ? values[0]! : null;
 }
 
 function selfBaseUrl(event: ApiGwEvent): string {
@@ -210,8 +292,8 @@ export async function route(
     });
   }
 
-  // GET /oauth/authorize — wrap state + client redirect_uri into an
-  // HMAC-signed token, then 302 to Cognito Hosted UI.
+  // GET /oauth/authorize — store state + client redirect_uri in a signed
+  // callback cookie, then send a compact signed nonce to Cognito Hosted UI.
   if (path === "/oauth/authorize" && method === "GET") {
     const misconfigured = ensureHmacConfigured(cfg);
     if (misconfigured) return misconfigured;
@@ -257,15 +339,32 @@ export async function route(
       });
     }
 
-    const facadeState = signState(
-      { cs: clientState, r: clientRedirect },
+    const now = Date.now();
+    const nonce = randomBytes(OAUTH_STATE_NONCE_BYTES).toString("base64url");
+    const transactionCookie = createTransactionCookie(
+      clientState,
+      clientRedirect,
       cfg.hmacKey,
-      Date.now(),
+      now,
+      nonce,
     );
-    if (facadeState.length > COGNITO_STATE_MAX_LENGTH) {
+    if (!transactionCookie) {
       return json(400, {
         error: "invalid_request",
-        error_description: "redirect_uri and state exceed the supported length",
+        error_description:
+          "redirect_uri and state exceed the supported cookie length",
+      });
+    }
+
+    const facadeState = signState(
+      { cs: nonce, r: OAUTH_STATE_HANDLE_MARKER },
+      cfg.hmacKey,
+      now,
+    );
+    if (facadeState.length > COGNITO_STATE_MAX_LENGTH) {
+      return json(500, {
+        error: "server_error",
+        error_description: "generated OAuth state exceeds the upstream limit",
       });
     }
 
@@ -281,7 +380,9 @@ export async function route(
       client_id: inParams.get("client_id") ?? null,
       has_pkce: inParams.get("code_challenge") !== null,
     });
-    return redirect(`${cfg.authorize}?${out.toString()}`);
+    return redirect(`${cfg.authorize}?${out.toString()}`, [
+      transactionCookie,
+    ]);
   }
 
   // GET /oauth/callback — verify HMAC, decode original client state +
@@ -302,23 +403,55 @@ export async function route(
       });
     }
 
-    const decoded = verifyState(facadeState, cfg.hmacKey, Date.now());
-    if (!decoded) {
+    const now = Date.now();
+    const handle = verifyState(facadeState, cfg.hmacKey, now);
+    if (
+      !handle ||
+      handle.r !== OAUTH_STATE_HANDLE_MARKER ||
+      !OAUTH_STATE_NONCE_PATTERN.test(handle.cs)
+    ) {
       logEvent("oauth.callback.bad_state", {});
       return json(400, {
         error: "invalid_state",
         error_description: "state HMAC failed or token expired",
       });
     }
+    const clearStateCookie = stateCookie(OAUTH_STATE_COOKIE_NAME, "", 0);
+    const transaction = readCookie(event, OAUTH_STATE_COOKIE_NAME);
+    const signedTransaction = transaction
+      ? verifyOAuthTransaction(transaction, cfg.hmacKey, now)
+      : null;
+    if (!signedTransaction) {
+      logEvent("oauth.callback.bad_state_cookie", {});
+      const response = json(400, {
+        error: "invalid_state",
+        error_description: "OAuth state cookie is missing, invalid, or expired",
+      });
+      response.cookies = [clearStateCookie];
+      return response;
+    }
+    if (signedTransaction.nonce !== handle.cs) {
+      // A newer authorization may have replaced the single transaction slot.
+      // Do not let a stale callback clear that newer, otherwise valid cookie.
+      logEvent("oauth.callback.stale_state_cookie", {});
+      return json(400, {
+        error: "invalid_state",
+        error_description: "OAuth state cookie does not match this request",
+      });
+    }
+    const clientState = signedTransaction.clientState;
+    const clientRedirect = signedTransaction.redirectUri;
     // Defense-in-depth: re-enforce the current allowlist at the redirect step.
     if (
-      !isAllowedClientRedirect(decoded.r, cfg.allowedClientRedirectUris)
+      !isAllowedClientRedirect(clientRedirect, cfg.allowedClientRedirectUris)
     ) {
       logEvent("oauth.callback.disallowed_redirect", {});
-      return json(400, {
+      const response = json(400, {
         error: "invalid_state",
         error_description: "decoded redirect_uri is not allowed",
       });
+      response.cookies = [clearStateCookie];
+      return response;
     }
 
     const out = new URLSearchParams();
@@ -326,9 +459,9 @@ export async function route(
       out.set(
         "code",
         signAuthorizationCode(
-          { code, redirectUri: decoded.r },
+          { code, redirectUri: clientRedirect },
           cfg.hmacKey,
-          Date.now(),
+          now,
         ),
       );
     }
@@ -337,15 +470,15 @@ export async function route(
       const errDesc = params.get("error_description");
       if (errDesc) out.set("error_description", errDesc);
     }
-    out.set("state", decoded.cs);
+    out.set("state", clientState);
 
     logEvent("oauth.callback", { ok: !error, error: error ?? null });
-    const clientRedirect = new URL(decoded.r);
+    const redirectUrl = new URL(clientRedirect);
     for (const key of ["code", "error", "error_description", "state"]) {
-      clientRedirect.searchParams.delete(key);
+      redirectUrl.searchParams.delete(key);
     }
-    for (const [key, value] of out) clientRedirect.searchParams.set(key, value);
-    return redirect(clientRedirect.toString());
+    for (const [key, value] of out) redirectUrl.searchParams.set(key, value);
+    return redirect(redirectUrl.toString(), [clearStateCookie]);
   }
 
   // POST /oauth/token — replace the client redirect_uri with the façade's so
@@ -535,7 +668,7 @@ export async function route(
         (uri) =>
           typeof uri !== "string" ||
           !isAllowedClientRedirect(uri, cfg.allowedClientRedirectUris) ||
-          !canEncodeCognitoState({ cs: "", r: uri }),
+          !canFitTransactionCookie(uri),
       )
     ) {
       return json(400, {

--- a/infra/src/oauth-facade/state.test.ts
+++ b/infra/src/oauth-facade/state.test.ts
@@ -7,8 +7,10 @@ import { describe, expect, it } from "vitest";
 
 import {
   signAuthorizationCode,
+  signOAuthTransaction,
   signState,
   verifyAuthorizationCode,
+  verifyOAuthTransaction,
   verifyState,
 } from "./state.js";
 
@@ -76,5 +78,17 @@ describe("façade state (TC-MCPGW-040..046)", () => {
       r: REDIRECT,
     });
     expect(verifyAuthorizationCode(`${token}x`, KEY, now)).toBeNull();
+  });
+
+  it("round-trips an OAuth transaction with explicit nonce binding", () => {
+    const now = Date.now();
+    const transaction = {
+      nonce: "nonce",
+      clientState: "client-state",
+      redirectUri: REDIRECT,
+    };
+    const token = signOAuthTransaction(transaction, KEY, now);
+    expect(verifyOAuthTransaction(token, KEY, now)).toMatchObject(transaction);
+    expect(verifyOAuthTransaction(`${token}x`, KEY, now)).toBeNull();
   });
 });

--- a/infra/src/oauth-facade/state.ts
+++ b/infra/src/oauth-facade/state.ts
@@ -3,21 +3,23 @@
  *
  * State format (URL-safe, ASCII): `<base64url(payload)>.<base64url(sig)>`
  *
- * Payload is JSON `{ cs: <client_state>, r: <client_redirect_uri>,
- * ts: <ms epoch> }`. We HMAC-SHA-256 the payload's base64url form (not the
+ * Client state and authorization-code wrappers retain their compact historical
+ * field names. OAuth browser transactions use explicit nonce, client-state,
+ * and redirect fields. Every token HMACs the payload's base64url form (not the
  * raw bytes) so verification compares the recomputed b64-form signature
  * byte-for-byte with `crypto.timingSafeEqual`.
  *
- * Stateless by design — no DDB / no TTL store / no extra IAM. A typical token
- * is ~150-200 bytes, well under Cognito's 1024-char `state` limit.
+ * Stateless by design — no DDB / no TTL store / no extra IAM. Only the compact
+ * nonce token is sent through Cognito; the client transaction token is held in
+ * a short-lived HttpOnly cookie.
  *
- * Forked verbatim from the proven mem9 MCP surface façade
- * (`src/lambdas/oauth2-facade/state.ts`).
+ * Originally adapted from the mem9 MCP surface façade.
  */
 
 import { createHmac, timingSafeEqual } from "node:crypto";
 
-const STATE_TTL_MS = 10 * 60 * 1000;
+export const SIGNED_PAYLOAD_TTL_SECONDS = 10 * 60;
+const STATE_TTL_MS = SIGNED_PAYLOAD_TTL_SECONDS * 1000;
 export const COGNITO_STATE_MAX_LENGTH = 1024;
 
 export interface StatePayload {
@@ -29,6 +31,13 @@ export interface StatePayload {
 export interface AuthorizationCodePayload {
   c: string;
   r: string;
+  ts: number;
+}
+
+export interface OAuthTransactionPayload {
+  nonce: string;
+  clientState: string;
+  redirectUri: string;
   ts: number;
 }
 
@@ -67,19 +76,20 @@ export function signState(
   return signPayload({ cs: input.cs, r: input.r, ts: now }, key);
 }
 
-export function canEncodeCognitoState(
-  input: { cs: string; r: string },
-  now: number = Date.now(),
-): boolean {
-  return signState(input, "", now).length <= COGNITO_STATE_MAX_LENGTH;
-}
-
 export function signAuthorizationCode(
   input: { code: string; redirectUri: string },
   key: string,
   now: number,
 ): string {
   return signPayload({ c: input.code, r: input.redirectUri, ts: now }, key);
+}
+
+export function signOAuthTransaction(
+  input: Omit<OAuthTransactionPayload, "ts">,
+  key: string,
+  now: number,
+): string {
+  return signPayload({ ...input, ts: now }, key);
 }
 
 function verifyPayload(
@@ -156,4 +166,27 @@ export function verifyAuthorizationCode(
     return null;
   }
   return { c: payload.c, r: payload.r, ts: payload.ts as number };
+}
+
+export function verifyOAuthTransaction(
+  token: string,
+  key: string,
+  now: number,
+  ttlMs: number = STATE_TTL_MS,
+): OAuthTransactionPayload | null {
+  const payload = verifyPayload(token, key, now, ttlMs);
+  if (
+    !payload ||
+    typeof payload.nonce !== "string" ||
+    typeof payload.clientState !== "string" ||
+    typeof payload.redirectUri !== "string"
+  ) {
+    return null;
+  }
+  return {
+    nonce: payload.nonce,
+    clientState: payload.clientState,
+    redirectUri: payload.redirectUri,
+    ts: payload.ts as number,
+  };
 }

--- a/infra/sst-types.d.ts
+++ b/infra/sst-types.d.ts
@@ -379,7 +379,7 @@ declare namespace aws {
   }
 }
 
-// ── The `random` provider (infra/tenant-identity.ts uses RandomId for the tenant key) ──
+// ── The `random` provider (tenant identity + non-production OAuth HMAC key) ──
 declare namespace random {
   interface RandomIdArgs {
     byteLength: Input<number>;
@@ -389,6 +389,15 @@ declare namespace random {
     constructor(name: string, args: RandomIdArgs);
     readonly hex: Output<string>;
     readonly id: Output<string>;
+  }
+
+  interface RandomPasswordArgs {
+    length: Input<number>;
+    special?: Input<boolean>;
+  }
+  class RandomPassword {
+    constructor(name: string, args: RandomPasswordArgs);
+    readonly result: Output<string>;
   }
 }
 

--- a/scripts/run-oauth-facade-smoke.sh
+++ b/scripts/run-oauth-facade-smoke.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# run-oauth-facade-smoke.sh — verify the OAuth façade metadata endpoints are live.
-# The full browser authorization-code flow can't run headless (needs a human at a
-# browser), so CI validates the RFC 8414/9728 metadata + registration endpoint.
+# run-oauth-facade-smoke.sh — verify the OAuth façade's public protocol boundary.
+# The full authorization-code flow needs an interactive login, so CI validates
+# metadata, registration, and the authorize redirect/cookie response.
 set -euo pipefail
 STAGE="${STAGE:?STAGE is required}"
 REGION="${AWS_REGION:-ap-northeast-1}"
@@ -33,5 +33,56 @@ DCR=$(curl -fsS -X POST -H 'Content-Type: application/json' -d '{"redirect_uris"
 echo "$DCR" | jq -e '.client_id | length > 0' >/dev/null || { echo "::error::DCR did not return client_id"; exit 1; }
 echo "$DCR" | jq -e 'has("client_secret") | not' >/dev/null || { echo "::error::DCR must NOT return client_secret (public client)"; exit 1; }
 echo "$DCR" | jq -e '.token_endpoint_auth_method == "none"' >/dev/null || { echo "::error::DCR token_endpoint_auth_method must be \"none\""; exit 1; }
+
+echo "run-oauth-facade-smoke: checking /oauth/authorize state cookie"
+AUTH_HEADERS=$(mktemp)
+AUTH_BODY=$(mktemp)
+trap 'rm -f "$AUTH_HEADERS" "$AUTH_BODY"' EXIT
+CLIENT_ID=$(echo "$DCR" | jq -er '.client_id')
+LONG_STATE=$(printf '%*s' 2200 '' | tr ' ' g)
+AUTH_STATUS=$(
+  curl -sS -G -D "$AUTH_HEADERS" -o "$AUTH_BODY" -w '%{http_code}' \
+    --data-urlencode 'response_type=code' \
+    --data-urlencode "client_id=${CLIENT_ID}" \
+    --data-urlencode 'redirect_uri=http://localhost:8080/cb' \
+    --data-urlencode 'scope=mem9-mcp/read' \
+    --data-urlencode 'code_challenge=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' \
+    --data-urlencode 'code_challenge_method=S256' \
+    --data-urlencode "state=${LONG_STATE}" \
+    "${FACADE}/oauth/authorize"
+)
+[[ "$AUTH_STATUS" == "302" ]] || { echo "::error::authorize did not return 302"; exit 1; }
+SET_COOKIE_COUNT=$(awk 'tolower($1) == "set-cookie:" { count++ } END { print count + 0 }' "$AUTH_HEADERS")
+[[ "$SET_COOKIE_COUNT" == "1" ]] || { echo "::error::authorize must return exactly one transaction cookie"; exit 1; }
+TRANSACTION_COOKIE=$(
+  awk 'tolower($1) == "set-cookie:" {
+    sub(/^[^:]+:[[:space:]]*/, "")
+    sub(/\r$/, "")
+    print
+    exit
+  }' "$AUTH_HEADERS"
+)
+[[ "$TRANSACTION_COOKIE" == __Secure-mem9-oauth=* ]] || { echo "::error::authorize returned the wrong transaction cookie"; exit 1; }
+for ATTRIBUTE in 'Path=/oauth/callback' 'Secure' 'HttpOnly' 'SameSite=Lax'; do
+  [[ "$TRANSACTION_COOKIE" == *"; ${ATTRIBUTE}"* ]] || { echo "::error::transaction cookie is missing ${ATTRIBUTE}"; exit 1; }
+done
+COOKIE_BYTES=$(printf '%s' "$TRANSACTION_COOKIE" | wc -c | tr -d ' ')
+(( COOKIE_BYTES <= 4096 )) || { echo "::error::transaction cookie exceeds 4 KiB"; exit 1; }
+LOCATION=$(
+  awk 'tolower($1) == "location:" {
+    sub(/^[^:]+:[[:space:]]*/, "")
+    sub(/\r$/, "")
+    print
+    exit
+  }' "$AUTH_HEADERS"
+)
+COGNITO_STATE_LENGTH=$(
+  LOCATION="$LOCATION" node -e '
+    const location = new URL(process.env.LOCATION);
+    process.stdout.write(String(location.searchParams.get("state")?.length ?? 0));
+  '
+)
+(( COGNITO_STATE_LENGTH > 0 && COGNITO_STATE_LENGTH <= 1024 )) || { echo "::error::upstream state exceeds Cognito limit"; exit 1; }
+[[ "$LOCATION" != *"$LONG_STATE"* ]] || { echo "::error::client state leaked into the upstream redirect"; exit 1; }
 
 echo "run-oauth-facade-smoke: OK — façade metadata valid for stage ${STAGE}"

--- a/scripts/run-oauth-facade-smoke.sh
+++ b/scripts/run-oauth-facade-smoke.sh
@@ -51,7 +51,14 @@ AUTH_STATUS=$(
     --data-urlencode "state=${LONG_STATE}" \
     "${FACADE}/oauth/authorize"
 )
-[[ "$AUTH_STATUS" == "302" ]] || { echo "::error::authorize did not return 302"; exit 1; }
+if [[ "$AUTH_STATUS" != "302" ]]; then
+  AUTH_ERROR=$(
+    jq -r '.error_description // .message // .error // "non-JSON response"' \
+      "$AUTH_BODY" 2>/dev/null || printf '%s' 'non-JSON response'
+  )
+  echo "::error::authorize returned HTTP ${AUTH_STATUS}: ${AUTH_ERROR}"
+  exit 1
+fi
 SET_COOKIE_COUNT=$(awk 'tolower($1) == "set-cookie:" { count++ } END { print count + 0 }' "$AUTH_HEADERS")
 [[ "$SET_COOKIE_COUNT" == "1" ]] || { echo "::error::authorize must return exactly one transaction cookie"; exit 1; }
 TRANSACTION_COOKIE=$(

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -50,13 +50,13 @@ export default $config({
         ...(cloudflareEnabled
           ? { cloudflare: { version: "6.15.0" } }
           : {}),
-        // The `random` provider exposes the `random` global (random.RandomId) used
-        // by infra/tenant-identity.ts to mint the STABLE tenant id / X-API-Key. It must
-        // be declared here for the global to bind at run() (SST only injects a
-        // provider's namespace when it's in this block). Pulumi-internal (no cloud
-        // API) → no deploy-role IAM. Version pinned explicitly (SST v4.17 rejects
-        // `random: true` — "Specify the version explicitly"); 4.16.6 matches the
-        // @pulumi/random SST bundles for sst.aws.Aurora's RandomPassword.
+        // The `random` provider exposes the stable tenant RandomId and the
+        // non-production OAuth RandomPassword. It must be declared here for the
+        // global to bind at run() (SST only injects a provider's namespace when
+        // it is in this block). Pulumi-internal (no cloud API) → no deploy-role
+        // IAM. Version pinned explicitly (SST v4.17 rejects `random: true` —
+        // "Specify the version explicitly"); 4.16.6 matches the @pulumi/random
+        // version SST bundles for sst.aws.Aurora's RandomPassword.
         random: { version: "4.16.6" },
         // The `command` provider exposes the `command` global (command.local.Command)
         // used by infra/gateway.ts to provision the AgentCore GatewayTarget via the


### PR DESCRIPTION
## Summary
- Keep upstream OAuth state compact by storing the signed client transaction in a short-lived callback cookie.
- Bound pending authorization state to one cookie slot and verify the deployed response contract.

## Test Plan
- [x] Test cases updated (`docs/test-cases/configurable-oauth-callbacks.md`)
- [x] Root tests pass (657)
- [x] Infra tests pass (227)
- [x] Type checks pass
- [x] Shell validation and shellcheck pass
- [x] Public artifact scan passes
- [x] Code simplification review passes
- [x] Independent PR review passes
- [x] CI checks pass
- [x] Preview OAuth smoke passes

## Checklist
- [x] New regression tests cover long state, cookie validation, expiry, tampering, and replacement
- [x] Documentation updated
- [x] Reviewer bot findings addressed
- [x] Preview E2E verification complete
