### PR TITLE
feat(cleanup): route cleanup through reasoning models; alarm zero-fact blackouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -865,14 +865,25 @@ behavior is pinned by the unit suite (`scripts/memory-cleanup.test.mjs`), and
 live verification is the operator dry-run below, executed from a VPC-internal
 host. Production execution is a deliberate manual flow:
 
-1. **Dry-run** (read-only; classifies every active memory with GLM-5):
+1. **Dry-run** (read-only; classifies every active memory):
 
    ```bash
    node scripts/memory-cleanup.mjs --stage prod \
+     --model openai.gpt-5.6-terra --effort high \
      --tenant-secret-arn "$(aws ssm get-parameter \
        --name /mem9-on-aws/prod/tenant/secret-arn \
        --query Parameter.Value --output text)"
    ```
+
+   **Use a reasoning model for cleanup.** `--model` selects the classifier;
+   omitted, it falls back to `MEM9_LLM_MODEL` and then `zai.glm-5`. An
+   `openai.gpt-5.6-*` value routes to the Responses API in `--llm-region`
+   (default `us-west-2`) with a 24k output budget; anything else uses
+   chat-completions in the application region. Measured on the same
+   2271-memory corpus: GLM-5 left **33% of memories unclassified** (batch JSON
+   truncated at its 4096-token cap) while `gpt-5.6-terra` had zero
+   classification failures and found ~6× more merge groups. GLM-5 remains
+   usable and is the cheaper zero-cross-region-dependency fallback.
 
    The decision list is written to `~/.mem9-cleanup/prod/decisions-*.json`
    (mode 0600, outside any checkout — it contains memory content and must
@@ -899,15 +910,26 @@ host. Production execution is a deliberate manual flow:
    contract).
 
    Exit codes: `0` success, `1` unexpected error, `2` discovery failed,
-   `3` another run holds the lock, `4` cap exceeded (aborted), `5` GLM-5
+   `3` another run holds the lock, `4` cap exceeded (aborted), `5`
    classification failed for every batch.
+
+   **Read the `UNCLASSIFIED=` count in the summary before trusting a run.**
+   Exit 5 fires only when *every* batch fails, so a partial classifier outage
+   exits 0; the summary reports how many memories went unaudited and what share
+   of batches failed. "We never looked at these 740 memories" is not the same
+   result as "these 740 are fine" — re-run before treating the audit as
+   complete.
 
 Requires VPC-internal network access to `mnemo.mem9-<stage>.local:8080` (the
 script discovers the task IP via Cloud Map `DiscoverInstances`; pass
 `--base-url` explicitly when tunneling) plus IAM for `ssm:GetParameter` on
 `/mem9-on-aws/<stage>/tenant/secret-arn`, `secretsmanager:GetSecretValue` on
 the tenant secret, `servicediscovery:DiscoverInstances`, and
-`bedrock-mantle:CreateInference`/`CallWithBearerToken`.
+`bedrock-mantle:CreateInference`/`CallWithBearerToken`. A reasoning-model run
+needs those Bedrock grants in the **responses region** as well (default
+`us-west-2`), since the bearer is minted per region; cost attribution uses
+`MEM9_BEDROCK_PROJECT_OPENAI` there and `MEM9_BEDROCK_PROJECT` in the
+application region (Mantle projects are regional and never cross-applied).
 
 
 ## License

--- a/docker/llm-proxy/server.mjs
+++ b/docker/llm-proxy/server.mjs
@@ -49,9 +49,9 @@ const DEFAULT_MAX_TOKENS = 4096;
 // chat-completions path; only `openai/v1/responses` serves them.
 const DEFAULT_RESPONSES_MODEL_PREFIXES = ["openai.gpt-5.6-"];
 const DEFAULT_RESPONSES_REGION = "us-west-2";
-const DEFAULT_REASONING_EFFORT = "high";
+export const DEFAULT_REASONING_EFFORT = "high";
 const DEFAULT_RESPONSES_MAX_OUTPUT_TOKENS = 16384;
-const REASONING_EFFORTS = Object.freeze(["low", "medium", "high"]);
+export const REASONING_EFFORTS = Object.freeze(["low", "medium", "high"]);
 const REQUEST_POLICY_DEFAULTS = Object.freeze({
   overallDeadlineMs: 110_000,
   maxCallMs: 108_000,
@@ -395,7 +395,7 @@ function sendError(
   return sendJson(res, status, { error: { message, type, param, code } });
 }
 
-class RequestValidationError extends Error {
+export class RequestValidationError extends Error {
   constructor(status, code, message) {
     super(message);
     this.name = "RequestValidationError";

--- a/docs/designs/cleanup-reasoning-model.md
+++ b/docs/designs/cleanup-reasoning-model.md
@@ -1,0 +1,173 @@
+# Design Canvas: reasoning-model route for cleanup + zero-fact quality alarm
+
+Feature: `scripts/memory-cleanup.mjs` responses route, `ZeroFactSuccess` alarm
+Date: 2026-08-01
+Status: Approved (interactive session)
+
+## Problem
+
+Two gaps left open after the model comparison (GLM-5 vs terra vs luna):
+
+1. **The cleanup script cannot reach a reasoning model.** `productionDeps`
+   hard-codes Bedrock Mantle's `/v1/chat/completions` with `max_tokens: 4096`.
+   The `openai.gpt-5.6-*` models are Responses-API-only and live in a different
+   region, so the only way to run cleanup on terra was a gitignored operator
+   wrapper. That wrapper is the thing that produced the current prod decision
+   list — an unreviewable, untested path for a destructive tool.
+
+   Measured on the same 2271-memory corpus: GLM-5 left **740 memories (33%)
+   unclassified** (32 of 117 batches failed JSON twice, root cause `max_tokens:
+   4096` truncation); terra had **zero** classification failures. The batch
+   ceiling, not the prompt, is the limiting factor.
+
+2. **Nothing watches smart-ingest extraction quality.** A model swap that
+   silently degrades extraction is invisible: `ZeroFactSuccess` counts a
+   *successful* job that produced no facts, so a wholly broken extractor still
+   reports `JobsSucceeded` and pages nobody.
+
+## Part 1: responses route in the cleanup script
+
+Reuse the sidecar's already-reviewed translation instead of re-deriving it.
+`docker/llm-proxy/server.mjs` exports `resolveRoute`,
+`translateChatToResponses`, and `translateResponsesToChat`; those are pure
+functions with no server or AWS dependency, and the cleanup script already runs
+from a repo checkout with `node_modules` present. Importing them means the
+fail-loud contract (`status: "failed"` → throw, `completed` with no
+`output_text` → throw) is enforced identically on both paths, and one test suite
+covers both callers.
+
+Route selection is by model prefix, exactly as the sidecar does it — so
+`--model openai.gpt-5.6-terra` picks the Responses API in the responses region,
+and `zai.glm-5` keeps the existing chat-completions request byte for byte. Its
+*reply* handling gains one guard: a `finish_reason: "length"` response now fails
+the batch instead of forwarding partial text. On the chat route that previously
+reached `parseVerdicts` and almost always failed JSON parse anyway (the measured
+GLM-5 mode); in the rare case the partial text parsed, it produced actionable
+verdicts from an unfinished reply, so failing is strictly safer.
+
+### Why the token cap differs per route
+
+`max_tokens: 4096` is correct for GLM-5 and *catastrophic* for a reasoning
+model: reasoning tokens are billed and consumed as output tokens before any
+visible text is produced, so a 4096 cap truncates the JSON mid-object. That is
+precisely the GLM-5 failure mode, and it would recur on terra at the same cap.
+The responses route therefore defaults to a much larger output budget
+(`RESPONSES_MAX_OUTPUT_TOKENS = 24_000`, the value that ran the corpus clean)
+and the chat route keeps 4096.
+
+A truncated reply is rejected outright rather than parsed: at a 24k budget,
+truncation is the *expected* failure mode, and it can land on syntactically
+valid JSON (a partial verdict list, or a MERGE whose `merged_content` is cut
+mid-sentence). Classifying that would delete memories the model never finished
+judging and overwrite a survivor with half a fact, so `finish_reason: "length"`
+fails the batch and the existing retry→SKIP machinery takes over.
+
+`LLM_TIMEOUT_MS` also rises to 300s on the responses route only: observed p50
+was ~3.4s but max 29.5s, and a high-effort batch legitimately runs longer than
+the 120s the chat route allows.
+
+### Non-goals
+
+- Not routing cleanup through the sidecar over the network. The sidecar is a
+  localhost-only container inside the task; an operator host cannot reach it.
+  Sharing the *translation code* gets the contract without the network path.
+- Not changing `MNEMO_LLM_MODEL` (what smart-ingest uses). Cleanup's model is
+  an operator choice per run; ingest's is a deployed setting.
+
+## Part 2: `ZeroFactSuccess` quality alarm
+
+### The measurement that shaped this
+
+`ZeroFactSuccess` is emitted **once per succeeded job** (verified against prod:
+a 6h bucket has `Sum=105`, `SampleCount=133`, and `JobsSucceeded=133` for the
+same window). So `Average` of `ZeroFactSuccess` *is* the zero-fact rate
+directly, with no second metric needed — the metric is a 0/1 gauge per job, not
+a sparse counter.
+
+The naive alarm ("rate too high") is **not viable**, and the baseline says why:
+
+| Window (prod, healthy) | zero-fact rate |
+|---|---|
+| Jul 28 | 96% |
+| Jul 29 | 82% |
+| Jul 30 | 91% |
+| Jul 31 | 90% |
+| Aug 1 | 77% |
+| Jul 30 17:00–23:00 (hourly) | **100%, 100%, 100%, 100%, 100%, 100%** |
+
+Six consecutive fully-zero-fact hours occur in a **healthy** baseline — most
+agent sessions genuinely carry no durable takeaway, which is the documented
+correct outcome of rule D4. Any threshold that would catch a broken extractor
+within hours also fires constantly on normal traffic. This is why the alarm is
+scoped as below, and why the earlier framing of "watch that the rate stays in
+the 82–98% band" cannot be implemented as an hourly alarm.
+
+### What the alarm actually asserts
+
+A **daily** window (`period: 86400`) at a threshold **above the observed
+maximum**, alarming only on a *sustained, total* extraction blackout:
+
+- `Average(ZeroFactSuccess) >= 1.0` over 24h, with `Sum(JobsSucceeded) > 50`
+  guarding against a low-traffic day trivially reading 100%. The threshold is
+  **exactly** 1.0, not a fraction: 0.995 looks like a comfortable margin over
+  the 96% worst healthy day but is not one — at 200 jobs it pages on a day that
+  extracted a single real fact. "Not one extraction succeeded" is the honest
+  line for a blackout detector and cannot false-positive while memories are
+  still being written.
+- Daily is the shortest window where the healthy signal separates from the
+  broken one at all (windows are 24h and sliding, not calendar-aligned — see
+  Known limits). The six healthy 100% hours above total 134 succeeded jobs
+  with zero facts — past the traffic guard and a breach at any threshold — so
+  an hourly (or any sub-day) window would page on that stretch. Aggregated over
+  its real day, the same traffic extracted 35 facts from 377 jobs.
+- `treatMissingData: notBreaching` — no ingest traffic is not a quality
+  regression (and the liveness alarm already owns "telemetry stopped").
+
+This is deliberately a **backstop, not a sensitive detector**. It catches "the
+extractor returns nothing, ever" (a bad model swap, a broken prompt, a
+translation regression returning empty content) within a day. It does *not*
+catch subtle quality drift — that is genuinely not detectable from this metric,
+and #104/#106's shadow scoring is the right instrument for it. Stating that
+limit here so the alarm is not mistaken for coverage it does not provide.
+
+## Classification-failure visibility
+
+`classifierBroken` (exit 5) fires only when **every** batch fails. A partial
+outage therefore exits 0, and its SKIPs land in the same bucket as legitimate
+planner SKIPs — so the measured GLM-5 run, which failed 27% of batches, reported
+success. Every terminal summary now states how many memories went unclassified
+and what share of batches failed, because on a destructive tool "we did not look
+at 740 memories" must not read the same as "those 740 are fine".
+
+Relatedly, a request the translator rejects is a deterministic defect thrown
+before any network call: it fails identically on all batches, so it aborts the
+run instead of degrading it to a clean-looking audit of an unexamined corpus.
+
+## Known limits of the alarm
+
+Stated so it is not mistaken for coverage it lacks:
+
+- **Dilution.** `ZeroFactSuccess` is dimensioned only by `stage`, so extraction
+  that still works for one session type keeps the aggregate off 1.0 while it is
+  broken for everything else.
+- **Traffic-guard silence.** A break that also pushes jobs to `dead` instead of
+  `succeeded` drops volume below 51/day, and the guard returns 0. The dead-job
+  alarm owns that failure; no single alarm owns "extraction is broken".
+- **`notBreaching` conflates "no data" with "all good."** A total emitter stop
+  reads healthy here; the telemetry-liveness alarm owns it.
+- **The 24h window slides.** CloudWatch advances the evaluation window by a
+  minute and does not align it to the wall clock, and `@pulumi/aws` at the
+  pinned version exposes no `evaluationWindow` for wall-clock alignment. The
+  baseline figures above are calendar-day aggregates, so "daily" means "a 24h
+  window", not "midnight to midnight". Accepted: at a threshold of exactly 1.0
+  a single fact-producing job anywhere in the window clears the alarm.
+- **A single surviving extraction silences it.** By construction — see the
+  threshold rationale. This is a blackout detector, not a degradation detector.
+
+## Verification
+
+Pre-merge, in CI: unit tests for route selection, per-route token/timeout
+budgets, the shared fail-loud contract, and the synthesized alarm's semantics
+(namespace, statistic, period, threshold, comparison, missing-data policy,
+traffic guard). The alarm's *live* behavior against real prod traffic is
+observable only post-deploy and is not gated on.

--- a/docs/designs/durable-ingest-telemetry.md
+++ b/docs/designs/durable-ingest-telemetry.md
@@ -142,6 +142,20 @@ every metric alarm declares missing-data behavior:
   gated with `IF(JobsTerminated >= 20, ratio, 0)`, missing data not breaching.
 - `AWS/BedrockMantle InferenceClientErrors >= 1` in 15 minutes for the configured
   `Project`, missing data not breaching.
+- `Average(ZeroFactSuccess) >= 1.0` over **24 hours**, gated with
+  `IF(JobsSucceeded > 50, rate, 0)`, missing data not breaching. Because
+  `ZeroFactSuccess` is emitted once per succeeded job, its `Average` is the
+  zero-fact rate directly. This is a smart-extraction *blackout* backstop, not
+  a quality monitor: the measured healthy baseline runs 77–96% by day, so a high
+  zero-fact rate is normal (rule D4's correct outcome for a session with no
+  durable takeaway) and only "not one of 50+ jobs extracted anything" is
+  conclusive — a bad model swap, a broken prompt, an llm-proxy translation
+  regression. The window must be a full day and the threshold exactly 1.0:
+  six consecutive healthy hours (Jul 30) totalled 134 jobs with zero facts, so
+  a sub-day window or a fractional threshold pages on healthy traffic, while
+  over its real day that traffic extracted 35 facts from 377 jobs. Subtle
+  quality drift is not observable in this metric; that is the pre-screen
+  scoring work's scope.
 
 The obsolete `ingest_dropped` filter is removed because durable jobs now have
 explicit retry and dead outcomes.

--- a/docs/test-cases/cleanup-reasoning-model.md
+++ b/docs/test-cases/cleanup-reasoning-model.md
@@ -1,0 +1,34 @@
+# Test Cases: reasoning-model route for cleanup + zero-fact quality alarm
+
+Feature: `scripts/memory-cleanup.mjs` responses route, `ZeroFactSuccess` alarm
+Design: [cleanup-reasoning-model.md](../designs/cleanup-reasoning-model.md)
+
+## Cleanup LLM route (`scripts/memory-cleanup.test.mjs`)
+
+| ID | Scenario | Expected |
+|---|---|---|
+| TC-MEMCLEAN-070 | `buildCompleteChat` with `zai.glm-5` | Posts to `/v1/chat/completions` in the app region with `max_tokens: 4096`; body has `messages` (no `input`/`reasoning`); returns `choices[0].message.content` |
+| TC-MEMCLEAN-071 | `buildCompleteChat` with `openai.gpt-5.6-terra` | Posts to `openai/v1/responses` in the **responses** region with `max_output_tokens: 24000` and `reasoning.effort`; system prompt becomes `instructions`, memories become `input` |
+| TC-MEMCLEAN-072 | Responses reply `status: "completed"` with `output_text` parts | Returns the concatenated text, so `parseVerdicts` sees exactly what the chat route would produce |
+| TC-MEMCLEAN-073 | Responses reply `status: "failed"` (HTTP 200, empty output) | Throws — never returns `""`. An empty string would parse as "no verdicts" and mark a whole batch SKIP on an authoritative-looking non-answer |
+| TC-MEMCLEAN-074 | Responses reply `status: "incomplete"` (output-token exhaustion), whose partial text is **valid** JSON | Throws. Truncation at the 24k budget can land on parseable JSON — a partial verdict list, or a MERGE with `merged_content` cut mid-sentence — so `finish_reason: "length"` fails the batch (→ retry → SKIP) instead of classifying a reply the upstream told us was incomplete |
+| TC-MEMCLEAN-074b | A truncated MERGE reply driven through `runCleanup --apply` with the real `buildCompleteChat` | Both memories SKIP, `writeCalls === 0`, the survivor's content is unchanged and the absorbed memory stays `active` — no delete, no half-written overwrite |
+| TC-MEMCLEAN-074c | A near-miss model id (`openai.gpt-5.6terra`, `openai.gpt-6-terra`, uppercase) | Documents that prefix matching is exact, so these fall to the chat route's 4096 cap; pins current behavior so a prefix change is a visible test change rather than a silent capability regression |
+| TC-MEMCLEAN-075 | 401 on either route | Re-mints the bearer once and retries; a second 401 throws. Responses route mints for the responses region, chat route for the app region |
+| TC-MEMCLEAN-076 | `--model` / `--effort` / `--llm-region` flags | Parsed by `parseArgs`; `--effort` rejects a value outside `low|medium|high`; `--model` defaults to `MEM9_LLM_MODEL` then `zai.glm-5` |
+| TC-MEMCLEAN-077 | Responses route timeout budget | Uses the 300s responses budget, not the 120s chat budget |
+| TC-MEMCLEAN-078 | `OpenAI-Project` header per route | Each route sends its own regional project id; the app-region project is never sent to the responses region (Mantle projects are regional) |
+| TC-MEMCLEAN-080 | 1 of 3 classification batches fails both attempts | Exit 0 (a partial outage is not "classifier broken"), but the summary reports `UNCLASSIFIED=20 of 60 memories (1/3 batches failed, 33%)` and says the run did not audit them. Without this the outage is indistinguishable from a legitimate planner `SKIP:20` |
+| TC-MEMCLEAN-081 | The request translator rejects the payload (deterministic config defect, thrown before any network call) | The run aborts instead of retrying and degrading every batch to SKIP — an invocation bug must not read as a clean audit of an unexamined corpus |
+| TC-MEMCLEAN-079 | Ambient `LLM_PROXY_*` sidecar env is exported in the operator's shell | Route, output budget, and effort are unchanged. The proxy config is built from a closed object, so a stray `LLM_PROXY_RESPONSES_MODEL_PREFIXES` cannot silently downgrade terra to the 4096-cap chat route, and a limit cleanup never reads (`LLM_PROXY_MAX_BODY_BYTES=0`) cannot abort the run |
+
+## Zero-fact quality alarm (`infra/observability.test.ts`)
+
+| ID | Scenario | Expected |
+|---|---|---|
+| TC-INGEST-METRIC-030 | Prod synthesis | A `DurableIngestZeroFactRateAlarm` exists on `mem9-on-aws/DurableIngest`, using `Average` of `ZeroFactSuccess` over `period: 86400`, `threshold: 1`, `GreaterThanOrEqualToThreshold`, `treatMissingData: notBreaching`, dimensioned `stage`. The rate expression is asserted as a **literal** string (not compared to its own constant), so a mutation of the traffic-guard value or the branch order fails the suite |
+| TC-INGEST-METRIC-031 | Low-traffic day | The alarm expression requires `JobsSucceeded > 50` in the window, so a day with a handful of legitimately zero-fact jobs cannot breach |
+| TC-INGEST-METRIC-032 | Healthy baseline replay + boundary | The measured healthy daily rates (96/82/91/90/77%) stay quiet. The six consecutive 100% *hours* (Jul 30 17:00-23:00) aggregate to 134 all-zero-fact jobs and **do** breach — the concrete reason the window must be a full day, since over their real day that traffic extracted 35 facts from 377 jobs and stays quiet. Boundary: at the smallest healthy daily volume (101 jobs) a single successful extraction keeps it quiet, and 51 all-zero-fact jobs is the first breach past the guard |
+| TC-INGEST-METRIC-033 | Alarm actions | Wired to the prod alert topic for both ALARM and OK, consistent with the other action-bearing alarms |
+| TC-INGEST-METRIC-034 | Non-prod synthesis | No alarm resources outside prod (existing contract preserved) |
+| TC-INGEST-METRIC-035 | Emitter producer contract | `ZeroFactSuccess` and `JobsSucceeded` are pinned in the emitter-metric assertion. Dropping either from the mnemo-server patch makes the metric vanish from CloudWatch, leaving the alarm `INSUFFICIENT_DATA` → `notBreaching` → healthy forever; verified by mutation |

--- a/infra/ecs.test.ts
+++ b/infra/ecs.test.ts
@@ -742,7 +742,7 @@ describe("ecs stack", () => {
     const alarms = created.filter((c) => c.kind === "MetricAlarm");
     const compositeAlarms = created.filter((c) => c.kind === "CompositeAlarm");
     expect(filters.length).toBe(3); // recall_zero_hit, recall_total, ingest_llm_auth_failure
-    expect(alarms.length).toBe(10);
+    expect(alarms.length).toBe(11);
     expect(compositeAlarms).toHaveLength(1);
     expect(created.filter((c) => c.kind === "Dashboard")).toHaveLength(1);
     // Queue health remains evidence-based; only sampler liveness treats loss
@@ -751,7 +751,7 @@ describe("ecs stack", () => {
     expect(missingPolicies.filter((policy) => policy === "breaching")).toHaveLength(1);
     expect(
       missingPolicies.filter((policy) => policy === "notBreaching"),
-    ).toHaveLength(9);
+    ).toHaveLength(10);
     // Metric filter patterns reference the correct log line msg values.
     const patterns = filters.map((f) => (f.args as { pattern: string }).pattern);
     expect(patterns.some((p) => p.includes("confidence recall search") && p.includes("returned = 0"))).toBe(true);

--- a/infra/observability.test.ts
+++ b/infra/observability.test.ts
@@ -3,6 +3,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { parse } from "yaml";
 import {
   DURABLE_FAILURE_RATIO_EXPRESSION,
+  ZERO_FACT_ALARM_THRESHOLD,
+  ZERO_FACT_RATE_EXPRESSION,
   observability,
 } from "./observability";
 
@@ -171,6 +173,15 @@ function durableFailureRatio(failures: number, terminal: number): number {
   return terminal >= 20 ? failures / terminal : 0;
 }
 
+/** Mirrors ZERO_FACT_RATE_EXPRESSION — the zero-fact alarm's math. */
+function zeroFactRate(zeroFactJobs: number, succeeded: number): number {
+  return succeeded > 50 ? zeroFactJobs / succeeded : 0;
+}
+
+function zeroFactBreaches(zeroFactJobs: number, succeeded: number): boolean {
+  return zeroFactRate(zeroFactJobs, succeeded) >= ZERO_FACT_ALARM_THRESHOLD;
+}
+
 beforeEach(() => {
   resources = [];
   installGlobals();
@@ -216,11 +227,11 @@ describe("observability alert delivery", () => {
     const topic = one("Topic");
     expect(topic.args).toEqual({ name: "mem9-on-aws-prod-alerts" });
     const alarms = resources.filter((resource) => resource.kind === "MetricAlarm");
-    expect(alarms).toHaveLength(10);
+    expect(alarms).toHaveLength(11);
     const actionBearingMetricAlarms = alarms.filter(
       (alarm) => alarm.args.alarmActions !== undefined,
     );
-    expect(actionBearingMetricAlarms).toHaveLength(8);
+    expect(actionBearingMetricAlarms).toHaveLength(9);
     for (const alarm of actionBearingMetricAlarms) {
       expect(materialize(alarm.args.alarmActions)).toEqual([
         "arn:aws:sns:ap-northeast-1:123456789012:mem9-on-aws-prod-alerts",
@@ -650,6 +661,47 @@ describe("observability alert delivery", () => {
       comparisonOperator: "GreaterThanThreshold",
       treatMissingData: "notBreaching",
     });
+    expect(named("MetricAlarm", "DurableIngestZeroFactRateAlarm").args).toMatchObject({
+      threshold: ZERO_FACT_ALARM_THRESHOLD,
+      evaluationPeriods: 1,
+      comparisonOperator: "GreaterThanOrEqualToThreshold",
+      treatMissingData: "notBreaching",
+    });
+    expect(
+      named("MetricAlarm", "DurableIngestZeroFactRateAlarm").args.metricQueries,
+    ).toEqual([
+      {
+        id: "zero_rate",
+        metric: {
+          namespace: "mem9-on-aws/DurableIngest",
+          metricName: "ZeroFactSuccess",
+          dimensions: { stage: "prod" },
+          // ZeroFactSuccess is 0/1 per succeeded job, so Average IS the rate.
+          stat: "Average",
+          // Daily, not hourly: healthy prod runs six consecutive 100% HOURS.
+          period: 86400,
+        },
+        returnData: false,
+      },
+      {
+        id: "succeeded",
+        metric: {
+          namespace: "mem9-on-aws/DurableIngest",
+          metricName: "JobsSucceeded",
+          dimensions: { stage: "prod", result_class: "succeeded" },
+          stat: "Sum",
+          period: 86400,
+        },
+        returnData: false,
+      },
+      {
+        id: "rate",
+        expression: ZERO_FACT_RATE_EXPRESSION,
+        label: "Zero-fact extraction rate (>50 jobs/day)",
+        returnData: true,
+      },
+    ]);
+
     expect(named("MetricAlarm", "DurableIngestTelemetryLivenessAlarm").args).toEqual({
       alarmDescription:
         "The once-per-minute durable ingest sampler stopped emitting ECS-origin telemetry.",
@@ -878,6 +930,55 @@ describe("observability alert delivery", () => {
     expect(durableFailureRatio(3, 30)).toBe(0.1);
   });
 
+  it("TC-INGEST-METRIC-031/032: zero-fact alarm clears the measured healthy baseline", () => {
+    // Pin the shipped expression as a LITERAL. The mirror below reimplements
+    // this math, so comparing the constant to itself would let a mutation of
+    // either the guard value or the branch order pass unnoticed.
+    expect(ZERO_FACT_RATE_EXPRESSION).toBe("IF(succeeded > 50, zero_rate, 0)");
+    // Exactly 1.0, not a fraction: at 200 jobs, 0.995 pages on a day that
+    // extracted a single real fact.
+    expect(ZERO_FACT_ALARM_THRESHOLD).toBe(1);
+
+    // Real prod daily buckets (Jul 28 - Aug 1, 2026), zero-fact / succeeded.
+    // Every one is a HEALTHY day: a high zero-fact rate is the correct outcome
+    // of rule D4 for sessions with no durable takeaway.
+    for (const [zero, succeeded] of [
+      [97, 101], // 96%
+      [144, 176], // 82%
+      [342, 377], // 91%
+      [280, 312], // 90%
+      [231, 300], // 77%
+    ]) {
+      expect(zeroFactBreaches(zero, succeeded)).toBe(false);
+    }
+
+    // Six consecutive 100% HOURS from the same healthy baseline (Jul 30
+    // 17:00-23:00). Aggregated they are 134 succeeded jobs with ZERO facts —
+    // past the traffic guard and a breach at any threshold. This is the
+    // concrete reason the window is a full day: evaluated hourly (or over any
+    // sub-day window covering this stretch) the alarm would page on traffic
+    // that was healthy.
+    const healthyHours = [41, 3, 27, 8, 37, 18];
+    const stretch = healthyHours.reduce((sum, jobs) => sum + jobs, 0);
+    expect(stretch).toBe(134);
+    expect(zeroFactBreaches(stretch, stretch)).toBe(true);
+    // Over the real day those hours belong to, the same traffic stays quiet:
+    // Jul 30 extracted 35 facts across 377 jobs.
+    expect(zeroFactBreaches(342, 377)).toBe(false);
+
+    // A quiet day that is entirely zero-fact still cannot page: too few jobs
+    // to distinguish a blackout from normal low-signal traffic.
+    expect(zeroFactBreaches(50, 50)).toBe(false);
+    expect(zeroFactBreaches(51, 51)).toBe(true); // one job past the guard
+
+    // The boundary that matters: ONE successful extraction keeps it quiet, at
+    // the smallest healthy daily volume observed (101 jobs). The alarm asserts
+    // a TOTAL blackout, never degraded quality (that is #104/#106's scope).
+    expect(zeroFactBreaches(101, 101)).toBe(true);
+    expect(zeroFactBreaches(100, 101)).toBe(false);
+    expect(zeroFactBreaches(299, 300)).toBe(false);
+  });
+
   it("TC-INGEST-METRIC-015/016/017/023: pins emitter metrics to dashboard and alarms", () => {
     const patch = readFileSync(
       new URL(
@@ -905,6 +1006,13 @@ describe("observability alert delivery", () => {
       "JobsTerminated",
       "DeadlineTransientTerminalFailures",
       "SamplerHeartbeat",
+      // Both feed DurableIngestZeroFactRateAlarm. If the emitter stops
+      // publishing either, the metric vanishes from CloudWatch and the alarm
+      // sits INSUFFICIENT_DATA → notBreaching → reads healthy forever. Pinning
+      // the PRODUCER matters most on the one alarm whose failure mode is
+      // silence.
+      "ZeroFactSuccess",
+      "JobsSucceeded",
     ]) {
       expect(emitter).toContain(`countMetric("${metric}")`);
     }

--- a/infra/observability.ts
+++ b/infra/observability.ts
@@ -39,6 +39,17 @@ export interface ObservabilityInputs {
 export const DURABLE_FAILURE_RATIO_EXPRESSION =
   "IF(terminal >= 20, failures / terminal, 0)";
 
+// The traffic guard is load-bearing: a quiet day with a handful of legitimately
+// zero-fact jobs reads 100% and would otherwise page.
+export const ZERO_FACT_RATE_EXPRESSION = "IF(succeeded > 50, zero_rate, 0)";
+// Exactly 1.0: breach only when NOT ONE of the day's 50+ succeeded jobs
+// extracted a fact. A fractional threshold reads as a comfortable margin over
+// the 96% worst healthy day but is not one — at 200 jobs, 0.995 would page on a
+// day that extracted a single real fact. "Any extraction at all" is the honest
+// line for a blackout detector, and it cannot false-positive on traffic that is
+// still producing memories.
+export const ZERO_FACT_ALARM_THRESHOLD = 1;
+
 export function observability(inputs: ObservabilityInputs) {
   const { stage, logGroupName, slackWebhookUrl, mantleProject } = inputs;
   if (stage !== "prod") return;
@@ -422,6 +433,78 @@ export function observability(inputs: ObservabilityInputs) {
     evaluationPeriods: 1,
     threshold: 1,
     comparisonOperator: "GreaterThanOrEqualToThreshold",
+    treatMissingData: "notBreaching",
+    alarmActions,
+    okActions,
+  });
+
+  // Smart-extraction quality backstop. `ZeroFactSuccess` is emitted once per
+  // SUCCEEDED job (0 or 1), so its Average over a window IS the zero-fact rate
+  // — no second metric is needed for the ratio.
+  //
+  // Deliberately a blackout detector, not a sensitive quality monitor. Measured
+  // healthy prod baseline: 96/82/91/90/77% by day, and SIX CONSECUTIVE 100%
+  // hours (Jul 30) — most agent sessions genuinely carry no durable takeaway,
+  // the documented correct outcome of rule D4. Those six hours total 134 jobs
+  // with zero facts, which is why the window is DAILY and the threshold is
+  // exactly 1.0: a sub-day window or a fractional threshold would page on that
+  // healthy stretch. Over the calendar day those hours belong to, Jul 30
+  // extracted 35 facts from 377 jobs and stays quiet.
+  //
+  // NOTE the evaluation window SLIDES: CloudWatch advances it by a minute and
+  // does not align it to the wall clock, and @pulumi/aws at the pinned version
+  // exposes no `evaluationWindow` to request wall-clock alignment. So this is
+  // not literally a per-calendar-day check — some 24h window could enclose the
+  // 134-job stretch plus quieter hours. That is an accepted residual: the
+  // threshold of exactly 1.0 means any single fact-producing job anywhere in
+  // the window clears it, and the stretch above is bracketed on both sides by
+  // fact-producing hours in the real series.
+  //
+  // What it catches: "the extractor returns nothing, ever" — a bad model swap,
+  // a broken prompt, a translation regression yielding empty content. What it
+  // does NOT catch: subtle quality drift, which is not observable in this
+  // metric at all (that is #104/#106's shadow scoring).
+  new aws.cloudwatch.MetricAlarm("DurableIngestZeroFactRateAlarm", {
+    alarmDescription:
+      "Not one of 50+ succeeded ingest jobs extracted a fact in 24h. Suspect a " +
+      "broken extractor (model swap, prompt, or llm-proxy translation), not " +
+      "normal traffic: healthy days run 77-96% zero-fact but always extract " +
+      "something. Check MNEMO_LLM_MODEL and the llm-proxy request log.",
+    metricQueries: [
+      {
+        id: "zero_rate",
+        metric: {
+          namespace: durableNamespace,
+          metricName: "ZeroFactSuccess",
+          dimensions: { stage },
+          stat: "Average",
+          period: 86400,
+        },
+        returnData: false,
+      },
+      {
+        id: "succeeded",
+        metric: {
+          namespace: durableNamespace,
+          metricName: "JobsSucceeded",
+          dimensions: { stage, result_class: "succeeded" },
+          stat: "Sum",
+          period: 86400,
+        },
+        returnData: false,
+      },
+      {
+        id: "rate",
+        expression: ZERO_FACT_RATE_EXPRESSION,
+        label: "Zero-fact extraction rate (>50 jobs/day)",
+        returnData: true,
+      },
+    ],
+    threshold: ZERO_FACT_ALARM_THRESHOLD,
+    evaluationPeriods: 1,
+    comparisonOperator: "GreaterThanOrEqualToThreshold",
+    // No ingest traffic is not a quality regression; the liveness alarm owns
+    // "telemetry stopped".
     treatMissingData: "notBreaching",
     alarmActions,
     okActions,

--- a/scripts/memory-cleanup.mjs
+++ b/scripts/memory-cleanup.mjs
@@ -1,17 +1,24 @@
 #!/usr/bin/env node
 // memory-cleanup.mjs — retroactive memory cleanup for the mem9 store (issue #102).
 //
-// Classifies every active memory with GLM-5 (Bedrock Mantle chat-completions)
-// against the same D1–D4 durability rules smart-ingest uses (patch 0002), then
-// applies KEEP / DELETE / MERGE decisions through the public REST API. Dry-run
-// is the default; `--apply` executes; `--ids` restricts apply to a reviewed
-// subset. Design: docs/designs/memory-cleanup.md. Tests: memory-cleanup.test.mjs.
+// Classifies every active memory with a Bedrock Mantle model against the same
+// D1–D4 durability rules smart-ingest uses (patch 0002), then applies KEEP /
+// DELETE / MERGE decisions through the public REST API. Dry-run is the default;
+// `--apply` executes; `--ids` restricts apply to a reviewed subset.
+// Design: docs/designs/memory-cleanup.md. Tests: memory-cleanup.test.mjs.
+//
+// Two model routes (see docs/designs/cleanup-reasoning-model.md): `zai.glm-5`
+// on chat-completions in the app region, and the `openai.gpt-5.6-*` reasoning
+// models on the Responses API in a different region. Route selection and the
+// request/reply translation are the llm-proxy sidecar's, imported directly so
+// both callers share one reviewed contract.
 //
 // Usage:
 //   node scripts/memory-cleanup.mjs --stage prod [--base-url http://host:8080]
 //        [--tenant-secret-arn arn | MEM9_TENANT_ID env]
 //        [--apply] [--decisions file.json] [--ids approved.txt]
 //        [--cap 50] [--out dir] [--lock-file path] [--lock-ttl hours]
+//        [--model openai.gpt-5.6-terra] [--effort high] [--llm-region us-west-2]
 //
 // The decision log contains memory snippets — instance-private data. It is
 // written OUTSIDE the repository (default ~/.mem9-cleanup/<stage>/) and must
@@ -24,6 +31,19 @@ import process from "node:process";
 import { setTimeout as delay } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
 
+// The llm-proxy sidecar owns model routing and chat ⇄ Responses translation.
+// These are pure functions (no server, no AWS client), so importing them here
+// shares one reviewed contract instead of forking it into a second caller.
+import {
+  readConfig as readProxyConfig,
+  resolveRoute,
+  translateChatToResponses,
+  translateResponsesToChat,
+  DEFAULT_REASONING_EFFORT,
+  REASONING_EFFORTS,
+  RequestValidationError,
+} from "../docker/llm-proxy/server.mjs";
+
 const MEMORIES_PATH = "/v1alpha2/mem9s/memories";
 const LIST_PAGE_LIMIT = 200; // server max for GET /memories
 const BATCH_DELETE_MAX = 1000; // server ValidateBulkDeleteIDs cap
@@ -35,6 +55,16 @@ const DISCOVERY_RETRIES = 3;
 const DEFAULT_CAP = 50;
 const REQUEST_TIMEOUT_MS = 30_000; // REST calls; the LLM call sets its own
 const LLM_TIMEOUT_MS = 120_000;
+// Reasoning models consume output tokens on hidden reasoning BEFORE emitting
+// visible text, so the chat route's 4096 cap truncates the verdict JSON
+// mid-object — the measured root cause of GLM-5 leaving 33% of the corpus
+// unclassified. 24k is the budget that classified the full corpus clean.
+const RESPONSES_MAX_OUTPUT_TOKENS = 24_000;
+const RESPONSES_TIMEOUT_MS = 300_000; // observed max ~30s; high effort runs longer
+const DEFAULT_CHAT_MODEL = "zai.glm-5";
+// The SKIP reason for a batch the classifier never judged. Counted in the run
+// summary, so it must stay in sync with the decision rows.
+const UNCLASSIFIED_REASON = "classification failed after retry";
 const HOUR_MS = 3600 * 1000;
 const DEFAULT_LOCK_TTL_MS = 2 * HOUR_MS;
 const SNIPPET_LEN = 120;
@@ -333,6 +363,12 @@ async function classifyBatch(batch, batchIndex, completeChat, log) {
     try {
       return parseVerdicts(await completeChat(CLASSIFY_SYSTEM_PROMPT, input));
     } catch (err) {
+      // A request the translator rejects is a DETERMINISTIC config defect (bad
+      // message content, bad effort) thrown before any network call: it will
+      // fail identically on all remaining batches. Retrying it wastes a scan
+      // and then degrades the whole run to SKIP, which reads as a clean audit.
+      // Abort instead so the operator fixes the invocation.
+      if (err instanceof RequestValidationError) throw err;
       // MalformedResponse messages are fixed strings; transport errors (HTTP
       // status, timeout, auth) carry safe, load-bearing messages. Raw JSON
       // SyntaxErrors never reach here — parseVerdicts wraps them.
@@ -354,7 +390,7 @@ async function classifyAll(memories, completeChat, log) {
       // Never destructive on classification failure: whole batch becomes SKIP.
       failedBatches += 1;
       for (const m of batch) {
-        decisions.push({ id: m.id, verdict: "SKIP", reason: "classification failed after retry" });
+        decisions.push({ id: m.id, verdict: "SKIP", reason: UNCLASSIFIED_REASON });
       }
       continue;
     }
@@ -502,6 +538,36 @@ function verdictSummary(decisions) {
 }
 
 /**
+ * How much of the corpus the classifier never judged.
+ *
+ * Without this, a partial transport outage is invisible: its SKIPs land in the
+ * same bucket as legitimate planner SKIPs (invalid merge graph, contradictory
+ * verdicts), and `classifierBroken` only fires when EVERY batch failed — so a
+ * run that classified one batch of 117 still exits 0 and reads as a clean
+ * audit. The measured GLM-5 run failed 27% of batches and reported exit 0.
+ */
+function classificationFailureNote({ batches, failedBatches, decisions, scanned }) {
+  const unclassified = decisions.filter(
+    (d) => d.verdict === "SKIP" && d.reason === UNCLASSIFIED_REASON,
+  ).length;
+  if (unclassified === 0) return "";
+  // `decisions.length` is NOT the memory count — planDecisions folds absorbed
+  // ids into the surviving MERGE row, so a merge group of k contributes one
+  // row. Replaying a decision file has no scan, so recover the total from the
+  // rows themselves.
+  const total = scanned ?? decisions.reduce((n, d) => n + 1 + (d.absorbs?.length ?? 0), 0);
+  // Batch counters exist only on a fresh scan; the count itself always does,
+  // and --apply always replays a file, which is the run that deletes.
+  const detail = batches
+    ? `${failedBatches}/${batches} batches failed, ${Math.round((failedBatches / batches) * 100)}%`
+    : "from the replayed decision list";
+  return (
+    `; UNCLASSIFIED=${unclassified} of ${total} memories (${detail}) — ` +
+    `NOT audited by this classification; re-run before treating the result as complete`
+  );
+}
+
+/**
  * Obtain the decision list: replay a prior dry-run file, or scan + classify and
  * persist a new one outside the repo (0700/0600 — it holds memory snippets).
  */
@@ -520,13 +586,20 @@ async function loadDecisions(opts, deps, { client, fs, clock, log }) {
       throw new Error("decision file has no decisions array");
     }
     validateDecisions(loaded.decisions);
-    return { decisions: loaded.decisions, decisionPath: opts.decisionsFile, classifierBroken: false };
+    return {
+      decisions: loaded.decisions,
+      decisionPath: opts.decisionsFile,
+      classifierBroken: false,
+      batches: 0,
+      failedBatches: 0,
+    };
   }
   const memories = await scanActiveMemories(client);
   const { decisions, batches, failedBatches } = await classifyAll(memories, deps.completeChat, log);
-  // Zero successful batches on a non-empty store = the GLM-5 path is broken
-  // (IAM, model id, endpoint), not "nothing to clean". Surfaced as a distinct
-  // exit code so CI cannot report a green E2E for a classifier that never ran.
+  // Zero successful batches on a non-empty store = the classifier path is
+  // broken (IAM, model id, endpoint), not "nothing to clean". Surfaced as a
+  // distinct exit code so CI cannot report a green E2E for a run that never
+  // classified anything.
   const classifierBroken = batches > 0 && failedBatches === batches;
 
   const generatedAt = new Date(clock()).toISOString();
@@ -539,7 +612,14 @@ async function loadDecisions(opts, deps, { client, fs, clock, log }) {
     { mode: 0o600 },
   );
   log(`decision list written to ${decisionPath}`);
-  return { decisions, decisionPath, classifierBroken };
+  return {
+    decisions,
+    decisionPath,
+    classifierBroken,
+    batches,
+    failedBatches,
+    scanned: memories.length,
+  };
 }
 
 /**
@@ -670,20 +750,24 @@ export async function runCleanup(opts, deps) {
   }
   const client = restClient(baseUrl, opts.tenantId, deps.fetchImpl, counters);
 
-  const { decisions, decisionPath, classifierBroken } = await loadDecisions(opts, deps, {
+  const { decisions, decisionPath, classifierBroken, batches, failedBatches, scanned } = await loadDecisions(opts, deps, {
     client,
     fs,
     clock,
     log,
   });
   const summary = verdictSummary(decisions);
+  const failureNote = classificationFailureNote({ batches, failedBatches, decisions, scanned });
 
   if (classifierBroken) {
-    log(`classification failed for every batch — GLM-5 path is broken; ${JSON.stringify(summary)}`);
+    log(
+      `classification failed for EVERY batch — the classifier path is broken ` +
+        `(check the model id, region, and Bedrock IAM); ${JSON.stringify(summary)}`,
+    );
     return result({ exitCode: 5, decisions, decisionPath });
   }
   if (!opts.apply) {
-    log(`dry-run: ${JSON.stringify(summary)}; writeCalls=${counters.writeCalls}`);
+    log(`dry-run: ${JSON.stringify(summary)}; writeCalls=${counters.writeCalls}${failureNote}`);
     return result({ exitCode: 0, decisions, decisionPath });
   }
 
@@ -716,9 +800,120 @@ export async function runCleanup(opts, deps) {
   log(
     `apply done: ${JSON.stringify(summary)}; capUsed=${applied.capUsed}/${cap}; ` +
       `writeCalls=${counters.writeCalls}; skippedLww=${counters.skippedLww}; ` +
-      `skippedByFilter=${applied.skippedByFilter}`,
+      `skippedByFilter=${applied.skippedByFilter}${failureNote}`,
   );
   return result({ ...applied, decisions, decisionPath });
+}
+
+// ---------------------------------------------------------------------------
+// LLM transport
+
+/**
+ * Build the `completeChat` dep for the configured model.
+ *
+ * Route selection and both translation directions are the llm-proxy sidecar's
+ * (`resolveRoute`, `translateChatToResponses`, `translateResponsesToChat`) —
+ * imported rather than reimplemented so the reviewed fail-loud contract holds
+ * identically for smart-ingest and for cleanup. That contract matters most
+ * here: a Responses `status: "failed"` arrives as HTTP 200 with empty output,
+ * and returning "" for it would parse as "no verdicts" and mark a whole batch
+ * SKIP on what looks like an authoritative answer.
+ */
+export function buildCompleteChat(opts, deps) {
+  const model = opts.model || process.env.MEM9_LLM_MODEL || DEFAULT_CHAT_MODEL;
+  const appRegion = opts.region || "ap-northeast-1";
+  // A CLOSED object, never a spread of process.env: `readProxyConfig` is
+  // written for a container where the whole LLM_PROXY_* namespace is set by
+  // infra/ecs.ts. Spreading the operator's shell in would make every sidecar
+  // variable a live input here — and an ambient
+  // LLM_PROXY_RESPONSES_MODEL_PREFIXES would silently route a gpt-5.6 model to
+  // the chat route at its 4096 cap, reintroducing the truncation this exists to
+  // fix. Only the keys cleanup actually maps are passed.
+  const cfg = readProxyConfig({
+    LLM_PROXY_REGION: appRegion,
+    LLM_PROXY_RESPONSES_REGION: opts.llmRegion || process.env.MEM9_LLM_RESPONSES_REGION,
+    LLM_PROXY_OPENAI_PROJECT: process.env.MEM9_BEDROCK_PROJECT,
+    LLM_PROXY_RESPONSES_OPENAI_PROJECT: process.env.MEM9_BEDROCK_PROJECT_OPENAI,
+    LLM_PROXY_RESPONSES_MAX_OUTPUT_TOKENS: String(RESPONSES_MAX_OUTPUT_TOKENS),
+    // Routed through the config reader (not applied after it) so its
+    // low|medium|high validation is the single check on this value.
+    LLM_PROXY_REASONING_EFFORT: opts.effort || DEFAULT_REASONING_EFFORT,
+  });
+  const route = resolveRoute(model, cfg);
+  const isResponses = route.kind === "responses";
+  const timeoutMs = isResponses ? RESPONSES_TIMEOUT_MS : LLM_TIMEOUT_MS;
+
+  let bearer = null;
+  return async function completeChat(systemPrompt, memories) {
+    const chatPayload = {
+      model,
+      max_tokens: isResponses ? RESPONSES_MAX_OUTPUT_TOKENS : 4096,
+      messages: [
+        { role: "system", content: systemPrompt },
+        { role: "user", content: JSON.stringify({ memories }) },
+      ],
+    };
+    const payload = isResponses ? translateChatToResponses(chatPayload, cfg) : chatPayload;
+
+    // Minting is a free local SigV4 presign (12h TTL); re-mint once on 401/403
+    // so a long scan outliving the bearer self-heals (llm-proxy pattern).
+    for (let attempt = 1; attempt <= 2; attempt += 1) {
+      if (!bearer) bearer = await deps.mintToken(route.region);
+      const res = await deps.fetchImpl(route.url, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${bearer}`,
+          ...(route.openaiProject ? { "OpenAI-Project": route.openaiProject } : {}),
+        },
+        body: JSON.stringify(payload),
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+      if (res.status === 401 || res.status === 403) {
+        bearer = null;
+        // A second rejection after a fresh presign is a credentials/permission
+        // problem, not a stale token. Say so instead of reporting a bare 401 an
+        // operator would read as a transient upstream blip and retry forever.
+        if (attempt === 2) {
+          throw new Error(
+            `Mantle ${route.kind}: HTTP ${res.status} after bearer re-mint ` +
+              // `bedrock-mantle:`, NOT `bedrock:` — a DIFFERENT service. Granting
+              // the `bedrock:` variant mints a valid bearer and still 403s every
+              // inference (the issue #11 dead end); see infra/ecs.ts. Inference
+              // is what denies here: minting is a local presign that never calls AWS.
+              `(check credentials and bedrock-mantle:CreateInference on the ` +
+              `${route.region} project)`,
+          );
+        }
+        continue;
+      }
+      if (!res.ok) throw new Error(`Mantle ${route.kind} -> HTTP ${res.status}`);
+      let body;
+      try {
+        body = await res.json();
+      } catch {
+        // A truncated or HTML body would otherwise surface as a bare
+        // SyntaxError with no hint of which route produced it.
+        throw new Error(`Mantle ${route.kind}: 2xx body is not valid JSON`);
+      }
+      // `translateResponsesToChat` throws on a broken contract; the chat route
+      // has no equivalent guard upstream, so keep its original ?? "" behavior.
+      const completion = isResponses ? translateResponsesToChat(body, model) : body;
+      // A truncated reply must NEVER be classified. Truncation at the 24k
+      // budget can land on syntactically valid JSON — a partial verdict list,
+      // or a MERGE whose merged_content is cut mid-sentence. Parsing that
+      // would delete memories the model never finished judging and overwrite a
+      // survivor with a half-written fact. `finish_reason: "length"` is the
+      // upstream telling us the output is incomplete, so treat it as a failed
+      // batch: classifyBatch retries, then SKIPs (non-destructive).
+      const choice = completion.choices?.[0];
+      if (choice?.finish_reason === "length") {
+        throw new Error(`Mantle ${route.kind}: reply truncated (finish_reason=length)`);
+      }
+      return choice?.message?.content ?? "";
+    }
+    throw new Error(`Mantle ${route.kind}: retry loop exhausted`);
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -726,6 +921,7 @@ export async function runCleanup(opts, deps) {
 
 // --flag -> the opts key it sets. `flag: true` takes no value; `number: true`
 // values must parse to a positive number (a NaN cap would disable the cap).
+// `choices` restricts the accepted values.
 const ARG_SPECS = {
   "--stage": { key: "stage" },
   "--base-url": { key: "baseUrl" },
@@ -737,6 +933,9 @@ const ARG_SPECS = {
   "--cap": { key: "cap", number: true },
   "--lock-ttl": { key: "lockTtlHours", number: true },
   "--apply": { key: "apply", flag: true },
+  "--model": { key: "model" },
+  "--effort": { key: "effort", choices: REASONING_EFFORTS },
+  "--llm-region": { key: "llmRegion" },
 };
 
 export function parseArgs(argv) {
@@ -752,6 +951,9 @@ export function parseArgs(argv) {
     i += 1;
     const raw = argv[i];
     if (raw === undefined) throw new Error(`${name} requires a value`);
+    if (spec.choices && !spec.choices.includes(raw)) {
+      throw new Error(`${name} must be one of ${spec.choices.join("|")}`);
+    }
     if (!spec.number) {
       opts[spec.key] = raw;
       continue;
@@ -784,37 +986,14 @@ async function productionDeps(opts) {
 
   const { getToken } = await import("@aws/bedrock-token-generator");
   const { fromNodeProviderChain } = await import("@aws-sdk/credential-providers");
-  let bearer = null;
-  async function completeChat(systemPrompt, memories) {
-    // Minting is a free local SigV4 presign (12h TTL); re-mint once on 401/403
-    // so a long scan outliving the bearer self-heals (llm-proxy pattern).
-    for (let attempt = 1; attempt <= 2; attempt += 1) {
-      if (!bearer) {
-        bearer = await getToken({ credentials: fromNodeProviderChain(), region });
-      }
-      const res = await fetch(`https://bedrock-mantle.${region}.api.aws/v1/chat/completions`, {
-        method: "POST",
-        headers: { "content-type": "application/json", authorization: `Bearer ${bearer}` },
-        body: JSON.stringify({
-          model: process.env.MEM9_LLM_MODEL || "zai.glm-5",
-          max_tokens: 4096,
-          messages: [
-            { role: "system", content: systemPrompt },
-            { role: "user", content: JSON.stringify({ memories }) },
-          ],
-        }),
-        signal: AbortSignal.timeout(LLM_TIMEOUT_MS),
-      });
-      if ((res.status === 401 || res.status === 403) && attempt === 1) {
-        bearer = null;
-        continue;
-      }
-      if (!res.ok) throw new Error(`Mantle chat-completions -> HTTP ${res.status}`);
-      const body = await res.json();
-      return body.choices?.[0]?.message?.content ?? "";
-    }
-    throw new Error("Mantle chat-completions: authentication failed after re-mint");
-  }
+  const completeChat = buildCompleteChat(
+    { ...opts, region },
+    {
+      fetchImpl: fetch,
+      mintToken: (tokenRegion) =>
+        getToken({ credentials: fromNodeProviderChain(), region: tokenRegion }),
+    },
+  );
 
   async function discoverInstances(stage) {
     const { ServiceDiscoveryClient, DiscoverInstancesCommand } = await import("@aws-sdk/client-servicediscovery");

--- a/scripts/memory-cleanup.test.mjs
+++ b/scripts/memory-cleanup.test.mjs
@@ -8,6 +8,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  buildCompleteChat,
   contentHash,
   parseArgs,
   parseVerdicts,
@@ -669,5 +670,366 @@ describe("verdict parsing units", () => {
 
   it("contentHash is a stable sha256 label", () => {
     expect(contentHash("abc")).toBe(`sha256:${createHash("sha256").update("abc").digest("hex")}`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// LLM route (TC-MEMCLEAN-070..078) — docs/test-cases/cleanup-reasoning-model.md
+
+describe("LLM route", () => {
+  const APP_REGION = "ap-northeast-1";
+  const CLASSIFY_ATTEMPTS = 2; // mirrors memory-cleanup.mjs
+
+  /** Record every request; reply with the queued responses in order. */
+  function recorder(replies) {
+    const calls = [];
+    const queue = [...replies];
+    const fetchImpl = (url, init) => {
+      calls.push({ url, body: JSON.parse(init.body), headers: init.headers });
+      const next = queue.shift();
+      if (!next) throw new Error("unexpected extra request");
+      return Promise.resolve({
+        ok: next.status === undefined || next.status < 400,
+        status: next.status ?? 200,
+        json: async () => next.body,
+      });
+    };
+    return { calls, fetchImpl };
+  }
+
+  const chatReply = (content) => ({ body: { choices: [{ message: { content } }] } });
+  const responsesReply = (overrides) => ({
+    body: {
+      id: "resp_1",
+      status: "completed",
+      output: [{ content: [{ type: "output_text", text: "[]" }] }],
+      usage: { input_tokens: 10, output_tokens: 20 },
+      ...overrides,
+    },
+  });
+
+  const build = (opts, deps) =>
+    buildCompleteChat({ region: APP_REGION, ...opts }, { mintToken: async (r) => `tok-${r}`, ...deps });
+
+  it("TC-MEMCLEAN-070: GLM-5 keeps the chat-completions contract unchanged", async () => {
+    const { calls, fetchImpl } = recorder([chatReply("[]")]);
+    const completeChat = build({ model: "zai.glm-5" }, { fetchImpl });
+
+    expect(await completeChat("sys", [{ id: "m1" }])).toBe("[]");
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe(`https://bedrock-mantle.${APP_REGION}.api.aws/v1/chat/completions`);
+    // The chat route must keep the 4096 cap and the messages shape: GLM-5 has
+    // no Responses surface, and a reasoning field would 400.
+    expect(calls[0].body).toMatchObject({
+      model: "zai.glm-5",
+      max_tokens: 4096,
+      messages: [
+        { role: "system", content: "sys" },
+        { role: "user", content: JSON.stringify({ memories: [{ id: "m1" }] }) },
+      ],
+    });
+    expect(calls[0].body.input).toBeUndefined();
+    expect(calls[0].body.reasoning).toBeUndefined();
+    expect(calls[0].headers.authorization).toBe(`Bearer tok-${APP_REGION}`);
+  });
+
+  it("TC-MEMCLEAN-071: a gpt-5.6 model routes to Responses in the responses region", async () => {
+    const { calls, fetchImpl } = recorder([responsesReply()]);
+    const completeChat = build(
+      { model: "openai.gpt-5.6-terra", effort: "high", llmRegion: "us-west-2" },
+      { fetchImpl },
+    );
+
+    await completeChat("sysprompt", [{ id: "m1" }]);
+    expect(calls[0].url).toBe("https://bedrock-mantle.us-west-2.api.aws/openai/v1/responses");
+    expect(calls[0].body).toMatchObject({
+      model: "openai.gpt-5.6-terra",
+      instructions: "sysprompt",
+      reasoning: { effort: "high" },
+      // 4096 truncates reasoning output mid-JSON — the measured GLM-5 failure.
+      max_output_tokens: 24000,
+    });
+    expect(calls[0].body.input).toEqual([
+      { role: "user", content: JSON.stringify({ memories: [{ id: "m1" }] }) },
+    ]);
+    expect(calls[0].body.messages).toBeUndefined();
+    // The bearer is minted for the RESPONSES region, not the app region.
+    expect(calls[0].headers.authorization).toBe("Bearer tok-us-west-2");
+  });
+
+  it("TC-MEMCLEAN-072: responses output_text parts reach parseVerdicts verbatim", async () => {
+    const verdicts = '{"verdicts":[{"id":"m1","verdict":"KEEP","reason":"durable"}]}';
+    const { fetchImpl } = recorder([
+      responsesReply({
+        // Split across parts: the route must concatenate, not take the first.
+        output: [
+          { content: [{ type: "output_text", text: verdicts.slice(0, 10) }] },
+          { content: [{ type: "output_text", text: verdicts.slice(10) }] },
+        ],
+      }),
+    ]);
+    const completeChat = build({ model: "openai.gpt-5.6-terra" }, { fetchImpl });
+
+    const raw = await completeChat("sys", [{ id: "m1" }]);
+    expect(raw).toBe(verdicts);
+    expect(parseVerdicts(raw)).toEqual([{ id: "m1", verdict: "KEEP", reason: "durable" }]);
+  });
+
+  it("TC-MEMCLEAN-073: a failed responses status throws instead of returning empty", async () => {
+    // status:"failed" arrives as HTTP 200 with empty output. Returning "" would
+    // parse as "no verdicts" and SKIP a whole batch on a non-answer that looks
+    // authoritative — the exact silent skip this route must not introduce.
+    const { fetchImpl } = recorder([
+      responsesReply({ status: "failed", output: [], error: { message: "upstream boom" } }),
+    ]);
+    const completeChat = build({ model: "openai.gpt-5.6-terra" }, { fetchImpl });
+
+    await expect(completeChat("sys", [{ id: "m1" }])).rejects.toThrow(/failed/);
+  });
+
+  it("TC-MEMCLEAN-073b: a completed reply with no output_text throws", async () => {
+    const { fetchImpl } = recorder([responsesReply({ output: [{ content: [] }] })]);
+    const completeChat = build({ model: "openai.gpt-5.6-terra" }, { fetchImpl });
+
+    await expect(completeChat("sys", [{ id: "m1" }])).rejects.toThrow(/no output_text/);
+  });
+
+  it("TC-MEMCLEAN-074: a truncated reply is rejected even when its JSON parses", async () => {
+    // The dangerous case is truncation that lands on VALID JSON. Parsing it
+    // would delete memories the model never finished judging, so an
+    // `incomplete` status must fail the batch (→ retry → SKIP), not classify.
+    const truncatedButValid = JSON.stringify({
+      verdicts: [{ id: "m1", verdict: "DELETE", reason: "noise" }],
+    });
+    for (const text of [truncatedButValid, '{"verdicts":[{"id":"m1"']) {
+      const { fetchImpl } = recorder([
+        responsesReply({
+          status: "incomplete",
+          incomplete_details: { reason: "max_output_tokens" },
+          output: [{ content: [{ type: "output_text", text }] }],
+        }),
+      ]);
+      const completeChat = build({ model: "openai.gpt-5.6-terra" }, { fetchImpl });
+      await expect(completeChat("sys", [{ id: "m1" }])).rejects.toThrow(/truncated/);
+    }
+  });
+
+  it("TC-MEMCLEAN-074b: a truncated reply cannot delete or merge end-to-end", async () => {
+    // Drives the REAL buildCompleteChat through runCleanup: a truncated MERGE
+    // whose merged_content is cut mid-sentence must not rewrite the survivor
+    // or delete the absorbed memory.
+    const dir = tempDir();
+    const server = fakeServer([memory("s", "fragment a"), memory("a", "fragment b")]);
+    const { fetchImpl } = recorder([
+      responsesReply({
+        status: "incomplete",
+        output: [{
+          content: [{
+            type: "output_text",
+            text: JSON.stringify({
+              verdicts: [
+                { id: "s", verdict: "MERGE", reason: "frags", merge_into: "s",
+                  absorbs: ["a"], merged_content: "fragment a and the deploy pipeline was" },
+                { id: "a", verdict: "MERGE", reason: "frags", merge_into: "s" },
+              ],
+            }),
+          }],
+        }],
+      }),
+      // classifyBatch retries once; fail the same way.
+      responsesReply({
+        status: "incomplete",
+        output: [{ content: [{ type: "output_text", text: "{}" }] }],
+      }),
+    ]);
+    const completeChat = build({ model: "openai.gpt-5.6-terra" }, { fetchImpl });
+
+    const result = await runCleanup(
+      baseOpts({ apply: true }),
+      { ...baseDeps(server, completeChat, dir), completeChat },
+    );
+    expect(result.decisions.map((d) => d.verdict)).toEqual(["SKIP", "SKIP"]);
+    expect(result.writeCalls).toBe(0);
+    expect(server.store.get("s").content).toBe("fragment a");
+    expect(server.store.get("a").state).toBe("active");
+  });
+
+  it("TC-MEMCLEAN-074c: a near-miss model id must not silently use the 4096 cap", async () => {
+    // Prefix matching is exact: a typo or the next model generation would
+    // otherwise route to chat-completions at the truncating cap and produce a
+    // run that looks successful while a third of the corpus goes unclassified.
+    for (const model of ["openai.gpt-5.6terra", "openai.gpt-6-terra", "OPENAI.GPT-5.6-TERRA"]) {
+      const { calls, fetchImpl } = recorder([chatReply('{"verdicts":[]}')]);
+      await build({ model }, { fetchImpl })("sys", []);
+      // Documents the CURRENT behavior so a future prefix change is a visible
+      // test change, not a silent capability regression.
+      expect(calls[0].body.max_tokens).toBe(4096);
+    }
+  });
+
+  it("TC-MEMCLEAN-075: a 401 re-mints once per route, then gives up", async () => {
+    const minted = [];
+    const { calls, fetchImpl } = recorder([{ status: 401, body: {} }, responsesReply()]);
+    const completeChat = build(
+      { model: "openai.gpt-5.6-terra", llmRegion: "us-west-2" },
+      { fetchImpl, mintToken: async (r) => `tok-${r}-${minted.push(r)}` },
+    );
+
+    await completeChat("sys", [{ id: "m1" }]);
+    expect(minted).toEqual(["us-west-2", "us-west-2"]);
+    expect(calls[1].headers.authorization).toBe("Bearer tok-us-west-2-2");
+
+    const second = recorder([{ status: 401, body: {} }, { status: 401, body: {} }]);
+    const giveUp = build({ model: "openai.gpt-5.6-terra" }, { fetchImpl: second.fetchImpl });
+    await expect(giveUp("sys", [{ id: "m1" }])).rejects.toThrow(/after bearer re-mint/);
+  });
+
+  it("TC-MEMCLEAN-075b: a non-auth HTTP error names the route and does not retry", async () => {
+    const { calls, fetchImpl } = recorder([{ status: 500, body: {} }]);
+    const completeChat = build({ model: "openai.gpt-5.6-terra" }, { fetchImpl });
+
+    await expect(completeChat("sys", [{ id: "m1" }])).rejects.toThrow(/responses -> HTTP 500/);
+    expect(calls).toHaveLength(1);
+  });
+
+  it("TC-MEMCLEAN-076: --model/--effort/--llm-region parse; --effort is bounded", () => {
+    expect(
+      parseArgs([
+        "--stage", "prod",
+        "--model", "openai.gpt-5.6-luna",
+        "--effort", "medium",
+        "--llm-region", "us-east-1",
+      ]),
+    ).toMatchObject({ model: "openai.gpt-5.6-luna", effort: "medium", llmRegion: "us-east-1" });
+
+    // An unbounded effort would reach Mantle and 400 mid-scan.
+    expect(() => parseArgs(["--stage", "prod", "--effort", "ultra"])).toThrow(/low\|medium\|high/);
+    expect(parseArgs(["--stage", "prod"]).model).toBeUndefined();
+  });
+
+  it("TC-MEMCLEAN-077: each route carries its own timeout budget", async () => {
+    const budgets = [];
+    const spy = vi.spyOn(AbortSignal, "timeout");
+    try {
+      for (const model of ["zai.glm-5", "openai.gpt-5.6-terra"]) {
+        const reply = model === "zai.glm-5" ? chatReply("[]") : responsesReply();
+        const { fetchImpl } = recorder([reply]);
+        spy.mockClear();
+        await build({ model }, { fetchImpl })("sys", [{ id: "m1" }]);
+        budgets.push(spy.mock.calls.at(-1)[0]);
+      }
+    } finally {
+      spy.mockRestore();
+    }
+    // High-effort reasoning legitimately outlives the 120s chat budget.
+    expect(budgets).toEqual([120_000, 300_000]);
+  });
+
+  it("TC-MEMCLEAN-080: a partial classification outage is reported, not hidden in SKIP", async () => {
+    // 3 batches of 20. The first fails BOTH attempts (classifyBatch retries
+    // once), so exactly one batch goes unclassified while two succeed.
+    // classifierBroken requires ALL batches to fail, so this exits 0 — the
+    // summary MUST say how much of the corpus went unaudited, or a partial
+    // outage is indistinguishable from a clean audit.
+    const memories = Array.from({ length: 60 }, (_, i) => memory(`m-${i}`, `fact ${i}`));
+    const server = fakeServer(memories);
+    let call = 0;
+    const llm = vi.fn(async (_p, batch) => {
+      call += 1;
+      if (call <= CLASSIFY_ATTEMPTS) throw new Error("Mantle responses -> HTTP 500");
+      // A merge group in a SUCCEEDING batch: planDecisions folds the absorbed
+      // ids into the survivor's row, so decisions.length < scanned memories.
+      // The denominator must still be the memory count an operator can verify
+      // against the store, not the row count.
+      if (call === CLASSIFY_ATTEMPTS + 1) {
+        const [s1, a1, a2, ...rest] = batch;
+        return JSON.stringify({
+          verdicts: [
+            { id: s1.id, verdict: "MERGE", reason: "frags", merge_into: s1.id,
+              absorbs: [a1.id, a2.id], merged_content: "merged fact" },
+            { id: a1.id, verdict: "MERGE", reason: "frags", merge_into: s1.id },
+            { id: a2.id, verdict: "MERGE", reason: "frags", merge_into: s1.id },
+            ...keepAll(rest),
+          ],
+        });
+      }
+      return JSON.stringify({ verdicts: keepAll(batch) });
+    });
+    const deps = baseDeps(server, llm, tempDir());
+    const result = await runCleanup(baseOpts(), deps);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.decisions.length).toBeLessThan(60); // merge folding shrank the rows
+    const summaryLine = deps.log.mock.calls.map((c) => c[0]).find((m) => m.startsWith("dry-run:"));
+    expect(summaryLine).toMatch(/UNCLASSIFIED=20 of 60 memories \(1\/3 batches failed, 33%\)/);
+    expect(summaryLine).toMatch(/NOT audited by this classification/);
+    // The old summary reported only SKIP:20, which is also what a legitimate
+    // planner SKIP looks like — the whole point of the new note.
+    expect(summaryLine).toContain('"SKIP":20');
+
+    // The apply run replays the file and is the run that DELETES, so it must
+    // carry the same warning; batch counters are absent there.
+    const applyServer = fakeServer(memories);
+    const applyDeps = baseDeps(applyServer, llm, tempDir());
+    await runCleanup(
+      baseOpts({ apply: true, decisionsFile: result.decisionPath, cap: 500 }),
+      applyDeps,
+    );
+    const applyLine = applyDeps.log.mock.calls.map((c) => c[0]).find((m) => m.startsWith("apply done:"));
+    expect(applyLine).toMatch(/UNCLASSIFIED=20 of 60 memories \(from the replayed decision list\)/);
+  });
+
+  it("TC-MEMCLEAN-081: a deterministic request-translation defect aborts the run", async () => {
+    // Non-string message content is rejected by the translator BEFORE any
+    // network call, so it fails identically on every batch. Retrying it and
+    // degrading to SKIP would turn an invocation bug into a clean-looking
+    // audit of an unexamined corpus.
+    const server = fakeServer([memory("m-1", "x")]);
+    const { fetchImpl } = recorder([]);
+    const completeChat = build({ model: "openai.gpt-5.6-terra" }, { fetchImpl });
+    const boom = () => completeChat(null, [{ id: "m-1" }]); // null system prompt
+
+    await expect(boom()).rejects.toThrow(/string content/);
+    await expect(
+      runCleanup(baseOpts(), { ...baseDeps(server, boom, tempDir()), completeChat: boom }),
+    ).rejects.toThrow(/string content/);
+  });
+
+  it("TC-MEMCLEAN-079: ambient LLM_PROXY_* sidecar env cannot alter the route", async () => {
+    // The config is assembled from a CLOSED object, not a spread of process.env.
+    // A debug host with the sidecar's container env exported would otherwise
+    // silently route terra to chat-completions at its 4096 cap (reintroducing
+    // the truncation this route exists to fix) or crash on a limit cleanup
+    // never reads.
+    vi.stubEnv("LLM_PROXY_RESPONSES_MODEL_PREFIXES", "nothing-matches");
+    vi.stubEnv("LLM_PROXY_UPSTREAM_BASE", "http://localhost:8082/v1");
+    vi.stubEnv("LLM_PROXY_MAX_BODY_BYTES", "0");
+    vi.stubEnv("LLM_PROXY_REASONING_EFFORT", "not-an-effort");
+    try {
+      const { calls, fetchImpl } = recorder([responsesReply()]);
+      await build({ model: "openai.gpt-5.6-terra" }, { fetchImpl })("sys", []);
+      expect(calls[0].url).toBe("https://bedrock-mantle.us-west-2.api.aws/openai/v1/responses");
+      expect(calls[0].body.max_output_tokens).toBe(24000);
+      expect(calls[0].body.reasoning).toEqual({ effort: "high" });
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("TC-MEMCLEAN-078: regional project ids are never cross-applied", async () => {
+    vi.stubEnv("MEM9_BEDROCK_PROJECT", "proj_tokyo");
+    vi.stubEnv("MEM9_BEDROCK_PROJECT_OPENAI", "proj_uswest");
+    try {
+      const chat = recorder([chatReply("[]")]);
+      await build({ model: "zai.glm-5" }, { fetchImpl: chat.fetchImpl })("sys", []);
+      expect(chat.calls[0].headers["OpenAI-Project"]).toBe("proj_tokyo");
+
+      const resp = recorder([responsesReply()]);
+      await build({ model: "openai.gpt-5.6-terra" }, { fetchImpl: resp.fetchImpl })("sys", []);
+      // Mantle projects are regional: the Tokyo id means nothing in us-west-2.
+      expect(resp.calls[0].headers["OpenAI-Project"]).toBe("proj_uswest");
+    } finally {
+      vi.unstubAllEnvs();
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Adds a configurable Responses route for cleanup classification, sharing route
  selection and translation code with the local LLM proxy.
- Rejects truncated responses before they can produce actionable decisions,
  including syntactically valid but incomplete JSON.
- Reports unclassified memories and failed batches so partial failures cannot
  be mistaken for a complete audit.
- Adds a daily all-zero extraction alarm with an explicit traffic guard.

The Responses route uses a 24,000-token output budget. The blackout alarm uses
`Average(ZeroFactSuccess) >= 1.0` over 24 hours with `Sum(JobsSucceeded) > 50`.
These are implementation settings; public verification uses synthetic fixtures,
not operator model comparisons or traffic baselines.

## Validation

Unit coverage verifies route selection, independent output/timeout budgets,
truncated-but-valid replies, classification-failure reporting, translation-error
handling, metric emission, and alarm expression boundaries. The design and test
cases are in `docs/designs/cleanup-reasoning-model.md` and
`docs/test-cases/cleanup-reasoning-model.md`.

Cleanup requires access to the private service network. Namespace v1 disables
the legacy cleanup entry points pending a complete namespace contract.
