### PR TITLE
feat(iam): admit consolidation roles to the workload boundary and deploy role

### DIFF
--- a/infra/cloudformation/github-actions-role.yaml
+++ b/infra/cloudformation/github-actions-role.yaml
@@ -235,9 +235,19 @@ Resources:
             Resource:
               - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/mem9-on-a*-*Mem9ServerExecutionRole-*
               - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/mem9-on-a*-*Mem9BootstrapExecutionRole-*
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/mem9-on-a*-*Mem9ConsolidationExecutionRole-*
             Condition:
               StringNotEquals:
                 iam:PassedToService: ecs-tasks.amazonaws.com
+          - Sid: DenyConsolidationSchedulerRolePassToOtherServices
+            Effect: Deny
+            Action:
+              - iam:PassRole
+            Resource:
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/mem9-on-a*-*Mem9ConsolidationSchedulerRole-*
+            Condition:
+              StringNotEquals:
+                iam:PassedToService: scheduler.amazonaws.com
           - Sid: DenyWorkloadBoundaryRemoval
             Effect: Deny
             Action:
@@ -456,6 +466,56 @@ Resources:
                 iam:PassedToService:
                   - lambda.amazonaws.com
                   - ecs-tasks.amazonaws.com
+          - Sid: EventBridgeConsolidationFailures
+            Effect: Allow
+            Action:
+              - events:DeleteRule
+              - events:DescribeRule
+              - events:ListTagsForResource
+              - events:ListTargetsByRule
+              - events:PutRule
+              - events:PutTargets
+              - events:RemoveTargets
+              - events:TagResource
+              - events:UntagResource
+            Resource:
+              - !Sub arn:${AWS::Partition}:events:${ApplicationRegion}:${AWS::AccountId}:rule/mem9-on-aws-*
+          - Sid: SchedulerConsolidation
+            Effect: Allow
+            Action:
+              - scheduler:CreateSchedule
+              - scheduler:DeleteSchedule
+              - scheduler:GetSchedule
+              - scheduler:UpdateSchedule
+            Resource:
+              - !Sub arn:${AWS::Partition}:scheduler:${ApplicationRegion}:${AWS::AccountId}:schedule/mem9-on-aws-*/mem9-on-aws-*
+          - Sid: SchedulerConsolidationGroup
+            Effect: Allow
+            Action:
+              - scheduler:CreateScheduleGroup
+              - scheduler:DeleteScheduleGroup
+              - scheduler:GetScheduleGroup
+              - scheduler:ListTagsForResource
+              - scheduler:TagResource
+              - scheduler:UntagResource
+            Resource:
+              - !Sub arn:${AWS::Partition}:scheduler:${ApplicationRegion}:${AWS::AccountId}:schedule-group/mem9-on-aws-*
+          - Sid: PassConsolidationSchedulerRole
+            Effect: Allow
+            Action:
+              - iam:PassRole
+            Resource:
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/mem9-on-a*-*Mem9ConsolidationSchedulerRole-*
+            Condition:
+              StringEquals:
+                iam:PassedToService: scheduler.amazonaws.com
+          - Sid: LogsResourcePolicy
+            Effect: Allow
+            Action:
+              - logs:DeleteResourcePolicy
+              - logs:DescribeResourcePolicies
+              - logs:PutResourcePolicy
+            Resource: "*"
 
   # ───────────────────────────────────────────────────────────────────────────
   # Policy 4 — Database stack (infra/db.ts): Aurora PostgreSQL Serverless v2 +
@@ -699,7 +759,8 @@ Resources:
             # group is `/sst/cluster/<cluster>/<service>/<container>`, covered by
             # the `/sst/*` ARNs below. StartQuery/GetQueryResults are used by the
             # E2E log-scan hardening (issue #26) to detect 401s in the service
-            # logs during the deploy.
+            # logs during the deploy. FilterLogEvents reads only the exact
+            # consolidation task stream's content-free REVIEW_LIST marker.
             Effect: Allow
             Action:
               - logs:CreateLogGroup
@@ -713,6 +774,7 @@ Resources:
               - logs:PutLogEvents
               - logs:StartQuery
               - logs:GetQueryResults
+              - logs:FilterLogEvents
               - logs:PutMetricFilter
               - logs:DeleteMetricFilter
               - logs:DescribeMetricFilters

--- a/infra/cloudformation/workload-permissions-boundary.yaml
+++ b/infra/cloudformation/workload-permissions-boundary.yaml
@@ -58,15 +58,18 @@ Resources:
               - bedrock-mantle:GetProject
               - bedrock-mantle:ListProjects
               - bedrock-mantle:ListTagsForResource
+              - ecs:RunTask
               - ecr:BatchCheckLayerAvailability
               - ecr:BatchGetImage
               - ecr:GetDownloadUrlForLayer
               - lambda:InvokeFunction
+              - iam:PassRole
               - logs:CreateLogGroup
               - logs:CreateLogStream
               - logs:PutLogEvents
               - secretsmanager:GetSecretValue
               - sqs:SendMessage
+              - sns:Publish
               - ssm:GetParameters
               - ec2:AssignPrivateIpAddresses
               - ec2:CreateNetworkInterface
@@ -98,6 +101,7 @@ Resources:
               - logs:PutLogEvents
               - secretsmanager:GetSecretValue
               - sqs:SendMessage
+              - sns:Publish
               - ssm:GetParameters
             NotResource:
               - !Ref BedrockProjectArn
@@ -111,6 +115,7 @@ Resources:
               - !Sub arn:${AWS::Partition}:secretsmanager:${ApplicationRegion}:${AWS::AccountId}:secret:mem9-on-aws-*
               - !Sub arn:${AWS::Partition}:sqs:${ApplicationRegion}:${AWS::AccountId}:AlertTransportFailureQueue-*
               - !Sub arn:${AWS::Partition}:sqs:${ApplicationRegion}:${AWS::AccountId}:AlertExecutionFailureQueue-*
+              - !Sub arn:${AWS::Partition}:sns:${ApplicationRegion}:${AWS::AccountId}:mem9-on-aws-*-alerts
               - !Sub arn:${AWS::Partition}:ssm:${ApplicationRegion}:${AWS::AccountId}:parameter/mem9-on-aws/*
           # Lambda cold starts, SSM SecureStrings, and the two ECS task-definition
           # secret families use different KMS encryption contexts. Missing and
@@ -174,6 +179,7 @@ Resources:
                 "aws:PrincipalArn":
                   - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/mem9-on-a*-*Mem9ServerExecutionRole-*
                   - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/mem9-on-a*-*Mem9BootstrapExecutionRole-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/mem9-on-a*-*Mem9ConsolidationExecutionRole-*
           # Only the reviewed Lambda execution-role types may present the Lambda
           # cold-start context. Other workload roles cannot forge it.
           - Sid: DenyLambdaContextDecryptFromNonLambdaRoles

--- a/scripts/lib/workload-permissions-boundary.mjs
+++ b/scripts/lib/workload-permissions-boundary.mjs
@@ -90,11 +90,13 @@ function matchesProjectLambdaRoleName(roleName, type) {
 const ECS_EXECUTION_ROLE_TOKENS = [
   "Mem9ServerExecutionRole-",
   "Mem9BootstrapExecutionRole-",
+  "Mem9ConsolidationExecutionRole-",
 ];
 const ALLOWED_PASS_SERVICES = new Set([
   "bedrock-agentcore.amazonaws.com",
   "ecs-tasks.amazonaws.com",
   "lambda.amazonaws.com",
+  "scheduler.amazonaws.com",
 ]);
 const PROJECT_RESOURCE_RUNTIME_ACTIONS = [
   "bedrock-mantle:CreateInference",
@@ -109,11 +111,13 @@ const PROJECT_RESOURCE_RUNTIME_ACTIONS = [
   "logs:CreateLogStream",
   "logs:PutLogEvents",
   "secretsmanager:GetSecretValue",
+  "sns:Publish",
   "sqs:SendMessage",
   "ssm:GetParameters",
 ];
 const MANTLE_BEARER_ACTION = "bedrock-mantle:CallWithBearerToken";
 const GLOBAL_RUNTIME_ACTIONS = [
+  "ecs:RunTask",
   "ec2:AssignPrivateIpAddresses",
   "ec2:CreateNetworkInterface",
   "ec2:DeleteNetworkInterface",
@@ -121,6 +125,7 @@ const GLOBAL_RUNTIME_ACTIONS = [
   "ec2:DescribeSubnets",
   "ec2:UnassignPrivateIpAddresses",
   "ecr:GetAuthorizationToken",
+  "iam:PassRole",
   "ssmmessages:CreateControlChannel",
   "ssmmessages:CreateDataChannel",
   "ssmmessages:OpenControlChannel",
@@ -165,6 +170,13 @@ export function expectedRolePatterns(identity) {
   return ROLE_PREFIXES.map(
     (prefix) =>
       `arn:${identity.partition}:iam::${identity.accountId}:role/${prefix}*`,
+  );
+}
+
+function consolidationSchedulerRoleArnPattern({ partition, accountId }) {
+  return (
+    `arn:${partition}:iam::${accountId}:role/` +
+    "mem9-on-a*-*Mem9ConsolidationSchedulerRole-*"
   );
 }
 
@@ -319,6 +331,7 @@ function boundaryContract({
       `arn:${partition}:secretsmanager:${applicationRegion}:${accountId}:secret:mem9-on-aws-*`,
       `arn:${partition}:sqs:${applicationRegion}:${accountId}:AlertTransportFailureQueue-*`,
       `arn:${partition}:sqs:${applicationRegion}:${accountId}:AlertExecutionFailureQueue-*`,
+      `arn:${partition}:sns:${applicationRegion}:${accountId}:mem9-on-aws-*-alerts`,
       `arn:${partition}:ssm:${applicationRegion}:${accountId}:parameter/mem9-on-aws/*`,
     ],
   };
@@ -617,11 +630,14 @@ function validatePassServices(statement) {
       "iam:PassRole has an unsupported iam:PassedToService scope",
     );
   }
+  return services;
 }
 
 export function extractPassRoleScope(policyDocuments, identity) {
   const expected = expectedRolePatterns(identity);
   const expectedSet = new Set(expected);
+  const schedulerRolePattern =
+    consolidationSchedulerRoleArnPattern(identity);
   const resources = new Set();
 
   for (const rawDocument of policyDocuments) {
@@ -645,10 +661,22 @@ export function extractPassRoleScope(policyDocuments, identity) {
         throw new Error("PassRole NotResource is unsupported");
       }
 
-      validatePassServices(statement);
+      const services = validatePassServices(statement);
       const statementResources = list(statement.Resource);
       if (statementResources.length === 0) {
         throw new Error("PassRole statement has no resource scope");
+      }
+      if (services.includes("scheduler.amazonaws.com")) {
+        if (
+          services.length !== 1 ||
+          statementResources.length !== 1 ||
+          statementResources[0] !== schedulerRolePattern
+        ) {
+          throw new Error(
+            "Scheduler PassRole scope does not match the consolidation role",
+          );
+        }
+        continue;
       }
       for (const resource of statementResources) {
         if (
@@ -925,6 +953,17 @@ export function verifyPermanentEnforcementDocuments(
     conditionOperator: "StringNotEquals",
     conditionKey: "iam:PassedToService",
     conditionValue: "ecs-tasks.amazonaws.com",
+  });
+  requireStatement(documents, {
+    sid: "DenyConsolidationSchedulerRolePassToOtherServices",
+    effect: "Deny",
+    actions: ["iam:PassRole"],
+    resources: [
+      consolidationSchedulerRoleArnPattern({ partition, accountId }),
+    ],
+    conditionOperator: "StringNotEquals",
+    conditionKey: "iam:PassedToService",
+    conditionValue: "scheduler.amazonaws.com",
   });
   requireStatement(documents, {
     sid: "DenyOperatorOwnedIamMutation",

--- a/scripts/workload-permissions-boundary.test.mjs
+++ b/scripts/workload-permissions-boundary.test.mjs
@@ -113,6 +113,9 @@ const boundaryContract = {
   partition,
 };
 const patterns = expectedRolePatterns({ partition, accountId });
+const consolidationSchedulerRolePattern =
+  `arn:${partition}:iam::${accountId}:role/` +
+  "mem9-on-a*-*Mem9ConsolidationSchedulerRole-*";
 const denyPolicyId = DENY_DANGEROUS_POLICY_NAME;
 const denyPolicyArn = `arn:${partition}:iam::${accountId}:policy/${denyPolicyId}`;
 const independentRuntimeActions = [
@@ -138,9 +141,12 @@ const independentRuntimeActions = [
   "bedrock-mantle:GetProject",
   "bedrock-mantle:ListProjects",
   "bedrock-mantle:ListTagsForResource",
+  "ecs:RunTask",
+  "iam:PassRole",
   "kms:Decrypt",
   "lambda:InvokeFunction",
   "secretsmanager:GetSecretValue",
+  "sns:Publish",
   "sqs:SendMessage",
   "ssm:GetParameters",
   // SST Service/Task ECS Exec channels.
@@ -531,6 +537,27 @@ function passRolePolicy(resources = patterns) {
               "ecs-tasks.amazonaws.com",
               "bedrock-agentcore.amazonaws.com",
             ],
+          },
+        },
+      },
+    ],
+  };
+}
+
+function consolidationSchedulerPassRolePolicy({
+  resources = [consolidationSchedulerRolePattern],
+  services = ["scheduler.amazonaws.com"],
+} = {}) {
+  return {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Action: "iam:PassRole",
+        Resource: resources,
+        Condition: {
+          StringEquals: {
+            "iam:PassedToService": services,
           },
         },
       },
@@ -1709,6 +1736,46 @@ describe("deployed PassRole scope", () => {
         accountId,
       }),
     ).toEqual(patterns);
+  });
+
+  it("accepts the exact consolidation Scheduler role separately", () => {
+    expect(
+      extractPassRoleScope(
+        [
+          passRolePolicy([...patterns].reverse()),
+          consolidationSchedulerPassRolePolicy(),
+        ],
+        { partition, accountId },
+      ),
+    ).toEqual(patterns);
+  });
+
+  it.each([
+    [
+      "generic project roles",
+      consolidationSchedulerPassRolePolicy({ resources: patterns }),
+    ],
+    [
+      "additional service",
+      consolidationSchedulerPassRolePolicy({
+        services: ["scheduler.amazonaws.com", "ecs-tasks.amazonaws.com"],
+      }),
+    ],
+    [
+      "foreign scheduler role",
+      consolidationSchedulerPassRolePolicy({
+        resources: [
+          `arn:${partition}:iam::${accountId}:role/other-scheduler-role-*`,
+        ],
+      }),
+    ],
+  ])("rejects Scheduler PassRole for %s", (_name, policy) => {
+    expect(() =>
+      extractPassRoleScope([passRolePolicy(), policy], {
+        partition,
+        accountId,
+      }),
+    ).toThrow(/PassRole/u);
   });
 
   it.each([
@@ -3431,6 +3498,19 @@ describe("quarantine and permanent policy verification", () => {
         for (const document of documents) {
           document.Statement = document.Statement.filter(
             ({ Sid }) => Sid !== "DenyEcsExecutionRolePassToOtherServices",
+          );
+        }
+        return documents;
+      },
+    ],
+    [
+      "missing consolidation Scheduler role PassRole deny",
+      () => {
+        const documents = structuredClone(deployedManagedPolicyDocuments());
+        for (const document of documents) {
+          document.Statement = document.Statement.filter(
+            ({ Sid }) =>
+              Sid !== "DenyConsolidationSchedulerRolePassToOtherServices",
           );
         }
         return documents;
@@ -7315,12 +7395,14 @@ describe("boundary and deploy-role templates", () => {
           "AlertTransportFailureQueue-*",
         "arn:aws:sqs:ap-northeast-1:123456789012:" +
           "AlertExecutionFailureQueue-*",
+        "arn:aws:sns:ap-northeast-1:123456789012:mem9-on-aws-*-alerts",
         expect.stringContaining("parameter/mem9-on-aws/*"),
       ]),
     );
     expect(bySid("DenyProjectRuntimeOutsideResources").Action).toEqual(
       expect.arrayContaining([
         "secretsmanager:GetSecretValue",
+        "sns:Publish",
         "sqs:SendMessage",
         "ssm:GetParameters",
       ]),
@@ -7399,6 +7481,8 @@ describe("boundary and deploy-role templates", () => {
               "mem9-on-a*-*Mem9ServerExecutionRole-*",
             "arn:aws:iam::123456789012:role/" +
               "mem9-on-a*-*Mem9BootstrapExecutionRole-*",
+            "arn:aws:iam::123456789012:role/" +
+              "mem9-on-a*-*Mem9ConsolidationExecutionRole-*",
           ],
         },
       },
@@ -7506,7 +7590,9 @@ describe("boundary and deploy-role templates", () => {
   it("keeps the boundary within the IAM managed-policy size quota", () => {
     const template = parseCloudFormation(boundaryTemplatePath);
     const size = JSON.stringify(
-      template.Resources.WorkloadPermissionsBoundary.Properties.PolicyDocument,
+      resolveTemplateValue(
+        template.Resources.WorkloadPermissionsBoundary.Properties.PolicyDocument,
+      ),
     ).length;
     expect(size).toBeLessThanOrEqual(6_144);
   });
@@ -7594,6 +7680,7 @@ describe("boundary and deploy-role templates", () => {
       "DenyUnboundedProjectRolePolicyWrites",
       "DenyLambdaRolePassToOtherServices",
       "DenyEcsExecutionRolePassToOtherServices",
+      "DenyConsolidationSchedulerRolePassToOtherServices",
       "DenyWorkloadBoundaryRemoval",
       "DenyOperatorOwnedIamMutation",
       "DenyOperatorOwnedStackMutation",
@@ -7696,10 +7783,29 @@ describe("boundary and deploy-role templates", () => {
           "mem9-on-a*-*Mem9ServerExecutionRole-*",
         "arn:aws:iam::123456789012:role/" +
           "mem9-on-a*-*Mem9BootstrapExecutionRole-*",
+        "arn:aws:iam::123456789012:role/" +
+          "mem9-on-a*-*Mem9ConsolidationExecutionRole-*",
       ],
       Condition: {
         StringNotEquals: {
           "iam:PassedToService": "ecs-tasks.amazonaws.com",
+        },
+      },
+    });
+    expect(
+      resolveTemplateValue(
+        bySid(
+          denyStatements,
+          "DenyConsolidationSchedulerRolePassToOtherServices",
+        ),
+      ),
+    ).toMatchObject({
+      Effect: "Deny",
+      Action: ["iam:PassRole"],
+      Resource: [consolidationSchedulerRolePattern],
+      Condition: {
+        StringNotEquals: {
+          "iam:PassedToService": "scheduler.amazonaws.com",
         },
       },
     });


### PR DESCRIPTION
## Summary

Splits the **out-of-band IAM prerequisites** out of #113 so they can land and be rolled out independently of the application code. No resource is created here — three operator-owned templates plus the contract library.

## Why this split exists

#113 has failed four review rounds on one blocker, and it is **structural, not a code defect**:

- CI preflight compares the **checkout's** boundary contract against the **live** managed policy (`.github/workflows/infra-ci.yml:277`).
- The guarded rollout that updates that live policy refuses to run from anything but the **exact current default-branch commit with a clean tree** (`scripts/rollout-workload-permissions-boundary.sh:228-236`).

So any branch carrying the template change fails preflight forever — the rollout can only ever apply `main`'s template. Verified both directions locally: `--verify-only` exits **0** on `main` (live policy is not independently drifted) and exits **1** on this branch (the expected drift the rollout will close).

## What is in scope

| File | Change |
|---|---|
| `workload-permissions-boundary.yaml` | `ecs:RunTask` + `iam:PassRole` (the boundary attaches to **every** `aws.iam.Role` via `$transform`, so it also caps the scheduler role, whose own policy needs both), `sns:Publish` scoped to `mem9-on-aws-*-alerts`, and `Mem9ConsolidationExecutionRole-*` admitted to `DenySecretContextDecryptFromNonEcsExecutionRoles` so it can inject `MEM9_DB_SECRET`/`MEM9_TENANT_ID` |
| `github-actions-role.yaml` | `scheduler:*` + `events:*`, the matching `iam:PassRole`, and a new permanent-enforcement statement `DenyConsolidationSchedulerRolePassToOtherServices` pinning the scheduler role to `scheduler.amazonaws.com` |
| `scripts/lib/workload-permissions-boundary.mjs` | The same additions — `--verify-only` compares the live policy against `expectedBoundaryPolicyDocument()`, not against the YAML |

## Deliberately NOT in scope

`infra/workload-permissions-boundary.test-fixtures.ts` and every consolidation resource stay in #113: the fixtures name roles that only exist once `infra/consolidation.ts` lands, and including them here fails `workload-permissions-boundary.roles.test.ts` against the real SST graph (confirmed — the graph resolves 8 roles, not 10). After this merges, #113 becomes application code only.

## One test fix travels with the change

The boundary size-quota assertion measured the **unresolved** template, counting `!If`/`!Sub` objects as policy bytes and reporting 6338 against the 6144 quota. It now measures `resolveTemplateValue(...)` — the document IAM actually receives. This is why the quota test passes in #113 but failed when the templates were split out without it.

## Operator steps after merge (expected, not a defect)

1. Deploy fails with `Workload permissions-boundary policy drift detected` — this is the designed gate.
2. Run the guarded rollout (`WORKLOAD_BOUNDARY_MAINTENANCE_ACK=true scripts/rollout-workload-permissions-boundary.sh`) in a maintenance window with `DEPLOYMENT_MAINTENANCE_PAUSED=true`.
3. If the next deploy returns `scheduler:*` AccessDenied, re-run `scripts/deploy-github-role.sh`.

## Test Plan

- [x] Unit tests pass — 678 root + 228 infra
- [x] Boundary suite green — 340 tests in `scripts/workload-permissions-boundary.test.mjs`
- [x] Both typechecks clean (`tsc --noEmit`)
- [x] Public-artifact scan clean
- [x] `--verify-only` reports the expected drift on this branch and clean on `main` (attribution proven)
- [ ] CI checks pass
- [x] Code simplification review passed

## Checklist

- [x] New unit tests written for new functionality (permanent-enforcement statement, scheduler PassRole scoping)
- [x] E2E test cases updated if needed — n/a, no resource is created by this PR
- [x] Documentation updated if needed — the rollout runbook (README.md) already covers this procedure verbatim

## Related

Unblocks #103 / #113.