### PR TITLE
fix(consolidation): budget Pulumi's name suffix, not just the prefix

### DIFF
--- a/infra/consolidation.test.ts
+++ b/infra/consolidation.test.ts
@@ -836,3 +836,32 @@ describe("scheduler role name (TC-CONSOL-047)", () => {
     );
   });
 });
+
+describe("name budgets account for Pulumi's suffix (TC-CONSOL-048)", () => {
+  it("keeps every namePrefix under its resource limit once the suffix is appended", async () => {
+    const mod = await import("./consolidation");
+    const { boundedNamePrefix, PULUMI_NAME_SUFFIX_LEN } = mod;
+
+    // The lesson from a PROD deploy failure: checking the prefix against the
+    // resource's name limit is not enough. Pulumi appends a 26-character unique
+    // suffix, so a 39-char EventBridge rule prefix produced a 65-char name and
+    // PutRule rejected it with a ValidationException — after the PR had merged
+    // and every preview check was green.
+    expect(PULUMI_NAME_SUFFIX_LEN).toBe(26);
+
+    // The old failure-rule prefix must now be rejected at synth.
+    expect(() =>
+      boundedNamePrefix("mem9-on-aws-prod-consolidation-failure-", 64, "rule"),
+    ).toThrow(/65-character name/);
+
+    // Every prefix this stack builds must fit for the longest realistic stage.
+    for (const stage of ["prod", "pr-1", "pr-113", "pr-99999"]) {
+      const rule = `mem9-on-aws-${stage}-consol-failure-`;
+      expect(rule.length + PULUMI_NAME_SUFFIX_LEN).toBeLessThanOrEqual(64);
+      expect(() => boundedNamePrefix(rule, 64, "rule")).not.toThrow();
+
+      const group = mod.consolidationScheduleGroupPrefix(stage);
+      expect(group.length + PULUMI_NAME_SUFFIX_LEN).toBeLessThanOrEqual(64);
+    }
+  });
+});

--- a/infra/consolidation.ts
+++ b/infra/consolidation.ts
@@ -28,16 +28,46 @@ export interface ConsolidationOutputs {
  * name_prefix limit. Exported so a unit test can assert the bound for realistic
  * stage names instead of discovering it in a failed deploy.
  */
+// Pulumi appends a 26-character unique suffix to every `namePrefix` (observed:
+// "20260803182536887300000001"). A prefix that fits its own documented limit can
+// therefore still produce an over-long NAME — prod's EventBridge rule prefix was
+// 39 chars against a 64-char rule limit and PutRule rejected the resulting
+// 65-char name. Budget the SUFFIX, not just the prefix.
+export const PULUMI_NAME_SUFFIX_LEN = 26;
+
+/**
+ * Assert a `namePrefix` leaves room for Pulumi's suffix under the resource's own
+ * name limit, for the longest stage this project realistically deploys.
+ */
+export function boundedNamePrefix(
+  prefix: string,
+  nameMax: number,
+  what: string,
+): string {
+  const worst = prefix.length + PULUMI_NAME_SUFFIX_LEN;
+  if (worst > nameMax) {
+    throw new Error(
+      `${what} prefix ${prefix} yields a ${worst}-character name, over the ` +
+        `${nameMax}-character limit`,
+    );
+  }
+  return prefix;
+}
+
 export const SCHEDULE_GROUP_NAME_PREFIX_MAX = 38;
 
 export function consolidationScheduleGroupPrefix(stage: string): string {
   const prefix = `mem9-on-aws-${stage}-consolidation-`;
+  // Two limits apply. Check the TIGHTER one (Scheduler's 38-char prefix cap)
+  // first so the error names the binding constraint; the suffix-aware 64-char
+  // NAME check follows.
   if (prefix.length > SCHEDULE_GROUP_NAME_PREFIX_MAX) {
     throw new Error(
       `schedule-group name prefix ${prefix} exceeds ` +
         `${SCHEDULE_GROUP_NAME_PREFIX_MAX} characters`,
     );
   }
+  boundedNamePrefix(prefix, 64, "consolidation schedule");
   return prefix;
 }
 
@@ -185,7 +215,15 @@ export function consolidation(
     const failureRule = new aws.cloudwatch.EventRule(
       "ConsolidationTaskFailureRule",
       {
-        namePrefix: `mem9-on-aws-${$app.stage}-consolidation-failure-`,
+        // 64-char rule limit MINUS Pulumi's 26-char suffix. The former
+        // `...-consolidation-failure-` prefix was 39 chars for `prod` alone,
+        // producing a 65-char name that PutRule rejected on the first prod
+        // deploy after merge.
+        namePrefix: boundedNamePrefix(
+          `mem9-on-aws-${$app.stage}-consol-failure-`,
+          64,
+          "consolidation failure rule",
+        ),
         description:
           "Captures non-zero exits from the exact consolidation task revision.",
         eventPattern: $jsonStringify({


### PR DESCRIPTION
## Summary

The prod deploy after #113 merged failed on `PutRule`:

```
Value 'mem9-on-aws-prod-consolidation-failure-20260803182536887300000001'
at 'name' failed to satisfy constraint: Member must have length less than or equal to 64
```

My name-length audit during #113 checked each `namePrefix` against its resource's own limit and cleared the failure rule at 39 chars against 64. **That was the wrong comparison.** Pulumi appends a 26-character unique suffix, so the real prefix budget is `limit - 26`, and 39 + 26 = 65.

Every preview check was green because the same arithmetic error applied uniformly — the prefix always looked fine, and the rule is only created when the schedule is enabled.

## Fix

- `boundedNamePrefix(prefix, nameMax, what)` asserts `prefix + 26 <= nameMax` and throws at **synth** with both numbers named.
- The failure-rule prefix shortens to `...-consol-failure-` (36 chars for prod, 62 with the suffix; fits through `pr-99999`).
- `consolidationScheduleGroupPrefix` now asserts both applicable limits, tighter first so the error names the binding constraint: Scheduler's 38-char *prefix* cap, then the 64-char *name*.

## Blast radius

None in prod. Consolidation resources are absent unless `MEM9_CONSOLIDATION_SCHEDULE_ENABLED` is set; the deploy failed *before* creating the rule and the rest of the stage is unchanged. Verified prod `Mem9Server` is `COMPLETED` 1/1.

## Test Plan

- [x] Unit tests pass — 711 root + 238 infra
- [x] Both typechecks clean
- [x] Public-artifact scan clean
- [ ] CI checks pass
- [x] TC-CONSOL-048 pins the lesson: `PULUMI_NAME_SUFFIX_LEN === 26`, the old prefix must throw with "65-character name", and every prefix this stack builds fits for the longest realistic stage
- [x] Verified by reversion: restoring the old prefix now fails three tests **at synth** instead of failing a prod deploy

## Why this class kept recurring

This is the fourth naming defect in this stack, and the first three were fixed one resource at a time as each deploy surfaced it. The shared helper plus TC-CONSOL-048 replaces that with a single rule applied to every prefix, so the next one fails in CI rather than in AWS.