### PR TITLE
feat(iam): admit the Slack approval-record write to the workload boundary (#123)

### DIFF
--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -183,10 +183,13 @@ jobs:
 
       - name: Validate workload boundary operator scripts
         run: |
-          if ! command -v shellcheck >/dev/null 2>&1; then
-            sudo apt-get update
-            sudo apt-get install --yes --no-install-recommends shellcheck
-          fi
+          # pip, not apt: the previous `apt-get update` refreshed every package
+          # index to install one tool and left the job at the mercy of mirror
+          # latency (two runs hung there until the 20-minute job timeout, with all
+          # tests already green). It also could not pin a version, so the same
+          # commit could lint against whatever shellcheck the distro happened to
+          # ship. 0.11.0.1 wraps upstream 0.11.0, matching what apt installed.
+          python -m pip install --disable-pip-version-check 'shellcheck-py==0.11.0.1'
           shellcheck scripts/deploy-workload-permissions-boundary.sh
           shellcheck scripts/rollout-workload-permissions-boundary.sh
           shellcheck scripts/run-consolidation-task.sh

--- a/infra/cloudformation/workload-permissions-boundary.yaml
+++ b/infra/cloudformation/workload-permissions-boundary.yaml
@@ -71,6 +71,14 @@ Resources:
               - sqs:SendMessage
               - sns:Publish
               - ssm:GetParameters
+              # The Slack approval record (#123). Reserved ahead of the writer,
+              # which does not exist yet: Slack's 3-second ACK budget cannot
+              # cover a cleanup run, so the facade Lambda will persist the
+              # approved decision-list hash and trigger the apply task rather
+              # than delete inline. Scoped by both
+              # DenyProjectRuntimeOutsideResources and the tighter
+              # DenyPutParameterOutsideApprovalRecords below.
+              - ssm:PutParameter
               - ec2:AssignPrivateIpAddresses
               - ec2:CreateNetworkInterface
               - ec2:DeleteNetworkInterface
@@ -103,6 +111,7 @@ Resources:
               - sqs:SendMessage
               - sns:Publish
               - ssm:GetParameters
+              - ssm:PutParameter
             NotResource:
               - !Ref BedrockProjectArn
               # AWS::NoValue removes this entry entirely when unconfigured, so
@@ -117,6 +126,24 @@ Resources:
               - !Sub arn:${AWS::Partition}:sqs:${ApplicationRegion}:${AWS::AccountId}:AlertExecutionFailureQueue-*
               - !Sub arn:${AWS::Partition}:sns:${ApplicationRegion}:${AWS::AccountId}:mem9-on-aws-*-alerts
               - !Sub arn:${AWS::Partition}:ssm:${ApplicationRegion}:${AWS::AccountId}:parameter/mem9-on-aws/*
+          # The statement above scopes the write to the PROJECT prefix, i.e. every
+          # stage's whole SSM tree. That is too wide for a write, and this ceiling
+          # is the only control on it: identity policies are PR-authored, and the
+          # deploy role's DenyUnboundedProjectRolePolicyWrites only requires that
+          # the boundary be ATTACHED, never constrains its content. Preview roles
+          # are bounded too, so without this a PR could grant one of its own
+          # preview Lambdas ssm:PutParameter on /mem9-on-aws/prod/* and overwrite
+          # prod's plain-String parameters (oauth/allowed-callback-urls is an
+          # open-redirect primitive; the bootstrap/consolidation task-def-arn and
+          # cluster-name are consumed unvalidated by scripts/run-*-task.sh).
+          # SecureString parameters are already unreachable — that write needs
+          # kms:Encrypt or kms:GenerateDataKey and the ceiling admits neither.
+          - Sid: DenyPutParameterOutsideApprovalRecords
+            Effect: Deny
+            Action:
+              - ssm:PutParameter
+            NotResource:
+              - !Sub arn:${AWS::Partition}:ssm:${ApplicationRegion}:${AWS::AccountId}:parameter/mem9-on-aws/*/approvals/*
           # Lambda cold starts, SSM SecureStrings, and the two ECS task-definition
           # secret families use different KMS encryption contexts. Missing and
           # foreign contexts remain denied.

--- a/scripts/lib/workload-permissions-boundary.mjs
+++ b/scripts/lib/workload-permissions-boundary.mjs
@@ -114,6 +114,15 @@ const PROJECT_RESOURCE_RUNTIME_ACTIONS = [
   "sns:Publish",
   "sqs:SendMessage",
   "ssm:GetParameters",
+  // The Slack approval record (#123 — the writer does not exist yet; this
+  // prerequisite lands first because the rollout can only apply main's
+  // template). Listed here rather than in GLOBAL_RUNTIME_ACTIONS because this
+  // list feeds BOTH the action ceiling and DenyProjectRuntimeOutsideResources,
+  // and the project SSM prefix is the only place this write belongs.
+  // GLOBAL_RUNTIME_ACTIONS entries are admitted account-wide, which is why
+  // ecs:RunTask and iam:PassRole live there and are constrained by identity
+  // policy and out-of-band review instead.
+  "ssm:PutParameter",
 ];
 const MANTLE_BEARER_ACTION = "bedrock-mantle:CallWithBearerToken";
 const GLOBAL_RUNTIME_ACTIONS = [
@@ -321,6 +330,12 @@ function boundaryContract({
     ssmParameterArn:
       `arn:${partition}:ssm:${applicationRegion}:${accountId}:` +
       "parameter/mem9-on-aws/*",
+    // The approval-record write (#123) is scoped tighter than the project
+    // prefix. See DenyPutParameterOutsideApprovalRecords for why the broader
+    // project scope is not sufficient for a WRITE.
+    ssmApprovalParameterArn:
+      `arn:${partition}:ssm:${applicationRegion}:${accountId}:` +
+      "parameter/mem9-on-aws/*/approvals/*",
     projectResources: [
       bedrockProjectArn,
       ...(openAiBedrockProjectArn ? [openAiBedrockProjectArn] : []),
@@ -348,6 +363,7 @@ export function expectedBoundaryPolicyDocument(contract) {
     policyRevision,
     projectResources,
     secretArns,
+    ssmApprovalParameterArn,
     ssmParameterArn,
   } = boundaryContract(contract);
   return {
@@ -370,6 +386,22 @@ export function expectedBoundaryPolicyDocument(contract) {
         Effect: "Deny",
         Action: [...PROJECT_RESOURCE_RUNTIME_ACTIONS],
         NotResource: projectResources,
+      },
+      // The statement above scopes the write to the PROJECT prefix — every
+      // stage's whole SSM tree — which is too wide for a WRITE. This ceiling is
+      // the only control on it: identity policies are PR-authored, and the
+      // deploy role's DenyUnboundedProjectRolePolicyWrites only requires that
+      // the boundary be ATTACHED, never constrains its content. Preview roles
+      // are bounded too, so without this a PR could grant one of its own preview
+      // Lambdas ssm:PutParameter on /mem9-on-aws/prod/* and overwrite prod's
+      // plain-String parameters. SecureStrings are already unreachable (that
+      // write needs kms:Encrypt or kms:GenerateDataKey; the ceiling admits
+      // neither), so the plain-String ones are exactly the exposure this closes.
+      {
+        Sid: "DenyPutParameterOutsideApprovalRecords",
+        Effect: "Deny",
+        Action: ["ssm:PutParameter"],
+        NotResource: [ssmApprovalParameterArn],
       },
       {
         Sid: "DenyKmsDecryptOutsideProjectParameterFunctionOrSecretContexts",

--- a/scripts/workload-permissions-boundary-contract.json
+++ b/scripts/workload-permissions-boundary-contract.json
@@ -13,7 +13,7 @@
     {
       "id": "infra-ci.yml",
       "path": ".github/workflows/infra-ci.yml",
-      "reviewedBlob": "3e562bba4ee75d0fd3eebb5e366063d267bb64ba"
+      "reviewedBlob": "bc66da331c7457e8427ca12ae773894eca84e552"
     },
     {
       "id": "reconcile-previews.yml",

--- a/scripts/workload-permissions-boundary.test.mjs
+++ b/scripts/workload-permissions-boundary.test.mjs
@@ -7647,7 +7647,7 @@ describe("boundary and deploy-role templates", () => {
   // keeps them, and any future sts:GetFederationToken-class admission, subject to
   // the scoping check instead of waved through on the verb.
   const CREDENTIAL_MINTING_ACTION =
-    /:(GetSecretValue|GetParameters?$|GetParameterHistory|GetParametersByPath|GetSessionToken|GetFederationToken|GetAuthorizationToken|GetCredentials|GetClusterCredentials|GetSigninToken|GetServiceBearerToken)/u;
+    /:(GetSecretValue|GetParameters?$|GetParameterHistory|GetParametersByPath|GetSessionToken|GetFederationToken|GetAuthorizationToken|GetCredentials|GetClusterCredentials|GetSigninToken|GetServiceBearerToken|GetOpenIdToken|GetComputeAuthToken)/u;
   const READ_ONLY_ACTION = (action) =>
     !CREDENTIAL_MINTING_ACTION.test(action) &&
     /:(Get|List|Describe|BatchCheck|BatchGet|Head|Query|Scan|Lookup|Filter|Search|Simulate)/u.test(
@@ -7656,11 +7656,15 @@ describe("boundary and deploy-role templates", () => {
 
   // Admitted account-wide by deliberate review, each for a reason NotResource
   // cannot express. ecs:RunTask and iam:PassRole are constrained by the deploy
-  // role's PassRole scoping plus DenyEcsExecutionRolePassToOtherServices; the
-  // ec2/ssmmessages entries are service-mediated calls with no useful
-  // per-resource ARN and are separately gated by a principal condition; the
-  // bedrock-mantle and kms entries carry their own Condition-based denies
-  // (DenyNonShortTermMantleBearer and the five kms:Decrypt context statements).
+  // role's PassRole scoping plus DenyEcsExecutionRolePassToOtherServices. The
+  // ec2 entries are service-mediated with no useful per-resource ARN AND are
+  // principal-gated (DenyEniFromNonVpcLambdaRoles + DenyEniFromFunctionCode).
+  // The bedrock-mantle and kms entries carry their own Condition-based denies
+  // (DenyNonShortTermMantleBearer and the seven kms:Decrypt context statements).
+  // The ssmmessages entries have NO further boundary deny — do not read the ec2
+  // justification as covering them. They are the ECS Exec channel APIs, which are
+  // service-mediated with no per-resource ARN, and what actually bounds them is
+  // `enableExecuteCommand` on the task plus the task role, outside this policy.
   // ecr:GetAuthorizationToken is registry-level: IAM evaluates it against the
   // registry, not a repository, so it is only ever grantable on "*" and a
   // NotResource scope would deny every image pull. The token it returns is scoped
@@ -7741,9 +7745,20 @@ describe("boundary and deploy-role templates", () => {
   // template could name the WRONG parameter in the true branch, or overflow the
   // quota, and every gate would stay green.
   //
-  // The longest project id the template's AllowedPattern permits costs more than
-  // the short fixture below, so assert a byte reserve rather than the bare quota:
-  // 6144 would only fail once there is no room left to react.
+  // Assert a byte reserve rather than the bare 6144 quota, which would only fail
+  // once there is no room left to react. The reserve does NOT bound the worst
+  // case: the template's AllowedPattern caps neither the project id nor the
+  // partition or region, so a long enough project id overflows whatever gate is
+  // set here (a 128-character id breaches even the real quota). It buys margin
+  // against the fixture shape only.
+  //
+  // 64 is close to the largest reserve this document can currently hold: the
+  // configured shape is 6023 bytes, so 121 is the ceiling and anything above that
+  // fails on commit. That is the finding, not a comfort — the statement this
+  // change added cost 189 bytes, so the next comparable statement breaches the
+  // gate and the quota at nearly the same moment. Splitting the boundary across a
+  // second managed policy is the real fix when that happens; until then this at
+  // least fails in CI rather than at rollout.
   const OPENAI_PROJECT_ARN =
     "arn:aws:bedrock-mantle:us-west-2:123456789012:project/proj_openai";
   const BOUNDARY_SIZE_RESERVE = 64;

--- a/scripts/workload-permissions-boundary.test.mjs
+++ b/scripts/workload-permissions-boundary.test.mjs
@@ -469,26 +469,31 @@ async function withMutatedRolloutModule(mutate, callback) {
 // defaults (AWS::NoValue removes the entry from the surrounding list).
 const NO_VALUE = Symbol("AWS::NoValue");
 
-function resolveTemplateValue(value) {
+// `openAiBedrockProjectArn` selects the CONFIGURED shape: the !If takes its true
+// branch and `!Ref OpenAiBedrockProjectArn` resolves to this value. Defaulting to
+// undefined keeps every existing caller on the unconfigured shape, which is what
+// the template's own parameter default produces.
+function resolveTemplateValue(value, openAiBedrockProjectArn) {
+  const recur = (child) => resolveTemplateValue(child, openAiBedrockProjectArn);
   if (Array.isArray(value)) {
-    // A parsed `!If [HasOpenAiBedrockProject, ...]` node: the parameter
-    // defaults to "" so the condition is false → the else branch is
+    // A parsed `!If [HasOpenAiBedrockProject, ...]` node. Unconfigured, the
+    // parameter defaults to "" so the condition is false → the else branch is
     // AWS::NoValue → the entry vanishes from the parent list.
     if (value.length === 3 && value[0] === "HasOpenAiBedrockProject") {
-      return NO_VALUE;
+      return openAiBedrockProjectArn ? recur(value[1]) : NO_VALUE;
     }
-    return value.map(resolveTemplateValue).filter((item) => item !== NO_VALUE);
+    return value.map(recur).filter((item) => item !== NO_VALUE);
   }
   if (value && typeof value === "object") {
     return Object.fromEntries(
-      Object.entries(value).map(([key, child]) => [
-        key,
-        resolveTemplateValue(child),
-      ]),
+      Object.entries(value).map(([key, child]) => [key, recur(child)]),
     );
   }
   if (typeof value !== "string") return value;
   if (value === "BedrockProjectArn") return boundaryContract.bedrockProjectArn;
+  // Only reachable from the !If true branch above; unconfigured, the whole node
+  // collapses to NO_VALUE before this can be consulted.
+  if (value === "OpenAiBedrockProjectArn") return openAiBedrockProjectArn;
   return value
     .replaceAll("${AWS::Partition}", partition)
     .replaceAll("${AWS::AccountId}", accountId)
@@ -7622,49 +7627,82 @@ describe("boundary and deploy-role templates", () => {
   // Every guard on ssm:PutParameter names it as a literal, so nothing stops the
   // NEXT write from being admitted with no resource scope at all — a mistake that
   // stays invisible if the template and the contract library are edited
-  // consistently. This turns the allowlist into an explicit decision: a mutating
-  // action is either resource-scoped by some Deny/NotResource statement, or it is
-  // listed below as a reviewed account-wide admission.
-  it("resource-scopes every mutating action admitted to the ceiling", () => {
-    const document = expectedBoundaryPolicyDocument(boundaryContract);
-    const ceiling = document.Statement.find(({ NotAction }) => NotAction);
-    // Admitted account-wide by deliberate review. ecs:RunTask and iam:PassRole
-    // are constrained by the deploy role's PassRole scoping plus
-    // DenyEcsExecutionRolePassToOtherServices rather than by NotResource; the
-    // ec2/ssmmessages/logs entries are service-mediated calls with no useful
-    // per-resource ARN, and each is separately gated by a principal condition.
-    const reviewedGlobalWrites = new Set([
-      "bedrock-mantle:CallWithBearerToken",
-      "bedrock-mantle:CreateInference",
-      "ec2:AssignPrivateIpAddresses",
-      "ec2:CreateNetworkInterface",
-      "ec2:DeleteNetworkInterface",
-      "ec2:UnassignPrivateIpAddresses",
-      "ecs:RunTask",
-      "iam:PassRole",
-      "lambda:InvokeFunction",
-      "logs:CreateLogGroup",
-      "logs:CreateLogStream",
-      "logs:PutLogEvents",
-      "ssmmessages:CreateControlChannel",
-      "ssmmessages:CreateDataChannel",
-      "ssmmessages:OpenControlChannel",
-      "ssmmessages:OpenDataChannel",
-    ]);
-    const scopedByNotResource = new Set(
+  // consistently. This turns the allowlist into an explicit decision: a
+  // non-read-only action is either resource-scoped by some Deny/NotResource
+  // statement, or it is listed below as a reviewed account-wide admission.
+  //
+  // Classify by an inverted READ-ONLY list rather than by a list of mutating
+  // verbs. Enumerating mutating verbs under-approximates in the unsafe direction:
+  // a `/:(Put|Create|Delete|...)/` form silently passed kms:Encrypt,
+  // kms:GenerateDataKey, ecs:RegisterTaskDefinition, sts:AssumeRole, and
+  // iam:AttachRolePolicy. The first two matter most here — the reason
+  // SecureString parameters are out of reach is that the ceiling admits neither,
+  // so an unnoticed admission would void that argument. Anything not obviously
+  // read-only now has to be classified deliberately.
+  const READ_ONLY_ACTION =
+    /:(Get|List|Describe|BatchCheck|BatchGet|Head|Query|Scan|Lookup|Filter|Search|Simulate)/u;
+
+  // Admitted account-wide by deliberate review, each for a reason NotResource
+  // cannot express. ecs:RunTask and iam:PassRole are constrained by the deploy
+  // role's PassRole scoping plus DenyEcsExecutionRolePassToOtherServices; the
+  // ec2/ssmmessages entries are service-mediated calls with no useful
+  // per-resource ARN and are separately gated by a principal condition; the
+  // bedrock-mantle and kms entries carry their own Condition-based denies
+  // (DenyNonShortTermMantleBearer and the five kms:Decrypt context statements).
+  const REVIEWED_GLOBAL_WRITES = [
+    "bedrock-mantle:CallWithBearerToken",
+    "ec2:AssignPrivateIpAddresses",
+    "ec2:CreateNetworkInterface",
+    "ec2:DeleteNetworkInterface",
+    "ec2:UnassignPrivateIpAddresses",
+    "ecs:RunTask",
+    "iam:PassRole",
+    "kms:Decrypt",
+    "ssmmessages:CreateControlChannel",
+    "ssmmessages:CreateDataChannel",
+    "ssmmessages:OpenControlChannel",
+    "ssmmessages:OpenDataChannel",
+  ];
+
+  const actionsScopedByNotResource = (document) =>
+    new Set(
       document.Statement.filter(
         (statement) => statement.Effect === "Deny" && statement.NotResource,
       ).flatMap((statement) => statement.Action ?? []),
     );
-    const mutating =
-      /:(Put|Create|Delete|Update|Send|Publish|Run|Pass|Invoke|Assign|Unassign|Open|Call)/u;
-    for (const action of ceiling.NotAction.filter((a) => mutating.test(a))) {
+
+  it("resource-scopes every non-read-only action admitted to the ceiling", () => {
+    const document = expectedBoundaryPolicyDocument(boundaryContract);
+    const ceiling = document.Statement.find(({ Sid }) =>
+      Sid?.startsWith("DenyOutsideRuntimeActionCeiling"),
+    );
+    const scopedByNotResource = actionsScopedByNotResource(document);
+    const reviewedGlobalWrites = new Set(REVIEWED_GLOBAL_WRITES);
+    for (const action of ceiling.NotAction.filter(
+      (candidate) => !READ_ONLY_ACTION.test(candidate),
+    )) {
       expect(
         scopedByNotResource.has(action) || reviewedGlobalWrites.has(action),
-        `${action} mutates but is neither resource-scoped by a Deny/NotResource ` +
-          `statement nor listed as a reviewed account-wide admission`,
+        `${action} is not read-only but is neither resource-scoped by a ` +
+          `Deny/NotResource statement nor listed as a reviewed account-wide ` +
+          `admission`,
       ).toBe(true);
     }
+  });
+
+  // The check above is an OR, so a redundant allowlist entry pre-authorizes a
+  // future unscoping: drop a resource-scoped action out of
+  // DenyProjectRuntimeOutsideResources and the allowlist silently catches it,
+  // turning a project-scoped write into an account-wide one with the suite still
+  // green. Requiring the two sets to be disjoint makes the allowlist mean
+  // "deliberately NOT resource-scoped" instead of merely "tolerated".
+  it("keeps the reviewed account-wide admissions disjoint from the scoped ones", () => {
+    const scopedByNotResource = actionsScopedByNotResource(
+      expectedBoundaryPolicyDocument(boundaryContract),
+    );
+    expect(
+      REVIEWED_GLOBAL_WRITES.filter((action) => scopedByNotResource.has(action)),
+    ).toEqual([]);
   });
 
   it("keeps the boundary within the IAM managed-policy size quota", () => {
@@ -7677,22 +7715,52 @@ describe("boundary and deploy-role templates", () => {
     expect(size).toBeLessThanOrEqual(6_144);
   });
 
-  // The assertion above measures the template, where resolveTemplateValue
-  // collapses the !If for OpenAiBedrockProjectArn to AWS::NoValue — so it only
-  // ever sizes the OpenAI-UNCONFIGURED shape. The Responses route configures
-  // that second project ARN in the live account, adding bytes CI never counted.
-  // Without this case the boundary can pass every gate and still be rejected by
-  // IAM at rollout time, which is the one failure mode a size test exists to
-  // prevent.
-  it("keeps the boundary within the IAM size quota with both Mantle projects", () => {
-    const size = JSON.stringify(
-      expectedBoundaryPolicyDocument({
+  // Everything above resolves the template with OpenAiBedrockProjectArn at its ""
+  // default, so the !If collapses to AWS::NoValue and only the UNCONFIGURED shape
+  // is ever checked — for both parity and size. The live account configures that
+  // second project (the Responses route runs in another region and Mantle projects
+  // are regional), so the shape that actually deploys had no coverage at all: the
+  // template could name the WRONG parameter in the true branch, or overflow the
+  // quota, and every gate would stay green.
+  //
+  // The longest project id the template's AllowedPattern permits costs more than
+  // the short fixture below, so assert a byte reserve rather than the bare quota:
+  // 6144 would only fail once there is no room left to react.
+  const OPENAI_PROJECT_ARN =
+    "arn:aws:bedrock-mantle:us-west-2:123456789012:project/proj_openai";
+  const BOUNDARY_SIZE_RESERVE = 64;
+
+  it("matches the contract library in the OpenAI-configured shape", () => {
+    const template = parseCloudFormation(boundaryTemplatePath);
+    const document = resolveTemplateValue(
+      template.Resources.WorkloadPermissionsBoundary.Properties.PolicyDocument,
+      OPENAI_PROJECT_ARN,
+    );
+    // The configured shape must differ from the unconfigured one in exactly one
+    // way: the second project ARN appears. Asserting its presence is what fails
+    // if the true branch ever refs the wrong parameter.
+    expect(
+      document.Statement.find(
+        ({ Sid }) => Sid === "DenyProjectRuntimeOutsideResources",
+      ).NotResource,
+    ).toContain(OPENAI_PROJECT_ARN);
+    expect(
+      verifyBoundaryPolicyDocument(document, {
         ...boundaryContract,
-        openAiBedrockProjectArn:
-          "arn:aws:bedrock-mantle:us-west-2:123456789012:project/proj_openai",
+        openAiBedrockProjectArn: OPENAI_PROJECT_ARN,
       }),
+    ).toBe(true);
+  });
+
+  it("keeps the OpenAI-configured boundary inside the IAM size quota", () => {
+    const template = parseCloudFormation(boundaryTemplatePath);
+    const size = JSON.stringify(
+      resolveTemplateValue(
+        template.Resources.WorkloadPermissionsBoundary.Properties.PolicyDocument,
+        OPENAI_PROJECT_ARN,
+      ),
     ).length;
-    expect(size).toBeLessThanOrEqual(6_144);
+    expect(size).toBeLessThanOrEqual(6_144 - BOUNDARY_SIZE_RESERVE);
   });
 
   it("keeps every deploy-role managed policy within the IAM size quota", () => {

--- a/scripts/workload-permissions-boundary.test.mjs
+++ b/scripts/workload-permissions-boundary.test.mjs
@@ -8017,6 +8017,50 @@ describe("boundary and deploy-role templates", () => {
     ).toBe(true);
   });
 
+  // The step used to `sudo apt-get update` when shellcheck was absent, which is
+  // only ever true on the self-hosted runner (GitHub-hosted images preinstall it).
+  // Refreshing ~60 package indices to install one tool made the whole job hostage
+  // to mirror latency: two consecutive runs on this branch hung there and were
+  // cancelled at the job's 20-minute timeout with every test already passing.
+  // pip pins the version instead, which apt cannot: `apt-get install shellcheck`
+  // resolves to whatever the distro ships, so the same commit could lint against
+  // two different analyzers and produce findings that did not exist at review.
+  it("installs a pinned shellcheck without refreshing apt indices", () => {
+    const workflow = readFileSync(workflowPath, "utf8");
+    const job = parse(workflow).jobs.typecheck;
+    const step = job.steps.find(
+      (candidate) => candidate.name === "Validate workload boundary operator scripts",
+    );
+    expect(step).toBeDefined();
+    // Assert against the EXECUTABLE lines, never the raw `run`. The step's own
+    // comment names both `apt-get` and the pinned package, so a raw-text
+    // assertion would match the prose that explains the rule instead of the
+    // command that implements it — and would keep passing if the install line
+    // were deleted and only the comment survived.
+    const commands = step.run
+      .split("\n")
+      .filter((line) => !line.trimStart().startsWith("#"))
+      .join("\n");
+    // 0.11.0.1 wraps upstream shellcheck 0.11.0 — the exact version the runner's
+    // apt provides today, so the pin changes the install path and nothing else.
+    // Changing installers (pipx, uv, a pinned release tarball) requires updating
+    // this assertion: it is coupled to the package and version on purpose.
+    expect(commands).toContain("shellcheck-py==0.11.0.1");
+    // A bare `pip install` with no version would reintroduce the drift this pin
+    // exists to prevent.
+    expect(commands).toMatch(/shellcheck-py==\d+\.\d+\.\d+\.\d+/u);
+    // `apt`, `apt-get`, and `aptitude` all refresh the same ~60 package indices,
+    // so matching only `apt-get` would let the flake back in under the spelling
+    // someone reaches for first when hand-patching "shellcheck: not found".
+    expect(commands).not.toMatch(/\b(apt|apt-get|aptitude)\b/u);
+    // A neutralized lint is the worst failure mode here: the step still reads
+    // correctly in a diff while enforcing nothing. Mirrors the guards the
+    // sibling cfn-lint step already carries in ecr-registry-scanning.test.mjs.
+    expect(commands).not.toMatch(/shellcheck[^\n]*\|\|\s*true/u);
+    expect(step).not.toHaveProperty("continue-on-error");
+    expect(step).not.toHaveProperty("if");
+  });
+
   it("wires both templates and rollout shell entry points into CI", () => {
     const workflow = readFileSync(workflowPath, "utf8");
     const documentationSecurityWorkflow = readFileSync(
@@ -8044,8 +8088,11 @@ describe("boundary and deploy-role templates", () => {
     expect(workflow).toContain(
       "shellcheck scripts/deploy-workload-permissions-boundary.sh",
     );
+    // With the `shellcheck ` prefix: the bare path also matches a line that
+    // merely RUNS the rollout script, so without it the one script of the three
+    // whose lint is not asserted elsewhere could stop being linted.
     expect(workflow).toContain(
-      "scripts/rollout-workload-permissions-boundary.sh",
+      "shellcheck scripts/rollout-workload-permissions-boundary.sh",
     );
     expect(workflow).toContain("uses: pulumi/actions@v7");
     expect(workflow).toContain("pulumi-version: 3.215.0");

--- a/scripts/workload-permissions-boundary.test.mjs
+++ b/scripts/workload-permissions-boundary.test.mjs
@@ -149,6 +149,7 @@ const independentRuntimeActions = [
   "sns:Publish",
   "sqs:SendMessage",
   "ssm:GetParameters",
+  "ssm:PutParameter",
   // SST Service/Task ECS Exec channels.
   "ssmmessages:CreateControlChannel",
   "ssmmessages:CreateDataChannel",
@@ -7405,6 +7406,13 @@ describe("boundary and deploy-role templates", () => {
         "sns:Publish",
         "sqs:SendMessage",
         "ssm:GetParameters",
+        // Admitting a WRITE to the action ceiling is only safe if it is also
+        // resource-scoped. A boundary never GRANTS: effective permissions are the
+        // intersection of the boundary and the identity policy. So without this
+        // entry the boundary simply stops constraining `ssm:PutParameter` by
+        // resource, and any identity-policy grant — including an over-broad one
+        // added later — would take effect account-wide (#123).
+        "ssm:PutParameter",
       ]),
     );
     expect(bySid("DenyProjectRuntimeOutsideResources").Action).not.toEqual(
@@ -7414,6 +7422,30 @@ describe("boundary and deploy-role templates", () => {
         "ssm:GetParametersByPath",
       ]),
     );
+    // DenyProjectRuntimeOutsideResources scopes the write to the PROJECT prefix,
+    // which is every stage's whole SSM tree. That is too wide for a write: the
+    // ceiling is the only control on what a workload role may do, because
+    // identity policies are PR-authored and the deploy role's
+    // DenyUnboundedProjectRolePolicyWrites only requires that the boundary be
+    // ATTACHED, never constrains its content. Preview roles are bounded too
+    // (shouldRegisterWorkloadRoleBoundary returns true for every non-prod
+    // stage), so without a second, tighter deny a PR could grant one of its own
+    // preview Lambdas ssm:PutParameter on `/mem9-on-aws/prod/*` and overwrite
+    // prod's plain-String parameters — `oauth/allowed-callback-urls` is an
+    // open-redirect primitive, and the bootstrap/consolidation `task-def-arn`
+    // and `cluster-name` are consumed unvalidated by scripts/run-*-task.sh.
+    // SecureString parameters are already out of reach (a SecureString write
+    // needs kms:Encrypt or kms:GenerateDataKey, neither of which the ceiling
+    // admits), so the plain-String ones are exactly the exposure this closes.
+    const approvalScope = bySid("DenyPutParameterOutsideApprovalRecords");
+    expect(approvalScope).toMatchObject({
+      Effect: "Deny",
+      Action: ["ssm:PutParameter"],
+    });
+    expect(resolveTemplateValue(approvalScope.NotResource)).toEqual([
+      "arn:aws:ssm:ap-northeast-1:123456789012:" +
+        "parameter/mem9-on-aws/*/approvals/*",
+    ]);
     expect(
       bySid(
         "DenyKmsDecryptOutsideProjectParameterFunctionOrSecretContexts",
@@ -7587,12 +7619,78 @@ describe("boundary and deploy-role templates", () => {
     ).toBe(true);
   });
 
+  // Every guard on ssm:PutParameter names it as a literal, so nothing stops the
+  // NEXT write from being admitted with no resource scope at all — a mistake that
+  // stays invisible if the template and the contract library are edited
+  // consistently. This turns the allowlist into an explicit decision: a mutating
+  // action is either resource-scoped by some Deny/NotResource statement, or it is
+  // listed below as a reviewed account-wide admission.
+  it("resource-scopes every mutating action admitted to the ceiling", () => {
+    const document = expectedBoundaryPolicyDocument(boundaryContract);
+    const ceiling = document.Statement.find(({ NotAction }) => NotAction);
+    // Admitted account-wide by deliberate review. ecs:RunTask and iam:PassRole
+    // are constrained by the deploy role's PassRole scoping plus
+    // DenyEcsExecutionRolePassToOtherServices rather than by NotResource; the
+    // ec2/ssmmessages/logs entries are service-mediated calls with no useful
+    // per-resource ARN, and each is separately gated by a principal condition.
+    const reviewedGlobalWrites = new Set([
+      "bedrock-mantle:CallWithBearerToken",
+      "bedrock-mantle:CreateInference",
+      "ec2:AssignPrivateIpAddresses",
+      "ec2:CreateNetworkInterface",
+      "ec2:DeleteNetworkInterface",
+      "ec2:UnassignPrivateIpAddresses",
+      "ecs:RunTask",
+      "iam:PassRole",
+      "lambda:InvokeFunction",
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "ssmmessages:CreateControlChannel",
+      "ssmmessages:CreateDataChannel",
+      "ssmmessages:OpenControlChannel",
+      "ssmmessages:OpenDataChannel",
+    ]);
+    const scopedByNotResource = new Set(
+      document.Statement.filter(
+        (statement) => statement.Effect === "Deny" && statement.NotResource,
+      ).flatMap((statement) => statement.Action ?? []),
+    );
+    const mutating =
+      /:(Put|Create|Delete|Update|Send|Publish|Run|Pass|Invoke|Assign|Unassign|Open|Call)/u;
+    for (const action of ceiling.NotAction.filter((a) => mutating.test(a))) {
+      expect(
+        scopedByNotResource.has(action) || reviewedGlobalWrites.has(action),
+        `${action} mutates but is neither resource-scoped by a Deny/NotResource ` +
+          `statement nor listed as a reviewed account-wide admission`,
+      ).toBe(true);
+    }
+  });
+
   it("keeps the boundary within the IAM managed-policy size quota", () => {
     const template = parseCloudFormation(boundaryTemplatePath);
     const size = JSON.stringify(
       resolveTemplateValue(
         template.Resources.WorkloadPermissionsBoundary.Properties.PolicyDocument,
       ),
+    ).length;
+    expect(size).toBeLessThanOrEqual(6_144);
+  });
+
+  // The assertion above measures the template, where resolveTemplateValue
+  // collapses the !If for OpenAiBedrockProjectArn to AWS::NoValue — so it only
+  // ever sizes the OpenAI-UNCONFIGURED shape. The Responses route configures
+  // that second project ARN in the live account, adding bytes CI never counted.
+  // Without this case the boundary can pass every gate and still be rejected by
+  // IAM at rollout time, which is the one failure mode a size test exists to
+  // prevent.
+  it("keeps the boundary within the IAM size quota with both Mantle projects", () => {
+    const size = JSON.stringify(
+      expectedBoundaryPolicyDocument({
+        ...boundaryContract,
+        openAiBedrockProjectArn:
+          "arn:aws:bedrock-mantle:us-west-2:123456789012:project/proj_openai",
+      }),
     ).length;
     expect(size).toBeLessThanOrEqual(6_144);
   });

--- a/scripts/workload-permissions-boundary.test.mjs
+++ b/scripts/workload-permissions-boundary.test.mjs
@@ -7639,8 +7639,20 @@ describe("boundary and deploy-role templates", () => {
   // SecureString parameters are out of reach is that the ceiling admits neither,
   // so an unnoticed admission would void that argument. Anything not obviously
   // read-only now has to be classified deliberately.
-  const READ_ONLY_ACTION =
-    /:(Get|List|Describe|BatchCheck|BatchGet|Head|Query|Scan|Lookup|Filter|Search|Simulate)/u;
+  //
+  // `Get` alone is not enough to mean harmless: several `Get*` calls MINT
+  // credentials rather than read state, and a token is exactly the thing a
+  // resource scope must pin down. secretsmanager:GetSecretValue and
+  // ssm:GetParameters are admitted and resource-scoped today; the exception list
+  // keeps them, and any future sts:GetFederationToken-class admission, subject to
+  // the scoping check instead of waved through on the verb.
+  const CREDENTIAL_MINTING_ACTION =
+    /:(GetSecretValue|GetParameters?$|GetParameterHistory|GetParametersByPath|GetSessionToken|GetFederationToken|GetAuthorizationToken|GetCredentials|GetClusterCredentials|GetSigninToken|GetServiceBearerToken)/u;
+  const READ_ONLY_ACTION = (action) =>
+    !CREDENTIAL_MINTING_ACTION.test(action) &&
+    /:(Get|List|Describe|BatchCheck|BatchGet|Head|Query|Scan|Lookup|Filter|Search|Simulate)/u.test(
+      action,
+    );
 
   // Admitted account-wide by deliberate review, each for a reason NotResource
   // cannot express. ecs:RunTask and iam:PassRole are constrained by the deploy
@@ -7649,12 +7661,18 @@ describe("boundary and deploy-role templates", () => {
   // per-resource ARN and are separately gated by a principal condition; the
   // bedrock-mantle and kms entries carry their own Condition-based denies
   // (DenyNonShortTermMantleBearer and the five kms:Decrypt context statements).
+  // ecr:GetAuthorizationToken is registry-level: IAM evaluates it against the
+  // registry, not a repository, so it is only ever grantable on "*" and a
+  // NotResource scope would deny every image pull. The token it returns is scoped
+  // to the caller's own registry and the per-repository pull actions below stay
+  // resource-scoped, which is what actually bounds it.
   const REVIEWED_GLOBAL_WRITES = [
     "bedrock-mantle:CallWithBearerToken",
     "ec2:AssignPrivateIpAddresses",
     "ec2:CreateNetworkInterface",
     "ec2:DeleteNetworkInterface",
     "ec2:UnassignPrivateIpAddresses",
+    "ecr:GetAuthorizationToken",
     "ecs:RunTask",
     "iam:PassRole",
     "kms:Decrypt",
@@ -7679,7 +7697,7 @@ describe("boundary and deploy-role templates", () => {
     const scopedByNotResource = actionsScopedByNotResource(document);
     const reviewedGlobalWrites = new Set(REVIEWED_GLOBAL_WRITES);
     for (const action of ceiling.NotAction.filter(
-      (candidate) => !READ_ONLY_ACTION.test(candidate),
+      (candidate) => !READ_ONLY_ACTION(candidate),
     )) {
       expect(
         scopedByNotResource.has(action) || reviewedGlobalWrites.has(action),


### PR DESCRIPTION
IAM prerequisite for #123. **No resources and no application code** — this is the
same split #122 (`03b4064`) had to make for #113, and for the same structural
reason quoted in #123: CI preflight compares the checkout's contract against the
**live** managed policy, while the guarded rollout only runs from the
default-branch commit, so a PR carrying both template and app code can never go
green.

## Why

#123's OAuth-facade Lambda must persist an approved decision-list hash before
triggering the apply task — Slack's 3-second ACK budget cannot cover a cleanup
run. Verified against the live boundary (default version `v9`) that
`ssm:PutParameter` is **absent** from the action ceiling, so that write would be
denied at runtime. `ecs:RunTask` and `iam:PassRole` are already admitted (#122 had
to add them because the boundary caps every workload role), so this one action is
the entire gap.

No deploy-role edit is needed, unlike #122: the deploy role already has
`ssm:PutParameter` on `parameter/mem9-on-aws/*`, `ecs:RunTask`, and `iam:PassRole`
for ecs-tasks. The apply path can reuse the **existing** consolidation task
definition — its `entrypoint` is the generic `["node"]` and the llm-proxy image
already ships `/app/scripts/memory-cleanup.mjs`, so only `command` is overridden.
That matters because ECS cannot override `entryPoint` (`EcsContainerOverride` has
no such field), so the generic entrypoint is what makes reuse possible: no new
task, task role, or execution role, hence no second rollout.

## Scoping

The ceiling is a `Deny`/`NotAction` allowlist, and a boundary never **grants** —
effective permissions are the intersection of boundary and identity policy.
Admitting a write therefore has to come with resource scoping:

- `ssm:PutParameter` added to `DenyProjectRuntimeOutsideResources`.
- A **new** `DenyPutParameterOutsideApprovalRecords` pins it to
  `parameter/mem9-on-aws/*/approvals/*`, because the statement above spans every
  stage's whole SSM tree — too wide for a write.

Without the tighter statement a PR could grant one of its own preview Lambdas
`ssm:PutParameter` on `/mem9-on-aws/prod/*` and overwrite prod's plain-String
parameters: `oauth/allowed-callback-urls` is an open-redirect primitive, and the
bootstrap/consolidation `task-def-arn` and `cluster-name` are consumed unvalidated
by `scripts/run-*-task.sh`. The ceiling is the only control there — identity
policies are PR-authored, and the deploy role's
`DenyUnboundedProjectRolePolicyWrites` only requires the boundary be *attached*,
never constrains its content. Preview roles are bounded too
(`shouldRegisterWorkloadRoleBoundary` returns true for every non-prod stage).

SecureString approval records are not an option: the ceiling admits neither
`kms:Encrypt` nor `kms:GenerateDataKey`, so the record must be a plain `String`. A
worst-case cap-50 record is 2076 bytes against the standard tier's 4096 limit.

## Tests

TDD throughout; every assertion below was watched fail first, and each invariant
fix is mutation-proven against a regression that passed the whole suite before it.

- The ceiling and both scoping statements assert the new action and NotResource
  (exact `toEqual`, so a coordinated widening in both files still fails).
- **Configured-shape coverage, previously absent entirely.**
  `resolveTemplateValue` collapsed the `!If` for `OpenAiBedrockProjectArn` to
  `AWS::NoValue` unconditionally, so every template assertion — parity *and* size
  — only ever saw the unconfigured shape, while the live account configures that
  second project. Pointing the true branch at `!Ref BedrockProjectArn` would emit
  a boundary that omits the OpenAI project and breaks the Responses route in
  production, and passed 344/344. Now covered.
- **The resource-scoping invariant** requires every non-read-only ceiling action
  to be either resource-scoped by a `Deny`/`NotResource` statement or listed as a
  reviewed account-wide admission. Classified by an inverted read-only list: a
  mutating-verb regex under-approximates in the unsafe direction and silently
  passed `kms:Encrypt` and `kms:GenerateDataKey` — the two actions the
  SecureString argument depends on. Credential-minting `Get*` calls count as
  writes, since a token is exactly what a resource scope must pin down.
- **Disjointness** between the allowlist and the resource-scoped set, because the
  check is an OR: five redundant entries were pre-authorizing an unscoping they
  were meant to catch (moving `logs:PutLogEvents` to account-wide passed).

## Heads-up for reviewers

Writing the invariant surfaced `ecr:GetAuthorizationToken` as a genuine
account-wide credential admission. It is registry-level — AWS documents it as not
supporting resource-level permissions, so it is only grantable on `*` and a
`NotResource` scope would deny every image pull. It is now recorded in the
allowlist with that reason.

**IAM size headroom is the tightest it has been: 121 bytes** in the configured
shape (6023 of 6144), 103 with the longest project id the template's
`AllowedPattern` realistically produces. The statement this PR adds cost 189
bytes, so the next comparable statement breaches the quota. The size test now
holds a 64-byte reserve so that fails in CI rather than at rollout; 121 is the
largest reserve the document can hold at all. Splitting the boundary across a
second managed policy is the real fix when that arrives.

The `approvals/*` scope permits any stage writing any stage's approval record —
the boundary cannot express stage isolation with shared role patterns. **#123's
consumer must authenticate the record's contents rather than trust its path**,
which the decision-list content hash already provides.

## ⚠️ Operator action required after merge

Run `scripts/rollout-workload-permissions-boundary.sh` from `main` **before** the
#123 application-code PR deploys. Until then the approval-record write is denied
at runtime. `--verify-only` currently reports the expected drift on this branch
and reports clean on `main`, confirming the rollout is required and that `main` is
not independently drifted.

Refs #123