### PR TITLE
feat(cleanup): gate memory deletion behind a signed Slack approval (#123)

### DIFF
--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -196,6 +196,7 @@ jobs:
           shellcheck scripts/deploy-workload-permissions-boundary.sh
           shellcheck scripts/rollout-workload-permissions-boundary.sh
           shellcheck scripts/run-consolidation-task.sh
+          shellcheck scripts/run-slack-approval-e2e.sh
 
       - name: PostgreSQL durable ingest integration tests
         run: bash scripts/run-ingest-queue-integration.sh
@@ -342,6 +343,16 @@ jobs:
           # check. Read at synth time, so it must be set here — a deploy without it
           # silently strips the authorizer and reopens the finding.
           MEM9_FACADE_AUTHORIZER_ENABLED: "1"
+          # Slack approval (#123). Opt-in through repo variables/secrets rather than
+          # a literal "1": infra/slack-approval.ts FAILS SYNTHESIS when the flag is
+          # set and either secret is unseeded, and GitHub hands an unset secret to
+          # the job as an EMPTY STRING — so hardcoding the flag would break every
+          # PR on a repo that has not seeded a Slack app. Unset leaves the whole
+          # stack ABSENT (not present-and-idle) and the E2E step below skips.
+          MEM9_SLACK_APPROVAL_ENABLED: ${{ vars.MEM9_SLACK_APPROVAL_ENABLED }}
+          MEM9_SLACK_APPROVAL_CHANNEL: ${{ vars.MEM9_SLACK_APPROVAL_CHANNEL }}
+          SST_SECRET_SlackBotToken: ${{ secrets.SLACK_BOT_TOKEN }}
+          SST_SECRET_SlackSigningSecret: ${{ secrets.SLACK_SIGNING_SECRET }}
         run: |
           # PR_NUMBER comes from GitHub's pull_request payload (integer);
           # validate to short-circuit any injection risk.
@@ -414,6 +425,28 @@ jobs:
           AWS_REGION: ap-northeast-1
         run: bash scripts/run-oauth-facade-smoke.sh
 
+      - name: Slack approval E2E (preview)
+        # TC-SLACKAPP-090. A signed synthetic interaction through the deployed
+        # façade: the handler distinguishes Slack from anyone else ONLY by the
+        # signature, so this exercises the identical path a real click takes,
+        # plus everything the unit tests inject (API Gateway routing, the
+        # Lambda's own SSM/ECS grants, the task definition, the entrypoint).
+        # Self-skipping when the stage seeded no Slack secret, because approval
+        # is gated on MEM9_SLACK_APPROVAL_ENABLED at synth time — a hard failure
+        # there would block every PR on a feature the stage does not deploy.
+        #
+        # PREVIEW ONLY, and deliberately not mirrored into deploy-prod. The harness
+        # OVERWRITES `approvals/offered` to seed its synthetic id, so on prod it
+        # would destroy a pending human approval — the operator's next click would
+        # be answered against CI's record — and it approves a DELETION against the
+        # live database. The per-PR stage is disposable and holds only bootstrap
+        # data, which is what makes the same script safe there.
+        if: steps.gate.outputs.skip != 'true' && steps.deploy.outputs.stage != ''
+        shell: bash
+        env:
+          STAGE: ${{ steps.deploy.outputs.stage }}
+          AWS_REGION: ap-northeast-1
+        run: bash scripts/run-slack-approval-e2e.sh
 
       - name: Auto-cleanup on deploy failure
         # Best-effort — if the deploy half-applied resources, remove them so the

--- a/README.md
+++ b/README.md
@@ -1068,7 +1068,84 @@ only after the initial cleanup and a report-only run show actionable drift.
 Production then runs Sunday at 03:00 UTC; previews synthesize a disabled
 schedule for infrastructure coverage.
 
+## Slack approval for cleanup deletions
 
+The step above — read the review list, copy ids into a local file, run
+`--apply --ids` — is the manual path, and it stays supported. Slack approval
+(issue #123; test cases: `docs/test-cases/slack-approval-loop.md`) replaces the
+copying with a click: the review run posts the list to a private channel with
+Approve/Reject buttons, and Approve starts the same `--apply --ids` task.
+
+What a click can and cannot do is the whole design:
+
+- The button carries a **content hash**, never ids. A Slack action `value` is
+  capped at 2000 characters, and more importantly the ids applied come from the
+  `{prefix}/approvals/offered` record, not from the payload — the signature
+  proves the request came from the workspace, not that the ids in it are the ones
+  the classifier chose.
+- A click whose hash no longer matches the current record is refused. That is
+  what stops an approval of a list read last week from applying to a corpus that
+  has since changed.
+- Exactly one delivery wins. Slack redelivers after 3 seconds, so the claim is
+  written with `Overwrite: false` and the loser branches on the record's
+  `taskArn`. Both approval records are plain `String` parameters holding **ids
+  and a hash only, never memory content**; snippets go to Slack and CloudWatch
+  Logs.
+- `--cap` still bounds a single click's blast radius (50 by default, passed
+  explicitly by the task definition), and the apply task holds the same advisory
+  mutex as scheduled consolidation.
+
+The whole feature is **absent** unless `MEM9_SLACK_APPROVAL_ENABLED=1` at deploy
+time: disabled means no task definition and no grants, because a task definition
+that exists is one `RunTask` can start. Enabling it needs a Slack app with
+`chat:write`, its Request URL pointed at `{facade-url}/slack/interactions`, and
+four values at deploy time — the flag and channel id as repository variables, the
+bot token and signing secret as repository secrets:
+
+```bash
+gh variable set MEM9_SLACK_APPROVAL_ENABLED --body 1
+gh variable set MEM9_SLACK_APPROVAL_CHANNEL --body "<private-channel-id>"
+gh secret set SLACK_BOT_TOKEN
+gh secret set SLACK_SIGNING_SECRET
+```
+
+Synthesis **fails** when the flag is set and either secret is unseeded. That is
+deliberate: GitHub exposes an unset secret as an empty string, so the failure it
+replaces is a Slack app that answers 401 to every click after a completely green
+deploy.
+
+Two prerequisites are not part of an application deploy. The workload
+permissions boundary must already admit the approval-record write
+(`ssm:PutParameter` scoped to `parameter/mem9-on-aws/*/approvals/*`) — until that
+rollout runs, the claim is denied at runtime and the click reports that the
+approval could not be recorded. Use a **private** channel: anyone who can click
+can approve a deletion, and the message shows every offered id and snippet.
+
+**Nothing scheduled posts the review list yet.** The weekly Scheduler target is
+`memory-consolidation.mjs`, which never executes a DELETE, and this stack's
+Fargate task is the `--apply` half. The offer is produced by a
+`memory-cleanup.mjs` **dry run** with a channel configured — so today that is an
+operator-initiated command, and a click can only ever apply a list a human just
+asked for:
+
+```bash
+MEM9_SLACK_APPROVAL_CHANNEL="<private-channel-id>" \
+  node scripts/memory-cleanup.mjs --stage prod \
+  --model openai.gpt-5.6-terra --effort high
+```
+
+The offer happens on the dry run and never on `--apply`: an apply that re-offered
+would overwrite the record its own claim was derived from, so a Slack redelivery
+mid-apply would be compared against a list the running task never saw. A failed
+offer exits **1** and keeps its decision file, which is what a manual
+`--apply --ids` reads.
+
+`scripts/run-slack-approval-e2e.sh` verifies a deployed stage by POSTing a
+correctly signed synthetic interaction (the handler distinguishes Slack from
+anyone else *only* by the signature) and then reading the approval record back by
+name. It refuses to run anywhere but a `pr-N` stage: it overwrites
+`approvals/offered`, which on a shared stage would destroy a pending human
+approval, and the id it approves is a deletion. CI runs it on preview only.
 
 ## License
 

--- a/docker/llm-proxy/Dockerfile
+++ b/docker/llm-proxy/Dockerfile
@@ -24,7 +24,13 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Deps first (layer cache). The sidecar uses the token dependencies; the
-# consolidation entrypoint additionally uses PostgreSQL and SNS.
+# consolidation entrypoint additionally uses PostgreSQL and SNS, and the
+# cleanup-apply entrypoint (#123) adds SSM, Secrets Manager, and Cloud Map. Every
+# AWS client in those two files is imported LAZILY so the operator CLI pays only
+# for the paths its flags reach — which also means a missing one is invisible
+# until that exact path runs, i.e. after a Slack approval has been spent. The
+# RUN guard below is a STATIC import check and cannot see them, so
+# scripts/cleanup-image-contract.test.mjs pins this dependency list instead.
 COPY docker/llm-proxy/package*.json ./
 RUN npm ci --omit=dev --no-audit --no-fund
 
@@ -39,9 +45,16 @@ COPY scripts/memory-cleanup.mjs /app/scripts/memory-cleanup.mjs
 COPY scripts/memory-consolidation.mjs /app/scripts/memory-consolidation.mjs
 
 # Fail the BUILD, not the weekly run, if that import graph ever breaks again.
+# Per entrypoint, not once: both COPY the sidecar as `../docker/llm-proxy/`, but a
+# guard on one file says nothing about the other's own imports — and the cleanup
+# entrypoint is started by a Slack click, where a MODULE_NOT_FOUND costs an
+# approval that is already claimed and cannot be re-clicked.
 RUN node --input-type=module \
       -e "await import('/app/scripts/memory-consolidation.mjs')" \
     && echo "consolidation entrypoint imports OK"
+RUN node --input-type=module \
+      -e "await import('/app/scripts/memory-cleanup.mjs')" \
+    && echo "cleanup entrypoint imports OK"
 
 # Listens on LLM_PROXY_PORT (default 8082); mem9 reaches it at
 # http://localhost:8082/v1. Not published outside the task — localhost only.

--- a/docker/llm-proxy/package-lock.json
+++ b/docker/llm-proxy/package-lock.json
@@ -8,13 +8,54 @@
       "name": "mem9-llm-proxy",
       "version": "1.0.0",
       "dependencies": {
+        "@aws-sdk/client-secrets-manager": "^3.1100.0",
+        "@aws-sdk/client-servicediscovery": "^3.1100.0",
         "@aws-sdk/client-sns": "^3.1100.0",
+        "@aws-sdk/client-ssm": "^3.1092.0",
         "@aws-sdk/credential-providers": "^3.700.0",
         "@aws/bedrock-token-generator": "^1.1.0",
         "pg": "^8.16.3"
       },
       "engines": {
         "node": ">=24"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager": {
+      "version": "3.1103.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1103.0.tgz",
+      "integrity": "sha512-LHX7O/50macEHNZdN776FfuU83BlP0fhRrB2TzzoLaJKVSuuFLnY3dUBPQmhejJDzG5vY9hXqoSVZUWDs6eydA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/credential-provider-node": "^3.972.78",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-servicediscovery": {
+      "version": "3.1103.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-servicediscovery/-/client-servicediscovery-3.1103.0.tgz",
+      "integrity": "sha512-YINnb5zUAdFhMu1hS1QBhCXbjJ1Zpw31a4ZLURbsU4NY0/S98HuF1Iwl6qv1le/6KSO645LOTHoGbxDu8BwBcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/credential-provider-node": "^3.972.78",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sns": {
@@ -36,10 +77,29 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-ssm": {
+      "version": "3.1103.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1103.0.tgz",
+      "integrity": "sha512-B4huQqWLqBIYpb+1mo8kYGJ9dlZPtndiGHcTFFUiCeTCdFUrkvEUJNoEDHuInAkh0cPwRxjfoACu4kwwSt738Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/credential-provider-node": "^3.972.78",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/core": {
-      "version": "3.977.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.4.tgz",
-      "integrity": "sha512-CEkcQlMOQJCvul60U7wdAOACjtdgFWDsfJI+6wUOGdhGNV2lGbuJpi/R50QLpFG3Tp+sQxa/RmzC3X7KHbhuTA==",
+      "version": "3.977.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.6.tgz",
+      "integrity": "sha512-QiaJV4/zDrB4ZY2mfeSXSzSTc36W16sZXcGz+SPFk0CJ26gziO0cS+4LjJUMAbdeeBOvS0k0Aq1cZpfGdUXxSw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.974.2",
@@ -72,12 +132,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.65",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.65.tgz",
-      "integrity": "sha512-lJT2aRw9wCV8jPHyFJjdZLD4HTydL6/22AnCSOB8e/LqOc55nEJGLHkJQeSxhn8QiqyjFwPKQFtMw0ovjRUY/g==",
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.67.tgz",
+      "integrity": "sha512-rcIpk5kxUqDaaNa6Xk23pQ6ViY7jlqzmfFWCahQcBT97ddXaXYYwzCen9Tz1Jvo6aJft6wDl5bN44/Jw5B4oLA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/core": "^3.977.6",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
@@ -88,12 +148,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.67",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.67.tgz",
-      "integrity": "sha512-N7fw/15hSwI/CPxe5ohOyb7O4ge9f5me1gVIn8OIkBRB0squ8OJqQyDyH/HoL+Sb1W5xdC88jVC+bHkw73iu+Q==",
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.69.tgz",
+      "integrity": "sha512-nggwJtZ4eeNsUw5IeWBMXsi1ryct5idi0K+/SCRF3kybLubOMaNTb3XCihXpWMiVpyzyPeIrl0zTkzhBH9porA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/core": "^3.977.6",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/fetch-http-handler": "^5.6.13",
@@ -106,19 +166,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.973.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.10.tgz",
-      "integrity": "sha512-Zh9XRaPnDN9buO7GfWBubS22R6Nq5D6hbyYEMN05LiOnXugm/8WDjUx6y756bSPbdn3aJB2qG4zFW3bN82QhoQ==",
+      "version": "3.973.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.12.tgz",
+      "integrity": "sha512-pNEf/OeyN5X3VmLKlgSO6TqaWmW10CvI3TfwL1XhsuhYjSLT2VDaxFnCPHnOeQXSaFisMX4jNhpETriqN8DOmg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/credential-provider-env": "^3.972.65",
-        "@aws-sdk/credential-provider-http": "^3.972.67",
-        "@aws-sdk/credential-provider-login": "^3.972.72",
-        "@aws-sdk/credential-provider-process": "^3.972.65",
-        "@aws-sdk/credential-provider-sso": "^3.973.9",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.71",
-        "@aws-sdk/nested-clients": "^3.997.39",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/credential-provider-env": "^3.972.67",
+        "@aws-sdk/credential-provider-http": "^3.972.69",
+        "@aws-sdk/credential-provider-login": "^3.972.74",
+        "@aws-sdk/credential-provider-process": "^3.972.67",
+        "@aws-sdk/credential-provider-sso": "^3.973.11",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.73",
+        "@aws-sdk/nested-clients": "^3.997.41",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/credential-provider-imds": "^4.4.16",
@@ -130,13 +190,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.72",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.72.tgz",
-      "integrity": "sha512-zZapIKwaHp7TdTf9hbH1I3CVUdEupmt7FXO/BoTQGC+4h6NkXKWpqF2p5WyfpjurDLHCpSyh+BzMlAg8arqWLA==",
+      "version": "3.972.74",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.74.tgz",
+      "integrity": "sha512-0AQfDcf99TNmqVKv0owHrw/TQs6i4ZE5t9qmz6NvO53bE/sA/tpXhXL9AAcEP1qHc6Zzjd1UMb69+/9zdhvY3g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/nested-clients": "^3.997.39",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
@@ -147,17 +207,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.76",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.76.tgz",
-      "integrity": "sha512-1yzLmRiYSgGC25v7ZZEwJn/auhHHTIHgFOmzL2f36hf1+7jSLcX+1QrAz4760WEzPiiQl8xmlpFhHfl2OoyVzA==",
+      "version": "3.972.78",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.78.tgz",
+      "integrity": "sha512-OgPAnfvbGAMWac6yvxJ1ihslrvDpPVwR68D2csospdNCCyPvHk9JLzYKwz48SNiS1T2znDwHauywRKRFfpyYng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.65",
-        "@aws-sdk/credential-provider-http": "^3.972.67",
-        "@aws-sdk/credential-provider-ini": "^3.973.10",
-        "@aws-sdk/credential-provider-process": "^3.972.65",
-        "@aws-sdk/credential-provider-sso": "^3.973.9",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.71",
+        "@aws-sdk/credential-provider-env": "^3.972.67",
+        "@aws-sdk/credential-provider-http": "^3.972.69",
+        "@aws-sdk/credential-provider-ini": "^3.973.12",
+        "@aws-sdk/credential-provider-process": "^3.972.67",
+        "@aws-sdk/credential-provider-sso": "^3.973.11",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.73",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/credential-provider-imds": "^4.4.16",
@@ -169,12 +229,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.65",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.65.tgz",
-      "integrity": "sha512-e5DbbNteOSalN58U83G6kFa4ECLEuGbGqNBHIXE7zYXA/m4GHblIGjFbSH7wYv6gBV8iNSDcRZBKfQZF5vF9nw==",
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.67.tgz",
+      "integrity": "sha512-IlUEejorGTWKb4/Dm7K5Yw4QxUmXLThLhrvBmzVBqZFTbW72cv9LTcITmo1dsnYriALE4h68mOq4LB99x6sQ7Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/core": "^3.977.6",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
@@ -185,14 +245,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.973.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.9.tgz",
-      "integrity": "sha512-0V0u4t+KBku9fbh5CPCaC5hUWwSzDafp8nCuDy817zWbp2gz80jO44rMQkiwnZ+k54B+tjAtzRy00DJRGTKGBg==",
+      "version": "3.973.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.11.tgz",
+      "integrity": "sha512-gAQBkBZxUB84d71+pPcI9L+jh2ujhuAVxc/4FgGiWFDjkPBlMKxzd5XDtkSXTFX8Ro7ansnT88+XadasxMeCRw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/nested-clients": "^3.997.39",
-        "@aws-sdk/token-providers": "3.1100.0",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
+        "@aws-sdk/token-providers": "3.1103.0",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
@@ -203,13 +263,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.71",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.71.tgz",
-      "integrity": "sha512-e4dwiRltGAaQ+2yxw57Hj0l/BF3BHiG14+QpYE7bGYBlpAq/fkIri2BDhjWon8c0mhhtd2txQBAkQb9BcTStFg==",
+      "version": "3.972.73",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.73.tgz",
+      "integrity": "sha512-SnlEmQa6SjOgs6iOPLUQl1Eyq4AKiAdPQlkOhFhqNfDtDCwibMGvL6QlkSmf3o6vAUSImzdPCxowT5dfQUZP1A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/nested-clients": "^3.997.39",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
@@ -247,12 +307,12 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.39",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.39.tgz",
-      "integrity": "sha512-wU5NPnj62Sb7A8xn/Zb+xThe05P3otNtDl37iOIi5DDMeCesNeCckaG+eXWGUs12Z9R34I8CD05TaTe6SIa61g==",
+      "version": "3.997.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.41.tgz",
+      "integrity": "sha512-RDHqPGQWlF6tatA/Tp3rg6oIwtgN9IVderxE+9av2Y93Dfyu+mO1hZ5Bu2jpfZg2rwdNbsssnwM+sLafIczMlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/core": "^3.977.6",
         "@aws-sdk/signature-v4-multi-region": "^3.996.43",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
@@ -281,13 +341,13 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1100.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1100.0.tgz",
-      "integrity": "sha512-THf3MkgY3fNJZ3zdgSenLqR7gSE68KccCj1RCKretlG73Ppszvues02VpCUO9NlB/tZDC483FvGCld+AiPCkvg==",
+      "version": "3.1103.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1103.0.tgz",
+      "integrity": "sha512-N4wy26MNn31ItGVHYHPrEuCIFY4MBBjC+C5v1lJKqIUSA7OZBdhleCY53zCCrXn27hsk7YNOaTuhQu807S4AfQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/nested-clients": "^3.997.39",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",

--- a/docker/llm-proxy/package.json
+++ b/docker/llm-proxy/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "type": "module",
-  "description": "OpenAI /v1/chat/completions proxy to Bedrock Mantle: refreshes the bearer and conditionally injects OpenAI-Project.",
+  "description": "OpenAI /v1/chat/completions proxy to Bedrock Mantle: refreshes the bearer and conditionally injects OpenAI-Project. Also the runtime for the consolidation and cleanup-apply entrypoints copied into the image, whose lazily-imported AWS clients are listed here (see scripts/cleanup-image-contract.test.mjs).",
   "engines": {
     "node": ">=24"
   },
@@ -12,7 +12,10 @@
   },
   "dependencies": {
     "@aws/bedrock-token-generator": "^1.1.0",
+    "@aws-sdk/client-secrets-manager": "^3.1100.0",
+    "@aws-sdk/client-servicediscovery": "^3.1100.0",
     "@aws-sdk/client-sns": "^3.1100.0",
+    "@aws-sdk/client-ssm": "^3.1092.0",
     "@aws-sdk/credential-providers": "^3.700.0",
     "pg": "^8.16.3"
   }

--- a/docs/test-cases/memory-restore.md
+++ b/docs/test-cases/memory-restore.md
@@ -331,6 +331,33 @@ consolidation, exactly what "a listing takes no lock" promises cannot happen.
 Declaring `mode` per flag rather than as a one-off check means a flag added later
 must answer the question — the test fails on a missing `mode`.
 
+## The CLI wiring layer
+
+`recoveryDeps` — the function that BUILDS the deps for both recovery modes — is
+module-private, and every case above hands fakes straight to `runListInactive` /
+`runRestore`. That leaves the wiring itself with no coverage from any of them, and
+it is not a theoretical gap: merging these modes with the #123 approval work left
+`recoveryDeps` calling `productionDatabaseMutex(stage, region)` after that
+function had gained a third `runtime` parameter that the helpers it delegates to
+dereference unguarded (`ssmClient`'s `runtime.ssm`, `readSecret`'s
+`runtime.secrets`). Both modes died with a `TypeError` before reaching AWS at all,
+while the full unit suite, the coverage gate, and `tsc` stayed green — nothing in
+the repo typechecks `scripts/*.mjs`.
+
+**TC-MEMRESTORE-071** runs each mode as a subprocess against a nonexistent stage.
+Both invocations fail either way, so the assertion is *which* failure — and it is
+deliberately a NEGATIVE one: no `TypeError`, and no
+`Cannot read properties of undefined`. Which diagnostic an operator actually gets
+depends on the runner (`database connection parameters are incomplete` where the
+SSM read succeeds and returns nothing, `CredentialsProviderError` where there are
+no credentials at all), so asserting one message by name would make the case fail
+on a laptop or pass for the wrong reason in CI. Both acceptable outcomes prove the
+same thing: the wiring got as far as the AWS call.
+
+`MEM9_DB_SECRET`/`_HOST`/`_NAME` are blanked so `resolveDatabaseConfig` takes the
+SSM branch — the one that reads `runtime` — since a runner with those set would
+otherwise skip the code path under test.
+
 ## Operator round trip (no CI E2E)
 
 - **TC-MEMRESTORE-070** — from a VPC-internal host on the PR preview stage:

--- a/docs/test-cases/slack-approval-loop.md
+++ b/docs/test-cases/slack-approval-loop.md
@@ -1,0 +1,426 @@
+# Test Cases: Slack interactive approval for cleanup deletions (issue #123)
+
+Unit tests live in three places, matching the three layers the feature spans:
+
+- `infra/src/oauth-facade/slack-interactions.test.ts` — the callback handler
+  (signature, replay, stale hash, idempotent claim, ACK budget), plus the
+  routing cases in `infra/src/oauth-facade/handler.test.ts`.
+- `scripts/memory-cleanup.test.mjs` — `topic` parsing, the protected-topic
+  downgrade, and the two-pass consensus wrapper.
+- `infra/oauth-facade.test.ts` / `infra/slack-approval.test.ts` — the route, the
+  apply task, secret handling, IAM scoping, and both flag states.
+
+E2E is a signed synthetic interaction against the PR preview facade
+(TC-SLACKAPP-090). A real Slack workspace round trip is not reproducible in CI;
+the synthetic payload exercises the identical handler path, because the handler
+distinguishes Slack from anyone else *only* by the signature.
+
+## Why the offered list lives in SSM and not in the button
+
+A Slack action `value` is capped at 2000 characters, so it cannot carry a
+decision list. It carries the list's content hash only. The ids therefore need a
+durable side channel that both the callback Lambda and the apply task can reach,
+and the workload permissions boundary (#123's prerequisite, landed separately)
+admits exactly one write for this: `ssm:PutParameter` scoped to
+`parameter/mem9-on-aws/*/approvals/*`. Two parameters:
+
+| parameter | written by | contents |
+|---|---|---|
+| `{prefix}/approvals/offered` | the cleanup run, when it posts to Slack | `{stage, hash, ids, generatedAt}` |
+| `{prefix}/approvals/approved-{hash}` | the callback Lambda, on Approve | `{stage, hash, ids, claimedAt, taskArn}` |
+
+`offered` is overwritten by each run, which is what makes a stale click
+detectable: the button's hash is compared against `offered.hash`, and a click
+carrying any earlier list's hash no longer matches (TC-SLACKAPP-020).
+
+Both records are plain `String`, not `SecureString`: the ceiling admits neither
+`kms:Encrypt` nor `kms:GenerateDataKey`, so a SecureString write would be denied
+at runtime. That bounds what may go in them — **ids and a hash only, never
+memory content** (TC-SLACKAPP-023). Snippets go to Slack and CloudWatch Logs,
+which is also why `--cap` bounds the offered list: a cap-50 record is ~2 KB
+against the standard tier's 4096-byte limit, and a run that would exceed the
+parameter limit must fail loud rather than truncate the list it is asking the
+operator to approve (TC-SLACKAPP-024).
+
+## Why the record is claimed before the task is started
+
+Slack redelivers an interaction when it does not get a response within 3
+seconds, so "write the record, start the task, ACK" has to be safe to run twice.
+The claim is the atomic primitive: `PutParameter` with `Overwrite: false` fails
+with `ParameterAlreadyExists` for the second caller, so exactly one delivery
+wins without a read-then-write race.
+
+That leaves one lossy interleaving — a Lambda that dies after claiming and
+before `RunTask`. `ssm:DeleteParameter` is **not** admitted by the boundary, so
+the claim cannot be rolled back. Instead the record carries `taskArn`, stamped
+by a second `PutParameter` (`Overwrite: true`) after `RunTask` returns, and a
+losing claimant branches on it:
+
+| record state | meaning | action |
+|---|---|---|
+| `taskArn` set | a previous delivery started the apply | ACK, start nothing (TC-SLACKAPP-030) |
+| `taskArn` null, claim younger than `CLAIM_STALE_MS` | the winning delivery is still in flight | ACK, start nothing (TC-SLACKAPP-031) |
+| `taskArn` null, claim older than `CLAIM_STALE_MS` | the winning delivery died before starting | start the task and stamp (TC-SLACKAPP-032) |
+
+The middle row is the only one that can lose an approval, and only if the
+winning invocation dies inside that window. It is logged at error level with the
+list hash, so the operator can re-click; the alternative — starting a second
+task whenever a claim looks unfinished — risks a double apply, and #102's cap
+and lockfile are a blast-radius limit, not a correctness guarantee against two
+concurrent applies of the same ids.
+
+## Signature verification
+
+- **TC-SLACKAPP-001** — a correctly signed request is accepted: HMAC-SHA256 over
+  `v0:{timestamp}:{rawBody}` keyed by `SLACK_SIGNING_SECRET`, compared against
+  `X-Slack-Signature`. The test computes the expected value independently rather
+  than calling the production signer, so a signer that agrees with itself but not
+  with Slack fails here.
+- **TC-SLACKAPP-002** — a body tampered with after signing is rejected with 401
+  and **no** side effect: no SSM write, no `RunTask`, no upstream proxy call. The
+  spies are asserted untouched, so an absent assertion cannot pass for a proven
+  one.
+- **TC-SLACKAPP-003** — a signature computed with the wrong secret is rejected
+  401. Comparison is `timingSafeEqual` over equal-length buffers, with the length
+  checked first (`timingSafeEqual` throws on a length mismatch — the
+  `infra/src/oauth-facade/state.ts` precedent), so a short or long signature is a
+  401 and never an unhandled 500.
+- **TC-SLACKAPP-004** — a missing `X-Slack-Signature` or missing
+  `X-Slack-Request-Timestamp` is rejected 401. Header lookup is
+  case-insensitive: API Gateway v2 lowercases header names, and matching only
+  the canonical spelling would reject every real request while the unit test
+  passed.
+- **TC-SLACKAPP-005** — verification happens **before** any parsing. The case
+  sends a signed-but-unparseable body and asserts the 400 comes from parsing,
+  then sends an unsigned well-formed body and asserts the 401 comes first and
+  `JSON.parse`/`URLSearchParams` were never reached. Order matters: parsing an
+  unauthenticated body is the attack surface this endpoint exists to close.
+- **TC-SLACKAPP-006** — an unset or empty `SLACK_SIGNING_SECRET` fails **closed**
+  (401/503), never open. Empty-string is the disabled sentinel elsewhere in this
+  Lambda (`hmacKey`), so the case pins that an empty secret cannot make every
+  signature valid.
+
+## Replay guard
+
+- **TC-SLACKAPP-010** — `X-Slack-Request-Timestamp` older than 5 minutes is
+  rejected with no side effect, even when the signature is valid: a captured
+  request must not be replayable forever.
+- **TC-SLACKAPP-011** — a timestamp more than 5 minutes in the **future** is also
+  rejected. A one-sided check accepts a signature minted against a clock the
+  attacker controls and keeps it valid indefinitely.
+- **TC-SLACKAPP-012** — a non-numeric, empty, or absurdly large timestamp is
+  rejected rather than coerced. `Number("")` is 0 and `NaN` comparisons are
+  always false, so a naive check would treat a garbage timestamp as either
+  ancient or acceptable depending on the operator; both must be an explicit 401.
+
+## Stale-hash rejection
+
+- **TC-SLACKAPP-020** — an Approve click whose `value` hash does not match the
+  current `approvals/offered` record is rejected: no claim, no `RunTask`, and the
+  Slack response says the list was regenerated. This is the case that stops an
+  operator approving a list they read last week against a corpus that has since
+  changed.
+- **TC-SLACKAPP-021** — a missing `approvals/offered` parameter is rejected the
+  same way, not treated as "nothing to compare against". A read failure must
+  never widen what is accepted.
+- **TC-SLACKAPP-022** — the ids applied come from the `offered` record, **not**
+  from the interaction payload. A payload carrying its own id list is rejected
+  outright: the signature proves the request came from the workspace, not that
+  the ids in it are the ids the classifier chose, and accepting them would let a
+  workspace member delete arbitrary memories by editing a payload.
+- **TC-SLACKAPP-023** — the offered record contains ids, a hash, a stage, and a
+  timestamp, and no memory content. Asserted structurally over the serialized
+  value, because this parameter is a plain `String` and is readable by anything
+  with `ssm:GetParameters` on the stage prefix.
+- **TC-SLACKAPP-024** — an offered list that would exceed the 4096-byte standard
+  parameter limit fails the run loud rather than truncating. Truncating would ask
+  the operator to approve a list that is not the list they were shown.
+- **TC-SLACKAPP-025** — the record is stage-bound, and a hash whose record names
+  another stage is refused. Same reasoning as #102's decision-file stage guard: a
+  preview approval must never apply to prod.
+
+## Idempotency and the apply trigger
+
+- **TC-SLACKAPP-030** — a duplicate delivery of the same interaction enqueues
+  **one** apply. The second `PutParameter` is asserted to carry
+  `Overwrite: false` (the atomic claim), and the second delivery returns 200 with
+  `RunTask` called exactly once across both.
+- **TC-SLACKAPP-031** — a losing claimant whose record has no `taskArn` and a
+  fresh `claimedAt` ACKs without starting a task, and logs the list hash at error
+  level so a lost approval is visible.
+- **TC-SLACKAPP-032** — a losing claimant whose record has no `taskArn` and a
+  `claimedAt` older than `CLAIM_STALE_MS` starts the task and stamps the ARN,
+  recovering from a Lambda that died mid-claim.
+- **TC-SLACKAPP-033** — the handler **never** calls the memory delete API. All
+  `fetch` calls are enumerated and asserted to be Slack or upstream only, with no
+  call to the mem9 REST surface. This is the structural guarantee behind "apply
+  happens only in the ECS task" — a future edit that inlines a delete to save a
+  hop fails here.
+- **TC-SLACKAPP-034** — a `RunTask` failure is surfaced, not swallowed: the
+  response text says the apply did not start, the error is logged without the
+  request body, and the claim remains so a retry can recover via
+  TC-SLACKAPP-032. The case asserts the response is not the plain success text,
+  because "recorded the approval and told the operator it worked" is the worst
+  available outcome.
+- **TC-SLACKAPP-035** — a Reject click writes no approval record, starts no task,
+  and updates the message. Reject must be cheap and total: it is the button an
+  operator presses when something looks wrong.
+- **TC-SLACKAPP-036** — the handler completes within the 3-second ACK budget with
+  both control-plane calls faked to a realistic latency, and it does not await
+  the apply task's completion. Asserted by construction — the handler never
+  polls — rather than by wall-clock timing, which would be a flaky test.
+
+## Routing on the shared facade
+
+- **TC-SLACKAPP-040** — `POST /slack/interactions` is matched **explicitly**
+  before the catch-all. The facade's router proxies every unmatched path to the
+  upstream AgentCore Gateway, so without an explicit match a Slack payload would
+  be forwarded to the Gateway and the Gateway's error shape returned to Slack.
+- **TC-SLACKAPP-041** — with the feature flag unset the path returns 404 and is
+  **not** proxied upstream. Falling through would send operator-approval data to
+  a component that has no business seeing it; 404 is also the correct answer,
+  since without the signing secret no request to this path can be authenticated.
+- **TC-SLACKAPP-042** — `GET /slack/interactions` is 405, and the OAuth routes
+  (`/oauth/authorize`, `/oauth/callback`, `/oauth/token`, `/register`, the
+  `.well-known` documents, and the upstream proxy) behave identically with the
+  Slack branch present. The Slack branch is additive; a regression in the OAuth
+  flow would break every MCP client.
+- **TC-SLACKAPP-043** — the Slack branch does not require any OAuth config to be
+  present, and an OAuth misconfiguration (`hmacKey` empty → 503 on OAuth routes)
+  does not disable the Slack route, nor vice versa. The two concerns share a
+  Lambda; they must not share a failure mode.
+
+## Classification: `topic`
+
+`topic` is required on **every** verdict, not only on `DELETE` ones, and that is
+a deliberate widening with a cost worth stating. It makes a model response that
+omits the field batch-SKIP on the plain #102 cleanup path too, including the
+scheduled weekly run — behavior that shipped before this change and worked. The
+alternative is worse: a `topic` required only where the code happens to consult
+it is a rule that protects finance memories exactly until a response arrives in a
+shape nobody predicted. SKIP is non-destructive, so the failure mode of strictness
+is a run that audits nothing and says so, against a failure mode of leniency that
+deletes the memories the operator asked to keep.
+
+- **TC-SLACKAPP-050** — `parseVerdicts` accepts the five known topics
+  (`personal-finance`, `engineering`, `content`, `operations`, `other`) and
+  returns them on the verdict.
+- **TC-SLACKAPP-051** — a missing `topic` is a `MalformedResponse`, so it lands
+  in the existing retry → SKIP machinery. Explicitly **not** defaulted to
+  `other`: defaulting would silently strip protection from every
+  `personal-finance` memory in a batch whose model forgot the field, which is the
+  exact failure the protected-topic rule exists to prevent.
+- **TC-SLACKAPP-052** — an unknown topic string is a `MalformedResponse` for the
+  same reason, and the error message is a fixed string that does not echo the
+  response (it can contain memory content) — matching the existing
+  `MalformedResponse` contract.
+- **TC-SLACKAPP-053** — a non-string `topic` (a hallucinated array or object) is
+  a `MalformedResponse`, not a crash mid-plan.
+- **TC-SLACKAPP-054** — the batch retry and whole-batch SKIP behavior is
+  unchanged for a topic failure: one retry, then every id in the batch becomes
+  SKIP with the existing `UNCLASSIFIED_REASON`, so the existing "how much of the
+  corpus was never audited" note still counts it.
+
+## Protected topics
+
+The rule implemented is stronger than "never offered for deletion": a protected
+memory is **never mutated by this tool at all** — not deleted, not absorbed into
+a merge, and not rewritten as a merge survivor. Stated that way it is one
+invariant with one test surface, rather than a per-verdict list that a fourth
+verdict would silently escape. The cost is real and accepted: fragmented finance
+memories never get consolidated automatically, so they accumulate until an
+operator merges them by hand. Retention is the requirement; tidiness is not.
+
+A downgraded row carries `verdict: "RETAIN"` — its own verdict rather than a
+`KEEP` with a note, so the summary counts it without special-casing and
+`applyDecisions` cannot act on it by reaching a `DELETE`/`MERGE` branch.
+
+- **TC-SLACKAPP-060** — a memory whose topic is in `protectedTopics` and whose
+  verdict is `DELETE` is downgraded and **never** enters the offered set. The
+  decision records the original verdict and an explicit
+  `retainedReason: "protected topic personal-finance"`, so the report shows the
+  classifier judged it deletable and policy overrode that — not that the
+  classifier kept it.
+- **TC-SLACKAPP-061** — the downgrade is reported in its own counter, not folded
+  into `SKIP`. `SKIP` is the bucket that means "something went wrong or was not
+  audited"; a policy retain is neither, and conflating them would make a
+  classifier outage and a working protection rule read identically in the
+  summary.
+- **TC-SLACKAPP-062** — a protected memory whose verdict is `MERGE` is also
+  withheld, including when it appears in another verdict's `absorbs` list.
+  Absorbing a protected memory into a survivor deletes it just as surely as
+  `DELETE` does; a rule that only checks the top-level verdict is a hole.
+- **TC-SLACKAPP-063** — `protectedTopics` is config-driven with default
+  `["personal-finance"]`, and an empty configured list means "protect nothing"
+  rather than falling back to the default. A silent fallback would make a
+  deliberate opt-out impossible to express; an operator who wants the default
+  omits the setting.
+- **TC-SLACKAPP-064** — an unrecognised entry in a configured `protectedTopics`
+  is rejected at argument-validation time. A typo (`personal_finance`) that
+  matches no topic would silently protect nothing, and the operator would not
+  find out until finance memories were deleted.
+- **TC-SLACKAPP-065** — an `--apply` run issues **no request at all** for a
+  RETAIN row, asserted over every recorded call including `GET`s. Protection
+  currently holds on the write path only because `destructiveCost` returns 0 for
+  an unrecognised verdict — accidental, and exactly what a fourth verdict would
+  inherit by accident. Asserting only "no write happened" is too weak: a RETAIN
+  row that reaches the delete branch is re-read and then skipped as an *LWW
+  guard*, because it carries no `contentHash`. That performs no write and so
+  passes the weak assertion, while the summary attributes the protection to a
+  concurrent write and the real rule has silently stopped applying.
+
+Two implementation facts the spec did not predict, both found by these tests:
+
+- **Withholding must happen before the merge graph is resolved.** A protected id
+  left in the verdict map as a `MERGE` consents to *its own* absorption, and
+  being absorbed deletes it just as surely as `DELETE` does. Removing it first
+  means its group loses that member and — with no consenting absorbed ids left —
+  degrades to `SKIP` through the existing path, so the survivor is not rewritten
+  either. TC-SLACKAPP-062 fails if the two steps are swapped.
+- **`RETAIN` had to be admitted to the replay validator.** A dry run over a
+  protected memory persists a RETAIN row, and the `--apply` that replays that
+  file validates every row's verdict against a closed list. Left out, the
+  protection rule would break the tool it protects memories in: every apply
+  following a run with one protected memory would fail at load. Caught by
+  TC-SLACKAPP-065 on first run.
+
+`KEEP` is deliberately exempt from the downgrade: `KEEP` mutates nothing, so
+reporting it as RETAIN would claim policy overrode a decision that already
+agreed with policy.
+
+- **TC-SLACKAPP-066** — the run summary counts **every** verdict, zeros included,
+  and its key set is closed. Both halves are about a summary an operator compares
+  across runs. A run where protection matched nothing must print `"RETAIN":0`
+  rather than omit the key, because an omitted key is indistinguishable from a
+  build with no protection rule at all — which is how a dropped
+  `--protected-topics` would go unnoticed. And a verdict misspelled at one push
+  site must throw rather than report `"RETAINED":1` beside `"RETAIN":0`, which
+  reads as a data oddity instead of as a memory routed onto a path nothing
+  audits. The closed-set half is asserted by calling `verdictSummary` directly:
+  `validateDecisions` rejects an unknown verdict in a replayed file before the
+  summary is built, so no *input* can reach that branch — only a planner push
+  site can, and an invariant nothing can trigger from outside still has to be
+  proven from inside or it is decoration.
+
+## Two-pass consensus
+
+- **TC-SLACKAPP-069** — `--consensus-passes` must be a whole integer of at least
+  2. `2.5` is the case that matters: `Number.isFinite` and `> 0` both accept it,
+  the pass loop runs twice, and the log says "pass 1 of 2.5" while the report
+  says 2 — a run whose own summary disagrees with its own invocation. And `1`
+  asks for consensus and gets none, which is exactly the single-pass behavior the
+  flag exists to replace, so it is refused by name rather than accepted and
+  quietly downgraded. Omitting the flag is the single-pass default, not an error:
+  consensus is opt-in and costs N times the inference.
+- **TC-SLACKAPP-070** — an id marked `DELETE` by both passes is offered; an id
+  marked `DELETE` by only one pass is not, and appears in the review list
+  labelled unstable. This is the acceptance criterion for the 66%-agreement
+  finding that motivated the issue.
+- **TC-SLACKAPP-071** — the two passes are independent requests, not one response
+  reused. The fake `completeChat` returns different verdicts per call and the
+  case asserts both were called with the same input and that the intersection —
+  not the first or last response — decided the offered set.
+- **TC-SLACKAPP-072** — the run reports pass-1 DELETE count, pass-2 DELETE count,
+  intersection size, and disagreement rate. A drop in reproducibility must be
+  visible in the summary; the whole design rests on that number, and an
+  unreported number is a number nobody watches.
+- **TC-SLACKAPP-073** — a pass that fails entirely does **not** collapse to "use
+  the other pass". With one usable pass there is no consensus, so nothing is
+  offered and the run says so. Falling back to a single pass would quietly
+  restore exactly the non-reproducible behavior consensus exists to remove.
+- **TC-SLACKAPP-074** — a partially failed pass reduces the offered set to ids
+  both passes actually judged; ids the second pass never classified are not
+  treated as agreement. Absence of a verdict is not a `DELETE` and is not a
+  `KEEP`.
+- **TC-SLACKAPP-075** — protection is applied to both passes before the
+  intersection, so a protected id cannot be admitted by an intersection computed
+  over raw verdicts. Order is asserted, because both orders produce the same
+  answer today and only one keeps producing it when a pass returns a different
+  topic for the same id.
+- **TC-SLACKAPP-076** — `MERGE` decisions are **not** offered via Slack in v1,
+  and the run reports how many it withheld. v1 approves deletions only; an
+  unreported withholding would read as "the classifier found no merges".
+- **TC-SLACKAPP-077** — consensus never widens the destructive set: the offered
+  ids are a subset of pass-1 ∩ pass-2 DELETE ids, asserted as a set relation
+  rather than a count, so a future refactor cannot add an id from anywhere else.
+- **TC-SLACKAPP-078** — a pass that lost **every** batch is reported as *no
+  consensus*, not as disagreement. `classifyAll` reports a total failure as a full
+  list of SKIP rows, which look exactly like "this pass judged the memory and
+  declined to delete it". The intersection is safe either way — a SKIP is not a
+  `DELETE`, so nothing extra is offered — but the *report* is not: an operator
+  reading `agreement=0%` would go looking for a classifier that changed its mind
+  rather than a transport that never answered. The same case pins the exit code:
+  pass 1 classified the whole corpus, so the classifier path demonstrably works
+  and exit 5 (`classifierBroken`) would misdiagnose a partial outage.
+- **TC-SLACKAPP-079** — a consensus dry run can be replayed with `--apply`. Same
+  defect class TC-SLACKAPP-065 caught for `RETAIN`: the planner writes `UNSTABLE`
+  rows to the decision file, so a replay validator that does not know the verdict
+  makes every apply following a consensus run fail at load — the safety mechanism
+  breaking the tool it exists to make safe. The agreed id is deleted and the
+  contested one is not touched at all, asserted over every recorded call.
+
+## Infrastructure
+
+- **TC-SLACKAPP-080** — with the enablement flag unset, no apply task and no
+  approval SSM parameters are created, and the facade Lambda gets no
+  `ssm:PutParameter`, `ecs:RunTask`, or `iam:PassRole`. Disabled must mean
+  absent, not present-and-idle.
+- **TC-SLACKAPP-081** — with the flag set, the facade Lambda's
+  `ssm:PutParameter` is scoped to `{prefix}/approvals/*` (not the stage prefix,
+  and not `*`), `ecs:RunTask` is scoped to the apply task definition, and
+  `iam:PassRole` is gated by `iam:PassedToService: ecs-tasks.amazonaws.com`.
+- **TC-SLACKAPP-082** — the resulting role satisfies the workload permissions
+  boundary: every action is inside the ceiling and inside
+  `DenyPutParameterOutsideApprovalRecords`. Run through the same
+  `scripts/lib/workload-permissions-boundary.mjs` helpers the boundary tests use,
+  so a scoping mistake fails in CI rather than at runtime as an opaque
+  `AccessDenied`.
+- **TC-SLACKAPP-083** — `SLACK_BOT_TOKEN` and `SLACK_SIGNING_SECRET` reach the
+  task and the Lambda as `sst.Secret` references, and no literal appears in the
+  task definition, the Lambda environment map, or any synthesized output.
+  Asserted by scanning the rendered shapes for the `xoxb-` prefix and the secret
+  value, matching `infra/ecs.test.ts`'s `isSecret` assertions.
+- **TC-SLACKAPP-084** — production fails closed when a required secret is empty
+  (the `SLACK_WEBHOOK_URL` precedent in `infra/ecs.ts`), while a preview stage
+  with the flag unset needs neither secret. An empty secret in prod must be a
+  synthesis error, not a runtime 401 loop.
+- **TC-SLACKAPP-085** — the approval channel id is a plain variable, not a
+  secret, and its absence with the flag set is a synthesis error.
+- **TC-SLACKAPP-086** — the apply task runs on the existing cluster with the
+  existing task SG and private subnets, and the diff adds **no** security-group
+  rule. Asserted against the rendered network configuration, because "no new
+  network surface" is the argument that chose ECS over a VPC-attached Lambda.
+- **TC-SLACKAPP-087** — the apply task's command is
+  `scripts/memory-cleanup.mjs --apply --ids <file>` with `entrypoint: ["node"]`
+  (ECS can override `command` but not `entryPoint`), and it inherits #102's
+  `--cap` and lockfile contract. A task definition that dropped `--cap` would
+  remove the blast-radius limit silently.
+- **TC-SLACKAPP-088** — the Lambda is `nodejs24.x` on `arm64`, and the route is
+  on the existing ApiGatewayV2 — no Lambda Function URL, no new API, no new
+  certificate.
+
+## Logging and privacy
+
+- **TC-SLACKAPP-089** — no log line contains the bot token, the signing secret,
+  the raw request body, or memory content, on **any** path including every error
+  path. Asserted by capturing all log output across the failure cases and
+  matching against the secret values and a sentinel memory snippet, rather than
+  by inspecting the happy path only.
+
+## E2E (PR preview stage)
+
+- **TC-SLACKAPP-090** — POST a correctly signed synthetic interaction to the
+  preview facade URL: expect 200, an approval record written under
+  `{prefix}/approvals/`, and the apply task reaching exit 0 against preview data.
+  Then POST the same body with an invalid signature: expect 401 and **no** new
+  record. The record is read back by name, so "no record" is a positive
+  assertion rather than the absence of one.
+
+## Exit codes
+
+The cleanup script's existing vocabulary is unchanged (0 ok, 1 error, 2
+discovery failed, 3 lock held, 4 cap exceeded, 5 classifier broken, 6 partially
+done). Consensus adds no code: a run with no usable consensus offered nothing
+and did nothing wrong, so it exits 0 with the disagreement rate in its summary —
+the number the operator is meant to act on, not an exit code the scheduler would
+have to interpret.

--- a/docs/test-cases/slack-approval-loop.md
+++ b/docs/test-cases/slack-approval-loop.md
@@ -578,6 +578,36 @@ agreed with policy.
 - **TC-SLACKAPP-088** — the Lambda is `nodejs24.x` on `arm64`, and the route is
   on the existing ApiGatewayV2 — no Lambda Function URL, no new API, no new
   certificate.
+- **TC-SLACKAPP-130** — an apply task that fails reaches a **human**. Every other
+  failure in this loop ends in a log line, and by then the operator has already been
+  told "Apply started"; the deletions they authorized either happened or did not,
+  and nothing else would tell them which. So a STOPPED task raises a CloudWatch
+  alarm on the stage's existing alerts topic, and four things about that are pinned:
+
+  - The EventBridge pattern matches on `taskDefinitionArn`, not on the cluster. The
+    cluster is shared with the server and the consolidation task, so a cluster-wide
+    rule would page the cleanup topic for every unrelated task failure.
+  - The exit-code filter is `{"anything-but": 0}`, not a `> 0` numeric comparison.
+    The predicted first-deploy failure is a task killed in the ECS agent's
+    secret-fetch phase, which reports **no** `exitCode` at all — precisely what a
+    numeric filter drops. `stoppedReason` rides along in the metric-filter document
+    because it is the only field where such a startup failure names itself
+    (`ResourceInitializationError`).
+  - The rule's `namePrefix` is budgeted against Pulumi's 26-character suffix for
+    every stage this project deploys, and synthesis **throws** for a stage name that
+    overruns EventBridge's 64-character limit. That is the #127 trap: a prefix that
+    fits 64 on its own still fails at CREATE, after the rest of the stack deployed.
+    `boundedNamePrefix` refuses rather than truncating on purpose — a silently
+    shortened prefix collides across stages, and two stages sharing one rule means
+    one stage's failures alarm on the other's topic.
+  - The task itself gets no `MEM9_ALERTS_TOPIC_ARN` and no `sns:Publish`. The
+    publishing is EventBridge's; `scripts/memory-cleanup.mjs` has no SNS client, so
+    a topic in its environment would read as wired-up alerting that never fires.
+
+  A stage with no alerts topic creates no alarm and still deploys the task: an alarm
+  whose `alarmActions` is `[undefined]` fails CREATE for the whole stack, which
+  would cost every preview stage its cleanup loop to gain paging it has no topic
+  for.
 
 ## Offering the list: the loop's entry point
 
@@ -740,6 +770,55 @@ made safe or quietly defeated.
   materialization is the cheapest guard, and a tampered claim failing later would
   hold the shared mutex for the length of its own failure and could block the
   weekly consolidation.
+- **TC-SLACKAPP-131** — the claim parameter name is one SSM will accept on
+  **write**, and the façade's copy of the derivation matches the script's
+  character for character.
+
+  `contentHash` returns `sha256:<hex>`, and a `:` cannot appear in an SSM parameter
+  name: `PutParameter` answers `ValidationException` ("each sub-path can be formed
+  as a mix of letters, numbers and the following 3 symbols .-_"), while a **read**
+  parses the colon as the version/label selector instead — so the two operations
+  disagree about what the name even is rather than both simply 404ing. Probed
+  against the live service: colon rejected on write, dash accepted.
+
+  Untreated this made the whole loop dead on arrival, and *silently*: `claimAndRun`
+  separates "someone else won" from every other failure by the error **name**, so a
+  `ValidationException` fell to the generic branch and answered "The approval could
+  not be recorded, so the apply did not start" for every click on every stage —
+  while pointing the operator at boundary rollout order, which is the wrong place
+  to look. Nothing caught it because every SSM double was a `Map` keyed on the name
+  string, and a `Map` cannot reject a name's **shape**. The doubles on both sides
+  now borrow the service's constraint from `assertClaimParameterName`; that, rather
+  than the one name-shape assertion, is what makes this class of defect catchable
+  at all.
+
+  The Lambda bundle and the container script share no module, so the derivation is
+  duplicated in `slack-interactions.ts`. This case asserts the two agree, because a
+  drift means the task looks for a claim at a name the Lambda never wrote and dies
+  with "no approval record" — the same symptom as a tampered claim, from a cause
+  no operator would guess.
+- **TC-SLACKAPP-132** — the approved-ids filter is authoritative for **every** id a
+  run deletes, not only the id each decision is keyed on.
+
+  `buildOfferedRecord` offers `DELETE` verdicts only, so no `MERGE` can ever be in
+  an approved list — but the filter checked `approved.has(decision.id)` on the
+  **survivor** alone, while a `MERGE` deletes its `absorbs[]` ids and rewrites the
+  survivor's content. The apply task re-classifies rather than replaying the
+  reviewed artifact (#119 is the replay path, and the task definition passes no
+  `--decisions`), so a fresh `MERGE` naming an approved id as its survivor deleted
+  memories the operator never saw and exited 0 reporting success. That is the one
+  guarantee the whole loop exists to provide, so a `MERGE` under `--ids` is refused
+  outright, counted in `skippedByFilter`, and logged. Asserted on no non-GET request
+  reaching the server at all, because a PUT writing identical content would leave
+  the store looking untouched.
+- **TC-SLACKAPP-132** — the converse, in the same pair: an approved id whose fresh
+  verdict is now `KEEP` fell out at `destructiveCost === 0` and incremented nothing,
+  so the outcome said "1 of 2 approved deletion(s)" with no note and a changed
+  verdict read as a partial failure. It is now counted as `reclassified` and gets
+  its own note, distinct from "not in the approved list": that one counts things the
+  operator did **not** approve, this counts things they did. Suppressed on a cap
+  abort, where the tail of the decision list was never examined and #121's note
+  already explains the shortfall.
 
 ## Closing the loop on the message
 
@@ -904,6 +983,39 @@ fail the run.
   reason: `infra/slack-approval.ts` fails synthesis when the flag is set and
   either secret is unseeded, and GitHub hands an unset secret to the job as an
   empty string.
+
+- **TC-SLACKAPP-090b** — the failure modes an earlier version of the harness
+  swallowed. Each is a case in `run-slack-approval-e2e.test.mjs`, and each was
+  mutation-verified: reverting the fix fails exactly the case that names it.
+
+  - **A parameter read that fails for any reason other than absence is a hard
+    failure.** `2>/dev/null || true` collapsed every error into `""` and every
+    `""` into a skip, so an `AccessDenied` — say a boundary change leaving the CI
+    role only the plural `ssm:GetParameters` — a KMS denial on
+    `--with-decryption`, throttling, expired credentials, or the wrong region all
+    read as "not deployed" and exited 0. The gate would report green forever while
+    sending no request at all: the same vacuous-gate failure the `pr-N` refusal
+    exists to prevent. The fake `aws` emits the real CLI's `ParameterNotFound`
+    text so only the one benign cause skips — a fake that merely exited 255 could
+    not tell the two apart.
+  - **The cluster comes from SSM, not from slicing the task ARN.**
+    `${TASK_ARN##*:task/}` assumes the long ARN format; on an account without the
+    long-ARN opt-in the ARN carries no cluster segment, so the slice yields the
+    task id and every `describe-tasks` runs against a cluster that does not exist.
+    The fake rejects a mismatched `--cluster` with `ClusterNotFoundException`.
+  - **A `describe-tasks` failure is not an unknown status.** Swallowing it spun
+    the full 15 minutes and then reported `lastStatus=UNKNOWN`, which reads as "the
+    task hung" and sends the next engineer to debug the apply task when the cause
+    is an IAM denial.
+  - **`exitCode: None` is named as a startup failure.** ECS reports a NULL exit
+    code as the literal `None` when the task died before its entrypoint — the
+    predicted first-deploy outcome while the execution role sits outside the
+    boundary's secret-decrypt exception list. "exited None" would send the reader
+    looking for an application bug.
+  - **An unexpected `stoppedReason` fails the run even at exit 0.**
+    `stoppedReason` was fetched, printed, and never asserted; a task killed by OOM
+    can stop with a reason set, and only `Essential container in task exited` is
+    benign here.
 
 ## Exit codes
 

--- a/docs/test-cases/slack-approval-loop.md
+++ b/docs/test-cases/slack-approval-loop.md
@@ -85,6 +85,12 @@ concurrent applies of the same ids.
   checked first (`timingSafeEqual` throws on a length mismatch — the
   `infra/src/oauth-facade/state.ts` precedent), so a short or long signature is a
   401 and never an unhandled 500.
+- **TC-SLACKAPP-003b** — the comparison is `timingSafeEqual`, asserted
+  **structurally** over the source. Deliberately so: `===` and `timingSafeEqual`
+  are behaviourally identical, so no input can distinguish them, which makes
+  timing safety unprovable from the outside — and an invariant nothing observes is
+  exactly the kind a later refactor drops. The same assertion pins that the length
+  check precedes it, since `timingSafeEqual` throws on unequal lengths.
 - **TC-SLACKAPP-004** — a missing `X-Slack-Signature` or missing
   `X-Slack-Request-Timestamp` is rejected 401. Header lookup is
   case-insensitive: API Gateway v2 lowercases header names, and matching only
@@ -144,9 +150,25 @@ concurrent applies of the same ids.
   timestamp, and no memory content. Asserted structurally over the serialized
   value, because this parameter is a plain `String` and is readable by anything
   with `ssm:GetParameters` on the stage prefix.
+- **TC-SLACKAPP-023b** — the same structural assertion on the **offered** record
+  that 023 makes on the claim, over `buildOfferedRecord`'s serialized output — a
+  nested field added later (a `snippet` on the decision row) satisfies a
+  field-by-field check and still publishes memory content. Two further properties
+  are pinned here because nothing else can see them: only `DELETE` rows are
+  offered (a record built over every row hands the apply task the very ids the
+  protected-topic rule withheld, with the operator's approval attached), and the
+  hash is over a join with a separator no id can contain (without it `["ab","c"]`
+  and `["a","bc"]` are one hash, so a click approving one list is accepted against
+  the other).
 - **TC-SLACKAPP-024** — an offered list that would exceed the 4096-byte standard
   parameter limit fails the run loud rather than truncating. Truncating would ask
-  the operator to approve a list that is not the list they were shown.
+  the operator to approve a list that is not the list they were shown — the one
+  failure mode here that produces a *wrong* apply rather than a failed one, since
+  the ids are exactly what the apply task deletes. Asserted on the **serialized**
+  length, not an id count: a limit expressed as "N ids" drifts from the real
+  constraint as soon as ids get longer, and bytes are what SSM rejects. The
+  advanced tier's 8 KB is deliberately not the answer — it incurs a charge and
+  cannot be reverted to standard without data loss, so `--cap` is the knob.
 - **TC-SLACKAPP-025** — the record is stage-bound, and a hash whose record names
   another stage is refused. Same reasoning as #102's decision-file stage guard: a
   preview approval must never apply to prod.
@@ -157,6 +179,11 @@ concurrent applies of the same ids.
   **one** apply. The second `PutParameter` is asserted to carry
   `Overwrite: false` (the atomic claim), and the second delivery returns 200 with
   `RunTask` called exactly once across both.
+- **TC-SLACKAPP-030b** — a claim that already carries a `taskArn` starts nothing
+  **however old it is**. `claimedAt` is set far past `CLAIM_STALE_MS` on purpose: a
+  fresh timestamp lets the stale-claim branch answer the case, leaving the
+  `taskArn` branch — the one that prevents a double apply on a redelivery arriving
+  after the apply already ran — unproven.
 - **TC-SLACKAPP-031** — a losing claimant whose record has no `taskArn` and a
   fresh `claimedAt` ACKs without starting a task, and logs the list hash at error
   level so a lost approval is visible.
@@ -217,6 +244,10 @@ concurrent applies of the same ids.
 - **TC-SLACKAPP-035** — a Reject click writes no approval record, starts no task,
   and updates the message. Reject must be cheap and total: it is the button an
   operator presses when something looks wrong.
+- **TC-SLACKAPP-035b** — an **unrecognised** `action_id` starts nothing. The
+  default has to be inert: a handler that treated "not reject" as approve would
+  turn any future button — or a typo in the message template — into a deletion
+  trigger. `cleanup_approve_v2` is the case, because it is what a rename produces.
 - **TC-SLACKAPP-036** — the handler completes within the 3-second ACK budget with
   both control-plane calls faked to a realistic latency, and it does not await
   the apply task's completion. Asserted by construction — the handler never

--- a/docs/test-cases/slack-approval-loop.md
+++ b/docs/test-cases/slack-approval-loop.md
@@ -108,10 +108,22 @@ concurrent applies of the same ids.
 - **TC-SLACKAPP-011** — a timestamp more than 5 minutes in the **future** is also
   rejected. A one-sided check accepts a signature minted against a clock the
   attacker controls and keeps it valid indefinitely.
-- **TC-SLACKAPP-012** — a non-numeric, empty, or absurdly large timestamp is
-  rejected rather than coerced. `Number("")` is 0 and `NaN` comparisons are
-  always false, so a naive check would treat a garbage timestamp as either
-  ancient or acceptable depending on the operator; both must be an explicit 401.
+- **TC-SLACKAPP-012** — a malformed timestamp is rejected **by shape**, asserted
+  on the logged reason rather than the status code. The status cannot tell the two
+  branches apart for most inputs: `Number("")` is 0, `Number("1e999")` is Infinity
+  and `Number("-1")` is -1, all of which the skew check would also reject, just as
+  `stale timestamp`. Only `"abc"` → `NaN` is uniquely the shape check's to catch,
+  since every NaN comparison is false and `Math.abs(NaN) > MAX` therefore
+  *accepts* it. The reason string is the observable that distinguishes "recognised
+  as garbage" from "did arithmetic on garbage and got lucky", and an operator told
+  `stale timestamp` for `"abc"` would go hunting a clock skew that does not exist.
+  `Number` also **trims**, so a whitespace-padded in-window value is the one input
+  the skew check genuinely cannot see. An empty header is reported as *missing*,
+  not malformed — a different and more accurate reason.
+- **TC-SLACKAPP-012b** — a well-formed but out-of-window timestamp is `stale`, not
+  `malformed`. Without it a shape check tightened until it rejected every timestamp
+  would pass TC-012 completely while the endpoint 401'd Slack forever; this is what
+  makes the shape check a filter rather than a wall.
 
 ## Stale-hash rejection
 
@@ -150,7 +162,30 @@ concurrent applies of the same ids.
   level so a lost approval is visible.
 - **TC-SLACKAPP-032** — a losing claimant whose record has no `taskArn` and a
   `claimedAt` older than `CLAIM_STALE_MS` starts the task and stamps the ARN,
-  recovering from a Lambda that died mid-claim.
+  recovering from a Lambda that died mid-claim. The stamp is asserted through the
+  store, on the **claim's own name**: a stamp written to any other parameter still
+  carries a `taskArn` and still uses `Overwrite: true`, so asserting only the call
+  arguments passes while the claim stays `taskArn`-less forever.
+- **TC-SLACKAPP-032b** — a claim that cannot be **read** refuses; it does not
+  recover. A read failure is not an absent record, and collapsing them
+  (`.catch(() => null)`) made `Date.parse(String(undefined))` return NaN and
+  `!Number.isFinite(NaN)` make `stale` true — so a losing delivery whose read was
+  merely throttled started a **second apply of the same ids**. Two redeliveries
+  hitting one parameter inside Slack's 3-second window is exactly when a
+  `ThrottlingException` is likely. We already know the claim exists (the
+  `Overwrite: false` write lost to it), so an unreadable claim is *unknown*, and
+  unknown is precisely when starting a destructive task is unsafe.
+- **TC-SLACKAPP-032c** — a claim that **was** read but carries a corrupt
+  `claimedAt` **is** stale, so it stays recoverable. The opposite of 032b and the
+  reason the two cases cannot share one branch: `ssm:DeleteParameter` is not
+  admitted by the boundary, so if a corrupt claim were not stale nothing could ever
+  clear it and the approval would be blocked permanently.
+- **TC-SLACKAPP-032d** — a delivery arriving **after** the stale window does not
+  re-apply a stamped claim. The end-to-end consequence of 032's store assertion:
+  recovery makes the claim fresh again only because the stamp lands on the claim
+  itself, so a misdirected stamp turns every late redelivery into another apply of
+  the same ids. The event's timestamp moves with the clock, or the skew check
+  answers the case at 401 before the claim logic is reached.
 - **TC-SLACKAPP-033** — the handler **never** calls the memory delete API. All
   `fetch` calls are enumerated and asserted to be Slack or upstream only, with no
   call to the mem9 REST surface. This is the structural guarantee behind "apply
@@ -162,6 +197,23 @@ concurrent applies of the same ids.
   TC-SLACKAPP-032. The case asserts the response is not the plain success text,
   because "recorded the approval and told the operator it worked" is the worst
   available outcome.
+- **TC-SLACKAPP-034b** — a claim write that fails for any **other** reason starts
+  nothing. Only `ParameterAlreadyExists` means "another delivery won"; an
+  `AccessDeniedException` (the boundary rollout has not happened yet), a throttle,
+  or a parameter-limit error must abort. Treating them all as a lost race would send
+  the delivery down the losing-claim path, where an **absent** claim reads as
+  recoverable and starts an apply no record vouches for. The log carries the error
+  **class**, not just the message: `AccessDeniedException` is a deploy-order
+  problem whose message ("not authorized to perform ssm:PutParameter") reads like a
+  policy bug without it.
+- **TC-SLACKAPP-034c** — a stamp failure is reported loudly but does **not** fail
+  the run. The apply has already started, so calling it a failure would be wrong;
+  but the claim now lacks a `taskArn`, so a redelivery past the stale window starts
+  a second apply. Nothing else can detect that, so the log has to name it.
+- **TC-SLACKAPP-034d** — an approve click carrying no list reference reads no SSM
+  and applies nothing. Falling through would hand `undefined` to `loadOffered`,
+  where the `record.hash !== hash` mismatch happens to refuse it — by accident, and
+  only while that comparison stays in that order.
 - **TC-SLACKAPP-035** — a Reject click writes no approval record, starts no task,
   and updates the message. Reject must be cheap and total: it is the button an
   operator presses when something looks wrong.
@@ -189,6 +241,67 @@ concurrent applies of the same ids.
   present, and an OAuth misconfiguration (`hmacKey` empty → 503 on OAuth routes)
   does not disable the Slack route, nor vice versa. The two concerns share a
   Lambda; they must not share a failure mode.
+
+## Entrypoint wiring and stage config
+
+These exist because the routing cases above pass the Slack deps in directly, which
+proves `route` dispatches but says nothing about whether the deployed Lambda ever
+builds them. Mutation-proved: deleting `buildSlackDeps(cfg)` from `handler` left
+every TC-040..049 case green while every real click would 404.
+
+- **TC-SLACKAPP-044** — the Slack signing secret is read from
+  `{prefix}/slack/signing-secret` **decrypted**, in the same `GetParameters` call
+  as the OAuth values. It must be a SecureString: a signing secret in a plain
+  String parameter is readable by anything holding `ssm:GetParameters` on the
+  stage tree. The boundary admits `kms:Decrypt` scoped to
+  `parameter/mem9-on-aws/*`, so this read is inside the ceiling.
+- **TC-SLACKAPP-045** — an absent secret resolves to empty rather than throwing.
+  Every MCP client's auth loads through the same function, so enabling Slack on one
+  stage must not be able to take OAuth down on another. Deliberately unlike the
+  OAuth values, which do throw when missing.
+- **TC-SLACKAPP-046** — the parameter name is built from the injected prefix, so a
+  preview stage cannot read prod's secret. The alternative spelling — one shared
+  secret under a stage-less path — would let any preview Lambda verify and act on
+  prod's approval clicks.
+- **TC-SLACKAPP-047** — deps are built when the stage has a secret, carrying the
+  stage and prefix from env rather than a constant.
+- **TC-SLACKAPP-047b** — `runTask` reads its ECS inputs from
+  `{prefix}/cleanup/{cluster-name,task-def-arn,task-sg-id,subnet-ids}`, the same
+  parameters `scripts/run-consolidation-task.sh` reads, so it does not depend on
+  the apply task's infra existing yet — only on the names being right. The
+  `StringList` values are split to arrays, each parameter is asserted to land in
+  the field **named** for it (reading four names and asserting only that all four
+  were read passes even when `cluster` receives the task-def ARN — both are
+  non-empty strings, so the required-value check cannot tell them apart and the
+  mistake surfaces only from ECS, as an opaque validation error, after the approval
+  is claimed), `assignPublicIp` is `DISABLED`, and the
+  container override carries the **hash only**: an override is echoed by
+  `DescribeTasks` and recorded in CloudTrail, so ids there would put memory
+  identifiers in an audit log. The task reads the ids from the approved SSM record
+  instead, which is also the only thing the signature does not vouch for.
+- **TC-SLACKAPP-047c** — `RunTask` answers HTTP 200 with an **empty** `tasks[]` and
+  a populated `failures[]` when placement fails, so reading `tasks[0].taskArn`
+  unchecked resolves `undefined` and the caller stamps the claim and reports an
+  apply that never started. The same trap `run-bootstrap-task.sh` calls out.
+- **TC-SLACKAPP-047d** — an incomplete SSM input set fails **before** `RunTask`,
+  naming the missing parameter. Otherwise a missing `task-def-arn` reaches ECS as
+  `undefined` and returns an opaque validation error after the claim was written.
+- **TC-SLACKAPP-047e** — the entrypoint passes the built deps to the router,
+  asserted through `handler` on a body that reports the apply started. A bare 200
+  would not distinguish it: the 404 branch and every refusal reply are 200s too.
+- **TC-SLACKAPP-047f** — the approval record is written as a plain `String` with
+  `Overwrite: false`, and the post-`RunTask` stamp can overwrite the same record.
+  Both are runtime-only failures the handler-level cases cannot see, since the
+  handler asks for `{ overwrite: false }` and trusts the closure to send it:
+  `SecureString` is denied by the boundary (no `kms:Encrypt`,
+  no `kms:GenerateDataKey`), and `Overwrite: true` destroys the atomic claim that
+  is the only reason Slack's 3-second redelivery is safe.
+- **TC-SLACKAPP-048** — no secret means no deps, which is what makes the route 404.
+- **TC-SLACKAPP-049** — a secret **without** `STAGE`/`SSM_PREFIX` refuses to build
+  rather than half-building. A dep set with an empty `stage` authenticates clicks
+  correctly and then has `loadOffered`'s stage guard refuse every one of them —
+  a feature that looks deployed and rejects every approval. Failing at build is
+  louder and cheaper to diagnose.
 
 ## Classification: `topic`
 

--- a/docs/test-cases/slack-approval-loop.md
+++ b/docs/test-cases/slack-approval-loop.md
@@ -76,6 +76,13 @@ concurrent applies of the same ids.
   `X-Slack-Signature`. The test computes the expected value independently rather
   than calling the production signer, so a signer that agrees with itself but not
   with Slack fails here.
+- **TC-SLACKAPP-001b** — a base64-encoded body is decoded before verification.
+  API Gateway base64-encodes whenever it does not recognise the content type as
+  text, and the signature covers the decoded bytes, so verifying the encoded
+  string would 401 every real click while the rest of this suite passed — a
+  production-only failure no other case can see.
+- **TC-SLACKAPP-001c** — a base64 body tampered with after signing is still
+  rejected 401 with no side effect, so the decode cannot become a bypass.
 - **TC-SLACKAPP-002** — a body tampered with after signing is rejected with 401
   and **no** side effect: no SSM write, no `RunTask`, no upstream proxy call. The
   spies are asserted untouched, so an absent assertion cannot pass for a proven
@@ -160,6 +167,24 @@ concurrent applies of the same ids.
   hash is over a join with a separator no id can contain (without it `["ab","c"]`
   and `["a","bc"]` are one hash, so a click approving one list is accepted against
   the other).
+- **TC-SLACKAPP-023c** — the claim carries the offered record's Slack message
+  coordinates (`messageTs`, `messageChannel`) forward, and **omits** the keys
+  rather than setting them to `undefined` when the offered record has none. The
+  two serialize identically through `JSON.stringify`, but the apply task guards on
+  the parsed object, where `"messageTs" in claim` is the difference between
+  skipping the outcome update and calling `chat.update` with `ts: undefined`. The
+  coordinates are copied from the *offered record*, never from the interaction
+  payload: `container.message_ts` is right there in the payload, and the signature
+  proves the request came from Slack rather than that a workspace member did not
+  hand-craft the body — so trusting it would let anyone who can click point the
+  outcome update at any message they liked.
+- **TC-SLACKAPP-023d** — the same property through a real click, because `023c`
+  pins the unit and this pins the *wiring*: `loadOffered` narrowed the parsed
+  record to `{stage, hash, ids}`, so the coordinates were dropped before the claim
+  was ever built and the unit could be perfect while the apply got nothing. Half a
+  pair (or a non-string in either) yields neither, since `chat.update` needs both —
+  carrying one forward would move the failure from here, where it is a skipped
+  update, to the apply task, where it is an error after the deletions are done.
 - **TC-SLACKAPP-024** — an offered list that would exceed the 4096-byte standard
   parameter limit fails the run loud rather than truncating. Truncating would ask
   the operator to approve a list that is not the list they were shown — the one
@@ -217,7 +242,11 @@ concurrent applies of the same ids.
   `fetch` calls are enumerated and asserted to be Slack or upstream only, with no
   call to the mem9 REST surface. This is the structural guarantee behind "apply
   happens only in the ECS task" — a future edit that inlines a delete to save a
-  hop fails here.
+  hop fails here. The case also seeds an attacker-chosen `response_url` (a
+  link-local metadata address) and asserts no request reaches that host, and that
+  the happy path makes no outbound call at all: the handler documents that it
+  never follows `response_url` because doing so is an SSRF primitive, and this is
+  what makes that claim enforceable rather than a comment.
 - **TC-SLACKAPP-034** — a `RunTask` failure is surfaced, not swallowed: the
   response text says the apply did not start, the error is logged without the
   request body, and the claim remains so a retry can recover via
@@ -550,6 +579,96 @@ agreed with policy.
   on the existing ApiGatewayV2 — no Lambda Function URL, no new API, no new
   certificate.
 
+## Offering the list: the loop's entry point
+
+Everything above starts from a click. These cover what produces the thing to
+click on — the review run's `approvals/offered` write and its `chat.postMessage`.
+Nothing else in the loop can be exercised for real until this exists, and the
+ordering between the two writes is the part that is easy to get backwards.
+
+- **TC-SLACKAPP-105** — the record is written **before** the message is posted,
+  as a plain `String` with `Overwrite: true`. Ordering first: posting first leaves
+  a live Approve button that the callback rejects with "there is no current
+  approval list", spending a click and sending the operator after a backend fault
+  that does not exist. The type and the overwrite flag are runtime-only failures
+  like TC-SLACKAPP-047f's — the boundary denies a `SecureString` write, and
+  `Overwrite: false` would succeed once and then fail every later week with
+  `ParameterAlreadyExists`, silently ending the loop. Asserted on a shared
+  SSM+Slack event log rather than per-client call counts, because the ordering
+  between the two clients is the property.
+- **TC-SLACKAPP-106** — the message carries `record.hash` in **both** action
+  values, uses the exact `action_id`s the deployed handler branches on
+  (`cleanup_approve` / `cleanup_reject`), authenticates with a bearer bot token,
+  sets `redirect: "manual"`, and renders every offered id and its snippet. A
+  renamed `action_id` is a click the callback answers with "that button is not one
+  this app knows how to handle" — after the operator reviewed the whole list. The
+  ids-are-shown assertion is TC-SLACKAPP-024's argument on the other surface: a
+  hash covering ids the operator never saw is a *wrong* apply, not a failed one.
+- **TC-SLACKAPP-107** — a list Block Kit could not carry whole is refused rather
+  than posted. Slack's ceilings are 50 blocks per message, 3000 characters per
+  section, 2000 per button value, 150 per header, and an over-limit message is
+  rejected wholesale — so the operator sees nothing either way, and the only thing
+  a fence buys is a clear error. Note that one section per id would hit the block
+  limit at ~46 ids, **below** #102's default `--cap 50`: the id lines are packed
+  into as few sections as the character limit allows, and the test asserts every
+  limit on the built message rather than only the block count.
+- **TC-SLACKAPP-108** — `{ok: false, error}` at HTTP **200** is a failure. Every
+  Slack Web API method answers 200 for application errors, so a `response.ok`
+  check alone reports a message that was never delivered and the weekly loop looks
+  healthy while no operator ever sees a review list. The same case asserts the log
+  carries neither the bot token nor a sentinel memory snippet.
+- **TC-SLACKAPP-109** — a run with no deletions still **overwrites** the record
+  and posts nothing. The write is not conditional on there being something to
+  post: last week's Approve button is still live in the channel and its hash still
+  matches the record it was posted with, so skipping the write leaves a click that
+  applies a list this run's audit no longer stands behind.
+- **TC-SLACKAPP-110** — the message `ts` and channel are stamped onto the record
+  in a **second** write, and a stamp failure is reported without failing the
+  offer. The apply has to `chat.update` the message it was approved from and the
+  record is the only durable path for that `ts`, which does not exist until the
+  post returns. Losing the audit-trail update is strictly better than refusing an
+  approval the operator can act on.
+- **TC-SLACKAPP-111** — the message reports the `RETAIN` and `UNSTABLE` counts
+  alongside the approve set. Same argument as `verdictSummary`'s printed zeros: a
+  protected-topic rule that started matching everything, or a consensus that
+  collapsed, would otherwise read as a clean corpus.
+- **TC-SLACKAPP-112** — the offer happens on the **dry run** and never on
+  `--apply`. An apply that re-offered would overwrite the very record its own
+  claim was derived from, so a redelivery mid-apply would be compared against a
+  list the running task never saw.
+- **TC-SLACKAPP-113** — a failed offer exits **1** and names the decision list it
+  kept. A review run whose post failed has done its whole audit and offered
+  nothing; exit 0 makes that indistinguishable from a healthy week, and the
+  operator would notice only by the absence of a message they were not expecting
+  on any particular day. The decision file survives and is what a manual
+  `--apply --ids` reads.
+- **TC-SLACKAPP-114** — with no channel configured there is **no** offer dep at
+  all, so #102's operator CLI is unchanged. A dep that existed unconditionally
+  would have every hand-run dry run attempt an approval-record write the
+  operator's identity may not hold, and would post a clickable Approve button for
+  a list they ran locally just to look at.
+- **TC-SLACKAPP-115** — the bot token is read from `{prefix}/slack/bot-token`
+  **decrypted**, via `GetParameters`. It is a SecureString, so without decryption
+  the value returns as ciphertext and every post 401s with `invalid_auth`; and the
+  singular `ssm:GetParameter` is a distinct IAM action the boundary does not admit
+  (TC-SLACKAPP-047g).
+- **TC-SLACKAPP-116** — an injected `SLACK_BOT_TOKEN` wins and **no** parameter is
+  read. The apply task receives the token from ECS `ssm:` already decrypted, and
+  its task role holds `ssm:GetParameters` under `approvals/*` only — a
+  `slack/bot-token` read is an `AccessDenied` there. Same two-caller split as
+  `resolveDatabaseConfig`.
+- **TC-SLACKAPP-117** — a configured channel with no reachable token is a
+  **failure**, not a skipped post. Skipping is TC-SLACKAPP-113 with the alarm
+  removed.
+- **TC-SLACKAPP-118** — the stage, the injected SSM prefix, and the channel all
+  reach a real offer: the record lands at `{prefix}/approvals/offered` built from
+  the prefix rather than a constant, so a preview run cannot write prod's record.
+- **TC-SLACKAPP-119** — a replayed `--decisions` file is re-offered under the
+  **file's** `generatedAt`, not the moment it was reposted. This is the path an
+  operator takes to repost after a failed offer; stamping `now` would claim a
+  fresh audit for a classification that may be days old, removing their only cue
+  that they are approving stale judgments.
+
 ## The apply task's in-container runtime
 
 Everything above gets a claimed approval as far as `RunTask`. These cover what
@@ -585,6 +704,12 @@ made safe or quietly defeated.
   quotes an id. The file lands on the task's ephemeral disk and the record it is
   built from is a plain `String` parameter, so a record that later grew a
   `snippet` must not have it copied through. The **count** is logged instead.
+- **TC-SLACKAPP-098b** — what `materializeApprovedIds` *returns* is a count and the
+  Slack message coordinates, never the ids. The return value is what the outcome
+  update closes over and it travels to `chat.update`, so ids on it would reach a
+  Slack message the moment anything spread the claim into a payload — the ids file
+  is the only place they go. Both halves are asserted, since "no ids returned"
+  would also be satisfied by not writing them anywhere.
 - **TC-SLACKAPP-099** — the image ships every module the entrypoints copied into it
   can import, its lockfile agrees with its `package.json` (`npm ci` refuses to
   install otherwise, so a stale lock means no image at all), and each entrypoint
@@ -616,13 +741,112 @@ made safe or quietly defeated.
   hold the shared mutex for the length of its own failure and could block the
   weekly consolidation.
 
+## Closing the loop on the message
+
+The offer posts and the apply deletes; without these the message keeps showing a
+live Approve button and no record of what happened, which is the audit trail the
+message exists to be. Everything here runs **after** irreversible deletions, and
+that is the single constraint that shapes all of it: nothing in this section may
+fail the run.
+
+- **TC-SLACKAPP-120** — the outcome reports what was **DELETED** (`capUsed`), not
+  what was approved. An apply that approved 3 and deleted 1 lost two to the LWW
+  guard and has to say so; the approved count would tell the operator memories are
+  gone that are still there, and since this message *is* the audit trail nothing
+  downstream would ever correct it. Asserted as an ordering of the two numbers
+  rather than against a phrase, so the wording is not pinned. The `actions` block
+  is **gone**: `chat.update` replaces blocks wholesale, which is what removes the
+  buttons — leaving them would offer a hash whose claim already exists, and the
+  callback answers that click with "someone else is already applying".
+- **TC-SLACKAPP-121** — a capped (exit 4) or partial (exit 6) apply says so, and is
+  distinguishable from a clean one. Both stop early with real deletions already
+  done, so a count-only message would read identically to a complete run while the
+  operator's next move differs: a capped run left approved ids untouched and needs
+  a fresh review. Named by what to *do* about it rather than by the exit code,
+  which in a Slack message is a lookup.
+- **TC-SLACKAPP-122** — the outcome names no memory id and no content. The review
+  message carries ids and snippets because that is what the operator reviews; the
+  outcome needs neither, and this runs in the apply task whose log already reaches
+  CloudWatch — adding them widens where identifiers live for no operator benefit.
+- **TC-SLACKAPP-123** — the update targets the **claim's** coordinates, and is
+  skipped when either is absent. `chat.update` requires both `channel` and `ts`;
+  calling with `undefined` earns a `channel_not_found` that reads like a
+  misconfigured channel rather than an unstamped record. Half a pair is included
+  and is the sharper case — the second of two independent guards (the Lambda's
+  `loadOffered` is the first), placed in the process that would have to report the
+  confusing error. A skip is logged: a systematically unstamped record must not
+  look like a working loop forever.
+- **TC-SLACKAPP-124** — a refused update never turns a completed apply into a
+  failure. `edit_window_closed` or a revoked token must not make the task exit
+  non-zero: that alarms on a successful apply, and under the callback's stale-claim
+  recovery a retried task would re-apply ids that are already gone. Loud in the
+  log, harmless to the exit code.
+- **TC-SLACKAPP-125** — the apply run reports **once**, after the lockfile and the
+  shared mutex are released, with the numbers it achieved. Once because a message
+  updated per flush would show intermediate counts as if they were outcomes; after
+  the release because reporting inside the `finally` would hold the shared mutex
+  across a Slack round trip and could block the weekly consolidation. The stamp
+  comes from the run's injected clock, so two timestamps on one run agree.
+- **TC-SLACKAPP-126** — a dry run does not update (it *posts*), and an apply with no
+  report dep runs to completion. The #102 operator CLI has no Slack at all and must
+  not throw on a missing function.
+- **TC-SLACKAPP-127** — a report that throws does not change the exit code, and the
+  reason reaches the log. Same argument as 124, one layer out.
+- **TC-SLACKAPP-128** — the coordinates reach the dep the container builds, closing
+  the chain the offer started: offered record → claim → materialize → dep →
+  `chat.update`. This link carries them out of a read that was already happening,
+  which makes it the one most likely to be forgotten because nothing else needs
+  them. The hash is on the message too — it is the only handle for correlating the
+  message with the task log and the claim parameter.
+- **TC-SLACKAPP-129** — two absences that must degrade rather than fail: a review
+  run builds no report dep, and a hash-driven run with no `SLACK_BOT_TOKEN` still
+  materializes its ids and applies. The asymmetry with the *offer*, which throws on
+  a missing token, is deliberate: there, failing loud costs an unposted list nobody
+  has acted on; here, it would cost deletions the operator already authorized. The
+  apply task cannot even read the token parameter — its role holds
+  `ssm:GetParameters` under `approvals/*` only, so the value arrives through the
+  task definition's `ssm:` block, already decrypted.
+
 ## Logging and privacy
 
 - **TC-SLACKAPP-089** — no log line contains the bot token, the signing secret,
-  the raw request body, or memory content, on **any** path including every error
-  path. Asserted by capturing all log output across the failure cases and
-  matching against the secret values and a sentinel memory snippet, rather than
-  by inspecting the happy path only.
+  the raw request body, memory content, or a memory **id**, on **any** path
+  including every error path. Asserted by capturing all log output across eleven
+  cases and matching against the secret values, a sentinel memory snippet, and
+  every id, rather than by inspecting the happy path only. The reply is held to
+  the same standard: "ephemeral" is a visibility scope in one workspace, not a
+  confidentiality boundary.
+
+  The sweep is what found the leaks, and all three were the same shape — **an
+  error's `message` echoes the argument the failed call was given**:
+
+  | call | what its message can echo |
+  |---|---|
+  | the claim write | its value is the id list, and an SSM `ValidationException` quotes the value it rejected |
+  | the claim stamp | the same list one call later, which the claim-write case cannot reach because it throws first |
+  | `JSON.parse` of the `payload` field | V8 quotes the first ten characters of the input, and that field is the one part of a signed request whose content the signature says nothing about |
+
+  The fix is to log the failure **class** (`err.name`, via `failureClass`) or a
+  fixed reason string chosen in the handler — never the message. Deliberately not
+  a redactor: a substring scrub would be a guess about what the SDK chose to
+  include and would silently stop matching when it changes.
+
+  Two properties keep the sweep honest, because a `not.toContain` sweep is the
+  easiest kind of test to make vacuous:
+
+  - each failure case also asserts a phrase **its own branch** must log, which
+    proves the fixture drove the handler down the path its label claims;
+  - a companion case logs a deliberate leak and asserts every matcher **fails**
+    on it.
+
+- **TC-SLACKAPP-034e** — the three ways a body yields no action ("no payload
+  field", the field is not valid JSON, no actions) stay distinguishable in the
+  log, asserted on the SET of messages so one string containing every phrase
+  cannot satisfy it. TC-089 forbids logging the parse error, and the cheapest way
+  to satisfy that is one flat "bad payload" for all three — but each sends the
+  operator somewhere different: a missing field means the form encoding is wrong,
+  unparseable JSON means the body is not Slack's, and no actions means the
+  message template changed.
 
 ## E2E (PR preview stage)
 
@@ -632,6 +856,54 @@ made safe or quietly defeated.
   Then POST the same body with an invalid signature: expect 401 and **no** new
   record. The record is read back by name, so "no record" is a positive
   assertion rather than the absence of one.
+
+  `scripts/run-slack-approval-e2e.sh` is the harness; the CI step runs it after
+  the preview deploy, and `scripts/run-slack-approval-e2e.test.mjs` drives the
+  script itself against a fake `aws` and a fake `curl` (the fake `curl` decides
+  which POST it is by the **signature header**, exactly as the real endpoint
+  does). Seven decisions in it are load-bearing:
+
+  - **The invalid POST goes first.** After a successful click there is a record,
+    and nothing can then tell the two writers apart — so ordering is what makes
+    "no record was written" assertable at all.
+  - **Same body both times.** A different body would make the 401 provable by the
+    body rather than by the signature, which is not the property under test.
+  - **A 200 on the invalid signature is a hard failure.** A façade that accepted
+    an unsigned interaction would otherwise pass every other assertion here.
+  - **The record is read back by name, and its `taskArn` is required.** A 200
+    alone proves nothing: the handler also answers 200 for a stale hash, an
+    unknown action, and "already applied". A claim with no `taskArn` is the exact
+    state a `RunTask` failure leaves behind.
+  - **The apply task's own exit code is checked.** Without it the run passes on a
+    click that started a task which then crashed.
+  - **The signing secret reaches the HMAC through the ENVIRONMENT**, not an argv:
+    `openssl dgst -hmac "$SECRET"` is the obvious way to write this in bash and
+    would put the secret in a world-readable command line. Pinned by a static
+    assertion over the script source, because the fakes only see the commands they
+    replace and would happily let the argv version pass.
+  - **`pr-N` stages only, refused before the first write.** The harness
+    *overwrites* `approvals/offered`, so on a shared stage it destroys a pending
+    human approval — the operator's next click would be answered against CI's
+    record — and the id it approves is a **deletion** against that stage's
+    database. Hence also no prod CI step, asserted on the workflow rather than
+    left to a comment, since copying a green preview step into `deploy-prod` is
+    the obvious next edit. A refusal, not a skip: exit 0 would let a workflow edit
+    silently stop testing anything while reporting green.
+
+  The approved id is a synthetic sentinel (`mem9-e2e-nonexistent-{stage}`) that
+  cannot name a real memory, and the apply's "already gone" branch is what makes
+  the run exit 0. Both records are deleted on **every** exit, including failure:
+  the claim is written `Overwrite: false`, so a leftover would make the next run's
+  click a losing claim that starts nothing.
+
+  Both absent prerequisites — no `facade/url`, no `slack/signing-secret` — are
+  `::warning::` skips rather than failures, matching `run-oauth-facade-smoke.sh`.
+  Slack approval is gated on `MEM9_SLACK_APPROVAL_ENABLED` at synth time, so a
+  hard failure would block every PR on a feature the stage does not deploy. That
+  flag is passed from a repo **variable** rather than a literal `1` for the same
+  reason: `infra/slack-approval.ts` fails synthesis when the flag is set and
+  either secret is unseeded, and GitHub hands an unset secret to the job as an
+  empty string.
 
 ## Exit codes
 

--- a/docs/test-cases/slack-approval-loop.md
+++ b/docs/test-cases/slack-approval-loop.md
@@ -327,6 +327,13 @@ every TC-040..049 case green while every real click would 404.
   `SecureString` is denied by the boundary (no `kms:Encrypt`,
   no `kms:GenerateDataKey`), and `Overwrite: true` destroys the atomic claim that
   is the only reason Slack's 3-second redelivery is safe.
+- **TC-SLACKAPP-047g** — every parameter read goes through `GetParametersCommand`.
+  `ssm:GetParameter` and `ssm:GetParameters` are **distinct** IAM actions and the
+  boundary's action ceiling admits only the plural, so the singular is an
+  `AccessDenied` on the first real click. Asserted on the command **class**, not
+  the response: the two are interchangeable from the caller's side — same
+  parameter in, same value back — so only IAM can tell them apart, and an
+  injected fake answers either shape. Runtime-only otherwise.
 - **TC-SLACKAPP-048** — no secret means no deps, which is what makes the route 404.
 - **TC-SLACKAPP-049** — a secret **without** `STAGE`/`SSM_PREFIX` refuses to build
   rather than half-building. A dep set with an empty `stage` authenticates clicks
@@ -542,6 +549,72 @@ agreed with policy.
 - **TC-SLACKAPP-088** — the Lambda is `nodejs24.x` on `arm64`, and the route is
   on the existing ApiGatewayV2 — no Lambda Function URL, no new API, no new
   certificate.
+
+## The apply task's in-container runtime
+
+Everything above gets a claimed approval as far as `RunTask`. These cover what
+the container itself then does, which is where the hash-only override is either
+made safe or quietly defeated.
+
+- **TC-SLACKAPP-091** — the ids come from the **claim**
+  (`approvals/approved-{hash}`), never from `approvals/offered`. Both are seeded
+  with **different** ids, so reading the wrong record cannot pass: `offered` is
+  overwritten by every run, and reading it would apply the CURRENT run's list
+  under an approval the operator gave for an earlier one. Asserted on which names
+  were read, not only on the resulting file.
+- **TC-SLACKAPP-092** — a claim whose ids do not hash to the requested hash is
+  refused, and no ids file is written. The record's own `hash` field is set to
+  **agree** with the request, so comparing those two strings passes; only
+  re-deriving the hash over the ids makes them the thing the hash vouches for.
+- **TC-SLACKAPP-093** — a claim naming another stage is refused. Same guard as
+  #102's decision-file stage check: a preview approval must never apply to prod.
+- **TC-SLACKAPP-094** — an absent claim is refused, not treated as an empty
+  approval. SSM echoes an unknown name in `InvalidParameters` and simply omits it
+  from `Parameters`, so the value is `undefined` and must not fall through to an
+  empty ids file.
+- **TC-SLACKAPP-095** — a claim with an empty id list is refused. `[]` hashes
+  consistently, so the hash check cannot catch this one.
+- **TC-SLACKAPP-096** — a malformed claim is refused by shape, and the error never
+  quotes the value: this parameter is the one place ids legitimately live, so a
+  stack that echoed it would copy them into the log.
+- **TC-SLACKAPP-097** — the ids file is newline-delimited exactly as `--ids`
+  parses it, round-tripped through the **real** `runCleanup`. `readApprovedIds`
+  splits on `"\n"`, so a JSON array or a comma-joined line parses as one id and
+  silently approves nothing — a shape assertion alone would not catch it.
+- **TC-SLACKAPP-098** — the ids file never contains memory content and no log line
+  quotes an id. The file lands on the task's ephemeral disk and the record it is
+  built from is a plain `String` parameter, so a record that later grew a
+  `snippet` must not have it copied through. The **count** is logged instead.
+- **TC-SLACKAPP-099** — the image ships every module the entrypoints copied into it
+  can import, its lockfile agrees with its `package.json` (`npm ci` refuses to
+  install otherwise, so a stale lock means no image at all), and each entrypoint
+  has a build-time import guard. Every AWS client in these files is imported
+  **lazily**, so a missing one is invisible until that exact path runs — i.e. after
+  an approval has been spent, on a click that cannot be re-made. Asserted over
+  every specifier the file can name rather than the ones a given argv reaches: the
+  two errors are not symmetric.
+- **TC-SLACKAPP-100** — in the container the database configuration comes from the
+  environment, with **no** SSM or Secrets Manager read. The task role holds
+  `ssm:GetParameters` only under `approvals/*`, so the operator CLI's `db/*`
+  discovery is an `AccessDenied` inside the task; ECS resolves the secret through
+  the execution role instead. Asserted on the connection options, because a path
+  that read the env and handed `pg` a partly-undefined config still constructs.
+- **TC-SLACKAPP-101** — the operator CLI still resolves the database through SSM
+  and Secrets Manager. Both paths must work from one function: a container-only
+  rewrite would break the #102 runbook.
+- **TC-SLACKAPP-102** — the ids are materialized at the **exact** `--ids` path the
+  task definition passes. That path is a contract spanning two files; a file
+  written elsewhere leaves `readApprovedIds` reading a missing or stale one.
+- **TC-SLACKAPP-103** — an approval hash with no `--ids` is refused. This is the
+  loop's worst failure mode rather than a degraded one: `readApprovedIds` returns
+  null for an absent `--ids`, null means "no filter", so the run would delete every
+  `DELETE` verdict it found instead of the approved subset and exit 0 reporting
+  success.
+- **TC-SLACKAPP-104** — a mismatched claim aborts **before** the database is opened
+  and before the advisory lock is taken. Ordering, not just the error: the
+  materialization is the cheapest guard, and a tampered claim failing later would
+  hold the shared mutex for the length of its own failure and could block the
+  weekly consolidation.
 
 ## Logging and privacy
 

--- a/infra/consolidation.test.ts
+++ b/infra/consolidation.test.ts
@@ -4,6 +4,7 @@ import { parse } from "yaml";
 import type { DbOutputs } from "./db";
 import type { EcsOutputs } from "./ecs";
 import type { TenantIdentityOutputs } from "./tenant-identity";
+import { cloudwatchStubs } from "./task-failure-alarm.test-fixtures";
 
 interface Output<T> {
   value: T;
@@ -188,44 +189,16 @@ function installGlobals(stage: string) {
         }
       },
     },
-    cloudwatch: {
-      EventRule: class {
-        arn = out("arn:aws:events:ap-northeast-1:123456789012:rule/consolidation");
-        name = out("consolidation");
-        constructor(logicalName: string, args: Record<string, unknown>) {
-          record("EventRule", logicalName, args);
-        }
-      },
-      EventTarget: class {
-        constructor(logicalName: string, args: Record<string, unknown>) {
-          record("EventTarget", logicalName, args);
-        }
-      },
-      LogGroup: class {
-        arn = out(
-          "arn:aws:logs:ap-northeast-1:123456789012:log-group:/aws/events/consolidation",
-        );
-        name = out("/aws/events/consolidation");
-        constructor(logicalName: string, args: Record<string, unknown>) {
-          record("LogGroup", logicalName, args);
-        }
-      },
-      LogResourcePolicy: class {
-        constructor(logicalName: string, args: Record<string, unknown>) {
-          record("LogResourcePolicy", logicalName, args);
-        }
-      },
-      LogMetricFilter: class {
-        constructor(logicalName: string, args: Record<string, unknown>) {
-          record("LogMetricFilter", logicalName, args);
-        }
-      },
-      MetricAlarm: class {
-        constructor(logicalName: string, args: Record<string, unknown>) {
-          record("MetricAlarm", logicalName, args);
-        }
-      },
-    },
+    // The task-failure alarm's six resources. Shared with slack-approval.test.ts
+    // because both stacks now build them through one helper; MetricAlarm is also
+    // used by this stack's Scheduler TargetErrorCount alarm, which the same stub
+    // records.
+    cloudwatch: cloudwatchStubs({
+      record,
+      out,
+      ruleName: "consolidation",
+      logGroupName: "/aws/events/consolidation",
+    }),
     ssm: {
       Parameter: class {
         constructor(logicalName: string, args: Record<string, unknown>) {

--- a/infra/consolidation.ts
+++ b/infra/consolidation.ts
@@ -3,6 +3,7 @@ import type { EcsOutputs } from "./ecs";
 import { resolveVpc } from "./vpc";
 import { accountId, ECR_REGION, ecrImage } from "./ecr";
 import type { TenantIdentityOutputs } from "./tenant-identity";
+import { taskFailureAlarm } from "./task-failure-alarm";
 
 const IMAGE_TAG = process.env.MEM9_IMAGE_TAG || "latest";
 const BEDROCK_PROJECT = process.env.MEM9_BEDROCK_PROJECT;
@@ -16,7 +17,6 @@ const RESPONSES_REGION = process.env.MEM9_LLM_RESPONSES_REGION || "us-west-2";
 const SCHEDULE_ENABLED =
   process.env.MEM9_CONSOLIDATION_SCHEDULE_ENABLED === "1";
 export const CONSOLIDATION_CONTAINER_NAME = "Mem9Consolidation";
-const FAILURE_NAMESPACE = "mem9-on-aws";
 const FAILURE_METRIC = "ConsolidationTaskFailures";
 
 export interface ConsolidationOutputs {
@@ -204,112 +204,25 @@ export function consolidation(
     });
 
   if (ecsOut.alertsTopicArn) {
-    const failureLogGroup = new aws.cloudwatch.LogGroup(
-      "ConsolidationTaskFailureEvents",
-      {
-        name: `/sst/consolidation/${$app.stage}/task-failures`,
-        retentionInDays: 30,
-        tags,
-      },
-    );
-    const failureRule = new aws.cloudwatch.EventRule(
-      "ConsolidationTaskFailureRule",
-      {
-        // 64-char rule limit MINUS Pulumi's 26-char suffix. The former
-        // `...-consolidation-failure-` prefix was 39 chars for `prod` alone,
-        // producing a 65-char name that PutRule rejected on the first prod
-        // deploy after merge.
-        namePrefix: boundedNamePrefix(
-          `mem9-on-aws-${$app.stage}-consol-failure-`,
-          64,
-          "consolidation failure rule",
-        ),
-        description:
-          "Captures non-zero exits from the exact consolidation task revision.",
-        eventPattern: $jsonStringify({
-          source: ["aws.ecs"],
-          "detail-type": ["ECS Task State Change"],
-          detail: {
-            lastStatus: ["STOPPED"],
-            taskDefinitionArn: [task.taskDefinition],
-            containers: {
-              exitCode: [{ "anything-but": 0 }],
-            },
-          },
-        }),
-        tags,
-      },
-    );
-
-    const failureLogPolicy = new aws.cloudwatch.LogResourcePolicy(
-      "ConsolidationTaskFailureLogPolicy",
-      {
-        policyName: `mem9-on-aws-${$app.stage}-consolidation-events`,
-        policyDocument: $jsonStringify({
-          Version: "2012-10-17",
-          Statement: [
-            {
-              Effect: "Allow",
-              Principal: {
-                Service: [
-                  "events.amazonaws.com",
-                  "delivery.logs.amazonaws.com",
-                ],
-              },
-              Action: ["logs:CreateLogStream", "logs:PutLogEvents"],
-              Resource: $interpolate`${failureLogGroup.arn}:*`,
-            },
-          ],
-        }),
-      },
-    );
-
-    new aws.cloudwatch.EventTarget(
-      "ConsolidationTaskFailureLogTarget",
-      {
-        arn: failureLogGroup.arn,
-        rule: failureRule.name,
-        inputTransformer: {
-          inputPaths: {
-            exitCode: "$.detail.containers[0].exitCode",
-          },
-          inputTemplate: JSON.stringify({
-            event: "consolidation_task_failed",
-            stage: $app.stage,
-            exitCode: "<exitCode>",
-          }),
-        },
-      },
-      { dependsOn: [failureLogPolicy] },
-    );
-
-    new aws.cloudwatch.LogMetricFilter("ConsolidationTaskFailureFilter", {
-      logGroupName: failureLogGroup.name,
-      pattern:
-        `{ $.event = "consolidation_task_failed" && ` +
-        `$.stage = "${$app.stage}" }`,
-      metricTransformation: {
-        name: FAILURE_METRIC,
-        namespace: FAILURE_NAMESPACE,
-        value: "1",
-        dimensions: { stage: "$.stage" },
-      },
-    });
-
-    new aws.cloudwatch.MetricAlarm("ConsolidationTaskFailureAlarm", {
+    taskFailureAlarm({
+      stem: "ConsolidationTaskFailure",
+      logGroupName: `/sst/consolidation/${$app.stage}/task-failures`,
+      // The former `...-consolidation-failure-` prefix was 39 chars for `prod`
+      // alone, producing a 65-char name that PutRule rejected on the first prod
+      // deploy after merge — hence the abbreviation, and hence the budget check
+      // inside the helper.
+      rulePrefix: `mem9-on-aws-${$app.stage}-consol-failure-`,
+      ruleWhat: "consolidation failure rule",
+      ruleDescription:
+        "Captures non-zero exits from the exact consolidation task revision.",
+      policyName: `mem9-on-aws-${$app.stage}-consolidation-events`,
+      eventName: "consolidation_task_failed",
+      metricName: FAILURE_METRIC,
       alarmDescription:
         "The weekly memory consolidation ECS task exited non-zero.",
-      namespace: FAILURE_NAMESPACE,
-      metricName: FAILURE_METRIC,
-      dimensions: { stage: $app.stage },
-      statistic: "Sum",
-      period: 300,
-      evaluationPeriods: 1,
-      datapointsToAlarm: 1,
-      threshold: 1,
-      comparisonOperator: "GreaterThanOrEqualToThreshold",
-      treatMissingData: "notBreaching",
-      alarmActions: [ecsOut.alertsTopicArn],
+      taskDefinitionArn: task.taskDefinition,
+      alertsTopicArn: ecsOut.alertsTopicArn,
+      tags,
     });
   }
 

--- a/infra/oauth-facade.test.ts
+++ b/infra/oauth-facade.test.ts
@@ -121,9 +121,16 @@ function installGlobals(stage: string) {
           created.push({ kind: "ApiGatewayV2", args: args ?? {} });
         }
       },
-      // Façade Function — SST zips the handler + makes the exec role. Exposes `.arn`.
+      // Façade Function — SST zips the handler + makes the exec role. Exposes
+      // `.arn` and `.nodes.role` (the role the approval grants attach to).
       Function: class {
         arn = out("arn:aws:lambda:ap-northeast-1:123456789012:function:facade");
+        nodes = {
+          role: {
+            name: out("facade-fn-role"),
+            arn: out("arn:aws:iam::123456789012:role/facade-fn-role"),
+          },
+        };
         constructor(_n: string, args: Record<string, unknown>) {
           created.push({ kind: "SstFunction", args });
         }
@@ -502,6 +509,31 @@ describe("oauthFacade factory", () => {
     expect(outs.readerClientId).toBeDefined();
     expect(outs.facadeUrl).toBeDefined();
     expect(outs.ssmPrefix).toBe("/mem9-on-aws/prod");
+  });
+
+  it("TC-SLACKAPP-081: sets STAGE so a configured signing secret can build the Slack callback", async () => {
+    installGlobals("prod");
+    const oauthFacade = await loadFacade();
+    oauthFacade(fakeCognitoOut());
+    const environment = only("SstFunction").environment as Record<
+      string,
+      unknown
+    >;
+    // buildSlackDeps THROWS when a signing secret exists but STAGE is unset, and
+    // it throws at cold start on EVERY invocation — so the interactions endpoint
+    // 500s for every click while the deploy stays green. Neither loadConfig nor
+    // resolveSsm reads STAGE, so nothing else in the config path surfaces this.
+    expect(unwrap(environment.STAGE)).toBe("prod");
+  });
+
+  it("TC-SLACKAPP-081: exposes the function role name so the approval grants can attach to it", async () => {
+    installGlobals("prod");
+    const oauthFacade = await loadFacade();
+    const outs = oauthFacade(fakeCognitoOut());
+    // The approval-record write and RunTask grants belong to THIS role. Without
+    // the name on the outputs, infra/slack-approval.ts cannot attach them, and a
+    // second role would need its own boundary exception.
+    expect(unwrap(outs.functionRoleName)).toBe("facade-fn-role");
   });
 
   it("exports the reader client id/secret + facade url/mcp-endpoint to SSM", async () => {

--- a/infra/oauth-facade.ts
+++ b/infra/oauth-facade.ts
@@ -62,6 +62,13 @@ export interface OauthFacadeOutputs {
   ssmPrefix: string;
   readerClientId: Output<string>;
   facadeUrl: Output<string>;
+  /**
+   * The façade Function's execution role NAME (not ARN — `aws.iam.RolePolicy`
+   * takes the name). `infra/slack-approval.ts` attaches the approval-record write
+   * and the RunTask/PassRole grants to this role rather than creating a second
+   * one, which would need its own workload-boundary exception (#123).
+   */
+  functionRoleName: Output<string>;
 }
 
 export function oauthFacade(cognitoOut: CognitoOutputs): OauthFacadeOutputs {
@@ -191,6 +198,12 @@ export function oauthFacade(cognitoOut: CognitoOutputs): OauthFacadeOutputs {
     memory: "256 MB",
     environment: {
       SSM_PREFIX: prefix,
+      // Read by buildSlackDeps (#123). It THROWS when a Slack signing secret is
+      // configured but STAGE is unset, and it throws at cold start on every
+      // invocation — so the interactions endpoint would 500 on every click while
+      // the deploy stayed green. Neither loadConfig nor resolveSsm reads STAGE,
+      // so nothing else in the config path would surface the omission.
+      STAGE: stage,
       COGNITO_ISSUER: cognitoOut.issuer,
       COGNITO_AUTHORIZE_ENDPOINT: cognitoOut.authorizeEndpoint,
       COGNITO_TOKEN_ENDPOINT: cognitoOut.tokenEndpoint,
@@ -282,5 +295,6 @@ export function oauthFacade(cognitoOut: CognitoOutputs): OauthFacadeOutputs {
     ssmPrefix: prefix,
     readerClientId: readerClient.id,
     facadeUrl: facadeApi.url,
+    functionRoleName: facadeFn.nodes.role.name,
   };
 }

--- a/infra/package.json
+++ b/infra/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-bedrock-agentcore-control": "^3.900.0",
+    "@aws-sdk/client-ecs": "^3.1103.0",
     "@aws-sdk/client-ssm": "^3.700.0"
   },
   "devDependencies": {

--- a/infra/pnpm-lock.yaml
+++ b/infra/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@aws-sdk/client-bedrock-agentcore-control':
         specifier: ^3.900.0
         version: 3.1086.0
+      '@aws-sdk/client-ecs':
+        specifier: ^3.1103.0
+        version: 3.1103.0
       '@aws-sdk/client-ssm':
         specifier: ^3.700.0
         version: 3.1084.0
@@ -46,6 +49,10 @@ packages:
     resolution: {integrity: sha512-1RBaTmpIME8kQzOSE3dH1Jj4nmXx1cWMi5KeX5b6HFxZgGsROisQJJ3PPidHPGrlr6Lj8JYWuIgjSPTSL5QoLQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-ecs@3.1103.0':
+    resolution: {integrity: sha512-tmciwOTT02q1BM+eub7WBUnOs4TvzbYPCu2hQRE+47boJD5XQKJUSKRIhzQ/zU2IL+sAv/S82hES8TDBCXzCpg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-lambda@3.1084.0':
     resolution: {integrity: sha512-4sc5dyO/nItSnsrTj2tE2LE8X2zG6UjYvNmiin+oSR8AcIouazAcH5sIJYS9Mv2vjOGL2w2g7LbvT3R3ZH69zg==}
     engines: {node: '>=20.0.0'}
@@ -58,20 +65,40 @@ packages:
     resolution: {integrity: sha512-8qh/6EYb7hl/ZwVfQufhbMEZs1gQIc7GbdrIf4eprQJ7cv042+74nE6l3YDfyWNzb9iPXb8fRyYSHkNIk5eE6Q==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/core@3.977.6':
+    resolution: {integrity: sha512-QiaJV4/zDrB4ZY2mfeSXSzSTc36W16sZXcGz+SPFk0CJ26gziO0cS+4LjJUMAbdeeBOvS0k0Aq1cZpfGdUXxSw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-env@3.972.57':
     resolution: {integrity: sha512-1RfJaF7SW1TOnvNGU7kaYjwUf5H3sfm+synGH1bHhRlqcnxCt3szebH3dmKEyY4tuGcbQ6ffzUT89cRitBV8OQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.67':
+    resolution: {integrity: sha512-rcIpk5kxUqDaaNa6Xk23pQ6ViY7jlqzmfFWCahQcBT97ddXaXYYwzCen9Tz1Jvo6aJft6wDl5bN44/Jw5B4oLA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-http@3.972.59':
     resolution: {integrity: sha512-sRCkpTiFnCdQvuaRVjQ6SVoHu6i7RUpurVo1c4F81HWhPvUJ7Wdp5MNtSdX1O29CNXc8em3O5m52hCjVtAD9SA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-http@3.972.69':
+    resolution: {integrity: sha512-nggwJtZ4eeNsUw5IeWBMXsi1ryct5idi0K+/SCRF3kybLubOMaNTb3XCihXpWMiVpyzyPeIrl0zTkzhBH9porA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-ini@3.973.1':
     resolution: {integrity: sha512-6d8H6ZAh3ZPKZ6fe1nG2OWeZEZPtt9ravoD1dezPdPtsSkJRoxGAnFSHwKT3E/Te6fHE30zRzjV6TD12rvF6yQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-ini@3.973.12':
+    resolution: {integrity: sha512-pNEf/OeyN5X3VmLKlgSO6TqaWmW10CvI3TfwL1XhsuhYjSLT2VDaxFnCPHnOeQXSaFisMX4jNhpETriqN8DOmg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-login@3.972.63':
     resolution: {integrity: sha512-GREWRrMj0XnNKMaVa/Mauoaui26qBEHu71WWqXbwZOu/jFQOnPZjTf7u0KtGKC8VGa6VUs9kDWGgocrKNLS9vw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.74':
+    resolution: {integrity: sha512-0AQfDcf99TNmqVKv0owHrw/TQs6i4ZE5t9qmz6NvO53bE/sA/tpXhXL9AAcEP1qHc6Zzjd1UMb69+/9zdhvY3g==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-node@3.972.66':
@@ -82,36 +109,72 @@ packages:
     resolution: {integrity: sha512-oYlzWst56rlhhjbYnexwv5hVLYe1cW4liLObhDfxDLI4RAQzleMVHQgQgx7XsC4HKj4e3kjT8v9DId+Pi/dndw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-node@3.972.78':
+    resolution: {integrity: sha512-OgPAnfvbGAMWac6yvxJ1ihslrvDpPVwR68D2csospdNCCyPvHk9JLzYKwz48SNiS1T2znDwHauywRKRFfpyYng==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-process@3.972.57':
     resolution: {integrity: sha512-TiVQhuU0pbhIZAUZacbPHMyzrIdiH+lnx+PMY/Pu/b93dJrq3wdZwzUJ0TPpvNxaqbHsxJvQZW3/h/beLiKq7Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.67':
+    resolution: {integrity: sha512-IlUEejorGTWKb4/Dm7K5Yw4QxUmXLThLhrvBmzVBqZFTbW72cv9LTcITmo1dsnYriALE4h68mOq4LB99x6sQ7Q==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-sso@3.973.1':
     resolution: {integrity: sha512-3foTZUJ4821Ij60X7K3NJroygiZLnbBmarN+T//O2cjkISan90zElN3NBmgSlDrTQ7Gs6z/yO8V7h60QNcDZHQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.973.11':
+    resolution: {integrity: sha512-gAQBkBZxUB84d71+pPcI9L+jh2ujhuAVxc/4FgGiWFDjkPBlMKxzd5XDtkSXTFX8Ro7ansnT88+XadasxMeCRw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.972.63':
     resolution: {integrity: sha512-8qZLFhM69eKcS37m459ctPR05Qimycm/74OPVioe6wNZabMT54GYhwBju0+J656RkMasNSawWQu+c8CmBe3TUQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.73':
+    resolution: {integrity: sha512-SnlEmQa6SjOgs6iOPLUQl1Eyq4AKiAdPQlkOhFhqNfDtDCwibMGvL6QlkSmf3o6vAUSImzdPCxowT5dfQUZP1A==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/nested-clients@3.997.31':
     resolution: {integrity: sha512-BDHTpwcsZHEBNEJzOg/B1BkFYJxAXY50dau/NyVWs3d51F0WgIUGSWZot/Os+N3KpDhXeaXnz37mWffAvduREw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/nested-clients@3.997.41':
+    resolution: {integrity: sha512-RDHqPGQWlF6tatA/Tp3rg6oIwtgN9IVderxE+9av2Y93Dfyu+mO1hZ5Bu2jpfZg2rwdNbsssnwM+sLafIczMlQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/signature-v4-multi-region@3.996.39':
     resolution: {integrity: sha512-8+srXqYIF8KYMLC4FxMLEM5Ek7kUNibJu1R4m8/fUhhNYIZZz26oGtKkCr8I/HiG2fFQxBvaGgQZT4/mqRCSnA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.43':
+    resolution: {integrity: sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.1083.0':
     resolution: {integrity: sha512-s0woKnxuHrExLc5L2ArIH5BMkbonHPtt+5hSBM8oknp9M6QTuUmmAmJ2E0EdzCGONrO+8+ADPqvv6UX0nNcc7A==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/token-providers@3.1103.0':
+    resolution: {integrity: sha512-N4wy26MNn31ItGVHYHPrEuCIFY4MBBjC+C5v1lJKqIUSA7OZBdhleCY53zCCrXn27hsk7YNOaTuhQu807S4AfQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/types@3.974.0':
     resolution: {integrity: sha512-QIBrw90CDm4O0UaIIzkU6DrFdeJzEb2Va5EPEVpyldj6sHJxB6cshhStJuhZxk3wR3PmjJlYsjPmY1kNb+KGBg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/types@3.974.2':
+    resolution: {integrity: sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/xml-builder@3.972.34':
     resolution: {integrity: sha512-wHhWL1y7sN3enBA8POrPpQM5jCcmu2ozyhbRei4c8OjVcEaEs6yLucLa/pla457ggS/ysuy7bosagz3HaJkZXA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.37':
+    resolution: {integrity: sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==}
     engines: {node: '>=20.0.0'}
 
   '@aws/durable-execution-sdk-js@1.0.2':
@@ -495,16 +558,36 @@ packages:
     resolution: {integrity: sha512-DXUk6yU0C1Q1tYvJh1VCtl8QOBcSoZpKwjTPkxT6A4MUQYHvgeKGByL8mrEdxnvhdf9nq5GyzmRb5n/vPgu3Lw==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.31.1':
+    resolution: {integrity: sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.4.16':
+    resolution: {integrity: sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.4.7':
     resolution: {integrity: sha512-UEMLOoA0Fl4uYBxh6l0uN0H6EJe/A89OGeDNTteQeXpJ20BcpfIr4wlCY9pel1jEAUHAxaYwuqrYlrKdXE1GKQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.6.13':
+    resolution: {integrity: sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/fetch-http-handler@5.6.4':
     resolution: {integrity: sha512-psnst7NZWdAEvJvyW8YZEE7xNVMyLrQFfHtyrVFrxNyy+dKWkQ+rqC6oI5ZhxThpUy9RSfEshgm34zqbOxzsRw==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/node-http-handler@4.9.13':
+    resolution: {integrity: sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/node-http-handler@4.9.4':
     resolution: {integrity: sha512-BNTop/fSOptmoVk8g+efwHCofFh37g70OWGAFES1TeAAJja1K5aAI8rTE26ETSc5k8IQuWY2kAIoPla01NgYrA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.6.12':
+    resolution: {integrity: sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/signature-v4@5.6.3':
@@ -513,6 +596,10 @@ packages:
 
   '@smithy/types@4.16.0':
     resolution: {integrity: sha512-aVUabzlBBmY0PfvVgLKQSOGFIL5/7R54JE3uD9a5Ay/jSED61SkuAcCYENNXJzYUvJ1NPrWO0P+rAXHCkbBUKw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.16.1':
+    resolution: {integrity: sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==}
     engines: {node: '>=18.0.0'}
 
   '@standard-schema/spec@1.1.0':
@@ -1758,6 +1845,17 @@ snapshots:
       '@smithy/types': 4.16.0
       tslib: 2.8.1
 
+  '@aws-sdk/client-ecs@3.1103.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.6
+      '@aws-sdk/credential-provider-node': 3.972.78
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/client-lambda@3.1084.0':
     dependencies:
       '@aws-sdk/core': 3.975.1
@@ -1791,12 +1889,31 @@ snapshots:
       bowser: 2.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.977.6':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@aws-sdk/xml-builder': 3.972.37
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.31.1
+      '@smithy/signature-v4': 5.6.12
+      '@smithy/types': 4.16.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-env@3.972.57':
     dependencies:
       '@aws-sdk/core': 3.975.1
       '@aws-sdk/types': 3.974.0
       '@smithy/core': 3.29.2
       '@smithy/types': 4.16.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.67':
+    dependencies:
+      '@aws-sdk/core': 3.977.6
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-http@3.972.59':
@@ -1807,6 +1924,16 @@ snapshots:
       '@smithy/fetch-http-handler': 5.6.4
       '@smithy/node-http-handler': 4.9.4
       '@smithy/types': 4.16.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.69':
+    dependencies:
+      '@aws-sdk/core': 3.977.6
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-ini@3.973.1':
@@ -1825,6 +1952,22 @@ snapshots:
       '@smithy/types': 4.16.0
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-ini@3.973.12':
+    dependencies:
+      '@aws-sdk/core': 3.977.6
+      '@aws-sdk/credential-provider-env': 3.972.67
+      '@aws-sdk/credential-provider-http': 3.972.69
+      '@aws-sdk/credential-provider-login': 3.972.74
+      '@aws-sdk/credential-provider-process': 3.972.67
+      '@aws-sdk/credential-provider-sso': 3.973.11
+      '@aws-sdk/credential-provider-web-identity': 3.972.73
+      '@aws-sdk/nested-clients': 3.997.41
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/credential-provider-imds': 4.4.16
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-login@3.972.63':
     dependencies:
       '@aws-sdk/core': 3.975.1
@@ -1832,6 +1975,15 @@ snapshots:
       '@aws-sdk/types': 3.974.0
       '@smithy/core': 3.29.2
       '@smithy/types': 4.16.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.74':
+    dependencies:
+      '@aws-sdk/core': 3.977.6
+      '@aws-sdk/nested-clients': 3.997.41
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-node@3.972.66':
@@ -1862,12 +2014,34 @@ snapshots:
       '@smithy/types': 4.16.0
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-node@3.972.78':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.67
+      '@aws-sdk/credential-provider-http': 3.972.69
+      '@aws-sdk/credential-provider-ini': 3.973.12
+      '@aws-sdk/credential-provider-process': 3.972.67
+      '@aws-sdk/credential-provider-sso': 3.973.11
+      '@aws-sdk/credential-provider-web-identity': 3.972.73
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/credential-provider-imds': 4.4.16
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-process@3.972.57':
     dependencies:
       '@aws-sdk/core': 3.975.1
       '@aws-sdk/types': 3.974.0
       '@smithy/core': 3.29.2
       '@smithy/types': 4.16.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.67':
+    dependencies:
+      '@aws-sdk/core': 3.977.6
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-sso@3.973.1':
@@ -1880,6 +2054,16 @@ snapshots:
       '@smithy/types': 4.16.0
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-sso@3.973.11':
+    dependencies:
+      '@aws-sdk/core': 3.977.6
+      '@aws-sdk/nested-clients': 3.997.41
+      '@aws-sdk/token-providers': 3.1103.0
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-web-identity@3.972.63':
     dependencies:
       '@aws-sdk/core': 3.975.1
@@ -1887,6 +2071,15 @@ snapshots:
       '@aws-sdk/types': 3.974.0
       '@smithy/core': 3.29.2
       '@smithy/types': 4.16.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.73':
+    dependencies:
+      '@aws-sdk/core': 3.977.6
+      '@aws-sdk/nested-clients': 3.997.41
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/nested-clients@3.997.31':
@@ -1900,11 +2093,29 @@ snapshots:
       '@smithy/types': 4.16.0
       tslib: 2.8.1
 
+  '@aws-sdk/nested-clients@3.997.41':
+    dependencies:
+      '@aws-sdk/core': 3.977.6
+      '@aws-sdk/signature-v4-multi-region': 3.996.43
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/signature-v4-multi-region@3.996.39':
     dependencies:
       '@aws-sdk/types': 3.974.0
       '@smithy/signature-v4': 5.6.3
       '@smithy/types': 4.16.0
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.43':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@smithy/signature-v4': 5.6.12
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/token-providers@3.1083.0':
@@ -1916,14 +2127,33 @@ snapshots:
       '@smithy/types': 4.16.0
       tslib: 2.8.1
 
+  '@aws-sdk/token-providers@3.1103.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.6
+      '@aws-sdk/nested-clients': 3.997.41
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/types@3.974.0':
     dependencies:
       '@smithy/types': 4.16.0
       tslib: 2.8.1
 
+  '@aws-sdk/types@3.974.2':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/xml-builder@3.972.34':
     dependencies:
       '@smithy/types': 4.16.0
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.37':
+    dependencies:
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws/durable-execution-sdk-js@1.0.2':
@@ -2367,10 +2597,27 @@ snapshots:
       '@smithy/types': 4.16.0
       tslib: 2.8.1
 
+  '@smithy/core@3.31.1':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.4.16':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.4.7':
     dependencies:
       '@smithy/core': 3.29.2
       '@smithy/types': 4.16.0
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.6.13':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/fetch-http-handler@5.6.4':
@@ -2379,10 +2626,22 @@ snapshots:
       '@smithy/types': 4.16.0
       tslib: 2.8.1
 
+  '@smithy/node-http-handler@4.9.13':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@smithy/node-http-handler@4.9.4':
     dependencies:
       '@smithy/core': 3.29.2
       '@smithy/types': 4.16.0
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.6.12':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/signature-v4@5.6.3':
@@ -2392,6 +2651,10 @@ snapshots:
       tslib: 2.8.1
 
   '@smithy/types@4.16.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/types@4.16.1':
     dependencies:
       tslib: 2.8.1
 

--- a/infra/slack-approval.test.ts
+++ b/infra/slack-approval.test.ts
@@ -5,6 +5,7 @@ import type { DbOutputs } from "./db";
 import type { EcsOutputs } from "./ecs";
 import type { OauthFacadeOutputs } from "./oauth-facade";
 import type { TenantIdentityOutputs } from "./tenant-identity";
+import { cloudwatchStubs } from "./task-failure-alarm.test-fixtures";
 
 // Harness copied from infra/consolidation.test.ts: the same Output/materialize
 // pair, the same `record`/`one` resource log, and the same faithful sst.aws.Task
@@ -205,13 +206,15 @@ function installGlobals(stage: string) {
         }
       },
     },
-    cloudwatch: {
-      MetricAlarm: class {
-        constructor(logicalName: string, args: Record<string, unknown>) {
-          record("MetricAlarm", logicalName, args);
-        }
-      },
-    },
+    // The apply task's failure signal — the SAME stub set consolidation.test.ts
+    // installs, because both stacks build these six resources through
+    // `taskFailureAlarm`.
+    cloudwatch: cloudwatchStubs({
+      record,
+      out,
+      ruleName: "cleanup-failure",
+      logGroupName: "/sst/cleanup-apply/prod/task-failures",
+    }),
   };
   (globalThis as Record<string, unknown>).sst = {
     aws: {
@@ -705,6 +708,150 @@ describe("slack approval infrastructure", () => {
     // rename here makes RunTask reject the override after the claim is written.
     expect(task.logicalName).toBe("Mem9Cleanup");
     expect(args.architecture).toBe("arm64");
+  });
+
+  it("TC-SLACKAPP-130: alarms on the exact task's non-zero or ABSENT exit through SNS", async () => {
+    installGlobals("prod");
+    enable();
+    await loadAndRun();
+
+    const rule = materialize(one("EventRule", "CleanupApplyFailureRule").args) as
+      Record<string, any>;
+    const pattern = JSON.parse(rule.eventPattern);
+    // Pinned to THIS task definition revision, not to the cluster: the cluster is
+    // shared with the server and the consolidation task, so a cluster-wide rule
+    // would alarm the cleanup topic on every unrelated task failure.
+    expect(pattern).toMatchObject({
+      source: ["aws.ecs"],
+      "detail-type": ["ECS Task State Change"],
+      detail: {
+        lastStatus: ["STOPPED"],
+        taskDefinitionArn: [
+          "arn:aws:ecs:ap-northeast-1:123456789012:task-definition/mem9-cleanup:1",
+        ],
+        // `anything-but: 0` and NOT a >0 comparison: the predicted first-deploy
+        // failure is a task that dies in the ECS agent's secret-fetch phase, which
+        // reports NO exitCode at all. A numeric filter would miss exactly that.
+        containers: { exitCode: [{ "anything-but": 0 }] },
+      },
+    });
+
+    expect(materialize(one("MetricAlarm", "CleanupApplyFailureAlarm").args))
+      .toMatchObject({
+        namespace: "mem9-on-aws",
+        metricName: "CleanupApplyTaskFailures",
+        dimensions: { stage: "prod" },
+        threshold: 1,
+        // The whole point: a task failure has to reach a human. Every other
+        // failure path in this loop ends in a log line, and a log line pages
+        // nobody — the operator was already told "Apply started".
+        alarmActions: [
+          "arn:aws:sns:ap-northeast-1:123456789012:mem9-on-aws-prod-alerts",
+        ],
+      });
+
+    // stoppedReason is carried into the metric-filter document because it is the
+    // only place a startup failure names itself (ResourceInitializationError).
+    const target = materialize(
+      one("EventTarget", "CleanupApplyFailureLogTarget").args,
+    ) as Record<string, any>;
+    expect(target.inputTransformer.inputPaths).toMatchObject({
+      exitCode: "$.detail.containers[0].exitCode",
+      stoppedReason: "$.detail.stoppedReason",
+    });
+    expect(JSON.parse(target.inputTransformer.inputTemplate)).toMatchObject({
+      event: "cleanup_apply_task_failed",
+      stage: "prod",
+      stoppedReason: "<stoppedReason>",
+    });
+
+    const logPolicy = JSON.parse(
+      String(
+        materialize(
+          one("LogResourcePolicy", "CleanupApplyFailureLogPolicy").args
+            .policyDocument,
+        ),
+      ),
+    );
+    expect(logPolicy.Statement).toEqual([
+      {
+        Effect: "Allow",
+        Principal: {
+          Service: ["events.amazonaws.com", "delivery.logs.amazonaws.com"],
+        },
+        Action: ["logs:CreateLogStream", "logs:PutLogEvents"],
+        Resource:
+          "arn:aws:logs:ap-northeast-1:123456789012:log-group:/sst/cleanup-apply/prod/task-failures:*",
+      },
+    ]);
+  });
+
+  it("TC-SLACKAPP-130: budgets the failure rule's name against Pulumi's suffix", async () => {
+    // The #127 trap: EventBridge caps a rule NAME at 64 characters and Pulumi
+    // appends a 26-character suffix to a namePrefix, so a prefix that fits in 64
+    // on its own still fails at CREATE time — after the rest of the stack has
+    // deployed. Every stage this project actually deploys has to fit.
+    const { PULUMI_NAME_SUFFIX_LEN } = await import("./consolidation");
+    for (const stage of ["prod", "pr-1", "pr-123", "pr-99999"]) {
+      resources = [];
+      installGlobals(stage);
+      enable();
+      await loadAndRun();
+
+      const rule = materialize(
+        one("EventRule", "CleanupApplyFailureRule").args,
+      ) as Record<string, any>;
+      expect(rule.namePrefix.length + PULUMI_NAME_SUFFIX_LEN)
+        .toBeLessThanOrEqual(64);
+    }
+  });
+
+  it("TC-SLACKAPP-130: refuses at SYNTH when a stage name overruns the rule limit", async () => {
+    // The failure has to land here rather than at CREATE. `boundedNamePrefix`
+    // throws instead of truncating on purpose: a silently shortened prefix would
+    // collide across two stages, and two stages sharing a rule means one stage's
+    // task failures alarm on the other's topic.
+    installGlobals("pr-1234567890123");
+    enable();
+    const module = await loadModule();
+    expect(() =>
+      module.slackApproval(fakeEcs(), fakeDb(), fakeIdentity(), fakeFacade()),
+    ).toThrow(/cleanup apply failure rule/u);
+  });
+
+  it("TC-SLACKAPP-130: passes no alerts topic and no sns:Publish to the task itself", async () => {
+    installGlobals("prod");
+    enable();
+    await loadAndRun();
+
+    const args = materialize(one("Task", "Mem9Cleanup").args) as Record<string, any>;
+    // scripts/memory-cleanup.mjs contains no SNS client, so a topic ARN in its
+    // environment plus an sns:Publish grant would read as wired-up alerting while
+    // nothing ever published — and would hand the task a grant it cannot use.
+    expect(Object.keys(args.environment)).not.toContain("MEM9_ALERTS_TOPIC_ARN");
+    const actions = (args.permissions as Array<Record<string, any>>).flatMap(
+      (statement) => list(statement.actions),
+    );
+    expect(actions).not.toContain("sns:Publish");
+  });
+
+  it("TC-SLACKAPP-130: creates no failure alarm when the stage has no alerts topic", async () => {
+    installGlobals("prod");
+    enable();
+    const module = await loadModule();
+    // A preview stage without an alerts topic must still deploy: an alarm whose
+    // alarmActions is [undefined] is a CREATE failure for the whole stack.
+    module.slackApproval(
+      { ...fakeEcs(), alertsTopicArn: undefined } as unknown as EcsOutputs,
+      fakeDb(),
+      fakeIdentity(),
+      fakeFacade(),
+    );
+    expect(all("MetricAlarm")).toEqual([]);
+    expect(all("EventRule")).toEqual([]);
+    expect(all("LogGroup")).toEqual([]);
+    // …and the task itself is still created, so the loop works minus the paging.
+    expect(all("Task")).toHaveLength(1);
   });
 
   it("TC-SLACKAPP-088: adds no Lambda, no API, and no certificate", async () => {

--- a/infra/slack-approval.test.ts
+++ b/infra/slack-approval.test.ts
@@ -1,0 +1,749 @@
+import { readFileSync } from "node:fs";
+import { parse } from "yaml";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DbOutputs } from "./db";
+import type { EcsOutputs } from "./ecs";
+import type { OauthFacadeOutputs } from "./oauth-facade";
+import type { TenantIdentityOutputs } from "./tenant-identity";
+
+// Harness copied from infra/consolidation.test.ts: the same Output/materialize
+// pair, the same `record`/`one` resource log, and the same faithful sst.aws.Task
+// stub (whose `subnets`/`securityGroups` ELEMENTS are Outputs, which is how the
+// `.join(",")` defect reached a live stack twice).
+interface Output<T> {
+  value: T;
+  apply(fn: (value: T) => unknown): unknown;
+}
+
+const out = <T>(value: T): Output<T> => ({
+  value,
+  apply(fn) {
+    const result = fn(value);
+    return result && typeof result === "object" && "apply" in result
+      ? result
+      : out(result);
+  },
+});
+
+function materialize(value: unknown): unknown {
+  if (
+    value &&
+    typeof value === "object" &&
+    "value" in value &&
+    "apply" in value &&
+    typeof (value as { apply?: unknown }).apply === "function"
+  ) {
+    return materialize((value as Output<unknown>).value);
+  }
+  if (Array.isArray(value)) return value.map(materialize);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, child]) => [key, materialize(child)]),
+    );
+  }
+  return value;
+}
+
+interface Resource {
+  kind: string;
+  logicalName: string;
+  args: Record<string, unknown>;
+}
+
+let resources: Resource[];
+
+function record(kind: string, logicalName: string, args: Record<string, unknown>) {
+  resources.push({ kind, logicalName, args });
+}
+
+function all(kind: string): Resource[] {
+  return resources.filter((resource) => resource.kind === kind);
+}
+
+function one(kind: string, logicalName?: string): Resource {
+  const matches = resources.filter(
+    (resource) =>
+      resource.kind === kind &&
+      (logicalName === undefined || resource.logicalName === logicalName),
+  );
+  expect(matches).toHaveLength(1);
+  return matches[0];
+}
+
+/** Every SSM parameter this stack emitted, keyed by its `name`. */
+function parametersByName(): Map<string, Record<string, any>> {
+  return new Map(
+    all("Parameter").map((resource) => {
+      const args = resource.args as Record<string, any>;
+      return [String(materialize(args.name)), args];
+    }),
+  );
+}
+
+const BOT_TOKEN = "xoxb-1111111111-2222222222-notarealtoken";
+const SIGNING_SECRET = "8f14e45fceea167a5a36dedd4bea2543";
+const CHANNEL_ID = "C0123456789";
+
+function fakeDb(): DbOutputs {
+  return {
+    ssmPrefix: "/mem9-on-aws/prod",
+    host: out("writer.example.com"),
+    port: out(5432),
+    database: out("mem9"),
+    secretArn: out(
+      "arn:aws:secretsmanager:ap-northeast-1:123456789012:secret:mem9-on-aws-prod-Mem9DbSecret-x",
+    ),
+    taskSecurityGroupId: out("sg-task"),
+  } as unknown as DbOutputs;
+}
+
+function fakeIdentity(): TenantIdentityOutputs {
+  return {
+    tenantSecretArn: out(
+      "arn:aws:secretsmanager:ap-northeast-1:123456789012:secret:mem9-on-aws-prod-tenant-api-key-x",
+    ),
+    tenantId: out("sensitive-tenant-id"),
+  } as unknown as TenantIdentityOutputs;
+}
+
+function fakeEcs(): EcsOutputs {
+  return {
+    ssmPrefix: "/mem9-on-aws/prod",
+    cluster: {
+      nodes: {
+        cluster: {
+          name: out("mem9-cluster"),
+          arn: out("arn:aws:ecs:ap-northeast-1:123456789012:cluster/mem9-cluster"),
+        },
+      },
+    },
+    clusterName: out("mem9-cluster"),
+    serviceName: out("mem9-service"),
+    image: out("mnemo-image"),
+    serviceDnsName: out("mnemo.mem9-prod.local"),
+    taskSecurityGroupId: out("sg-task"),
+    alertsTopicArn: out("arn:aws:sns:ap-northeast-1:123456789012:mem9-on-aws-prod-alerts"),
+  } as unknown as EcsOutputs;
+}
+
+const FACADE_ROLE_NAME = "mem9-on-aws-prod-Mem9OauthFacadeFnRole-2a4c8e1";
+
+function fakeFacade(): OauthFacadeOutputs {
+  return {
+    ssmPrefix: "/mem9-on-aws/prod",
+    readerClientId: out("reader-client-id"),
+    facadeUrl: out("https://facade.example.com"),
+    functionRoleName: out(FACADE_ROLE_NAME),
+  } as unknown as OauthFacadeOutputs;
+}
+
+function installGlobals(stage: string) {
+  (globalThis as Record<string, unknown>).$app = { name: "mem9-on-aws", stage };
+  (globalThis as Record<string, unknown>).$interpolate = (
+    strings: TemplateStringsArray,
+    ...values: unknown[]
+  ) =>
+    out(
+      strings.reduce((text, part, index) => {
+        const value = values[index];
+        return text + part + (index < values.length ? String(materialize(value)) : "");
+      }, ""),
+    );
+  (globalThis as Record<string, unknown>).$jsonStringify = (value: unknown) =>
+    out(JSON.stringify(materialize(value)));
+  (globalThis as Record<string, unknown>).aws = {
+    getCallerIdentityOutput: () => ({ accountId: out("123456789012") }),
+    getRegionOutput: () => ({ name: out("ap-northeast-1") }),
+    ec2: {
+      getVpcOutput: () => ({ id: out("vpc-test") }),
+      getSubnetsOutput: () => ({ ids: out(["subnet-a", "subnet-b", "subnet-c"]) }),
+      // Recorded so TC-086 can prove the diff adds NO new network surface.
+      SecurityGroup: class {
+        id = out("sg-new");
+        constructor(logicalName: string, args: Record<string, unknown>) {
+          record("SecurityGroup", logicalName, args);
+        }
+      },
+      SecurityGroupRule: class {
+        constructor(logicalName: string, args: Record<string, unknown>) {
+          record("SecurityGroupRule", logicalName, args);
+        }
+      },
+      VpcSecurityGroupIngressRule: class {
+        constructor(logicalName: string, args: Record<string, unknown>) {
+          record("VpcSecurityGroupIngressRule", logicalName, args);
+        }
+      },
+    },
+    iam: {
+      Role: class {
+        arn: Output<string>;
+        name: Output<string>;
+        constructor(logicalName: string, args: Record<string, unknown>) {
+          this.arn = out(`arn:aws:iam::123456789012:role/${logicalName}`);
+          this.name = out(logicalName);
+          record("Role", logicalName, args);
+        }
+      },
+      RolePolicy: class {
+        constructor(logicalName: string, args: Record<string, unknown>) {
+          record("RolePolicy", logicalName, args);
+        }
+      },
+    },
+    ssm: {
+      Parameter: class {
+        arn: Output<string>;
+        name: Output<string>;
+        constructor(logicalName: string, args: Record<string, unknown>) {
+          const name = String(materialize(args.name));
+          this.arn = out(
+            `arn:aws:ssm:ap-northeast-1:123456789012:parameter${name}`,
+          );
+          this.name = out(name);
+          record("Parameter", logicalName, args);
+        }
+      },
+    },
+    cloudwatch: {
+      MetricAlarm: class {
+        constructor(logicalName: string, args: Record<string, unknown>) {
+          record("MetricAlarm", logicalName, args);
+        }
+      },
+    },
+  };
+  (globalThis as Record<string, unknown>).sst = {
+    aws: {
+      Task: class {
+        taskDefinition = out(
+          "arn:aws:ecs:ap-northeast-1:123456789012:task-definition/mem9-cleanup:1",
+        );
+        subnets = out([out("subnet-a"), out("subnet-b")]);
+        securityGroups = out([out("sg-task")]);
+        assignPublicIp = out(false);
+        nodes = {
+          taskRole: { arn: out("arn:aws:iam::123456789012:role/cleanup-task") },
+          executionRole: {
+            arn: out("arn:aws:iam::123456789012:role/cleanup-execution"),
+          },
+          taskDefinition: out({
+            arn: out(
+              "arn:aws:ecs:ap-northeast-1:123456789012:task-definition/mem9-cleanup:1",
+            ),
+            containerDefinitions: out(
+              JSON.stringify([
+                {
+                  name: "Mem9Cleanup",
+                  logConfiguration: {
+                    options: { "awslogs-group": "/sst/cleanup" },
+                  },
+                },
+              ]),
+            ),
+          }),
+        };
+        constructor(logicalName: string, args: Record<string, unknown>) {
+          record("Task", logicalName, args);
+        }
+      },
+      // No new API surface may appear (TC-088). Recorded rather than omitted so
+      // an accidental Function URL or second gateway fails loudly.
+      Function: class {
+        arn = out("arn:aws:lambda:ap-northeast-1:123456789012:function:extra");
+        constructor(logicalName: string, args: Record<string, unknown>) {
+          record("Function", logicalName, args);
+        }
+      },
+      ApiGatewayV2: class {
+        url = out("https://extra.example.com");
+        constructor(logicalName: string, args: Record<string, unknown>) {
+          record("ApiGatewayV2", logicalName, args);
+        }
+      },
+    },
+    // Env-reading flavour from infra/ecs.test.ts: an UNSET repository secret
+    // arrives as an empty string, which is the case TC-084 exists for.
+    Secret: class {
+      value: ReturnType<typeof out<string>> & { isSecret: true };
+      constructor(logicalName: string) {
+        const value = process.env[`SST_SECRET_${logicalName}`];
+        if (typeof value !== "string") throw new Error(`Missing SST secret ${logicalName}`);
+        this.value = { ...out(value), isSecret: true };
+        record("Secret", logicalName, { logicalName });
+      }
+    },
+  };
+}
+
+async function loadModule() {
+  vi.resetModules();
+  return import("./slack-approval");
+}
+
+async function loadAndRun() {
+  const module = await loadModule();
+  module.slackApproval(fakeEcs(), fakeDb(), fakeIdentity(), fakeFacade());
+  return module;
+}
+
+/** The `Statement` array of the inline policy attached to the facade role. */
+function facadePolicyStatements(): Array<Record<string, any>> {
+  const policy = all("RolePolicy").filter(
+    ({ args }) => String(materialize((args as Record<string, any>).role)) === FACADE_ROLE_NAME,
+  );
+  expect(policy).toHaveLength(1);
+  const document = JSON.parse(
+    String(materialize((policy[0].args as Record<string, any>).policy)),
+  ) as { Statement: Array<Record<string, any>> };
+  return document.Statement;
+}
+
+function list(value: unknown): string[] {
+  return Array.isArray(value) ? value.map(String) : [String(value)];
+}
+
+/**
+ * Statements of the OPERATOR-OWNED boundary that this stack's role must survive.
+ *
+ * Read from the deployed CloudFormation template rather than from the exported
+ * helper in `scripts/lib/workload-permissions-boundary.mjs`: `infra/tsconfig.json`
+ * has no `allowJs`, so importing the untyped `.mjs` fails `pnpm -C infra
+ * typecheck` — a CI gate. This is the same idiom TC-CONSOL-032 uses.
+ */
+function boundaryStatements(): Array<Record<string, any>> {
+  const template = parse(
+    readFileSync(
+      new URL("./cloudformation/workload-permissions-boundary.yaml", import.meta.url),
+      "utf8",
+    ),
+    {
+      customTags: [
+        { tag: "!Ref", resolve: (value: string) => ({ Ref: value }) },
+        { tag: "!Sub", resolve: (value: string) => ({ "Fn::Sub": value }) },
+        {
+          tag: "!Equals",
+          collection: "seq",
+          resolve: (value) => ({ "Fn::Equals": value.toJSON() }),
+        },
+        {
+          tag: "!If",
+          collection: "seq",
+          resolve: (value) => ({ "Fn::If": value.toJSON() }),
+        },
+        {
+          tag: "!GetAtt",
+          resolve: (value: string) => ({ "Fn::GetAtt": value.split(".") }),
+        },
+      ],
+    },
+  ) as { Resources: Record<string, { Properties: Record<string, any> }> };
+  return template.Resources.WorkloadPermissionsBoundary.Properties.PolicyDocument
+    .Statement as Array<Record<string, any>>;
+}
+
+/**
+ * `!Sub` strings resolved against the same identity the fakes use, so a template
+ * pattern can be compared against a rendered ARN.
+ */
+function resolveSub(value: unknown): string {
+  const raw =
+    value && typeof value === "object" && "Fn::Sub" in (value as object)
+      ? String((value as { "Fn::Sub": string })["Fn::Sub"])
+      : String(value);
+  return raw
+    .replaceAll("${AWS::Partition}", "aws")
+    .replaceAll("${AWS::AccountId}", "123456789012")
+    .replaceAll("${ApplicationRegion}", "ap-northeast-1");
+}
+
+/** IAM glob match, the same semantics the boundary evaluator uses. */
+function globMatches(pattern: string, value: string): boolean {
+  const source = pattern
+    .split(/([*?])/u)
+    .map((part) =>
+      part === "*" ? ".*" : part === "?" ? "." : part.replace(/[.+^${}()|[\]\\]/gu, "\\$&"),
+    )
+    .join("");
+  return new RegExp(`^${source}$`, "iu").test(value);
+}
+
+const ENV_KEYS = [
+  "MEM9_SLACK_APPROVAL_ENABLED",
+  "MEM9_SLACK_APPROVAL_CHANNEL",
+  "SST_SECRET_SlackBotToken",
+  "SST_SECRET_SlackSigningSecret",
+  "MEM9_IMAGE_TAG",
+  "MEM9_BEDROCK_PROJECT",
+  "MEM9_BEDROCK_PROJECT_OPENAI",
+  "MEM9_CLEANUP_CAP",
+];
+
+function enable() {
+  process.env.MEM9_SLACK_APPROVAL_ENABLED = "1";
+  process.env.MEM9_SLACK_APPROVAL_CHANNEL = CHANNEL_ID;
+  process.env.SST_SECRET_SlackBotToken = BOT_TOKEN;
+  process.env.SST_SECRET_SlackSigningSecret = SIGNING_SECRET;
+}
+
+beforeEach(() => {
+  resources = [];
+  for (const key of ENV_KEYS) delete process.env[key];
+  process.env.MEM9_BEDROCK_PROJECT = "proj_test";
+  process.env.MEM9_BEDROCK_PROJECT_OPENAI = "proj_openai";
+});
+
+afterEach(() => {
+  for (const key of ["$app", "$interpolate", "$jsonStringify", "aws", "sst"]) {
+    delete (globalThis as Record<string, unknown>)[key];
+  }
+  for (const key of ENV_KEYS) delete process.env[key];
+  vi.resetModules();
+});
+
+describe("slack approval infrastructure", () => {
+  it("TC-SLACKAPP-080: creates nothing and grants nothing while the flag is unset", async () => {
+    installGlobals("prod");
+    await loadAndRun();
+
+    // Disabled must mean ABSENT, not present-and-idle: a task definition that
+    // exists is a task definition RunTask can start.
+    expect(resources).toEqual([]);
+  });
+
+  it("TC-SLACKAPP-080: grants the facade role no write, run, or pass while the flag is unset", async () => {
+    installGlobals("prod");
+    await loadAndRun();
+
+    const granted = all("RolePolicy").flatMap(({ args }) =>
+      list(
+        JSON.parse(String(materialize((args as Record<string, any>).policy)))
+          .Statement.flatMap((statement: Record<string, any>) => list(statement.Action)),
+      ),
+    );
+    for (const action of ["ssm:PutParameter", "ecs:RunTask", "iam:PassRole"]) {
+      expect(granted).not.toContain(action);
+    }
+  });
+
+  it("TC-SLACKAPP-081: scopes the facade grants to the approval path, the task definition, and ecs-tasks", async () => {
+    installGlobals("prod");
+    enable();
+    await loadAndRun();
+
+    const statements = facadePolicyStatements();
+    const byAction = (action: string) => {
+      const matches = statements.filter((statement) =>
+        list(statement.Action).includes(action),
+      );
+      expect(matches).toHaveLength(1);
+      return matches[0];
+    };
+
+    // The write is scoped to the approval RECORDS, not the stage prefix: the
+    // stage prefix holds the reader client secret, the gateway URL, and the
+    // cleanup task inputs this same Lambda reads, so a prefix-wide write would
+    // let a compromised callback rewrite its own ECS target.
+    const put = byAction("ssm:PutParameter");
+    expect(list(put.Resource)).toEqual([
+      "arn:aws:ssm:ap-northeast-1:123456789012:parameter/mem9-on-aws/prod/approvals/*",
+    ]);
+    expect(list(put.Resource)).not.toContain("*");
+    expect(list(put.Resource)).not.toContain(
+      "arn:aws:ssm:ap-northeast-1:123456789012:parameter/mem9-on-aws/prod/*",
+    );
+
+    const run = byAction("ecs:RunTask");
+    expect(list(run.Resource)).toEqual([
+      "arn:aws:ecs:ap-northeast-1:123456789012:task-definition/mem9-cleanup:1",
+    ]);
+
+    const pass = byAction("iam:PassRole");
+    expect(list(pass.Resource).sort()).toEqual([
+      "arn:aws:iam::123456789012:role/cleanup-execution",
+      "arn:aws:iam::123456789012:role/cleanup-task",
+    ]);
+    // Unconditioned iam:PassRole on an ECS role is a privilege-escalation
+    // primitive: the same role could be handed to any service that will assume
+    // it. Asserted on the condition, not just the resource.
+    expect(pass.Condition).toEqual({
+      StringEquals: { "iam:PassedToService": "ecs-tasks.amazonaws.com" },
+    });
+  });
+
+  it("TC-SLACKAPP-082: keeps every granted action inside the boundary ceiling and the approval NotResource", async () => {
+    installGlobals("prod");
+    enable();
+    await loadAndRun();
+
+    const statements = facadePolicyStatements();
+    const actions = statements.flatMap((statement) => list(statement.Action));
+    expect(actions.length).toBeGreaterThan(0);
+
+    // Same document the boundary tests assert against, so a scoping mistake
+    // fails in CI instead of surfacing as an opaque runtime AccessDenied on the
+    // operator's first real Slack click.
+    const boundary = boundaryStatements();
+    const ceiling = boundary.find(({ NotAction }) => NotAction);
+    expect(ceiling).toBeDefined();
+    const admitted = list(ceiling!.NotAction);
+    for (const action of actions) {
+      expect(
+        admitted.some((pattern) => globMatches(pattern, action)),
+        `${action} is outside the workload boundary action ceiling`,
+      ).toBe(true);
+    }
+
+    // DenyPutParameterOutsideApprovalRecords is a NotResource deny, so the
+    // grant is only reachable if EVERY resource it names is matched by the
+    // exception. One stray resource in the same statement denies the whole call.
+    const approvalDeny = boundary.find(
+      ({ Sid }) => Sid === "DenyPutParameterOutsideApprovalRecords",
+    );
+    expect(approvalDeny).toBeDefined();
+    // `!Sub` resolves to an OBJECT, so these must be resolved before comparing —
+    // stringifying them first yields "[object Object]", which matches nothing and
+    // would make the loop below fail for the wrong reason.
+    const exceptions = (approvalDeny!.NotResource as unknown[]).map(resolveSub);
+    const putResources = statements
+      .filter((statement) => list(statement.Action).includes("ssm:PutParameter"))
+      .flatMap((statement) => list(statement.Resource));
+    expect(putResources.length).toBeGreaterThan(0);
+    for (const resource of putResources) {
+      expect(
+        exceptions.some((pattern) => globMatches(pattern, resource)),
+        `${resource} is denied by DenyPutParameterOutsideApprovalRecords`,
+      ).toBe(true);
+    }
+  });
+
+  it("TC-SLACKAPP-083: passes both Slack secrets by reference, never as a literal", async () => {
+    installGlobals("prod");
+    enable();
+    await loadAndRun();
+
+    const parameters = parametersByName();
+    const botToken = parameters.get("/mem9-on-aws/prod/slack/bot-token");
+    const signing = parameters.get("/mem9-on-aws/prod/slack/signing-secret");
+    expect(botToken).toBeDefined();
+    expect(signing).toBeDefined();
+    // SecureString + a Pulumi secret Output: the value stays redacted in state,
+    // in the diff, and in every diagnostic.
+    for (const parameter of [botToken!, signing!]) {
+      expect(parameter.type).toBe("SecureString");
+      expect(parameter.value).toMatchObject({ isSecret: true });
+    }
+    expect(all("Secret").map(({ logicalName }) => logicalName).sort()).toEqual([
+      "SlackBotToken",
+      "SlackSigningSecret",
+    ]);
+
+    // Everything EXCEPT the two parameters that exist to hold the secret must be
+    // literal-free. The task definition is the one that matters most: a plain
+    // `environment` entry is readable by anyone with DescribeTaskDefinition,
+    // which is why the token has to ride `ssm:` as an ARN instead.
+    const secretParameterNames = new Set([
+      "/mem9-on-aws/prod/slack/bot-token",
+      "/mem9-on-aws/prod/slack/signing-secret",
+    ]);
+    const rendered = resources
+      .filter(
+        (resource) =>
+          !(
+            resource.kind === "Parameter" &&
+            secretParameterNames.has(
+              String(materialize((resource.args as Record<string, any>).name)),
+            )
+          ) && resource.kind !== "Secret",
+      )
+      .map((resource) => JSON.stringify(materialize(resource.args)))
+      .join("\n");
+    expect(rendered).not.toContain("xoxb-");
+    expect(rendered).not.toContain(BOT_TOKEN);
+    expect(rendered).not.toContain(SIGNING_SECRET);
+
+    const task = one("Task", "Mem9Cleanup");
+    const args = materialize(task.args) as Record<string, any>;
+    expect(args.ssm.SLACK_BOT_TOKEN).toBe(
+      "arn:aws:ssm:ap-northeast-1:123456789012:parameter/mem9-on-aws/prod/slack/bot-token",
+    );
+    expect(JSON.stringify(args.environment)).not.toContain("xoxb-");
+  });
+
+  it("TC-SLACKAPP-084: fails synthesis in production when a Slack secret is empty", async () => {
+    for (const empty of ["SST_SECRET_SlackBotToken", "SST_SECRET_SlackSigningSecret"]) {
+      resources = [];
+      installGlobals("prod");
+      enable();
+      // GitHub exposes an UNSET repository secret as an empty string, so the
+      // failure mode is not a missing variable — it is a Slack app that answers
+      // 401 to every click after a green deploy.
+      process.env[empty] = "";
+      const module = await loadModule();
+      expect(() =>
+        module.slackApproval(fakeEcs(), fakeDb(), fakeIdentity(), fakeFacade()),
+      ).toThrow(/Slack/i);
+      expect(resources).toEqual([]);
+      for (const key of ["$app", "$interpolate", "$jsonStringify", "aws", "sst"]) {
+        delete (globalThis as Record<string, unknown>)[key];
+      }
+    }
+  });
+
+  it("TC-SLACKAPP-084: needs neither Slack secret on a preview stage with the flag unset", async () => {
+    installGlobals("pr-99");
+    delete process.env.SST_SECRET_SlackBotToken;
+    delete process.env.SST_SECRET_SlackSigningSecret;
+    await loadAndRun();
+
+    expect(all("Secret")).toEqual([]);
+  });
+
+  it("TC-SLACKAPP-085: treats the approval channel as a plain variable and requires it when enabled", async () => {
+    installGlobals("prod");
+    enable();
+    await loadAndRun();
+
+    const channel = parametersByName().get("/mem9-on-aws/prod/slack/approval-channel");
+    expect(channel).toBeDefined();
+    // A channel id is public inside the workspace. Storing it as a SecureString
+    // would need kms:Decrypt on a read path the boundary conditions tightly, so
+    // the wrong type here is a runtime AccessDenied, not a leak.
+    expect(channel!.type).toBe("String");
+    expect(materialize(channel!.value)).toBe(CHANNEL_ID);
+    expect(channel!.value).not.toMatchObject({ isSecret: true });
+
+    const task = one("Task", "Mem9Cleanup");
+    const args = materialize(task.args) as Record<string, any>;
+    expect(args.environment.MEM9_SLACK_APPROVAL_CHANNEL).toBe(CHANNEL_ID);
+
+    resources = [];
+    for (const key of ["$app", "$interpolate", "$jsonStringify", "aws", "sst"]) {
+      delete (globalThis as Record<string, unknown>)[key];
+    }
+    installGlobals("prod");
+    enable();
+    delete process.env.MEM9_SLACK_APPROVAL_CHANNEL;
+    const module = await loadModule();
+    expect(() =>
+      module.slackApproval(fakeEcs(), fakeDb(), fakeIdentity(), fakeFacade()),
+    ).toThrow(/MEM9_SLACK_APPROVAL_CHANNEL/);
+    expect(resources).toEqual([]);
+  });
+
+  it("TC-SLACKAPP-086: reuses the existing cluster, task SG, and private subnets without adding a network rule", async () => {
+    installGlobals("prod");
+    enable();
+    await loadAndRun();
+
+    const task = one("Task", "Mem9Cleanup");
+    const args = materialize(task.args) as Record<string, any>;
+    expect(args.cluster.nodes.cluster.name).toBe("mem9-cluster");
+
+    // "No new network surface" is the argument that chose ECS over a
+    // VPC-attached Lambda. Assert it on the DIFF, not on a comment.
+    expect(all("SecurityGroup")).toEqual([]);
+    expect(all("SecurityGroupRule")).toEqual([]);
+    expect(all("VpcSecurityGroupIngressRule")).toEqual([]);
+
+    // The handler reads these four names (TC-SLACKAPP-047b) and RunTask fails
+    // opaquely, after the approval is claimed, if any value lands in the wrong
+    // field. Each is asserted in the field NAMED for it.
+    const parameters = parametersByName();
+    expect(materialize(parameters.get("/mem9-on-aws/prod/cleanup/cluster-name")!.value)).toBe(
+      "mem9-cluster",
+    );
+    expect(materialize(parameters.get("/mem9-on-aws/prod/cleanup/task-def-arn")!.value)).toBe(
+      "arn:aws:ecs:ap-northeast-1:123456789012:task-definition/mem9-cleanup:1",
+    );
+    expect(materialize(parameters.get("/mem9-on-aws/prod/cleanup/task-sg-id")!.value)).toBe(
+      "sg-task",
+    );
+    // resolveVpc(), NOT task.subnets: the Cluster's containerSubnets ELEMENTS
+    // are Outputs, so joining them writes "Calling [toString] on an [Output<T>]
+    // is not supported." into SSM and RunTask rejects it.
+    const subnets = parameters.get("/mem9-on-aws/prod/cleanup/subnet-ids")!;
+    expect(materialize(subnets.value)).toBe("subnet-a,subnet-b,subnet-c");
+    expect(subnets.type).toBe("StringList");
+  });
+
+  it("TC-SLACKAPP-087: runs memory-cleanup.mjs with --apply, an ids file, and an explicit cap", async () => {
+    installGlobals("prod");
+    enable();
+    await loadAndRun();
+
+    const task = one("Task", "Mem9Cleanup");
+    const args = materialize(task.args) as Record<string, any>;
+    // ECS can override `command` but NOT `entryPoint`, so the interpreter has to
+    // be the entrypoint for the handler's environment-only override to work.
+    expect(args.entrypoint).toEqual(["node"]);
+    const command = args.command as string[];
+    expect(command[0]).toBe("/app/scripts/memory-cleanup.mjs");
+    expect(command).toContain("--apply");
+
+    const idsIndex = command.indexOf("--ids");
+    expect(idsIndex).toBeGreaterThan(0);
+    expect(command[idsIndex + 1]).toMatch(/^\/\S+/u);
+
+    // #102's blast-radius limit. A task definition that dropped --cap would fall
+    // back to the script's default silently, so the number is pinned here.
+    const capIndex = command.indexOf("--cap");
+    expect(capIndex).toBeGreaterThan(0);
+    expect(Number(command[capIndex + 1])).toBe(50);
+
+    // --base-url avoids @aws-sdk/client-servicediscovery, which the image does
+    // not ship; without it the apply exits 2 on discovery rather than deleting.
+    const baseUrlIndex = command.indexOf("--base-url");
+    expect(baseUrlIndex).toBeGreaterThan(0);
+    expect(command[baseUrlIndex + 1]).toBe("http://mnemo.mem9-prod.local:8080");
+
+    const stageIndex = command.indexOf("--stage");
+    expect(stageIndex).toBeGreaterThan(0);
+    expect(command[stageIndex + 1]).toBe("prod");
+
+    // The container name is what the handler's containerOverride targets. A
+    // rename here makes RunTask reject the override after the claim is written.
+    expect(task.logicalName).toBe("Mem9Cleanup");
+    expect(args.architecture).toBe("arm64");
+  });
+
+  it("TC-SLACKAPP-088: adds no Lambda, no API, and no certificate", async () => {
+    installGlobals("prod");
+    enable();
+    await loadAndRun();
+
+    // The route lives on the existing ApiGatewayV2 (`ANY /{proxy+}` already
+    // reaches /slack/interactions). A second API or a Function URL would be a
+    // new public surface with its own authorizer story.
+    expect(all("Function")).toEqual([]);
+    expect(all("ApiGatewayV2")).toEqual([]);
+    expect(all("Certificate")).toEqual([]);
+  });
+
+  it("TC-SLACKAPP-088: exports the task definition the facade must target", async () => {
+    installGlobals("prod");
+    enable();
+    const module = await loadModule();
+    const outputs = module.slackApproval(
+      fakeEcs(),
+      fakeDb(),
+      fakeIdentity(),
+      fakeFacade(),
+    );
+    expect(outputs).toBeDefined();
+    expect(materialize(outputs!.taskDefinitionArn)).toBe(
+      "arn:aws:ecs:ap-northeast-1:123456789012:task-definition/mem9-cleanup:1",
+    );
+  });
+
+  it("TC-SLACKAPP-080: returns nothing to wire when the flag is unset", async () => {
+    installGlobals("prod");
+    const module = await loadModule();
+    // The caller must be able to tell "disabled" from "enabled": returning an
+    // object with an unresolved task-def ARN would let sst.config.ts wire a
+    // target that was never created.
+    expect(
+      module.slackApproval(fakeEcs(), fakeDb(), fakeIdentity(), fakeFacade()),
+    ).toBeUndefined();
+  });
+});

--- a/infra/slack-approval.ts
+++ b/infra/slack-approval.ts
@@ -55,6 +55,7 @@ import type { DbOutputs } from "./db";
 import type { EcsOutputs } from "./ecs";
 import type { OauthFacadeOutputs } from "./oauth-facade";
 import type { TenantIdentityOutputs } from "./tenant-identity";
+import { taskFailureAlarm } from "./task-failure-alarm";
 import { accountId, ECR_REGION, ecrImage } from "./ecr";
 import { resolveVpc } from "./vpc";
 
@@ -62,6 +63,10 @@ const IMAGE_TAG = process.env.MEM9_IMAGE_TAG || "latest";
 const BEDROCK_PROJECT = process.env.MEM9_BEDROCK_PROJECT;
 const BEDROCK_PROJECT_OPENAI = process.env.MEM9_BEDROCK_PROJECT_OPENAI || "";
 const RESPONSES_REGION = process.env.MEM9_LLM_RESPONSES_REGION || "us-west-2";
+
+// Same namespace as the consolidation alarm so both task failures aggregate in
+// one place; the metric name distinguishes them.
+const CLEANUP_FAILURE_METRIC = "CleanupApplyTaskFailures";
 
 export const SLACK_APPROVAL_ENABLED_ENV = "MEM9_SLACK_APPROVAL_ENABLED";
 export const SLACK_APPROVAL_CHANNEL_ENV = "MEM9_SLACK_APPROVAL_CHANNEL";
@@ -216,9 +221,13 @@ export function slackApproval(
       MEM9_SSM_PREFIX: prefix,
       MEM9_SLACK_APPROVAL_CHANNEL: channel,
       MEM9_APPROVED_IDS_PATH: APPROVED_IDS_PATH,
-      ...(ecsOut.alertsTopicArn
-        ? { MEM9_ALERTS_TOPIC_ARN: ecsOut.alertsTopicArn }
-        : {}),
+      // No MEM9_ALERTS_TOPIC_ARN and no sns:Publish: scripts/memory-cleanup.mjs
+      // contains no SNS code (memory-consolidation.mjs does, which is what makes
+      // the omission look like an oversight). Passing the variable and granting
+      // the action would read from this file as though alerting were wired up
+      // while nothing published, so the failure signal is the EventBridge rule
+      // and alarm below instead — which also catches the startup deaths a
+      // publish from inside the container could never report.
     },
     // Fetched by the EXECUTION role at task start, so no secret value is ever an
     // `environment` entry (those are readable by anyone holding
@@ -263,9 +272,6 @@ export function slackApproval(
           $interpolate`arn:aws:ssm:${region}:${accountId()}:parameter${prefix}/approvals/*`,
         ],
       },
-      ...(ecsOut.alertsTopicArn
-        ? [{ actions: ["sns:Publish"], resources: [ecsOut.alertsTopicArn] }]
-        : []),
     ],
     logging: { retention: "1 month" },
     transform: {
@@ -291,6 +297,40 @@ export function slackApproval(
     resolveVpc().privateSubnetIds.apply((ids) => ids.join(",")),
     "StringList",
   );
+
+  // --- The apply task's failure alarm ---
+  // Without this the whole loop has no automated failure signal. Every error path
+  // in the handler and the task ends in a log line, and a log line pages nobody:
+  // the operator is told "Apply started", the task then dies, and the next signal
+  // is a human noticing months of un-tidied memories.
+  //
+  // An EventBridge rule on ECS state change is used rather than a filter over the
+  // task's own logs BECAUSE the most likely first-deploy failure produces no
+  // application log at all: a task that dies in the ECS agent's secret-fetch phase
+  // (see the BOUNDARY NOTE at the top of this file) never runs its entrypoint.
+  // `anything-but: 0` also covers a NULL exitCode, which is exactly that case.
+  if (ecsOut.alertsTopicArn) {
+    taskFailureAlarm({
+      stem: "CleanupApplyFailure",
+      logGroupName: `/sst/cleanup-apply/${$app.stage}/task-failures`,
+      rulePrefix: `mem9-on-aws-${$app.stage}-cleanup-failure-`,
+      ruleWhat: "cleanup apply failure rule",
+      ruleDescription:
+        "Captures non-zero or absent exits from the exact cleanup apply task revision.",
+      policyName: `mem9-on-aws-${$app.stage}-cleanup-apply-events`,
+      eventName: "cleanup_apply_task_failed",
+      metricName: CLEANUP_FAILURE_METRIC,
+      alarmDescription:
+        "An approved memory cleanup apply task exited non-zero or never ran its container.",
+      taskDefinitionArn: task.taskDefinition,
+      alertsTopicArn: ecsOut.alertsTopicArn,
+      tags,
+      // On here and off for consolidation: the predicted first-deploy failure for
+      // THIS task is a death in the secret-fetch phase (see the BOUNDARY NOTE at
+      // the top of this file), and `stoppedReason` is the only field that names it.
+      includeStoppedReason: true,
+    });
+  }
 
   // --- The three grants the façade Lambda needs, on its EXISTING role ---
   new aws.iam.RolePolicy("Mem9SlackApprovalPolicy", {

--- a/infra/slack-approval.ts
+++ b/infra/slack-approval.ts
@@ -20,17 +20,31 @@
  * Lambda role would need its own workload-permissions-boundary exception, and the
  * boundary is operator-owned (rolled out separately from application deploys).
  *
- * BOUNDARY NOTE — the new task's roles are admissible under the DEPLOYED boundary
- * with no template change:
+ * BOUNDARY NOTE — the SSM half is admissible under the DEPLOYED boundary; the
+ * Secrets Manager half is NOT yet established and is a deploy-time risk:
  *   - The SecureString reads are gated by `DenyParameterContextDecryptOutsideSsm`
  *     on `kms:ViaService`, NOT on the `ECS_EXECUTION_ROLE_TOKENS` list, so an
  *     unlisted execution role may still decrypt a `/mem9-on-aws/*` parameter.
- *   - The Secrets Manager reads (`MEM9_DB_SECRET`, `MEM9_TENANT_ID`) resolve under
- *     the DEFAULT `aws/secretsmanager` key, for which AWS requires no identity
- *     `kms:Decrypt` at all — so `DenySecretContextDecryptFromNonEcsExecutionRoles`
- *     is never evaluated. If either secret is ever moved to a customer managed
- *     key, `Mem9CleanupExecutionRole-` must be added to that deny's exception
- *     list, which lives in the operator-owned boundary template.
+ *   - UNRESOLVED: the Secrets Manager reads (`MEM9_DB_SECRET`, `MEM9_TENANT_ID`)
+ *     resolve under the DEFAULT `aws/secretsmanager` key (neither secret sets
+ *     `kmsKeyId` — see infra/db.ts and infra/tenant-identity.ts). AWS needs no
+ *     identity `kms:Decrypt` ALLOW on that key, but an explicit DENY is a
+ *     different question, and three things in this repo say the deny does bite on
+ *     the service-mediated path: the boundary's own comment above
+ *     `DenySecretContextDecryptFromNonEcsExecutionRoles` says it "constrains which
+ *     project role types may use that service-mediated path"; the SecretARN
+ *     encryption-context allowlist enumerates `Mem9DbSecret-*` and
+ *     `tenant-api-key-*`, which would be pointless if the decrypt were never
+ *     attributed to the workload principal; and #122 had to admit
+ *     `Mem9ConsolidationExecutionRole-` to that same list for a task that reads
+ *     THESE SAME TWO default-key secrets (pinned by TC-CONSOL-032).
+ *     `Mem9CleanupExecutionRole-` is NOT in the list. If the deny is evaluated,
+ *     this execution role cannot fetch either secret and the task dies at startup
+ *     — AFTER the click has been spent — on every bounded stage. Adding the role
+ *     to the exception list is safe either way (it only narrows a deny, and is a
+ *     no-op if the deny never fires), but it changes the OPERATOR-OWNED template
+ *     and so needs its own guarded rollout ahead of this stack's first deploy.
+ *     Settle it before deploying, not by re-reading this comment.
  *
  * Gated on `MEM9_SLACK_APPROVAL_ENABLED=1`. Disabled means ABSENT, not
  * present-and-idle: a task definition that exists is a task definition `RunTask`

--- a/infra/slack-approval.ts
+++ b/infra/slack-approval.ts
@@ -1,0 +1,323 @@
+/**
+ * `slackApproval` stack — the apply half of the Slack approval loop (#123).
+ *
+ * The façade Lambda already serves `POST /slack/interactions` (it routes through
+ * the existing `ANY /{proxy+}`), verifies the Slack signature, and claims the
+ * approval in SSM. What it cannot do is run the deletion: `memory-cleanup.mjs
+ * --apply` needs the database, and the façade is deliberately NOT VPC-attached.
+ * This stack supplies the missing half — an on-demand Fargate task on the
+ * EXISTING cluster, in the EXISTING private subnets, behind the EXISTING task
+ * security group — plus the four SSM parameters the handler reads to start it and
+ * the three grants the handler needs to do so.
+ *
+ * ECS rather than a second VPC-attached Lambda: the deciding argument was "no new
+ * network surface". A VPC Lambda would add its own ENIs and a cold-start hop; the
+ * task reuses the network path the server already has. TC-SLACKAPP-086 asserts
+ * that on the rendered diff rather than trusting this paragraph.
+ *
+ * The grants attach to the FAÇADE's existing execution role
+ * (`facadeOut.functionRoleName`) instead of creating a role of its own: a new
+ * Lambda role would need its own workload-permissions-boundary exception, and the
+ * boundary is operator-owned (rolled out separately from application deploys).
+ *
+ * BOUNDARY NOTE — the new task's roles are admissible under the DEPLOYED boundary
+ * with no template change:
+ *   - The SecureString reads are gated by `DenyParameterContextDecryptOutsideSsm`
+ *     on `kms:ViaService`, NOT on the `ECS_EXECUTION_ROLE_TOKENS` list, so an
+ *     unlisted execution role may still decrypt a `/mem9-on-aws/*` parameter.
+ *   - The Secrets Manager reads (`MEM9_DB_SECRET`, `MEM9_TENANT_ID`) resolve under
+ *     the DEFAULT `aws/secretsmanager` key, for which AWS requires no identity
+ *     `kms:Decrypt` at all — so `DenySecretContextDecryptFromNonEcsExecutionRoles`
+ *     is never evaluated. If either secret is ever moved to a customer managed
+ *     key, `Mem9CleanupExecutionRole-` must be added to that deny's exception
+ *     list, which lives in the operator-owned boundary template.
+ *
+ * Gated on `MEM9_SLACK_APPROVAL_ENABLED=1`. Disabled means ABSENT, not
+ * present-and-idle: a task definition that exists is a task definition `RunTask`
+ * can start, and grants that exist are grants a compromised callback can use.
+ */
+
+import type { DbOutputs } from "./db";
+import type { EcsOutputs } from "./ecs";
+import type { OauthFacadeOutputs } from "./oauth-facade";
+import type { TenantIdentityOutputs } from "./tenant-identity";
+import { accountId, ECR_REGION, ecrImage } from "./ecr";
+import { resolveVpc } from "./vpc";
+
+const IMAGE_TAG = process.env.MEM9_IMAGE_TAG || "latest";
+const BEDROCK_PROJECT = process.env.MEM9_BEDROCK_PROJECT;
+const BEDROCK_PROJECT_OPENAI = process.env.MEM9_BEDROCK_PROJECT_OPENAI || "";
+const RESPONSES_REGION = process.env.MEM9_LLM_RESPONSES_REGION || "us-west-2";
+
+export const SLACK_APPROVAL_ENABLED_ENV = "MEM9_SLACK_APPROVAL_ENABLED";
+export const SLACK_APPROVAL_CHANNEL_ENV = "MEM9_SLACK_APPROVAL_CHANNEL";
+
+/**
+ * The single container's name, which SST derives from the Task's logical name
+ * (`normalizeContainers`). The handler's `containerOverrides` targets this exact
+ * string, so a rename here makes `RunTask` reject the override AFTER the approval
+ * has already been claimed — the click is spent and nothing runs.
+ */
+export const CLEANUP_CONTAINER_NAME = "Mem9Cleanup";
+
+/**
+ * Where the task writes the approved-id file it then passes to `--ids`.
+ * `/tmp` because the Fargate task's root filesystem is the only writable place it
+ * is guaranteed, and the file holds ids only — never memory content.
+ */
+export const APPROVED_IDS_PATH = "/tmp/mem9-approved-ids.txt";
+
+/**
+ * #102's blast-radius limit, passed EXPLICITLY rather than left to the script's
+ * default. An apply that silently fell back would remove the one bound on how
+ * many memories a single click can delete.
+ */
+export const CLEANUP_CAP = 50;
+
+export interface SlackApprovalOutputs {
+  taskDefinitionArn: Output<string>;
+}
+
+/**
+ * Assert every required secret is seeded and non-empty, BEFORE any of them is
+ * constructed — otherwise the first secret is already created when the second one
+ * throws, leaving a half-built stack behind.
+ *
+ * GitHub exposes an UNSET repository secret as an EMPTY STRING, so the failure
+ * this guards is not a missing variable — it is a Slack app that answers 401 to
+ * every click after a completely green deploy. Checked at synthesis, mirroring
+ * the SLACK_WEBHOOK_URL precedent in infra/ecs.ts.
+ */
+function assertSecretsSeeded(required: Record<string, string>): void {
+  const missing = Object.entries(required)
+    .filter(([logicalName]) => !process.env[`SST_SECRET_${logicalName}`]?.trim())
+    // Reported together rather than one per deploy attempt: an operator seeding
+    // Slack for the first time is missing both, and a one-at-a-time error costs
+    // them a second full deploy to discover the second one.
+    .map(([logicalName, what]) => `${what} (${logicalName})`);
+  if (missing.length > 0) {
+    throw new Error(
+      `Slack approval requires ${missing.join(" and ")} when ` +
+        `${SLACK_APPROVAL_ENABLED_ENV}=1; seed the secret(s) for this stage`,
+    );
+  }
+}
+
+export function slackApproval(
+  ecsOut: EcsOutputs,
+  dbOut: DbOutputs,
+  identity: TenantIdentityOutputs,
+  facadeOut: OauthFacadeOutputs,
+): SlackApprovalOutputs | undefined {
+  if (process.env[SLACK_APPROVAL_ENABLED_ENV] !== "1") return undefined;
+
+  const prefix = `/mem9-on-aws/${$app.stage}`;
+  const tags = { Project: "mem9-on-aws", Stage: $app.stage, ManagedBy: "sst" };
+  const region = aws.getRegionOutput().name;
+
+  // The channel id is PUBLIC inside the workspace, so it is a plain String. As a
+  // SecureString it would need a kms:Decrypt on every read path that the boundary
+  // conditions tightly — the wrong type here costs an AccessDenied, not a leak.
+  // Absent with the flag set is a synthesis error: the poster would have nowhere
+  // to send the approval request and the loop would silently never start.
+  const channel = process.env[SLACK_APPROVAL_CHANNEL_ENV]?.trim();
+  if (!channel) {
+    throw new Error(
+      `${SLACK_APPROVAL_CHANNEL_ENV} is required when ` +
+        `${SLACK_APPROVAL_ENABLED_ENV}=1; set the approval channel id`,
+    );
+  }
+
+  assertSecretsSeeded({
+    SlackBotToken: "the Slack bot token",
+    SlackSigningSecret: "the Slack signing secret",
+  });
+  const botToken = new sst.Secret("SlackBotToken").value;
+  const signingSecret = new sst.Secret("SlackSigningSecret").value;
+
+  const param = (
+    logicalName: string,
+    suffix: string,
+    value: Output<string> | string,
+    type: "String" | "SecureString" | "StringList" = "String",
+  ) =>
+    new aws.ssm.Parameter(logicalName, {
+      name: `${prefix}/${suffix}`,
+      type,
+      value,
+      tags,
+    });
+
+  // Both secrets land as SecureStrings so the value stays redacted in Pulumi
+  // state, in the deploy diff, and in every diagnostic. The façade Lambda already
+  // reads `slack/signing-secret` through its existing prefix-scoped
+  // ssm:GetParameters + conditioned kms:Decrypt, so it needs no new grant for it.
+  const botTokenParameter = param(
+    "SlackBotToken",
+    "slack/bot-token",
+    botToken,
+    "SecureString",
+  );
+  param(
+    "SlackSigningSecret",
+    "slack/signing-secret",
+    signingSecret,
+    "SecureString",
+  );
+  param("SlackApprovalChannel", "slack/approval-channel", channel);
+
+  const task = new sst.aws.Task(CLEANUP_CONTAINER_NAME, {
+    cluster: ecsOut.cluster,
+    architecture: "arm64",
+    cpu: "0.5 vCPU",
+    memory: "1 GB",
+    image: ecrImage("mem9-on-aws/llm-proxy", IMAGE_TAG),
+    // `node` is the ENTRYPOINT because ECS can override `command` but NOT
+    // `entryPoint`; the handler's environment-only override depends on that.
+    entrypoint: ["node"],
+    command: [
+      "/app/scripts/memory-cleanup.mjs",
+      "--stage",
+      $app.stage,
+      // Explicit base URL instead of Cloud Map discovery: the image does not ship
+      // @aws-sdk/client-servicediscovery, so `discoverInstances` would throw and
+      // the run would exit 2 having deleted nothing.
+      "--base-url",
+      $interpolate`http://${ecsOut.serviceDnsName}:8080`,
+      "--apply",
+      "--ids",
+      APPROVED_IDS_PATH,
+      "--cap",
+      String(CLEANUP_CAP),
+    ],
+    environment: {
+      MEM9_STAGE: $app.stage,
+      MEM9_DB_HOST: dbOut.host,
+      MEM9_DB_PORT: dbOut.port.apply(String),
+      MEM9_DB_NAME: dbOut.database,
+      MEM9_LLM_MODEL: process.env.MEM9_LLM_MODEL || "zai.glm-5",
+      MEM9_BEDROCK_PROJECT: BEDROCK_PROJECT || "",
+      MEM9_BEDROCK_PROJECT_OPENAI: BEDROCK_PROJECT_OPENAI,
+      MEM9_LLM_RESPONSES_REGION: RESPONSES_REGION,
+      MEM9_SSM_PREFIX: prefix,
+      MEM9_SLACK_APPROVAL_CHANNEL: channel,
+      MEM9_APPROVED_IDS_PATH: APPROVED_IDS_PATH,
+      ...(ecsOut.alertsTopicArn
+        ? { MEM9_ALERTS_TOPIC_ARN: ecsOut.alertsTopicArn }
+        : {}),
+    },
+    // Fetched by the EXECUTION role at task start, so no secret value is ever an
+    // `environment` entry (those are readable by anyone holding
+    // ecs:DescribeTaskDefinition) and none reaches Pulumi state as plaintext.
+    ssm: {
+      MEM9_DB_SECRET: dbOut.secretArn,
+      MEM9_TENANT_ID: identity.tenantSecretArn,
+      SLACK_BOT_TOKEN: botTokenParameter.arn,
+    },
+    permissions: [
+      {
+        actions: ["bedrock-mantle:CreateInference"],
+        resources: [
+          BEDROCK_PROJECT
+            ? $interpolate`arn:aws:bedrock-mantle:${ECR_REGION}:${accountId()}:project/${BEDROCK_PROJECT}`
+            : "*",
+          // A reasoning model is served from RESPONSES_REGION, whose project is a
+          // DIFFERENT resource — without this the task 403s on inference.
+          ...(BEDROCK_PROJECT_OPENAI
+            ? [
+                $interpolate`arn:aws:bedrock-mantle:${RESPONSES_REGION}:${accountId()}:project/${BEDROCK_PROJECT_OPENAI}`,
+              ]
+            : []),
+        ],
+      },
+      {
+        actions: [
+          "bedrock-mantle:CallWithBearerToken",
+          "bedrock-mantle:GetProject",
+          "bedrock-mantle:ListProjects",
+          "bedrock-mantle:ListTagsForResource",
+        ],
+        resources: ["*"],
+      },
+      // The task reads the approval record to learn WHICH ids were approved. It
+      // reads only under `approvals/`, and it never writes: the claim is the
+      // Lambda's to stamp, so a task that could rewrite it could re-approve
+      // itself.
+      {
+        actions: ["ssm:GetParameters"],
+        resources: [
+          $interpolate`arn:aws:ssm:${region}:${accountId()}:parameter${prefix}/approvals/*`,
+        ],
+      },
+      ...(ecsOut.alertsTopicArn
+        ? [{ actions: ["sns:Publish"], resources: [ecsOut.alertsTopicArn] }]
+        : []),
+    ],
+    logging: { retention: "1 month" },
+    transform: {
+      taskDefinition: (args: Record<string, any>) => {
+        args.tags = { ...(args.tags ?? {}), ...tags };
+      },
+    },
+  });
+
+  // --- The four inputs `readTaskInputs` reads to start the task ---
+  // Keyed by the field each one populates. Both the cluster name and the task-def
+  // ARN are non-empty strings, so swapping them passes the handler's own
+  // required-value check and surfaces from ECS as an opaque validation error.
+  param("CleanupClusterName", "cleanup/cluster-name", ecsOut.clusterName);
+  param("CleanupTaskDefArn", "cleanup/task-def-arn", task.taskDefinition);
+  param("CleanupTaskSgId", "cleanup/task-sg-id", dbOut.taskSecurityGroupId);
+  // resolveVpc(), NOT task.subnets: the Task's subnet ELEMENTS are themselves
+  // Outputs, so joining them writes the literal string "Calling [toString] on an
+  // [Output<T>] is not supported." into SSM and RunTask rejects it.
+  param(
+    "CleanupSubnetIds",
+    "cleanup/subnet-ids",
+    resolveVpc().privateSubnetIds.apply((ids) => ids.join(",")),
+    "StringList",
+  );
+
+  // --- The three grants the façade Lambda needs, on its EXISTING role ---
+  new aws.iam.RolePolicy("Mem9SlackApprovalPolicy", {
+    role: facadeOut.functionRoleName,
+    policy: $jsonStringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Sid: "WriteApprovalRecords",
+          Effect: "Allow",
+          Action: ["ssm:PutParameter"],
+          // Scoped to the approval RECORDS, not the stage prefix. The stage
+          // prefix also holds the reader client secret and the four cleanup task
+          // inputs THIS SAME Lambda reads, so a prefix-wide write would let a
+          // compromised callback repoint its own ECS target. This is also exactly
+          // what the boundary's DenyPutParameterOutsideApprovalRecords permits.
+          Resource: [
+            $interpolate`arn:aws:ssm:${region}:${accountId()}:parameter${prefix}/approvals/*`,
+          ],
+        },
+        {
+          Sid: "RunCleanupApplyTask",
+          Effect: "Allow",
+          Action: ["ecs:RunTask"],
+          Resource: [task.taskDefinition],
+        },
+        {
+          Sid: "PassCleanupTaskRoles",
+          Effect: "Allow",
+          Action: ["iam:PassRole"],
+          Resource: [task.nodes.taskRole.arn, task.nodes.executionRole.arn],
+          // Unconditioned iam:PassRole on an ECS role is a privilege-escalation
+          // primitive: the same role could be handed to any service willing to
+          // assume it. The condition pins it to the ECS task path.
+          Condition: {
+            StringEquals: { "iam:PassedToService": "ecs-tasks.amazonaws.com" },
+          },
+        },
+      ],
+    }),
+  });
+
+  return { taskDefinitionArn: task.taskDefinition };
+}

--- a/infra/src/oauth-facade/config.test.ts
+++ b/infra/src/oauth-facade/config.test.ts
@@ -53,6 +53,10 @@ describe("façade config loader (cycle-break SSM reads)", () => {
       userClientSecret: "csecret",
       allowedCallbackUrls:
         '["https://oauth.example.com/callback/app"]',
+      // `fullSsm` has no Slack app, and an exhaustive `toEqual` is kept
+      // deliberately: loosening it to `objectContaining` would stop this case from
+      // noticing a value silently added to the config surface.
+      slackSigningSecret: "",
     });
     const cmd = (ssm.send as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(cmd.input.WithDecryption).toBe(true);
@@ -61,6 +65,7 @@ describe("façade config loader (cycle-break SSM reads)", () => {
       `${PREFIX}/cognito/reader/client-id`,
       `${PREFIX}/cognito/reader/client-secret`,
       `${PREFIX}/oauth/allowed-callback-urls`,
+      `${PREFIX}/slack/signing-secret`,
     ]);
   });
 
@@ -157,5 +162,49 @@ describe("façade config loader (cycle-break SSM reads)", () => {
     expect(parseAllowedCallbackUrls(JSON.stringify([callback]))).toEqual([
       callback,
     ]);
+  });
+});
+
+describe("Slack signing secret in the façade config (TC-SLACKAPP-044..046)", () => {
+  it("TC-SLACKAPP-044 the Slack signing secret is read decrypted, alongside the OAuth values", async () => {
+    // Read through the SAME `GetParameters` call rather than a second round trip:
+    // the boundary admits `kms:Decrypt` scoped to `parameter/mem9-on-aws/*`, so a
+    // SecureString is available here — and it must be one, because a signing
+    // secret in a plain String parameter is readable by anything with
+    // `ssm:GetParameters` on the tree.
+    const ssm = ssmReturning({
+      ...fullSsm,
+      [`${PREFIX}/slack/signing-secret`]: "shhh",
+    });
+    const cfg = await loadConfig({ ssm, env: baseEnv });
+    expect(cfg.slackSigningSecret).toBe("shhh");
+    const cmd = (ssm.send as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(cmd.input.WithDecryption).toBe(true);
+    expect(cmd.input.Names).toContain(`${PREFIX}/slack/signing-secret`);
+  });
+
+  it("TC-SLACKAPP-045 an absent Slack secret is empty, NOT a config load failure", async () => {
+    // The whole OAuth façade — every MCP client's auth — loads through this
+    // function. A stage that has not been given a Slack app must therefore leave
+    // the secret absent WITHOUT throwing, or enabling Slack on one stage would
+    // take MCP auth down on every other. `resolveSsm`'s `get` throws by design for
+    // the OAuth values; this one deliberately does not share that behavior.
+    const ssm = ssmReturning(fullSsm);
+    const cfg = await loadConfig({ ssm, env: baseEnv });
+    expect(cfg.slackSigningSecret).toBe("");
+    expect(cfg.upstream).toBe("https://gw");
+  });
+
+  it("TC-SLACKAPP-046 a stage prefix is not enough to reach another stage's secret", async () => {
+    // The parameter name is built from the injected prefix, so a preview stage
+    // cannot read prod's secret by construction. Pinned because the alternative
+    // spelling — one shared secret under a stage-less path — would let any preview
+    // Lambda verify and act on prod's approval clicks.
+    const ssm = ssmReturning({
+      ...fullSsm,
+      "/mem9-on-aws/prod/slack/signing-secret": "prod-secret",
+    });
+    const cfg = await loadConfig({ ssm, env: baseEnv });
+    expect(cfg.slackSigningSecret).toBe("");
   });
 });

--- a/infra/src/oauth-facade/config.ts
+++ b/infra/src/oauth-facade/config.ts
@@ -48,6 +48,12 @@ export interface FacadeConfig {
   allowedClientRedirectUris: string[];
   /** HMAC key for state signing; empty disables the proxy (503). */
   hmacKey: string;
+  /**
+   * Slack app signing secret (issue #123). Empty means no Slack app is
+   * configured for this stage; the callback route then answers 404 and the OAuth
+   * façade is unaffected.
+   */
+  slackSigningSecret: string;
 }
 
 /** Minimal SSM surface used here — injected so tests need no AWS. */
@@ -137,12 +143,19 @@ export async function resolveSsm(
   userClientId: string;
   userClientSecret: string;
   allowedCallbackUrls: string;
+  slackSigningSecret: string;
 }> {
   const names = [
     `${prefix}/gateway/url`,
     `${prefix}/cognito/reader/client-id`,
     `${prefix}/cognito/reader/client-secret`,
     `${prefix}/oauth/allowed-callback-urls`,
+    // Stage-scoped by the prefix, so a preview Lambda cannot verify prod's
+    // approval clicks. Fetched in the SAME call as the OAuth values because
+    // `GetParameters` tolerates absent names (they come back in `InvalidParameters`
+    // rather than failing the call), which is what lets it be optional without a
+    // second round trip.
+    `${prefix}/slack/signing-secret`,
   ];
   const res = await ssm.send(
     new GetParametersCommand({ Names: names, WithDecryption: true }),
@@ -160,6 +173,11 @@ export async function resolveSsm(
     userClientId: get(names[1]!),
     userClientSecret: get(names[2]!),
     allowedCallbackUrls: get(names[3]!),
+    // Deliberately NOT `get`: every MCP client's auth loads through this
+    // function, so a stage with no Slack app must resolve to empty rather than
+    // throw. Enabling Slack on one stage must not be able to take OAuth down on
+    // another.
+    slackSigningSecret: byName.get(names[4]!) ?? "",
   };
 }
 
@@ -193,5 +211,6 @@ export async function loadConfig(
     ),
     // Empty (not missing) is the intended "proxy disabled" sentinel.
     hmacKey: env.OAUTH_STATE_HMAC_KEY ?? "",
+    slackSigningSecret: resolved.slackSigningSecret,
   };
 }

--- a/infra/src/oauth-facade/handler.test.ts
+++ b/infra/src/oauth-facade/handler.test.ts
@@ -1265,25 +1265,24 @@ describe("Slack deps at the Lambda entrypoint (TC-SLACKAPP-047..049)", () => {
       env: { SSM_PREFIX: "/mem9-on-aws/test", STAGE: SLACK_STAGE },
       clients: {
         ssm: {
-          send: async (cmd: { input: Record<string, unknown> }) => {
-            // The approval read (`GetParameter`, singular `Name`) vs the ECS input
-            // read (`GetParameters`, plural `Names`) — distinguished so this case
-            // reaches RunTask instead of stopping at the offered-list check.
-            if (cmd.input.Name) {
-              return {
-                Parameter: {
-                  Value: JSON.stringify({
-                    stage: SLACK_STAGE,
-                    hash: SLACK_HASH,
-                    ids: ["m-1"],
-                  }),
-                },
-              };
-            }
+          send: async (cmd) => {
+            // Both reads are `GetParameters` — the only read the action ceiling
+            // admits (TC-047g) — so they are told apart by NAME, not by command
+            // shape. The approval read has to answer the offered record or this
+            // case stops at the offered-list check and never reaches RunTask.
+            const names = ((cmd as { input: { Names?: string[] } }).input.Names) ?? [];
             return {
-              Parameters: ((cmd.input.Names as string[] | undefined) ?? []).map((Name) => ({
+              Parameters: names.map((Name) => ({
                 Name,
-                Value: Name.endsWith("/subnet-ids") ? "subnet-a" : "v",
+                Value: Name.endsWith("/approvals/offered")
+                  ? JSON.stringify({
+                      stage: SLACK_STAGE,
+                      hash: SLACK_HASH,
+                      ids: ["m-1"],
+                    })
+                  : Name.endsWith("/subnet-ids")
+                    ? "subnet-a"
+                    : "v",
               })),
             };
           },
@@ -1298,6 +1297,47 @@ describe("Slack deps at the Lambda entrypoint (TC-SLACKAPP-047..049)", () => {
     // branch and every refusal reply also produce.
     expect(res.statusCode).toBe(200);
     expect(JSON.parse(res.body).text).toMatch(/Apply started/u);
+  });
+
+  it("TC-SLACKAPP-047g every parameter read uses GetParameters, the only read the boundary admits", async () => {
+    // `ssm:GetParameter` and `ssm:GetParameters` are DISTINCT IAM actions, and the
+    // workload permissions boundary's action ceiling admits only the plural (the
+    // whole project reads through `GetParameters`, so nothing needed the singular
+    // until this handler). A `GetParameterCommand` is therefore an AccessDenied on
+    // the first real Slack click — a runtime-only failure, invisible to every test
+    // that injects a client, because an injected fake answers any command shape.
+    //
+    // Asserted on the command CLASS rather than the response, since the two commands
+    // are interchangeable from the caller's side: same parameter, same value back,
+    // and only IAM can tell them apart.
+    const { GetParametersCommand } = await import("@aws-sdk/client-ssm");
+    const sent: unknown[] = [];
+    const deps = buildSlackDeps(
+      cfg({ slackSigningSecret: "shhh" }),
+      { SSM_PREFIX: "/mem9-on-aws/pr-7", STAGE: "pr-7" },
+      {
+        ssm: {
+          send: async (cmd) => {
+            sent.push(cmd);
+            return {
+              Parameters: [
+                { Name: "/mem9-on-aws/pr-7/approvals/offered", Value: '{"ids":[]}' },
+              ],
+            };
+          },
+        },
+      },
+    );
+    const value = await deps!.getParameter("/mem9-on-aws/pr-7/approvals/offered");
+
+    expect(value).toBe('{"ids":[]}');
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toBeInstanceOf(GetParametersCommand);
+    // And an absent parameter is null, not the literal string "undefined": SSM
+    // reports a missing name in `InvalidParameters`, omitting it from `Parameters`
+    // entirely rather than returning an empty value.
+    const missing = await deps!.getParameter("/mem9-on-aws/pr-7/approvals/approved-x");
+    expect(missing).toBeNull();
   });
 
   it("TC-SLACKAPP-047f the approval record is a plain String written without overwrite", async () => {

--- a/infra/src/oauth-facade/handler.test.ts
+++ b/infra/src/oauth-facade/handler.test.ts
@@ -3,9 +3,17 @@
  * Exercised through the injected `route(event, cfg)` seam — no AWS/SSM.
  */
 
+import { createHmac } from "node:crypto";
+
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { isAllowedClientRedirect, route } from "./handler.js";
+import {
+  buildSlackDeps,
+  handler,
+  isAllowedClientRedirect,
+  route,
+} from "./handler.js";
+import type { SlackDeps } from "./slack-interactions.js";
 import {
   signAuthorizationCode,
   signOAuthTransaction,
@@ -35,6 +43,9 @@ function cfg(overrides: Partial<FacadeConfig> = {}): FacadeConfig {
     userClientSecret: "reader-client-secret",
     allowedClientRedirectUris: [],
     hmacKey: HMAC,
+    // Empty by default: the OAuth cases must not depend on a Slack app existing,
+    // and the Slack cases inject their own deps rather than reading this.
+    slackSigningSecret: "",
     ...overrides,
   };
 }
@@ -940,5 +951,401 @@ describe("façade routing (TC-MCPGW-060..073)", () => {
     );
     expect(res.statusCode).toBe(400);
     expect(JSON.parse(res.body).error).toBe("invalid_redirect_uri");
+  });
+});
+
+const SLACK_SECRET = "unit-test-signing-secret";
+const SLACK_STAGE = "test";
+const SLACK_HASH = "sha256:deadbeef";
+
+/**
+ * The Slack side of the façade, injected the same way `cfg` is. The Slack branch
+ * is reachable ONLY when these deps are present, which is what makes "the
+ * feature flag is unset" a structural state rather than a runtime string check.
+ */
+function slackDeps(overrides: Partial<SlackDeps> = {}): SlackDeps {
+  return {
+    signingSecret: SLACK_SECRET,
+    stage: SLACK_STAGE,
+    ssmPrefix: "/mem9-on-aws/test",
+    now: () => Date.now(),
+    getParameter: vi.fn(async () =>
+      JSON.stringify({ stage: SLACK_STAGE, hash: SLACK_HASH, ids: ["m-1"] }),
+    ),
+    putParameter: vi.fn(async () => {}),
+    runTask: vi.fn(async () => "arn:aws:ecs:region:account:task/cluster/abc"),
+    log: vi.fn(),
+    ...overrides,
+  };
+}
+
+/** Slack's scheme, computed here rather than by calling the production signer. */
+function slackEvent(
+  method = "POST",
+  opts: { secret?: string; now?: number } = {},
+) {
+  const body = `payload=${encodeURIComponent(
+    JSON.stringify({
+      type: "block_actions",
+      actions: [{ action_id: "cleanup_approve", value: SLACK_HASH }],
+    }),
+  )}`;
+  const ts = Math.floor((opts.now ?? Date.now()) / 1000);
+  const mac = createHmac("sha256", opts.secret ?? SLACK_SECRET)
+    .update(`v0:${ts}:${body}`)
+    .digest("hex");
+  return ev("/slack/interactions", method, {
+    body,
+    headers: {
+      "x-slack-request-timestamp": String(ts),
+      "x-slack-signature": `v0=${mac}`,
+      "content-type": "application/x-www-form-urlencoded",
+    },
+  });
+}
+
+describe("Slack callback routing on the shared façade (TC-SLACKAPP-040..043)", () => {
+  it("TC-SLACKAPP-040 POST /slack/interactions is matched explicitly, never proxied upstream", async () => {
+    // The façade proxies EVERY unmatched path to the AgentCore Gateway, so the
+    // failure this pins is not a 404 — it is a Slack payload arriving at the
+    // Gateway and the Gateway's error shape being returned to Slack. Asserted by
+    // watching `fetch`, because a route that returned 200 from the Slack handler
+    // AND forwarded upstream would still pass a status-only assertion.
+    // Stubbed rather than merely spied: an un-stubbed spy calls through, so a
+    // fallthrough would fail with ENOTFOUND and make the test depend on DNS
+    // resolution failing for `gateway.example`.
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async () => new Response("upstream", { status: 200 }));
+    const slack = slackDeps();
+    const res = await route(slackEvent(), cfg(), slack);
+
+    expect(res.statusCode).toBe(200);
+    expect(slack.runTask).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("TC-SLACKAPP-041 with the feature unconfigured the path is 404, not proxied", async () => {
+    // 404 rather than a fallthrough: forwarding would send operator-approval data
+    // to a component with no business seeing it. 404 rather than 401 because
+    // without deps there is no secret any request to this path could be
+    // authenticated against — the endpoint genuinely is not here.
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async () => new Response("upstream", { status: 200 }));
+    const res = await route(slackEvent(), cfg());
+
+    expect(res.statusCode).toBe(404);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("TC-SLACKAPP-042 GET /slack/interactions is 405 and the OAuth routes are unchanged", async () => {
+    const slack = slackDeps();
+    const get = await route(slackEvent("GET"), cfg(), slack);
+    expect(get.statusCode).toBe(405);
+    expect(slack.runTask).not.toHaveBeenCalled();
+
+    // The Slack branch is additive. A regression in the OAuth flow would break
+    // every MCP client, so the metadata documents are re-asserted WITH the Slack
+    // deps present rather than trusted to be unaffected.
+    const prm = await route(
+      ev("/.well-known/oauth-protected-resource"),
+      cfg(),
+      slack,
+    );
+    expect(prm.statusCode).toBe(200);
+    expect(JSON.parse(prm.body).resource).toBe(`${BASE}/mcp`);
+
+    const asm = await route(
+      ev("/.well-known/oauth-authorization-server"),
+      cfg(),
+      slack,
+    );
+    expect(asm.statusCode).toBe(200);
+    expect(JSON.parse(asm.body).registration_endpoint).toBe(`${BASE}/register`);
+
+    const reg = await route(
+      ev("/register", "POST", { body: JSON.stringify({}) }),
+      cfg(),
+      slack,
+    );
+    expect(reg.statusCode).toBe(201);
+  });
+
+  it("TC-SLACKAPP-043 the two concerns do not share a failure mode", async () => {
+    // OAuth misconfigured, Slack fine: the redirect proxy 503s while an approval
+    // click still applies. They share a Lambda, not a fate.
+    const slack = slackDeps();
+    const broken = cfg({ hmacKey: "" });
+    const oauth = await route(ev("/oauth/authorize", "GET", { query: "state=x" }), broken, slack);
+    expect(oauth.statusCode).toBe(503);
+
+    const click = await route(slackEvent(), broken, slack);
+    expect(click.statusCode).toBe(200);
+    expect(slack.runTask).toHaveBeenCalledTimes(1);
+
+    // And the converse: an unconfigured SLACK secret fails the Slack route closed
+    // (401, from the handler's own fail-closed branch — NOT 404, which would
+    // wrongly say the endpoint is absent) while OAuth keeps working.
+    const noSecret = slackDeps({ signingSecret: "" });
+    const closed = await route(slackEvent(), cfg(), noSecret);
+    expect(closed.statusCode).toBe(401);
+    expect(noSecret.runTask).not.toHaveBeenCalled();
+
+    const stillFine = await route(ev("/.well-known/oauth-protected-resource"), cfg(), noSecret);
+    expect(stillFine.statusCode).toBe(200);
+  });
+});
+
+describe("Slack deps at the Lambda entrypoint (TC-SLACKAPP-047..049)", () => {
+  it("TC-SLACKAPP-047 deps are built when the stage has a signing secret", () => {
+    // The routing cases above prove `route` dispatches when deps are PASSED. This
+    // proves the deployed Lambda actually builds them — without it the whole
+    // feature is unreachable in production while every routing test stays green.
+    const deps = buildSlackDeps(
+      cfg({ slackSigningSecret: "shhh" }),
+      { SSM_PREFIX: "/mem9-on-aws/pr-7", STAGE: "pr-7" },
+    );
+    expect(deps).not.toBeUndefined();
+    expect(deps!.signingSecret).toBe("shhh");
+    expect(deps!.stage).toBe("pr-7");
+    expect(deps!.ssmPrefix).toBe("/mem9-on-aws/pr-7");
+  });
+
+  it("TC-SLACKAPP-048 no secret means no deps, which is what makes the route 404", () => {
+    expect(
+      buildSlackDeps(cfg({ slackSigningSecret: "" }), {
+        SSM_PREFIX: "/mem9-on-aws/pr-7",
+        STAGE: "pr-7",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("TC-SLACKAPP-047b runTask reads its ECS inputs from the stage's SSM tree", async () => {
+    // The apply-task inputs live in SSM exactly as `scripts/run-consolidation-task.sh`
+    // reads them, so this dep does NOT need the apply task to exist yet in infra —
+    // it needs the names to be right. Asserted through the injected client seam so
+    // the case touches no AWS.
+    const sent: unknown[] = [];
+    const deps = buildSlackDeps(
+      cfg({ slackSigningSecret: "shhh" }),
+      { SSM_PREFIX: "/mem9-on-aws/pr-7", STAGE: "pr-7" },
+      {
+        ssm: {
+          send: async (cmd: { input: Record<string, unknown> }) => {
+            sent.push(cmd.input);
+            const names = cmd.input.Names as string[] | undefined;
+            if (!names) return {};
+            return {
+              Parameters: names.map((Name) => ({
+                Name,
+                Value: Name.endsWith("/subnet-ids")
+                  ? "subnet-a,subnet-b"
+                  : `value-for${Name.slice(Name.lastIndexOf("/"))}`,
+              })),
+            };
+          },
+        },
+        ecs: {
+          send: async (cmd: { input: Record<string, unknown> }) => {
+            sent.push(cmd.input);
+            return { tasks: [{ taskArn: "arn:aws:ecs:r:a:task/c/t1" }], failures: [] };
+          },
+        },
+      },
+    );
+    const arn = await deps!.runTask({ ids: ["m-1"], hash: "sha256:x", stage: "pr-7" });
+    expect(arn).toBe("arn:aws:ecs:r:a:task/c/t1");
+
+    const read = sent.find((i) => (i as { Names?: string[] }).Names) as { Names: string[] };
+    for (const suffix of ["cluster-name", "task-def-arn", "task-sg-id", "subnet-ids"]) {
+      expect(read.Names).toContain(`/mem9-on-aws/pr-7/cleanup/${suffix}`);
+    }
+
+    const run = sent.find((i) => (i as { taskDefinition?: string }).taskDefinition) as Record<
+      string,
+      unknown
+    >;
+    // Each parameter must land in the field NAMED for it, not merely be read. The
+    // fake echoes the name into the value so a swap is visible here: reading four
+    // names and asserting only that all four were read passes even if `cluster`
+    // receives the task-def ARN, because both are non-empty strings and the
+    // required-value check cannot tell them apart. The mistake would surface only
+    // from ECS, as an opaque validation error, after the approval was claimed.
+    expect(run.cluster).toBe("value-for/cluster-name");
+    expect(run.taskDefinition).toBe("value-for/task-def-arn");
+    // Private subnets with no public IP: the argument that chose ECS over a
+    // VPC-attached Lambda was "no new network surface", and `assignPublicIp:
+    // ENABLED` would quietly add one.
+    const net = (run.networkConfiguration as {
+      awsvpcConfiguration: { subnets: string[]; assignPublicIp: string };
+    }).awsvpcConfiguration;
+    expect(net.subnets).toEqual(["subnet-a", "subnet-b"]);
+    expect(net.assignPublicIp).toBe("DISABLED");
+
+    // The override carries the HASH ONLY. Memory ids must not ride it: an override
+    // is echoed back in `DescribeTasks` and recorded in the CloudTrail event, so
+    // ids there would put memory identifiers in an audit log the privacy rules keep
+    // them out of — and the task must read the ids from the approved SSM record
+    // anyway, not from anything a caller supplied.
+    const overrides = JSON.stringify(run.overrides);
+    expect(overrides).toContain("sha256:x");
+    expect(overrides).not.toContain("m-1");
+  });
+
+  it("TC-SLACKAPP-047c a RunTask that starts nothing is an error, not a silent success", async () => {
+    // ECS returns HTTP 200 with an empty `tasks[]` and a populated `failures[]`
+    // when placement fails, so a dep that returned `tasks[0].taskArn` without
+    // checking would resolve to `undefined` — and the handler would stamp the claim
+    // and tell the operator an apply started that never did. This is the same trap
+    // `run-bootstrap-task.sh` calls out for the CLI path.
+    const deps = buildSlackDeps(
+      cfg({ slackSigningSecret: "shhh" }),
+      { SSM_PREFIX: "/mem9-on-aws/pr-7", STAGE: "pr-7" },
+      {
+        ssm: {
+          send: async (cmd: { input: Record<string, unknown> }) => ({
+            Parameters: ((cmd.input.Names as string[] | undefined) ?? []).map((Name) => ({
+              Name,
+              Value: Name.endsWith("/subnet-ids") ? "subnet-a" : "v",
+            })),
+          }),
+        },
+        ecs: {
+          send: async () => ({
+            tasks: [],
+            failures: [{ reason: "RESOURCE:MEMORY", arn: "arn:aws:ecs:r:a:container-instance/x" }],
+          }),
+        },
+      },
+    );
+    await expect(
+      deps!.runTask({ ids: ["m-1"], hash: "sha256:x", stage: "pr-7" }),
+    ).rejects.toThrow(/RESOURCE:MEMORY/u);
+  });
+
+  it("TC-SLACKAPP-047d an incomplete SSM input set fails before RunTask", async () => {
+    // A missing `task-def-arn` would otherwise reach `RunTask` as `undefined` and
+    // come back as an opaque validation error, after the claim was already written.
+    let ranTask = false;
+    const deps = buildSlackDeps(
+      cfg({ slackSigningSecret: "shhh" }),
+      { SSM_PREFIX: "/mem9-on-aws/pr-7", STAGE: "pr-7" },
+      {
+        ssm: {
+          send: async (cmd: { input: Record<string, unknown> }) => ({
+            // `task-def-arn` deliberately absent, mirroring how `GetParameters`
+            // reports unknown names rather than failing the call.
+            Parameters: ((cmd.input.Names as string[] | undefined) ?? [])
+              .filter((n) => !n.endsWith("/task-def-arn"))
+              .map((Name) => ({ Name, Value: "v" })),
+          }),
+        },
+        ecs: {
+          send: async () => {
+            ranTask = true;
+            return { tasks: [{ taskArn: "arn" }], failures: [] };
+          },
+        },
+      },
+    );
+    await expect(
+      deps!.runTask({ ids: ["m-1"], hash: "sha256:x", stage: "pr-7" }),
+    ).rejects.toThrow(/task-def-arn/u);
+    expect(ranTask).toBe(false);
+  });
+
+  it("TC-SLACKAPP-047e the entrypoint passes the built deps to the router", async () => {
+    // The gap the isolated `buildSlackDeps` cases cannot see: deleting
+    // `buildSlackDeps(cfg)` from `handler` leaves every other case green while the
+    // deployed Lambda 404s every click. Exercised through `handler`, so the wiring
+    // itself is the thing under test.
+    const res = await handler(slackEvent(), {
+      loadConfig: async () => cfg({ slackSigningSecret: SLACK_SECRET }),
+      env: { SSM_PREFIX: "/mem9-on-aws/test", STAGE: SLACK_STAGE },
+      clients: {
+        ssm: {
+          send: async (cmd: { input: Record<string, unknown> }) => {
+            // The approval read (`GetParameter`, singular `Name`) vs the ECS input
+            // read (`GetParameters`, plural `Names`) — distinguished so this case
+            // reaches RunTask instead of stopping at the offered-list check.
+            if (cmd.input.Name) {
+              return {
+                Parameter: {
+                  Value: JSON.stringify({
+                    stage: SLACK_STAGE,
+                    hash: SLACK_HASH,
+                    ids: ["m-1"],
+                  }),
+                },
+              };
+            }
+            return {
+              Parameters: ((cmd.input.Names as string[] | undefined) ?? []).map((Name) => ({
+                Name,
+                Value: Name.endsWith("/subnet-ids") ? "subnet-a" : "v",
+              })),
+            };
+          },
+        },
+        ecs: {
+          send: async () => ({ tasks: [{ taskArn: "arn:aws:ecs:r:a:task/c/t9" }], failures: [] }),
+        },
+      },
+    });
+
+    // A 200 whose body reports the apply started — NOT merely a 200, which the 404
+    // branch and every refusal reply also produce.
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).text).toMatch(/Apply started/u);
+  });
+
+  it("TC-SLACKAPP-047f the approval record is a plain String written without overwrite", async () => {
+    // Two runtime-only failures that no handler-level test can see, because the
+    // handler asks for `{ overwrite: false }` and trusts this closure to send it:
+    //
+    //  - `SecureString` would be DENIED by the workload permissions boundary,
+    //    which admits neither `kms:Encrypt` nor `kms:GenerateDataKey`. The failure
+    //    would be an AccessDenied on the first real click, long after CI is green.
+    //  - `Overwrite: true` silently destroys the atomic claim: `Overwrite: false`
+    //    failing with `ParameterAlreadyExists` is the ONLY thing that makes Slack's
+    //    3-second redelivery safe, so this mutation double-applies instead of ACKing.
+    const puts: Array<Record<string, unknown>> = [];
+    const deps = buildSlackDeps(
+      cfg({ slackSigningSecret: "shhh" }),
+      { SSM_PREFIX: "/mem9-on-aws/pr-7", STAGE: "pr-7" },
+      {
+        ssm: {
+          send: async (cmd) => (puts.push(cmd.input as Record<string, unknown>), {}),
+        },
+      },
+    );
+    await deps!.putParameter("/mem9-on-aws/pr-7/approvals/approved-x", "{}", {
+      overwrite: false,
+    });
+    expect(puts[0]!.Type).toBe("String");
+    expect(puts[0]!.Overwrite).toBe(false);
+
+    // And the stamp-after-RunTask path must be able to overwrite the same record.
+    await deps!.putParameter("/mem9-on-aws/pr-7/approvals/approved-x", "{}", {
+      overwrite: true,
+    });
+    expect(puts[1]!.Overwrite).toBe(true);
+  });
+
+  it("TC-SLACKAPP-049 a secret without the stage config is refused, not half-built", () => {
+    // A dep set with an empty `stage` would make the stage guard in `loadOffered`
+    // compare against "" and refuse every click — a feature that looks deployed,
+    // authenticates correctly, and then rejects every approval with a message about
+    // the wrong stage. Failing to build is louder and cheaper to diagnose.
+    for (const env of [
+      { SSM_PREFIX: "/mem9-on-aws/pr-7" },
+      { STAGE: "pr-7" },
+      { SSM_PREFIX: "/mem9-on-aws/pr-7", STAGE: "" },
+    ]) {
+      expect(() => buildSlackDeps(cfg({ slackSigningSecret: "shhh" }), env)).toThrow(
+        /SLACK|STAGE|SSM_PREFIX/u,
+      );
+    }
   });
 });

--- a/infra/src/oauth-facade/handler.ts
+++ b/infra/src/oauth-facade/handler.ts
@@ -892,11 +892,20 @@ export function buildSlackDeps(
     ssmPrefix,
     now: () => Date.now(),
     getParameter: async (name) => {
-      const { GetParameterCommand } = await import("@aws-sdk/client-ssm");
+      // `GetParameters` (plural) for a single name, NOT `GetParameter`. They are
+      // distinct IAM actions and the workload permissions boundary's action
+      // ceiling admits only the plural — the rest of the project reads through it,
+      // so nothing needed the singular until this handler. The two are otherwise
+      // interchangeable here, which is what makes the mistake invisible: same
+      // parameter, same value back, and only IAM can tell them apart, so the
+      // failure would be an AccessDenied on the first real Slack click.
+      const { GetParametersCommand } = await import("@aws-sdk/client-ssm");
       const res = (await (await ssmClient()).send(
-        new GetParameterCommand({ Name: name }),
-      )) as { Parameter?: { Value?: string } };
-      return res.Parameter?.Value ?? null;
+        new GetParametersCommand({ Names: [name] }),
+      )) as { Parameters?: Array<{ Name?: string; Value?: string }> };
+      // An absent name comes back in `InvalidParameters` and is simply missing
+      // from `Parameters`, so there is no empty-value case to distinguish.
+      return res.Parameters?.find((p) => p.Name === name)?.Value ?? null;
     },
     putParameter: async (name, value, opts) => {
       const { PutParameterCommand } = await import("@aws-sdk/client-ssm");

--- a/infra/src/oauth-facade/handler.ts
+++ b/infra/src/oauth-facade/handler.ts
@@ -35,6 +35,10 @@ import { randomBytes } from "node:crypto";
 
 import { loadConfig, type FacadeConfig } from "./config.js";
 import {
+  handleSlackInteraction,
+  type SlackDeps,
+} from "./slack-interactions.js";
+import {
   COGNITO_STATE_MAX_LENGTH,
   SIGNED_PAYLOAD_TTL_SECONDS,
   signAuthorizationCode,
@@ -166,6 +170,17 @@ function selfBaseUrl(event: ApiGwEvent): string {
   return `https://${host}`;
 }
 
+/**
+ * Container name in the cleanup apply task definition, following the
+ * `Mem9Consolidation` convention in `scripts/run-consolidation-task.sh`.
+ *
+ * A `containerOverrides` entry must name a container in the task definition, so
+ * this string and the infra definition are a contract that spans two files with
+ * nothing linking them: the infra side (TC-SLACKAPP-087) has to assert this same
+ * literal, because a mismatch is not something the unit tests here can see.
+ */
+const CLEANUP_CONTAINER_NAME = "Mem9Cleanup";
+
 function logEvent(name: string, fields: Record<string, unknown>): void {
   // One structured line per OAuth step. No token bodies — only grant_type /
   // outcome / non-secret query params.
@@ -209,15 +224,47 @@ export function isAllowedClientRedirect(
   return url.protocol === "https:" && allowedHttpsUris.includes(uri);
 }
 
-/** Pure router — all façade logic; config injected so tests need no AWS. */
+/**
+ * Pure router — all façade logic; config injected so tests need no AWS.
+ *
+ * `slack` is optional, and its absence is the feature flag: the Slack approval
+ * callback is only reachable when the entrypoint could build its deps (issue
+ * #123). A boolean flag alongside possibly-absent deps would allow the state
+ * "enabled but unconfigured", which is a runtime crash on the first click; making
+ * the deps themselves the flag removes that state from the type.
+ */
 export async function route(
   event: ApiGwEvent,
   cfg: FacadeConfig,
+  slack?: SlackDeps,
 ): Promise<ApiGwResponse> {
   const path = event.rawPath ?? event.path ?? "/";
   const method =
     event.requestContext?.http?.method ?? event.httpMethod ?? "GET";
   const base = selfBaseUrl(event);
+
+  // Matched FIRST, not merely before the catch-all. The catch-all forwards every
+  // unmatched path to the AgentCore Gateway, so a Slack payload that fell through
+  // would be sent to a component with no business seeing operator-approval data
+  // and the Gateway's error shape would be returned to Slack. Placing it here
+  // makes that impossible by construction instead of by ordering discipline, and
+  // the path cannot collide with an OAuth route.
+  //
+  // Absent deps answer 404, not a fallthrough and not 401: with no signing secret
+  // there is no key any request to this path could be authenticated against, so
+  // the endpoint genuinely is not deployed. (A CONFIGURED route with an empty
+  // secret is different — that is 401 from the handler's own fail-closed branch,
+  // because the endpoint is there and the request cannot be trusted.)
+  if (path === "/slack/interactions") {
+    if (!slack) {
+      logEvent("slack_interactions_unconfigured", { method });
+      return json(404, {
+        error: "not_found",
+        error_description: "The Slack approval callback is not enabled on this stage.",
+      });
+    }
+    return handleSlackInteraction(event, slack);
+  }
 
   // Per RFC 9728 §3.1 / RFC 8414 §3.1, a client that found the resource at
   // `<base>/mcp` queries the metadata at the resource-suffixed well-known path
@@ -743,8 +790,208 @@ function getConfig(): Promise<FacadeConfig> {
   return configPromise;
 }
 
-export async function handler(event: ApiGwEvent): Promise<ApiGwResponse> {
-  return route(event, await getConfig());
+/** Minimal client surface, injected so the unit tests reach no AWS. */
+interface AwsClientLike {
+  // `input: unknown` rather than `Record<string, unknown>`: AWS SDK command inputs
+  // are specific interfaces with no index signature, so the narrower type forced a
+  // double cast at every call site — casts that meant the constraint was never
+  // checking anything anyway.
+  send(command: { input: unknown }): Promise<unknown>;
+}
+
+/**
+ * Read the apply task's ECS inputs from the stage's SSM tree.
+ *
+ * The same parameters `scripts/run-consolidation-task.sh` reads, under the
+ * cleanup prefix — so this does not depend on the apply task's infra being
+ * authored yet, only on the names being right. Every value is required: a missing
+ * `task-def-arn` reaching `RunTask` as `undefined` would come back as an opaque
+ * validation error AFTER the approval claim was already written.
+ */
+async function readTaskInputs(
+  ssm: AwsClientLike,
+  ssmPrefix: string,
+): Promise<{ cluster: string; taskDef: string; securityGroups: string[]; subnets: string[] }> {
+  const { GetParametersCommand } = await import("@aws-sdk/client-ssm");
+  const prefix = `${ssmPrefix}/cleanup`;
+  // Keyed by the field each name populates, not positional: read back by index, a
+  // reordering would silently hand `cluster` the task-def ARN. Both are non-empty
+  // strings, so the required-value check below would pass and the mistake would
+  // surface from ECS as an opaque validation error.
+  const names = {
+    cluster: `${prefix}/cluster-name`,
+    taskDef: `${prefix}/task-def-arn`,
+    securityGroups: `${prefix}/task-sg-id`,
+    subnets: `${prefix}/subnet-ids`,
+  };
+  const res = (await ssm.send(
+    new GetParametersCommand({ Names: Object.values(names) }),
+  )) as { Parameters?: Array<{ Name?: string; Value?: string }> };
+  const byName = new Map((res.Parameters ?? []).map((p) => [p.Name, p.Value ?? ""]));
+  const get = (name: string): string => {
+    const v = byName.get(name);
+    // Named in the message rather than reported as a generic failure: the operator
+    // reading this needs to know WHICH parameter the deploy did not write.
+    if (!v) throw new Error(`missing SSM parameter ${name}`);
+    return v;
+  };
+  // StringList parameters arrive comma-joined; `RunTask` wants arrays.
+  const list = (name: string): string[] =>
+    get(name)
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+  return {
+    cluster: get(names.cluster),
+    taskDef: get(names.taskDef),
+    securityGroups: list(names.securityGroups),
+    subnets: list(names.subnets),
+  };
+}
+
+/**
+ * Build the Slack callback deps for this stage, or `undefined` if the stage has
+ * no Slack app.
+ *
+ * `undefined` is the feature flag (see `route`). Returning it rather than a
+ * half-populated dep set is deliberate: a dep set with an empty `stage` would
+ * authenticate clicks correctly and then have `loadOffered`'s stage guard refuse
+ * every one of them, which reads as a Slack problem and is really a deploy
+ * problem. Throwing on a secret-without-stage is louder and cheaper to diagnose.
+ *
+ * The AWS clients are constructed lazily INSIDE the closures, not here: a cold
+ * start that never receives a Slack click should not pay for an SSM or ECS client,
+ * and `handler.ts` must stay importable in a unit test with no ECS SDK present.
+ */
+export function buildSlackDeps(
+  cfg: FacadeConfig,
+  env: Record<string, string | undefined> = process.env,
+  clients: { ssm?: AwsClientLike; ecs?: AwsClientLike } = {},
+): SlackDeps | undefined {
+  if (!cfg.slackSigningSecret) return undefined;
+  const ssmPrefix = env.SSM_PREFIX;
+  const stage = env.STAGE;
+  if (!ssmPrefix || !stage) {
+    throw new Error(
+      "a Slack signing secret is configured but SSM_PREFIX or STAGE is not; " +
+        "refusing to build a Slack callback that would reject every approval",
+    );
+  }
+  // One resolution point for the SSM client, so an injected client is honoured on
+  // EVERY call. Two of these closures previously constructed their own, which made
+  // them unreachable from a test that thought it had injected one — the test then
+  // failed against real AWS instead of against the code.
+  const ssmClient = async (): Promise<AwsClientLike> => {
+    if (clients.ssm) return clients.ssm;
+    const { SSMClient } = await import("@aws-sdk/client-ssm");
+    return new SSMClient({});
+  };
+  return {
+    signingSecret: cfg.slackSigningSecret,
+    stage,
+    ssmPrefix,
+    now: () => Date.now(),
+    getParameter: async (name) => {
+      const { GetParameterCommand } = await import("@aws-sdk/client-ssm");
+      const res = (await (await ssmClient()).send(
+        new GetParameterCommand({ Name: name }),
+      )) as { Parameter?: { Value?: string } };
+      return res.Parameter?.Value ?? null;
+    },
+    putParameter: async (name, value, opts) => {
+      const { PutParameterCommand } = await import("@aws-sdk/client-ssm");
+      await (await ssmClient()).send(
+        new PutParameterCommand({
+          Name: name,
+          Value: value,
+          // Plain String, never SecureString: the workload boundary admits neither
+          // `kms:Encrypt` nor `kms:GenerateDataKey`, so a SecureString write would
+          // be denied at runtime. That constraint is exactly why an approval record
+          // may hold ids and a hash and never memory content.
+          Type: "String",
+          Overwrite: opts?.overwrite ?? false,
+        }),
+      );
+    },
+    runTask: async ({ hash }) => {
+      const inputs = await readTaskInputs(await ssmClient(), ssmPrefix);
+
+      const { ECSClient, RunTaskCommand } = await import("@aws-sdk/client-ecs");
+      const ecs = clients.ecs ?? new ECSClient({});
+
+      const res = (await ecs.send(
+        new RunTaskCommand({
+          cluster: inputs.cluster,
+          taskDefinition: inputs.taskDef,
+          launchType: "FARGATE",
+          networkConfiguration: {
+            awsvpcConfiguration: {
+              subnets: inputs.subnets,
+              securityGroups: inputs.securityGroups,
+              // Private subnets reached through the existing NAT path. The
+              // argument that chose ECS over a VPC-attached Lambda was "no new
+              // network surface", and ENABLED would quietly add one.
+              assignPublicIp: "DISABLED",
+            },
+          },
+          overrides: {
+            containerOverrides: [
+              {
+                name: CLEANUP_CONTAINER_NAME,
+                // Only the HASH is passed. `--ids` takes a FILE, so the ids cannot
+                // ride an override anyway, and they are already in SSM under the
+                // claim this hash names — so the task reads them from the record
+                // that was actually approved rather than from a list a caller
+                // supplied. That closes the gap the signature does not cover: it
+                // proves the click came from the workspace, never that any ids in
+                // the request are the ids the classifier chose.
+                environment: [{ name: "MEM9_APPROVAL_HASH", value: hash }],
+              },
+            ],
+          },
+        }),
+      )) as {
+        tasks?: Array<{ taskArn?: string }>;
+        failures?: Array<{ reason?: string; detail?: string }>;
+      };
+
+      // ECS answers 200 with an EMPTY `tasks[]` and a populated `failures[]` when
+      // placement fails, so reading `tasks[0].taskArn` unchecked would resolve
+      // `undefined` — and the caller would stamp the claim and tell the operator an
+      // apply started that never did. Same trap `run-bootstrap-task.sh` calls out.
+      const taskArn = res.tasks?.[0]?.taskArn;
+      if (!taskArn) {
+        const why = (res.failures ?? [])
+          .map((f) => [f.reason, f.detail].filter(Boolean).join(": "))
+          .join("; ");
+        throw new Error(`RunTask started no task${why ? `: ${why}` : ""}`);
+      }
+      return taskArn;
+    },
+    log: (message) => logEvent("slack_interactions", { message }),
+  };
+}
+
+/**
+ * Lambda entrypoint.
+ *
+ * `overrides` exists only so a test can exercise THIS wiring — that the built
+ * Slack deps actually reach `route`. Without it, removing `buildSlackDeps(cfg)`
+ * from this line leaves every unit test green while the deployed Lambda 404s every
+ * approval click, which is the one defect no isolated test of either function can
+ * see. It defaults to the real cold-start path and Lambda never passes a second
+ * argument.
+ */
+export async function handler(
+  event: ApiGwEvent,
+  overrides: {
+    loadConfig?: () => Promise<FacadeConfig>;
+    env?: Record<string, string | undefined>;
+    clients?: { ssm?: AwsClientLike; ecs?: AwsClientLike };
+  } = {},
+): Promise<ApiGwResponse> {
+  const cfg = await (overrides.loadConfig ?? getConfig)();
+  return route(event, cfg, buildSlackDeps(cfg, overrides.env, overrides.clients));
 }
 
 /** Test-only: drop the cold-start config singleton between cases. */

--- a/infra/src/oauth-facade/slack-interactions.test.ts
+++ b/infra/src/oauth-facade/slack-interactions.test.ts
@@ -1,0 +1,769 @@
+/**
+ * Unit tests for the Slack interactive-approval callback (issue #123,
+ * TC-SLACKAPP-001..036). Test IDs map to docs/test-cases/slack-approval-loop.md.
+ *
+ * Everything AWS is injected through `SlackDeps`, so no case touches SSM or ECS.
+ * The signature is computed here from the raw HMAC primitives rather than by
+ * calling the production signer: a signer that agrees with itself but not with
+ * Slack would pass a test that reused it, and that is precisely the bug this
+ * endpoint cannot afford.
+ */
+
+import { createHmac } from "node:crypto";
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  CLAIM_STALE_MS,
+  handleSlackInteraction,
+  type SlackDeps,
+} from "./slack-interactions.js";
+
+const SECRET = "unit-test-signing-secret";
+const NOW = new Date("2026-08-05T12:00:00Z").getTime();
+const STAGE = "test";
+const IDS = ["m-1", "m-2", "m-3"];
+const HASH = "sha256:0f".padEnd(20, "a");
+
+/** Slack's documented scheme: `v0=` + HMAC-SHA256 over `v0:{ts}:{rawBody}`. */
+function sign(rawBody: string, timestamp: number, secret = SECRET): string {
+  const mac = createHmac("sha256", secret)
+    .update(`v0:${timestamp}:${rawBody}`)
+    .digest("hex");
+  return `v0=${mac}`;
+}
+
+function payload(
+  overrides: Record<string, unknown> = {},
+  action: Record<string, unknown> = {},
+): string {
+  const body = {
+    type: "block_actions",
+    user: { id: "U123", username: "operator" },
+    response_url: "https://hooks.slack.example/actions/T/B/x",
+    actions: [
+      { action_id: "cleanup_approve", value: HASH, ...action },
+    ],
+    ...overrides,
+  };
+  // Slack posts interactions as `application/x-www-form-urlencoded` with the
+  // JSON in a `payload` field, NOT as a JSON body. Getting this wrong is a
+  // 100%-reproducible production failure that a JSON-bodied test never sees.
+  return `payload=${encodeURIComponent(JSON.stringify(body))}`;
+}
+
+function ev(
+  rawBody: string,
+  opts: { timestamp?: number; signature?: string; method?: string } = {},
+) {
+  const ts = opts.timestamp ?? Math.floor(NOW / 1000);
+  const headers: Record<string, string> = {
+    // API Gateway v2 lowercases header names. Matching only the canonical
+    // spelling would reject every real request while the unit test passed.
+    "x-slack-request-timestamp": String(ts),
+    "x-slack-signature": opts.signature ?? sign(rawBody, ts),
+    "content-type": "application/x-www-form-urlencoded",
+  };
+  return {
+    rawPath: "/slack/interactions",
+    headers,
+    body: rawBody,
+    requestContext: { http: { method: opts.method ?? "POST" } },
+  };
+}
+
+function offered(overrides: Record<string, unknown> = {}) {
+  return JSON.stringify({
+    stage: STAGE,
+    hash: HASH,
+    ids: IDS,
+    generatedAt: "2026-08-05T11:59:00Z",
+    ...overrides,
+  });
+}
+
+function deps(overrides: Partial<SlackDeps> = {}): SlackDeps {
+  return {
+    signingSecret: SECRET,
+    stage: STAGE,
+    ssmPrefix: "/mem9-on-aws/test",
+    now: () => NOW,
+    getParameter: vi.fn(async () => offered()),
+    putParameter: vi.fn(async () => {}),
+    runTask: vi.fn(async () => "arn:aws:ecs:region:account:task/cluster/abc"),
+    log: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("Slack signature verification (TC-SLACKAPP-001..006)", () => {
+  it("TC-SLACKAPP-001 a correctly signed request is accepted", async () => {
+    const body = payload();
+    const d = deps();
+    const res = await handleSlackInteraction(ev(body), d);
+
+    expect(res.statusCode).toBe(200);
+    expect(d.runTask).toHaveBeenCalledTimes(1);
+  });
+
+  it("TC-SLACKAPP-002 a body tampered with after signing is rejected 401 with no side effect", async () => {
+    const body = payload();
+    const signature = sign(body, Math.floor(NOW / 1000));
+    const tampered = payload({}, { value: "sha256:attacker-chosen" });
+    const d = deps();
+    const res = await handleSlackInteraction(
+      ev(tampered, { signature }),
+      d,
+    );
+
+    expect(res.statusCode).toBe(401);
+    // Asserted as untouched spies, not as an absent assertion: "no side effect"
+    // is the whole property, and a rejection that still wrote the claim would
+    // satisfy a test that only checked the status code.
+    expect(d.putParameter).not.toHaveBeenCalled();
+    expect(d.runTask).not.toHaveBeenCalled();
+  });
+
+  it("TC-SLACKAPP-003 a signature from the wrong secret is 401, and a length mismatch is not a 500", async () => {
+    const body = payload();
+    const d = deps();
+    expect(
+      (await handleSlackInteraction(
+        ev(body, { signature: sign(body, Math.floor(NOW / 1000), "other") }),
+        d,
+      )).statusCode,
+    ).toBe(401);
+
+    // `timingSafeEqual` THROWS on a length mismatch (the state.ts precedent), so
+    // a truncated or padded signature must be caught by a length check first —
+    // otherwise the endpoint answers an unhandled 500, which tells an attacker
+    // their input reached the comparator.
+    for (const bogus of ["v0=abc", "", "v0=", `${sign(body, Math.floor(NOW / 1000))}00`]) {
+      const res = await handleSlackInteraction(ev(body, { signature: bogus }), d);
+      expect(res.statusCode).toBe(401);
+    }
+    expect(d.runTask).not.toHaveBeenCalled();
+  });
+
+  it("TC-SLACKAPP-004 a missing signature or timestamp header is 401, and lookup is case-insensitive", async () => {
+    const body = payload();
+    const ts = Math.floor(NOW / 1000);
+    const d = deps();
+
+    const noSig = ev(body);
+    delete noSig.headers["x-slack-signature"];
+    expect((await handleSlackInteraction(noSig, d)).statusCode).toBe(401);
+
+    const noTs = ev(body);
+    delete noTs.headers["x-slack-request-timestamp"];
+    expect((await handleSlackInteraction(noTs, d)).statusCode).toBe(401);
+
+    // Canonical-cased headers must also work: API Gateway v2 lowercases, but a
+    // handler that matched ONLY the lowercase spelling would be untestable
+    // against any other transport, and one that matched only the canonical
+    // spelling would reject every real request.
+    const canonical = {
+      ...ev(body),
+      headers: {
+        "X-Slack-Request-Timestamp": String(ts),
+        "X-Slack-Signature": sign(body, ts),
+      },
+    };
+    expect((await handleSlackInteraction(canonical, d)).statusCode).toBe(200);
+  });
+
+  it("TC-SLACKAPP-005 verification happens before any parsing", async () => {
+    const d = deps();
+    // Signed but unparseable → the 400 proves parsing ran only after the
+    // signature was verified.
+    const garbage = "payload=%7Bnot-json";
+    expect((await handleSlackInteraction(ev(garbage), d)).statusCode).toBe(400);
+
+    // Unsigned but well-formed → 401, and the parse never happens. Spying on
+    // JSON.parse is the only way to assert ORDER rather than outcome: parsing an
+    // unauthenticated body is the attack surface this endpoint exists to close.
+    const parseSpy = vi.spyOn(JSON, "parse");
+    const res = await handleSlackInteraction(
+      ev(payload(), { signature: "v0=deadbeef" }),
+      d,
+    );
+    expect(res.statusCode).toBe(401);
+    expect(parseSpy).not.toHaveBeenCalled();
+    parseSpy.mockRestore();
+  });
+
+  it("TC-SLACKAPP-006 an unset or empty signing secret fails closed", async () => {
+    const body = payload();
+    const ts = Math.floor(NOW / 1000);
+    // Empty string is the "disabled" sentinel elsewhere in this Lambda
+    // (`hmacKey`), so the risk is real: an empty key still produces a VALID HMAC.
+    // The signature below is therefore computed WITH the empty secret — an
+    // attacker who knows the app is unconfigured can do exactly this. Signing
+    // with the real secret instead would make the case pass on a signature
+    // mismatch and prove nothing about failing closed.
+    for (const secret of ["", undefined as unknown as string]) {
+      const d = deps({ signingSecret: secret });
+      const res = await handleSlackInteraction(
+        ev(body, { signature: sign(body, ts, secret ?? "") }),
+        d,
+      );
+      expect([401, 503]).toContain(res.statusCode);
+      expect(d.runTask).not.toHaveBeenCalled();
+      expect(d.putParameter).not.toHaveBeenCalled();
+    }
+  });
+
+  it("TC-SLACKAPP-003b the comparison is constant-time", async () => {
+    // A structural assertion, and deliberately so: `===` and `timingSafeEqual`
+    // are behaviourally identical, so NO input can distinguish them. Timing
+    // safety is therefore unprovable from the outside — and an invariant that
+    // cannot be observed is exactly the kind that gets refactored away. The
+    // `state.ts` precedent in this same Lambda makes the intent unambiguous.
+    const src = await readFile(
+      new URL("./slack-interactions.ts", import.meta.url),
+      "utf8",
+    );
+    expect(src).toMatch(/timingSafeEqual\(/u);
+    // And it must not be reached with unequal lengths, which throws.
+    expect(src).toMatch(/length !== .*length/u);
+  });
+});
+
+describe("Slack replay guard (TC-SLACKAPP-010..012)", () => {
+  it("TC-SLACKAPP-010 a timestamp older than 5 minutes is rejected even when signed", async () => {
+    const old = Math.floor(NOW / 1000) - 6 * 60;
+    const body = payload();
+    const d = deps();
+    const res = await handleSlackInteraction(
+      ev(body, { timestamp: old, signature: sign(body, old) }),
+      d,
+    );
+    expect(res.statusCode).toBe(401);
+    expect(d.runTask).not.toHaveBeenCalled();
+  });
+
+  it("TC-SLACKAPP-011 a timestamp more than 5 minutes in the future is also rejected", async () => {
+    // A one-sided check accepts a signature minted against a clock the attacker
+    // controls and keeps it valid indefinitely.
+    const future = Math.floor(NOW / 1000) + 6 * 60;
+    const body = payload();
+    const d = deps();
+    const res = await handleSlackInteraction(
+      ev(body, { timestamp: future, signature: sign(body, future) }),
+      d,
+    );
+    expect(res.statusCode).toBe(401);
+    expect(d.runTask).not.toHaveBeenCalled();
+  });
+
+  it("TC-SLACKAPP-012 a malformed timestamp is rejected BY SHAPE, not by coercion", async () => {
+    // Asserted on the logged REASON, not just the 401, because for most of these
+    // inputs the status code cannot tell the two branches apart: `Number("")` is
+    // 0, `Number("1e999")` is Infinity, and `Number("-1")` is -1 — all of which
+    // the skew check would also reject, just for the wrong reason. Only
+    // `"abc"` -> NaN is uniquely the shape check's to catch, since every NaN
+    // comparison is false and `Math.abs(NaN) > MAX` therefore ACCEPTS it.
+    //
+    // So the reason string is the observable that distinguishes "we recognised
+    // this as garbage" from "we did arithmetic on garbage and got lucky", and an
+    // operator reading `stale timestamp` for `"abc"` would go hunting a clock
+    // skew that does not exist.
+    const body = payload();
+    // The expected reason is per-case, not uniform, because an empty header is
+    // genuinely absent rather than malformed and saying otherwise would send an
+    // operator looking for a corrupt value that was never sent.
+    const cases: Array<[string, RegExp]> = [
+      ["", /missing signature headers/u],
+      ["abc", /malformed timestamp/u],
+      ["1e999", /malformed timestamp/u],
+      ["-1", /malformed timestamp/u],
+      ["99999999999999999999", /malformed timestamp/u],
+      // `Number` TRIMS, so this coerces to a valid epoch. The value is chosen to
+      // be inside the skew window on purpose: with an in-window value the skew
+      // check cannot reject it, so if the 401 arrives at all it arrives from the
+      // shape check and nowhere else.
+      [` ${Math.floor(NOW / 1000)} `, /malformed timestamp/u],
+    ];
+    for (const [ts, reason] of cases) {
+      const d = deps();
+      const headers = {
+        "x-slack-request-timestamp": ts,
+        // Signed with the REAL secret over the garbage timestamp, exactly as an
+        // attacker replaying a captured body would. A bare hex digest here (no
+        // `v0=`) would 401 on the signature and prove nothing about the
+        // timestamp — which is how this case first passed while accepting NaN.
+        "x-slack-signature": sign(body, ts as unknown as number),
+      };
+      const res = await handleSlackInteraction(
+        { rawPath: "/slack/interactions", headers, body, requestContext: { http: { method: "POST" } } },
+        d,
+      );
+      expect(res.statusCode, `timestamp ${JSON.stringify(ts)}`).toBe(401);
+      const logged = (d.log as ReturnType<typeof vi.fn>).mock.calls.map(String).join("\n");
+      expect(logged, `timestamp ${JSON.stringify(ts)}`).toMatch(reason);
+      expect(logged, `timestamp ${JSON.stringify(ts)}`).not.toMatch(/stale timestamp/u);
+      expect(d.runTask).not.toHaveBeenCalled();
+    }
+  });
+
+  it("TC-SLACKAPP-012b a well-formed but out-of-window timestamp is stale, not malformed", async () => {
+    // The other half of TC-012: without this, a shape check tightened until it
+    // rejected every timestamp would pass TC-012 completely, and the endpoint
+    // would answer 401 to Slack forever. This case is what makes the shape check
+    // a filter rather than a wall.
+    const body = payload();
+    for (const offsetSec of [-10 * 60, 10 * 60]) {
+      const ts = String(Math.floor(NOW / 1000) + offsetSec);
+      const d = deps();
+      const res = await handleSlackInteraction(
+        {
+          rawPath: "/slack/interactions",
+          headers: {
+            "x-slack-request-timestamp": ts,
+            "x-slack-signature": sign(body, ts as unknown as number),
+          },
+          body,
+          requestContext: { http: { method: "POST" } },
+        },
+        d,
+      );
+      expect(res.statusCode, `offset ${offsetSec}s`).toBe(401);
+      const logged = (d.log as ReturnType<typeof vi.fn>).mock.calls.map(String).join("\n");
+      expect(logged, `offset ${offsetSec}s`).toMatch(/stale timestamp/u);
+      expect(logged, `offset ${offsetSec}s`).not.toMatch(/malformed/u);
+    }
+  });
+});
+
+describe("Slack stale-hash rejection (TC-SLACKAPP-020..025)", () => {
+  it("TC-SLACKAPP-020 a click whose hash does not match the offered record is refused", async () => {
+    const body = payload({}, { value: "sha256:an-older-list" });
+    const d = deps();
+    const res = await handleSlackInteraction(ev(body), d);
+
+    expect(res.statusCode).toBe(200); // Slack needs a 200 to render the message
+    expect(d.putParameter).not.toHaveBeenCalled();
+    expect(d.runTask).not.toHaveBeenCalled();
+    expect(JSON.stringify(res.body)).toMatch(/regenerated/iu);
+  });
+
+  it("TC-SLACKAPP-021 a missing or unreadable offered parameter is refused, and the two are distinguishable", async () => {
+    // A read failure must never WIDEN what is accepted...
+    for (const getParameter of [
+      vi.fn(async () => null),
+      vi.fn(async () => "not json"),
+    ]) {
+      const d = deps({ getParameter });
+      await handleSlackInteraction(ev(payload()), d);
+      expect(d.runTask).not.toHaveBeenCalled();
+      expect(d.putParameter).not.toHaveBeenCalled();
+    }
+
+    // ...and a THROWN read is not the same event as an absent parameter. Both
+    // refuse, so "nothing was applied" alone cannot tell them apart — but one is
+    // a regenerated list and the other is an IAM denial or an SSM outage, and an
+    // operator who is told "regenerated" will re-run the classifier instead of
+    // fixing the permission. The failure must reach the log as a failure.
+    const d = deps({
+      getParameter: vi.fn(async () => {
+        throw new Error("AccessDeniedException: not authorized to perform ssm:GetParameter");
+      }),
+    });
+    const res = await handleSlackInteraction(ev(payload()), d);
+    expect(d.runTask).not.toHaveBeenCalled();
+    const logged = (d.log as ReturnType<typeof vi.fn>).mock.calls.map((c) => String(c[0]));
+    expect(logged.some((m) => m.includes("AccessDeniedException"))).toBe(true);
+    expect(JSON.stringify(res.body)).not.toMatch(/regenerated/iu);
+  });
+
+  it("TC-SLACKAPP-022 the applied ids come from the offered record, never from the payload", async () => {
+    // The signature proves the request came from the workspace, NOT that the ids
+    // in it are the ids the classifier chose. Accepting payload ids would let any
+    // workspace member delete arbitrary memories by editing a payload.
+    const body = payload({}, { value: HASH, ids: ["attacker-chosen"] });
+    const d = deps();
+    await handleSlackInteraction(ev(body), d);
+
+    const runArgs = (d.runTask as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+    expect(runArgs.ids).toEqual(IDS);
+    expect(JSON.stringify(runArgs)).not.toContain("attacker-chosen");
+  });
+
+  it("TC-SLACKAPP-023 the claim record carries ids, hash, stage, and timestamps only — no memory content", async () => {
+    // This parameter is a plain `String` (the boundary admits no KMS), readable
+    // by anything with `ssm:GetParameters` on the stage prefix. Asserted
+    // structurally over the serialized value rather than by eyeballing fields.
+    const d = deps();
+    await handleSlackInteraction(ev(payload()), d);
+
+    const [, value] = (d.putParameter as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    const record = JSON.parse(value as string);
+    expect(Object.keys(record).sort()).toEqual(["claimedAt", "hash", "ids", "stage"]);
+    expect(record.ids).toEqual(IDS);
+    expect(record.stage).toBe(STAGE);
+  });
+
+  it("TC-SLACKAPP-025 an offered record naming another stage is refused", async () => {
+    // Same reasoning as #102's decision-file stage guard: a preview approval must
+    // never apply to prod.
+    const d = deps({ getParameter: vi.fn(async () => offered({ stage: "prod" })) });
+    const res = await handleSlackInteraction(ev(payload()), d);
+
+    expect(d.runTask).not.toHaveBeenCalled();
+    expect(d.putParameter).not.toHaveBeenCalled();
+    expect(JSON.stringify(res.body)).toMatch(/stage/iu);
+  });
+});
+
+describe("Slack idempotency and the apply trigger (TC-SLACKAPP-030..036)", () => {
+  /** An SSM fake whose `Overwrite: false` write is genuinely atomic. */
+  function ssmFake(initialClaim?: string) {
+    const store = new Map<string, string>();
+    if (initialClaim) store.set(`/mem9-on-aws/test/approvals/approved-${HASH}`, initialClaim);
+    return {
+      store,
+      getParameter: vi.fn(async (name: string) => {
+        if (name.endsWith("/approvals/offered")) return offered();
+        return store.get(name) ?? null;
+      }),
+      putParameter: vi.fn(async (name: string, value: string, opts?: { overwrite?: boolean }) => {
+        if (opts?.overwrite === false && store.has(name)) {
+          const err = new Error("ParameterAlreadyExists");
+          err.name = "ParameterAlreadyExists";
+          throw err;
+        }
+        store.set(name, value);
+      }),
+    };
+  }
+
+  it("TC-SLACKAPP-030 a duplicate delivery enqueues exactly one apply", async () => {
+    // Slack redelivers when it does not get a response within 3 seconds, so the
+    // whole sequence has to be safe to run twice.
+    const ssm = ssmFake();
+    const runTask = vi.fn(async () => "arn:task/1");
+    const d = deps({ ...ssm, runTask });
+
+    const first = await handleSlackInteraction(ev(payload()), d);
+    const second = await handleSlackInteraction(ev(payload()), d);
+
+    expect(first.statusCode).toBe(200);
+    expect(second.statusCode).toBe(200);
+    expect(runTask).toHaveBeenCalledTimes(1);
+    // The claim must be the ATOMIC primitive, not a read-then-write: asserted on
+    // the flag, because a handler that read first and wrote second would pass a
+    // call-count test under this serialized fake and still double-apply in
+    // production.
+    const claim = ssm.putParameter.mock.calls.find(([n]) =>
+      String(n).includes("approved-"),
+    );
+    expect(claim?.[2]).toMatchObject({ overwrite: false });
+  });
+
+  it("TC-SLACKAPP-031 a losing claimant with a fresh claim and no taskArn ACKs and starts nothing", async () => {
+    const claimedAt = new Date(NOW - 1000).toISOString();
+    const ssm = ssmFake(JSON.stringify({ stage: STAGE, hash: HASH, ids: IDS, claimedAt }));
+    const d = deps(ssm);
+    const res = await handleSlackInteraction(ev(payload()), d);
+
+    expect(res.statusCode).toBe(200);
+    expect(d.runTask).not.toHaveBeenCalled();
+    // This is the one interleaving that can LOSE an approval, so it must be
+    // visible: logged with the hash so the operator can re-click.
+    const logged = (d.log as ReturnType<typeof vi.fn>).mock.calls.map((c) => String(c[0]));
+    expect(logged.some((m) => m.includes(HASH))).toBe(true);
+  });
+
+  it("TC-SLACKAPP-032 a losing claimant with a stale claim and no taskArn recovers the run", async () => {
+    // The winning invocation died between claiming and RunTask. `DeleteParameter`
+    // is not admitted by the boundary, so the claim cannot be rolled back — the
+    // stale window is the only recovery path.
+    const claimedAt = new Date(NOW - CLAIM_STALE_MS - 1000).toISOString();
+    const ssm = ssmFake(JSON.stringify({ stage: STAGE, hash: HASH, ids: IDS, claimedAt }));
+    const d = deps(ssm);
+    const res = await handleSlackInteraction(ev(payload()), d);
+
+    expect(res.statusCode).toBe(200);
+    expect(d.runTask).toHaveBeenCalledTimes(1);
+    // And the ARN is stamped, so a THIRD delivery takes the taskArn branch rather
+    // than starting yet another apply.
+    const stamped = ssm.putParameter.mock.calls.at(-1)!;
+    expect(JSON.parse(String(stamped[1])).taskArn).toBeTruthy();
+    expect(stamped[2]).toMatchObject({ overwrite: true });
+    // Onto the CLAIM's own name, asserted through the store rather than the call
+    // args: a stamp written to any other parameter still satisfies the two
+    // assertions above while leaving the claim `taskArn`-less forever, so every
+    // delivery past the stale window applies the same ids again.
+    expect(
+      JSON.parse(ssm.store.get(`/mem9-on-aws/test/approvals/approved-${HASH}`)!).taskArn,
+    ).toBeTruthy();
+  });
+
+  it("TC-SLACKAPP-032d a delivery after the stale window does NOT re-apply a stamped claim", async () => {
+    // The consequence of the assertion above, exercised end to end: recovery makes
+    // the claim fresh again only because the stamp lands on it. This is the case
+    // that turns a misdirected stamp into an unbounded re-apply loop — every
+    // redelivery arriving more than CLAIM_STALE_MS later would find a claim with no
+    // `taskArn` and recover it again.
+    const ssm = ssmFake(
+      JSON.stringify({
+        stage: STAGE,
+        hash: HASH,
+        ids: IDS,
+        claimedAt: new Date(NOW - CLAIM_STALE_MS - 1000).toISOString(),
+      }),
+    );
+    let clock = NOW;
+    const d = deps({ ...ssm, now: () => clock });
+
+    expect((await handleSlackInteraction(ev(payload()), d)).statusCode).toBe(200);
+    expect(d.runTask).toHaveBeenCalledTimes(1);
+
+    // Well past the stale window, so only the stamped taskArn can refuse it. The
+    // event's own timestamp moves with the clock: leave it at NOW and the skew
+    // check answers the case at 401 before the claim logic is ever reached.
+    clock = NOW + CLAIM_STALE_MS * 4;
+    const later = await handleSlackInteraction(
+      ev(payload(), { timestamp: Math.floor(clock / 1000) }),
+      d,
+    );
+
+    expect(later.statusCode).toBe(200);
+    expect(d.runTask).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(later.body).text).toMatch(/already been applied/iu);
+  });
+
+  it("TC-SLACKAPP-030b a delivery whose claim already carries a taskArn starts nothing, however old the claim", async () => {
+    // `claimedAt` is deliberately WAY past CLAIM_STALE_MS. A fresh timestamp here
+    // would let the stale-claim branch answer the case, and the taskArn branch —
+    // the one that actually prevents a double apply on a redelivery that arrives
+    // after the apply already ran — would go unproven.
+    const ssm = ssmFake(
+      JSON.stringify({ stage: STAGE, hash: HASH, ids: IDS, claimedAt: new Date(NOW - CLAIM_STALE_MS * 100).toISOString(), taskArn: "arn:task/earlier" }),
+    );
+    const d = deps(ssm);
+    const res = await handleSlackInteraction(ev(payload()), d);
+
+    expect(res.statusCode).toBe(200);
+    expect(d.runTask).not.toHaveBeenCalled();
+  });
+
+  it("TC-SLACKAPP-032b an UNREADABLE claim refuses, it does not recover", async () => {
+    // The nastiest branch in this file. A losing claimant whose claim READ throws
+    // used to be indistinguishable from one whose claim does not exist:
+    // `parseRecord(null)` is null, `Date.parse(String(undefined))` is NaN, and
+    // `!Number.isFinite(NaN)` made `stale` TRUE — so the losing delivery took the
+    // RECOVERY path and started a second apply over the same ids.
+    //
+    // Reachable in production: two Slack redeliveries hit the same parameter within
+    // ~3 seconds, the second loses the `Overwrite: false` write and then gets a
+    // ThrottlingException on its read. An unreadable claim is UNKNOWN, not stale,
+    // and unknown is exactly when starting a destructive task is unsafe.
+    const claimName = `/mem9-on-aws/test/approvals/approved-${HASH}`;
+    const store = new Map<string, string>([[claimName, "irrelevant"]]);
+    const d = deps({
+      getParameter: vi.fn(async (name: string) => {
+        if (name.endsWith("/approvals/offered")) return offered();
+        const err = new Error("Rate exceeded");
+        err.name = "ThrottlingException";
+        throw err;
+      }),
+      putParameter: vi.fn(async (name: string, value: string, opts?: { overwrite?: boolean }) => {
+        if (opts?.overwrite === false && store.has(name)) {
+          const err = new Error("ParameterAlreadyExists");
+          err.name = "ParameterAlreadyExists";
+          throw err;
+        }
+        store.set(name, value);
+      }),
+    });
+    const res = await handleSlackInteraction(ev(payload()), d);
+
+    expect(res.statusCode).toBe(200);
+    // The whole point: no second apply.
+    expect(d.runTask).not.toHaveBeenCalled();
+    const logged = (d.log as ReturnType<typeof vi.fn>).mock.calls.map((c) => String(c[0]));
+    expect(logged.some((m) => m.includes("ThrottlingException"))).toBe(true);
+    // And the reply must NOT claim the apply is already running, which would tell
+    // the operator to wait for something that may never have started.
+    expect(JSON.parse(res.body).text).toMatch(/could not/iu);
+  });
+
+  it("TC-SLACKAPP-032c a claim READ with a corrupt claimedAt is stale, so it stays recoverable", async () => {
+    // The deliberate counterpart to TC-032b, and the reason the two cases cannot
+    // share one branch: a claim that was READ but whose `claimedAt` will not parse
+    // is corrupt, and the stale window is the only path by which it is ever
+    // recoverable — without this it would block the approval forever, since
+    // `ssm:DeleteParameter` is not admitted by the boundary and nothing can clear it.
+    //
+    // That is the opposite answer from an unreadable claim, where the record may be
+    // perfectly valid and merely unread. Same `stale` variable, two different
+    // situations; asserting only TC-032b would leave a fix that refuses BOTH
+    // looking correct.
+    const ssm = ssmFake(
+      JSON.stringify({ stage: STAGE, hash: HASH, ids: IDS, claimedAt: "not-a-date" }),
+    );
+    const d = deps(ssm);
+    const res = await handleSlackInteraction(ev(payload()), d);
+
+    expect(res.statusCode).toBe(200);
+    expect(d.runTask).toHaveBeenCalledTimes(1);
+  });
+
+  it("TC-SLACKAPP-033 the handler never calls the memory REST API", async () => {
+    // The structural guarantee behind "apply happens only in the ECS task". A
+    // future edit that inlines a delete to save a hop fails here.
+    // Typed with `fetch`'s own parameter list, not inferred from the stub body: an
+    // inferred zero-arg spy makes `mock.calls` a `[]` tuple, so the destructure
+    // below would not compile — and dropping the destructure to appease it would
+    // stop the assertion from ever seeing a URL.
+    const fetchSpy = vi.fn(
+      async (..._args: Parameters<typeof fetch>) => new Response("{}", { status: 200 }),
+    );
+    const original = globalThis.fetch;
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    try {
+      const d = deps();
+      await handleSlackInteraction(ev(payload()), d);
+      for (const [url] of fetchSpy.mock.calls) {
+        expect(String(url)).not.toMatch(/\/v1alpha2\/mem9s\/memories/u);
+      }
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  it("TC-SLACKAPP-034 a RunTask failure is surfaced, not swallowed", async () => {
+    // "Recorded the approval and told the operator it worked" is the worst
+    // available outcome, so the case asserts the response is NOT the success text.
+    const ssm = ssmFake();
+    const d = deps({
+      ...ssm,
+      runTask: vi.fn(async () => {
+        throw new Error("InvalidParameterException: no container instances");
+      }),
+    });
+    const res = await handleSlackInteraction(ev(payload()), d);
+
+    expect(JSON.stringify(res.body)).toMatch(/did not start/iu);
+    expect(JSON.stringify(res.body)).not.toMatch(/apply started/iu);
+    // The claim REMAINS, so a retry recovers through the stale-claim path rather
+    // than being permanently blocked by a claim nobody will ever stamp.
+    expect([...ssm.store.keys()].some((k) => k.includes("approved-"))).toBe(true);
+    // The error is logged WITHOUT the request body: the body carries the payload
+    // and the ids, and this Lambda's logs are not the place for them.
+    const logged = (d.log as ReturnType<typeof vi.fn>).mock.calls.map((c) => String(c[0]));
+    expect(logged.some((m) => m.includes("InvalidParameterException"))).toBe(true);
+    expect(logged.some((m) => m.includes("payload="))).toBe(false);
+  });
+
+  it("TC-SLACKAPP-035 a Reject click writes no record and starts no task", async () => {
+    // Reject must be cheap and total: it is the button an operator presses when
+    // something looks wrong.
+    const d = deps();
+    const res = await handleSlackInteraction(
+      ev(payload({}, { action_id: "cleanup_reject" })),
+      d,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(d.putParameter).not.toHaveBeenCalled();
+    expect(d.runTask).not.toHaveBeenCalled();
+    expect(JSON.stringify(res.body)).toMatch(/reject/iu);
+  });
+
+  it("TC-SLACKAPP-035b an unrecognised action_id starts nothing", async () => {
+    // The default must be inert. A handler that treated "not reject" as approve
+    // would turn any future button — or a typo in the message template — into a
+    // deletion trigger.
+    const d = deps();
+    const res = await handleSlackInteraction(
+      ev(payload({}, { action_id: "cleanup_approve_v2" })),
+      d,
+    );
+    expect(d.runTask).not.toHaveBeenCalled();
+    expect(d.putParameter).not.toHaveBeenCalled();
+    expect(res.statusCode).toBeGreaterThanOrEqual(200);
+  });
+
+  it("TC-SLACKAPP-036 the handler does not await the apply task's completion", async () => {
+    // Asserted BY CONSTRUCTION — the handler never polls — rather than by
+    // wall-clock timing, which would be flaky. `runTask` resolves as soon as ECS
+    // accepts the task; if the handler waited for the task to finish it would
+    // need a describe/poll call, and there is none to make.
+    const d = deps();
+    let resolved = false;
+    const slow = vi.fn(async () => {
+      await new Promise((r) => setTimeout(r, 5));
+      resolved = true;
+      return "arn:task/slow";
+    });
+    const res = await handleSlackInteraction(ev(payload()), { ...d, runTask: slow });
+
+    // It awaits the ACCEPTANCE (so a failure can be reported — TC-034) and
+    // nothing beyond it.
+    expect(resolved).toBe(true);
+    expect(slow).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("TC-SLACKAPP-034b a claim write that fails for any OTHER reason starts nothing", async () => {
+    // Only `ParameterAlreadyExists` means "someone else won". Every other write
+    // failure — an `AccessDenied` before the boundary rollout, a throttle, a
+    // parameter-limit error — must abort. Treating them all as "lost the race"
+    // would send this delivery down the losing-claim path, where an absent claim
+    // reads as recoverable and starts an apply that no record vouches for.
+    const d = deps({
+      putParameter: vi.fn(async () => {
+        const err = new Error("User is not authorized to perform ssm:PutParameter");
+        err.name = "AccessDeniedException";
+        throw err;
+      }),
+    });
+    const res = await handleSlackInteraction(ev(payload()), d);
+
+    expect(res.statusCode).toBe(200);
+    expect(d.runTask).not.toHaveBeenCalled();
+    expect(JSON.parse(res.body).text).toMatch(/could not be recorded/iu);
+    expect(JSON.parse(res.body).text).not.toMatch(/apply started/iu);
+    const logged = (d.log as ReturnType<typeof vi.fn>).mock.calls.map((c) => String(c[0]));
+    expect(logged.some((m) => m.includes("AccessDenied"))).toBe(true);
+  });
+
+  it("TC-SLACKAPP-034c a stamp failure is reported loudly but does not fail the run", async () => {
+    // The apply HAS started, so this is not a failure of the run and must not be
+    // reported as one — but the claim now lacks a `taskArn`, so a redelivery after
+    // the stale window will start a second apply. That is exactly the risk the log
+    // has to name, because nothing else can detect it.
+    let calls = 0;
+    const d = deps({
+      putParameter: vi.fn(async () => {
+        calls += 1;
+        if (calls > 1) throw new Error("ThrottlingException: rate exceeded");
+      }),
+    });
+    const res = await handleSlackInteraction(ev(payload()), d);
+
+    expect(d.runTask).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(res.body).text).toMatch(/apply started/iu);
+    const logged = (d.log as ReturnType<typeof vi.fn>).mock.calls.map((c) => String(c[0]));
+    expect(logged.some((m) => m.includes("ThrottlingException"))).toBe(true);
+    expect(logged.some((m) => /second apply/iu.test(m))).toBe(true);
+  });
+
+  it("TC-SLACKAPP-034d an approve click carrying no list reference applies nothing", async () => {
+    // A button with no `value` cannot identify a list, so there is nothing to
+    // compare the offered hash against. Falling through would hand `undefined` to
+    // `loadOffered`, where a `record.hash !== undefined` mismatch happens to refuse
+    // it — by accident, and only while that comparison stays in that order.
+    const d = deps();
+    const res = await handleSlackInteraction(ev(payload({}, { value: "" })), d);
+
+    expect(res.statusCode).toBe(200);
+    expect(d.getParameter).not.toHaveBeenCalled();
+    expect(d.putParameter).not.toHaveBeenCalled();
+    expect(d.runTask).not.toHaveBeenCalled();
+    expect(JSON.parse(res.body).text).toMatch(/no list reference/iu);
+  });
+});

--- a/infra/src/oauth-facade/slack-interactions.test.ts
+++ b/infra/src/oauth-facade/slack-interactions.test.ts
@@ -15,6 +15,7 @@ import { readFile } from "node:fs/promises";
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  buildClaim,
   CLAIM_STALE_MS,
   handleSlackInteraction,
   type SlackDeps,
@@ -105,6 +106,49 @@ describe("Slack signature verification (TC-SLACKAPP-001..006)", () => {
 
     expect(res.statusCode).toBe(200);
     expect(d.runTask).toHaveBeenCalledTimes(1);
+  });
+
+  it("TC-SLACKAPP-001b a base64-encoded body is decoded before verification", async () => {
+    // API Gateway base64-encodes the body whenever it does not recognise the
+    // content type as text, and the signature covers the RAW (decoded) bytes.
+    // Verifying the still-encoded string would 401 every real Slack click while
+    // every other unit test passed, because nothing else sets isBase64Encoded —
+    // a production-only failure invisible to the rest of this suite.
+    const body = payload();
+    const ts = Math.floor(NOW / 1000);
+    const d = deps();
+    const res = await handleSlackInteraction(
+      {
+        ...ev(body, { timestamp: ts }),
+        body: Buffer.from(body, "utf8").toString("base64"),
+        isBase64Encoded: true,
+      },
+      d,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(d.runTask).toHaveBeenCalledTimes(1);
+  });
+
+  it("TC-SLACKAPP-001c a base64 body tampered with after signing is still rejected", async () => {
+    // The decode must not become a way to bypass the check: the signature is
+    // over the original body, so a different decoded payload must fail.
+    const signed = payload();
+    const ts = Math.floor(NOW / 1000);
+    const tampered = payload({}, { value: "sha256:attacker-chosen" });
+    const d = deps();
+    const res = await handleSlackInteraction(
+      {
+        ...ev(signed, { timestamp: ts }),
+        body: Buffer.from(tampered, "utf8").toString("base64"),
+        isBase64Encoded: true,
+      },
+      d,
+    );
+
+    expect(res.statusCode).toBe(401);
+    expect(d.putParameter).not.toHaveBeenCalled();
+    expect(d.runTask).not.toHaveBeenCalled();
   });
 
   it("TC-SLACKAPP-002 a body tampered with after signing is rejected 401 with no side effect", async () => {
@@ -404,6 +448,82 @@ describe("Slack stale-hash rejection (TC-SLACKAPP-020..025)", () => {
     expect(record.stage).toBe(STAGE);
   });
 
+  it("TC-SLACKAPP-023d a real click carries the coordinates from SSM into the claim, and drops half-stamped ones", async () => {
+    // TC-023c pins `buildClaim` in isolation; this pins the wiring, which is the
+    // half that actually broke: `loadOffered` narrowed the parsed record to
+    // {stage, hash, ids} and silently dropped the coordinates before the claim was
+    // ever built, so the unit could be perfect and the apply still get nothing.
+    const d = deps({
+      getParameter: vi.fn(async () =>
+        offered({ messageTs: "1754400000.000100", messageChannel: "C0APPROVAL" }),
+      ),
+    });
+    await handleSlackInteraction(ev(payload()), d);
+    const [, value] = (d.putParameter as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(JSON.parse(value as string)).toMatchObject({
+      messageTs: "1754400000.000100",
+      messageChannel: "C0APPROVAL",
+    });
+
+    // A record with only one of the two, or with a non-string in either, claims
+    // without both. `chat.update` needs BOTH channel and ts, so half a pair is not
+    // a usable coordinate — carrying it forward would move the failure from here
+    // (where it is a skipped update) to the apply task (where it is an error after
+    // the deletions already happened).
+    for (const partial of [
+      { messageTs: "1754400000.000100" },
+      { messageChannel: "C0APPROVAL" },
+      { messageTs: 1754400000.0001, messageChannel: "C0APPROVAL" },
+    ]) {
+      const dp = deps({ getParameter: vi.fn(async () => offered(partial)) });
+      await handleSlackInteraction(ev(payload()), dp);
+      const [, raw] = (dp.putParameter as ReturnType<typeof vi.fn>).mock.calls[0]!;
+      expect(Object.keys(JSON.parse(raw as string)).sort(), JSON.stringify(partial)).toEqual([
+        "claimedAt",
+        "hash",
+        "ids",
+        "stage",
+      ]);
+    }
+  });
+
+  it("TC-SLACKAPP-023c the claim carries the offered record's message coordinates forward", () => {
+    // The apply task has to `chat.update` the message it was approved from, and
+    // the ONLY thing the click gives it is the hash — so the coordinates have to
+    // ride the claim. Absent, the deletion happens and the message keeps showing a
+    // live Approve button with no record of the outcome, which is the audit trail
+    // the message is supposed to be.
+    //
+    // Copied from the offered record rather than read from the interaction
+    // payload: `container.message_ts` is in the payload and is exactly the kind of
+    // caller-supplied value the signature does not vouch for — trusting it would
+    // let a workspace member point the outcome update at any message they liked.
+    const record = { stage: STAGE, hash: HASH, ids: IDS, messageTs: "1754400000.000100", messageChannel: "C0APPROVAL" };
+    const claim = buildClaim(record, "2026-08-05T12:00:00.000Z");
+    expect(claim.messageTs).toBe("1754400000.000100");
+    expect(claim.messageChannel).toBe("C0APPROVAL");
+    // Still ids, hash, stage and timestamps only — the coordinates are neither
+    // memory content nor a secret, and the record stays a plain `String`.
+    expect(Object.keys(claim).sort()).toEqual([
+      "claimedAt",
+      "hash",
+      "ids",
+      "messageChannel",
+      "messageTs",
+      "stage",
+    ]);
+
+    // An offered record with no coordinates (a run that failed its stamp, or a
+    // pre-#123 record) claims WITHOUT them rather than with `undefined` fields:
+    // `JSON.stringify` drops an undefined value, so a key that is present-but-
+    // undefined and a key that is absent serialize identically — but the apply
+    // task's own guard reads the parsed object, and `"messageTs" in record` is the
+    // difference between "update skipped" and "update attempted against ts
+    // undefined".
+    const bare = buildClaim({ stage: STAGE, hash: HASH, ids: IDS }, "2026-08-05T12:00:00.000Z");
+    expect(Object.keys(bare).sort()).toEqual(["claimedAt", "hash", "ids", "stage"]);
+  });
+
   it("TC-SLACKAPP-025 an offered record naming another stage is refused", async () => {
     // Same reasoning as #102's decision-file stage guard: a preview approval must
     // never apply to prod.
@@ -587,7 +707,11 @@ describe("Slack idempotency and the apply trigger (TC-SLACKAPP-030..036)", () =>
     expect(logged.some((m) => m.includes("ThrottlingException"))).toBe(true);
     // And the reply must NOT claim the apply is already running, which would tell
     // the operator to wait for something that may never have started.
-    expect(JSON.parse(res.body).text).toMatch(/could not/iu);
+    // Pinned to "could not CONFIRM": the claim-write-failure branch also says
+    // "could not", and the two give OPPOSITE instructions — this branch means
+    // "an apply may be running, wait", that one means "nothing was recorded,
+    // re-click". A bare /could not/ is satisfied by either.
+    expect(JSON.parse(res.body).text).toMatch(/could not confirm/iu);
   });
 
   it("TC-SLACKAPP-032c a claim READ with a corrupt claimedAt is stale, so it stays recoverable", async () => {
@@ -625,10 +749,25 @@ describe("Slack idempotency and the apply trigger (TC-SLACKAPP-030..036)", () =>
     globalThis.fetch = fetchSpy as unknown as typeof fetch;
     try {
       const d = deps();
-      await handleSlackInteraction(ev(payload()), d);
+      // `response_url` is attacker-controlled in a payload whose only validation
+      // is the signature, so a compromised or misconfigured Slack app could point
+      // it anywhere — including link-local metadata. The handler documents that it
+      // never reads it; this asserts that, rather than trusting the comment.
+      const evil = "http://169.254.169.254/latest/meta-data/";
+      await handleSlackInteraction(
+        ev(payload({ response_url: evil })),
+        d,
+      );
       for (const [url] of fetchSpy.mock.calls) {
         expect(String(url)).not.toMatch(/\/v1alpha2\/mem9s\/memories/u);
+        // No request may target the payload-supplied host at all: following
+        // `response_url` is an SSRF primitive, and the endpoint's design is that
+        // the capability is absent rather than present-and-unused.
+        expect(String(url)).not.toContain("169.254.169.254");
       }
+      // Belt and braces: with no reason to make ANY outbound HTTP call on the
+      // happy path, a new call appearing here is itself the signal.
+      expect(fetchSpy).not.toHaveBeenCalled();
     } finally {
       globalThis.fetch = original;
     }
@@ -740,7 +879,14 @@ describe("Slack idempotency and the apply trigger (TC-SLACKAPP-030..036)", () =>
     const d = deps({
       putParameter: vi.fn(async () => {
         calls += 1;
-        if (calls > 1) throw new Error("ThrottlingException: rate exceeded");
+        if (calls > 1) {
+          // `name` set, because that is where the SDK puts the class — and since
+          // TC-089 forbids logging this call's message (its value is the claim,
+          // ids and all), the name is the only place the class can be read from.
+          const err = new Error("Rate exceeded");
+          err.name = "ThrottlingException";
+          throw err;
+        }
       }),
     });
     const res = await handleSlackInteraction(ev(payload()), d);
@@ -750,6 +896,39 @@ describe("Slack idempotency and the apply trigger (TC-SLACKAPP-030..036)", () =>
     const logged = (d.log as ReturnType<typeof vi.fn>).mock.calls.map((c) => String(c[0]));
     expect(logged.some((m) => m.includes("ThrottlingException"))).toBe(true);
     expect(logged.some((m) => /second apply/iu.test(m))).toBe(true);
+  });
+
+  it("TC-SLACKAPP-034e the three ways a body yields no action are distinguishable in the log", async () => {
+    // TC-089 forbids logging the parse error, and the cheapest way to satisfy that
+    // is one flat "bad payload" for all three — which is why this exists next to
+    // it. Each reason sends the operator somewhere different: a missing field means
+    // the form encoding is wrong (a transport or API Gateway change), unparseable
+    // JSON means the body is not Slack's at all, and no actions means the message
+    // template changed. One string for all three makes those indistinguishable
+    // exactly when a 400 needs explaining, and nothing else records which happened.
+    const cases: Array<{ body: string; expect: RegExp }> = [
+      { body: "not-a-form", expect: /no payload field/iu },
+      { body: "payload=", expect: /no payload field/iu },
+      { body: `payload=${encodeURIComponent("{oops")}`, expect: /not valid JSON/iu },
+      { body: `payload=${encodeURIComponent(JSON.stringify({ actions: [] }))}`, expect: /no actions/iu },
+      { body: `payload=${encodeURIComponent(JSON.stringify({ type: "block_actions" }))}`, expect: /no actions/iu },
+    ];
+    const seen = new Set<string>();
+    for (const c of cases) {
+      const d = deps();
+      const res = await handleSlackInteraction(ev(c.body), d);
+      expect(res.statusCode).toBe(400);
+      expect(d.getParameter).not.toHaveBeenCalled();
+      const logged = (d.log as ReturnType<typeof vi.fn>).mock.calls
+        .map((call) => String(call[0]))
+        .join("\n");
+      expect(logged, `body ${JSON.stringify(c.body)}`).toMatch(c.expect);
+      seen.add(logged);
+    }
+    // Three distinct messages across five bodies. Asserted on the SET so the
+    // per-case matchers above cannot all be satisfied by one string that happens
+    // to contain every phrase.
+    expect(seen.size).toBe(3);
   });
 
   it("TC-SLACKAPP-034d an approve click carrying no list reference applies nothing", async () => {
@@ -765,5 +944,200 @@ describe("Slack idempotency and the apply trigger (TC-SLACKAPP-030..036)", () =>
     expect(d.putParameter).not.toHaveBeenCalled();
     expect(d.runTask).not.toHaveBeenCalled();
     expect(JSON.parse(res.body).text).toMatch(/no list reference/iu);
+  });
+});
+
+describe("Slack logging and privacy (TC-SLACKAPP-089)", () => {
+  // The signing secret is the credential this endpoint's whole security rests on,
+  // and CloudWatch Logs is a different access boundary from SSM SecureString: a
+  // single leaked line makes the HMAC forgeable by anyone with log read. The raw
+  // body matters for the same reason with a second twist — it is the only place a
+  // `payload` field can arrive with attacker-chosen content, so echoing it makes
+  // the log injectable.
+  //
+  // Swept across EVERY path rather than the happy one, because the happy path is
+  // the one anybody would check: an error handler that interpolates `err.message`
+  // is where a secret actually escapes, since a thrown AWS SDK error can carry the
+  // request it was built from.
+  const SNIPPET = "SENTINEL-MEMORY-SNIPPET";
+
+  function forbidden(rawBody: string) {
+    return [
+      { label: "the signing secret", value: SECRET },
+      { label: "the raw request body", value: rawBody },
+      { label: "memory content", value: SNIPPET },
+      // Held to the same standard TC-098 sets for the container: an id is a memory
+      // identifier, and CloudWatch is a wider audience than the SSM parameter the
+      // ids legitimately live in.
+      ...IDS.map((id) => ({ label: `the memory id ${id}`, value: id })),
+    ];
+  }
+
+  it("TC-SLACKAPP-089 no log line on any path carries the secret, the raw body, or memory content", async () => {
+    const withSnippet = () =>
+      JSON.stringify({
+        stage: STAGE,
+        hash: HASH,
+        ids: IDS,
+        // A record that grew a snippet field later. The offered record is asserted
+        // not to have one (TC-023b), but this handler must not become the thing
+        // that would publish it if it did.
+        snippets: { "m-1": SNIPPET },
+        generatedAt: "2026-08-05T11:59:00Z",
+      });
+
+    // `reaches` is what keeps the sweep honest. Every `not.toContain` below passes
+    // trivially for a case that returns before logging at all, so each failure case
+    // also names a phrase its OWN branch must produce — which proves the fixture
+    // drove the handler down the path the label claims. Only the valid approve has
+    // none, because a success logs nothing.
+    const cases: Array<{
+      label: string;
+      body: string;
+      d: SlackDeps;
+      sig?: string;
+      reaches?: RegExp;
+    }> = [
+      { label: "a valid approve", body: payload(), d: deps({ getParameter: vi.fn(async () => withSnippet()) }) },
+      {
+        label: "a bad signature",
+        body: payload(),
+        d: deps(),
+        sig: "v0=deadbeef",
+        reaches: /rejected a .*interactions request/iu,
+      },
+      {
+        label: "an unparseable payload",
+        body: `payload=${encodeURIComponent("{oops")}`,
+        d: deps(),
+        reaches: /unparseable/iu,
+      },
+      {
+        label: "a stale hash",
+        body: payload({}, { value: "sha256:older" }),
+        d: deps({ getParameter: vi.fn(async () => withSnippet()) }),
+      },
+      {
+        label: "an unreadable offered record",
+        reaches: /offered could not be read/iu,
+        body: payload(),
+        d: deps({
+          getParameter: vi.fn(async () => {
+            throw new Error("AccessDeniedException: not authorized to perform ssm:GetParameter");
+          }),
+        }),
+      },
+      {
+        label: "a claim write rejected on its value",
+        reaches: /claim failed/iu,
+        body: payload(),
+        d: deps({
+          // The realistic leak vector, and the only one where sensitive data is an
+          // ARGUMENT rather than a result: the claim's value is the id list, and an
+          // SSM `ValidationException` echoes the value it rejected. A handler that
+          // interpolates `err.message` here copies memory ids into CloudWatch.
+          putParameter: vi.fn(async (_name: string, value: string) => {
+            const err = new Error(`ValidationException: value failed validation: ${value}`);
+            err.name = "ValidationException";
+            throw err;
+          }),
+        }),
+      },
+      {
+        // The SECOND write, which the case above can never reach: it throws on
+        // the first, so a stamp that interpolates its own error stays untested
+        // while the claim write looks fixed. The stamp's value is the claim plus
+        // a taskArn — the same id list, one call later.
+        label: "a claim stamp rejected on its value",
+        reaches: /could not be stamped/iu,
+        body: payload(),
+        d: (() => {
+          let call = 0;
+          return deps({
+            putParameter: vi.fn(async (_name: string, value: string) => {
+              if (++call === 1) return;
+              const err = new Error(`ValidationException: value failed validation: ${value}`);
+              err.name = "ValidationException";
+              throw err;
+            }),
+          });
+        })(),
+      },
+      {
+        // `JSON.parse` quotes the first ten characters of whatever it rejected,
+        // so a payload field that starts with an id puts that id in the log —
+        // and the field is the one part of a signed request whose content the
+        // signature says nothing about.
+        label: "an unparseable payload that begins with a memory id",
+        reaches: /unparseable/iu,
+        body: `payload=${encodeURIComponent(`${IDS[0]} is not json`)}`,
+        d: deps(),
+      },
+      {
+        label: "a losing claim",
+        reaches: /stale claim/iu,
+        body: payload(),
+        d: deps({
+          putParameter: vi.fn(async () => {
+            const err = new Error("ParameterAlreadyExists");
+            err.name = "ParameterAlreadyExists";
+            throw err;
+          }),
+        }),
+      },
+      {
+        label: "a failed RunTask",
+        reaches: /RunTask failed/iu,
+        body: payload(),
+        d: deps({
+          runTask: vi.fn(async () => {
+            throw new Error("InvalidParameterException: no such task definition");
+          }),
+        }),
+      },
+      {
+        label: "an unknown action_id",
+        body: payload({}, { action_id: "something_else" }),
+        d: deps(),
+        reaches: /unrecognised action_id/iu,
+      },
+    ];
+
+    for (const { label, body, d, sig, reaches } of cases) {
+      const res = await handleSlackInteraction(
+        ev(body, sig ? { signature: sig } : {}),
+        d,
+      );
+      const logged = (d.log as ReturnType<typeof vi.fn>).mock.calls
+        .map((c) => c.map(String).join(" "))
+        .join("\n");
+      if (reaches) {
+        expect(logged, `${label} never reached the branch it exists to cover`).toMatch(reaches);
+      }
+      for (const { label: what, value } of forbidden(body)) {
+        expect(logged, `${label} logged ${what}`).not.toContain(value);
+      }
+      // The REPLY too. It is ephemeral, but "ephemeral" is a visibility scope in
+      // one workspace, not a confidentiality boundary — and the secret has no
+      // business in either.
+      expect(res.body, `${label} replied with the secret`).not.toContain(SECRET);
+      expect(res.body, `${label} replied with memory content`).not.toContain(SNIPPET);
+    }
+  });
+
+  it("TC-SLACKAPP-089 the sweep is not vacuous: the same matchers catch a handler that does leak", () => {
+    // The other half of the honesty check. `reaches` proves each case ran the
+    // branch it names; this proves the matchers themselves can fail — otherwise a
+    // typo in `forbidden` (a value that is never in any log for an unrelated
+    // reason) leaves every `not.toContain` above passing forever.
+    const d = deps();
+    const body = payload();
+    d.log(`leaked: ${SECRET} ${body} ${SNIPPET} ${IDS.join(" ")}`);
+    const logged = (d.log as ReturnType<typeof vi.fn>).mock.calls
+      .map((c) => c.map(String).join(" "))
+      .join("\n");
+    for (const { label, value } of forbidden(body)) {
+      expect(() => expect(logged).not.toContain(value), label).toThrow();
+    }
   });
 });

--- a/infra/src/oauth-facade/slack-interactions.test.ts
+++ b/infra/src/oauth-facade/slack-interactions.test.ts
@@ -17,6 +17,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   buildClaim,
   CLAIM_STALE_MS,
+  claimParameterName,
   handleSlackInteraction,
   type SlackDeps,
 } from "./slack-interactions.js";
@@ -84,6 +85,30 @@ function offered(overrides: Record<string, unknown> = {}) {
   });
 }
 
+/**
+ * The name constraint `PutParameter` actually enforces: a path of sub-paths, each
+ * only letters, numbers and `.-_`. Probed live in ap-northeast-1 — the `sha256:`
+ * form is rejected on write while a READ parses the colon as a version selector,
+ * so the two operations disagree about the name rather than both 404ing.
+ *
+ * Every double here used to accept any string, which is precisely why a claim name
+ * carrying `sha256:` passed the whole suite and would have answered "The approval
+ * could not be recorded" on every real click. A fake that cannot fail the way the
+ * service fails proves nothing about the name.
+ */
+function assertWritableParameterName(name: string): void {
+  if (!/^(?:\/[A-Za-z0-9_.-]+)+$/u.test(name)) {
+    throw Object.assign(
+      new Error(
+        `Parameter name: if formed as a path, it can consist of sub-paths ` +
+          `divided by slash symbol; each sub-path can be formed as a mix of ` +
+          `letters, numbers and the following 3 symbols .-_ (got ${name})`,
+      ),
+      { name: "ValidationException" },
+    );
+  }
+}
+
 function deps(overrides: Partial<SlackDeps> = {}): SlackDeps {
   return {
     signingSecret: SECRET,
@@ -91,7 +116,7 @@ function deps(overrides: Partial<SlackDeps> = {}): SlackDeps {
     ssmPrefix: "/mem9-on-aws/test",
     now: () => NOW,
     getParameter: vi.fn(async () => offered()),
-    putParameter: vi.fn(async () => {}),
+    putParameter: vi.fn(async (name: string) => assertWritableParameterName(name)),
     runTask: vi.fn(async () => "arn:aws:ecs:region:account:task/cluster/abc"),
     log: vi.fn(),
     ...overrides,
@@ -540,7 +565,7 @@ describe("Slack idempotency and the apply trigger (TC-SLACKAPP-030..036)", () =>
   /** An SSM fake whose `Overwrite: false` write is genuinely atomic. */
   function ssmFake(initialClaim?: string) {
     const store = new Map<string, string>();
-    if (initialClaim) store.set(`/mem9-on-aws/test/approvals/approved-${HASH}`, initialClaim);
+    if (initialClaim) store.set(claimParameterName("/mem9-on-aws/test", HASH), initialClaim);
     return {
       store,
       getParameter: vi.fn(async (name: string) => {
@@ -616,7 +641,7 @@ describe("Slack idempotency and the apply trigger (TC-SLACKAPP-030..036)", () =>
     // assertions above while leaving the claim `taskArn`-less forever, so every
     // delivery past the stale window applies the same ids again.
     expect(
-      JSON.parse(ssm.store.get(`/mem9-on-aws/test/approvals/approved-${HASH}`)!).taskArn,
+      JSON.parse(ssm.store.get(claimParameterName("/mem9-on-aws/test", HASH))!).taskArn,
     ).toBeTruthy();
   });
 
@@ -680,7 +705,7 @@ describe("Slack idempotency and the apply trigger (TC-SLACKAPP-030..036)", () =>
     // ~3 seconds, the second loses the `Overwrite: false` write and then gets a
     // ThrottlingException on its read. An unreadable claim is UNKNOWN, not stale,
     // and unknown is exactly when starting a destructive task is unsafe.
-    const claimName = `/mem9-on-aws/test/approvals/approved-${HASH}`;
+    const claimName = claimParameterName("/mem9-on-aws/test", HASH);
     const store = new Map<string, string>([[claimName, "irrelevant"]]);
     const d = deps({
       getParameter: vi.fn(async (name: string) => {

--- a/infra/src/oauth-facade/slack-interactions.ts
+++ b/infra/src/oauth-facade/slack-interactions.ts
@@ -323,6 +323,26 @@ async function loadOffered(
 }
 
 /**
+ * The SSM parameter name of one approval claim.
+ *
+ * DUPLICATED from `claimParameterName` in scripts/memory-cleanup.mjs, which is
+ * the writer of the record this reads: the Lambda bundle and the container script
+ * share no module, and adding a build step to make them would be a larger change
+ * than the eight lines. TC-SLACKAPP-131 asserts the two agree character for
+ * character, so the duplication is checked rather than hoped for.
+ *
+ * The `:` in `sha256:...` cannot appear in an SSM parameter name — `PutParameter`
+ * answers `ValidationException`, while a READ parses it as a version/label
+ * selector, so the two operations disagree about the name. Building the name with
+ * the colon intact made every click answer "The approval could not be recorded",
+ * on every stage, because the catch below classifies by error NAME and
+ * `ValidationException` is not `ParameterAlreadyExists`.
+ */
+export function claimParameterName(ssmPrefix: string, hash: string): string {
+  return `${ssmPrefix}/approvals/approved-${hash.replace(/:/gu, "-")}`;
+}
+
+/**
  * Claim the approval and start the apply, or explain why this delivery is not
  * the one that should.
  *
@@ -333,7 +353,7 @@ async function claimAndRun(
   offered: OfferedRecord,
   deps: SlackDeps,
 ): Promise<SlackResponse> {
-  const claimName = `${deps.ssmPrefix}/approvals/approved-${offered.hash}`;
+  const claimName = claimParameterName(deps.ssmPrefix, offered.hash);
   const claim = buildClaim(offered, new Date(deps.now()).toISOString());
 
   let won = true;

--- a/infra/src/oauth-facade/slack-interactions.ts
+++ b/infra/src/oauth-facade/slack-interactions.ts
@@ -166,6 +166,99 @@ interface OfferedRecord {
   stage: string;
   hash: string;
   ids: string[];
+  /**
+   * Where the review message was posted, stamped by the review run's second
+   * `approvals/offered` write. Optional because the stamp is a best-effort
+   * follow-up to the post: a run whose post succeeded but whose re-write failed
+   * still offers a valid, clickable list.
+   */
+  messageTs?: string;
+  messageChannel?: string;
+}
+
+interface ApprovalClaim {
+  stage: string;
+  hash: string;
+  ids: string[];
+  claimedAt: string;
+  messageTs?: string;
+  messageChannel?: string;
+}
+
+/**
+ * The record written to win the apply, derived from the OFFERED record.
+ *
+ * The message coordinates are copied from what the review run stored, never from
+ * the interaction payload. `container.message_ts` is right there in the payload,
+ * but it is caller-supplied — the request signature proves the request came from
+ * Slack, not that a workspace member did not hand-craft the body — so trusting it
+ * would let anyone who can click point the outcome update at any message.
+ *
+ * Coordinates are OMITTED, not set to undefined, when the offered record has
+ * none. The two serialize identically through `JSON.stringify`, but the apply
+ * task guards on the parsed object, and there `"messageTs" in claim` is the
+ * difference between skipping the update and calling `chat.update` with
+ * `ts: undefined`.
+ */
+export function buildClaim(offered: OfferedRecord, claimedAt: string): ApprovalClaim {
+  return {
+    stage: offered.stage,
+    hash: offered.hash,
+    ids: offered.ids,
+    claimedAt,
+    ...(offered.messageTs === undefined ? {} : { messageTs: offered.messageTs }),
+    ...(offered.messageChannel === undefined ? {} : { messageChannel: offered.messageChannel }),
+  };
+}
+
+/**
+ * The parts of a failure that are safe to log, for an error raised by a call whose
+ * ARGUMENT was sensitive.
+ *
+ * An AWS SDK `ValidationException` quotes the value it rejected, and the claim
+ * write's value is the id list — so interpolating `err.message` from that call site
+ * copies memory identifiers into CloudWatch, which is a wider audience than the SSM
+ * parameter the ids legitimately live in. The `name` is what every branch here
+ * actually needs (it is the only part that names the failure CLASS), and the hash
+ * already identifies which approval failed.
+ *
+ * Deliberately not a general redactor: a substring scrub over the message would be
+ * a guess about what the SDK chose to include, and would silently stop matching the
+ * next time it changes. Dropping the message entirely cannot be defeated.
+ */
+function failureClass(err: unknown): string {
+  const name = (err as Error)?.name;
+  return name && name !== "Error" ? name : "an unnamed error";
+}
+
+/**
+ * The clicked action, or a reason the body could not yield one.
+ *
+ * The reason is one of three fixed strings chosen HERE, never the thrown message.
+ * V8 quotes the first ten characters of what it rejected (`Unexpected token 'm',
+ * "m-1 not js"... is not valid JSON`), and the `payload` field is the one part of a
+ * signed request whose content the signature says nothing about — so echoing the
+ * parse error publishes caller-chosen bytes, which is both a log-injection primitive
+ * and a way to put a memory id in CloudWatch (TC-SLACKAPP-089).
+ *
+ * Three reasons rather than one because they are the three different things the
+ * operator would do: a missing field means the form encoding is wrong, unparseable
+ * JSON means the body is not Slack's, and no actions means the message template
+ * changed. None of them needs the bytes to say which.
+ */
+function parseAction(
+  rawBody: string,
+): { action: { action_id?: string; value?: string } } | { error: string } {
+  const raw = new URLSearchParams(rawBody).get("payload");
+  if (!raw) return { error: "no payload field" };
+  let parsed: { actions?: Array<{ action_id?: string; value?: string }> };
+  try {
+    parsed = JSON.parse(raw) as typeof parsed;
+  } catch {
+    return { error: "the payload field is not valid JSON" };
+  }
+  const action = parsed?.actions?.[0];
+  return action ? { action } : { error: "the payload carries no actions" };
 }
 
 /** Parse a stored record, returning null for anything malformed. */
@@ -211,11 +304,20 @@ async function loadOffered(
   if (record.hash !== hash) {
     return { error: "That list has been regenerated since it was posted. Nothing was applied." };
   }
+  // The coordinates are carried forward only when both are strings. A record
+  // half-stamped (or stamped with a number, which is what a hand-edited parameter
+  // or a future Slack payload change would produce) yields neither, so the apply
+  // skips its update instead of calling `chat.update` with a value Slack rejects.
+  const coordinates =
+    typeof record.messageTs === "string" && typeof record.messageChannel === "string"
+      ? { messageTs: record.messageTs, messageChannel: record.messageChannel }
+      : {};
   return {
     record: {
       stage: record.stage,
       hash: record.hash,
       ids: record.ids.filter((id): id is string => typeof id === "string"),
+      ...coordinates,
     },
   };
 }
@@ -232,12 +334,7 @@ async function claimAndRun(
   deps: SlackDeps,
 ): Promise<SlackResponse> {
   const claimName = `${deps.ssmPrefix}/approvals/approved-${offered.hash}`;
-  const claim = {
-    stage: offered.stage,
-    hash: offered.hash,
-    ids: offered.ids,
-    claimedAt: new Date(deps.now()).toISOString(),
-  };
+  const claim = buildClaim(offered, new Date(deps.now()).toISOString());
 
   let won = true;
   try {
@@ -248,13 +345,15 @@ async function claimAndRun(
     const name = (err as Error).name;
     const message = (err as Error).message;
     if (name !== "ParameterAlreadyExists" && !message.includes("ParameterAlreadyExists")) {
-      // The NAME, not just the message: this branch exists to separate "someone
-      // else won" from every other failure, and the name is the only part that
-      // names the class. `AccessDeniedException` here means the workload
-      // permissions boundary has not been rolled out yet — a deploy-order problem
-      // whose message ("User is not authorized to perform ssm:PutParameter") reads
-      // like a policy bug if the class is missing.
-      deps.log(`approval claim failed for ${offered.hash}: ${name}: ${message}`);
+      // The NAME, not the message: this branch exists to separate "someone else
+      // won" from every other failure, and the name is the only part that names the
+      // class. `AccessDeniedException` here means the workload permissions boundary
+      // has not been rolled out yet — a deploy-order problem that reads like a
+      // policy bug if the class is missing. The message is DROPPED because this
+      // call's argument is the id list and a `ValidationException` echoes it
+      // (TC-SLACKAPP-089); the `.includes` check above still reads it, which is
+      // fine — inspecting a string is not publishing it.
+      deps.log(`approval claim failed for ${offered.hash}: ${failureClass(err)}`);
       return reply("The approval could not be recorded, so the apply did not start.");
     }
     won = false;
@@ -339,10 +438,11 @@ async function claimAndRun(
     // A stamp failure does not undo a started apply, so it is reported rather
     // than treated as a failure of the run: the risk it leaves is a redelivery
     // taking the stale-claim path and starting a second task, which is why it is
-    // logged loudly.
+    // logged loudly. Class only, for the same reason as the claim write above —
+    // this call's value is the claim, so its ids are in scope for an echo.
     deps.log(
       `ERROR apply started (${taskArn}) but the claim could not be stamped: ` +
-        `${(err as Error).message}; a redelivery may start a second apply`,
+        `${failureClass(err)}; a redelivery may start a second apply`,
     );
   }
   return reply(`Apply started for ${offered.ids.length} memories.`);
@@ -385,21 +485,12 @@ export async function handleSlackInteraction(
   // primitive unless the host is checked against Slack's own. Everything this
   // endpoint needs to say fits in the synchronous 200, so the capability is absent
   // rather than present-and-unused.
-  let action: { action_id?: string; value?: string };
-  try {
-    const form = new URLSearchParams(rawBody);
-    const raw = form.get("payload");
-    if (!raw) throw new Error("no payload field");
-    const parsed = JSON.parse(raw) as {
-      actions?: Array<{ action_id?: string; value?: string }>;
-    };
-    const first = parsed.actions?.[0];
-    if (!first) throw new Error("no actions");
-    action = first;
-  } catch (err) {
-    deps.log(`unparseable /slack/interactions payload: ${(err as Error).message}`);
+  const parsed = parseAction(rawBody);
+  if ("error" in parsed) {
+    deps.log(`unparseable /slack/interactions payload: ${parsed.error}`);
     return status(400, "bad request");
   }
+  const action = parsed.action;
 
   // The default is INERT. Treating "not reject" as approve would turn any future
   // button — or a typo in the message template — into a deletion trigger.

--- a/infra/src/oauth-facade/slack-interactions.ts
+++ b/infra/src/oauth-facade/slack-interactions.ts
@@ -1,0 +1,426 @@
+/**
+ * Slack interactive-approval callback for cleanup deletions (issue #123).
+ *
+ * The cleanup run posts a classified deletion list to Slack with Approve /
+ * Reject buttons and writes the list to `{prefix}/approvals/offered`. This
+ * handler verifies the click came from Slack, checks the click is for the list
+ * that is currently offered, claims the approval atomically, and starts the ECS
+ * apply task. It never deletes a memory itself — that happens only in the task,
+ * which is what bounds the blast radius of a compromised callback to "started an
+ * apply of a list the classifier chose and the operator was shown".
+ *
+ * Design notes that are load-bearing, not stylistic:
+ *
+ *  - A Slack action `value` is capped at 2000 characters, so it cannot carry the
+ *    id list. It carries the list's content hash, and the ids come from SSM. The
+ *    signature proves the request came from the workspace, NOT that the ids in
+ *    the payload are the ids the classifier chose.
+ *  - Slack redelivers an interaction it does not get a response to within 3
+ *    seconds, so this whole sequence must be safe to run twice. The claim is the
+ *    atomic primitive: `PutParameter` with `Overwrite: false` fails with
+ *    `ParameterAlreadyExists` for the second caller, so exactly one delivery
+ *    wins without a read-then-write race.
+ *  - `ssm:DeleteParameter` is NOT admitted by the workload permissions boundary,
+ *    so a claim cannot be rolled back. A Lambda that dies after claiming and
+ *    before `RunTask` is recovered through `CLAIM_STALE_MS` instead.
+ *
+ * Every AWS call is injected (`SlackDeps`) so the tests need no SSM and no ECS.
+ * Test cases: docs/test-cases/slack-approval-loop.md (TC-SLACKAPP-001..036).
+ */
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+/** Slack rejects its own requests outside this window; we match it. */
+const MAX_TIMESTAMP_SKEW_MS = 5 * 60 * 1000;
+
+/**
+ * How long a claim with no `taskArn` is assumed to belong to a delivery that is
+ * still in flight. Below it, a losing claimant ACKs and starts nothing; above
+ * it, the winner is assumed dead and the approval is recovered.
+ *
+ * The tradeoff is asymmetric and the direction is deliberate: too short risks a
+ * double apply, and #102's cap and lockfile are a blast-radius limit rather than
+ * a correctness guarantee against two concurrent applies of the same ids. Too
+ * long only risks an approval the operator has to click again, which is logged.
+ */
+export const CLAIM_STALE_MS = 60_000;
+
+export interface SlackDeps {
+  /** Slack app signing secret. Empty or absent must fail CLOSED. */
+  signingSecret: string;
+  stage: string;
+  /** SSM prefix, e.g. `/mem9-on-aws/prod`. */
+  ssmPrefix: string;
+  now: () => number;
+  getParameter: (name: string) => Promise<string | null>;
+  putParameter: (
+    name: string,
+    value: string,
+    opts?: { overwrite?: boolean },
+  ) => Promise<void>;
+  /** Start the apply task; resolves with the task ARN once ECS accepts it. */
+  runTask: (input: { ids: string[]; hash: string; stage: string }) => Promise<string>;
+  log: (message: string) => void;
+}
+
+interface SlackEvent {
+  rawPath?: string;
+  headers?: Record<string, string>;
+  body?: string;
+  isBase64Encoded?: boolean;
+  requestContext?: { http?: { method?: string } };
+}
+
+interface SlackResponse {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: string;
+}
+
+/**
+ * Slack's own text replies. `response_type: ephemeral` keeps them visible only
+ * to the operator who clicked, which matters because the text names memory ids.
+ */
+function reply(text: string): SlackResponse {
+  return {
+    statusCode: 200,
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ response_type: "ephemeral", replace_original: false, text }),
+  };
+}
+
+function status(code: number, text: string): SlackResponse {
+  return { statusCode: code, headers: { "content-type": "text/plain" }, body: text };
+}
+
+/**
+ * Case-insensitive header lookup. API Gateway v2 lowercases header names, but
+ * matching only the canonical spelling would reject every real request, and
+ * matching only lowercase makes the handler untestable against any other
+ * transport — so neither spelling is privileged.
+ */
+function header(event: SlackEvent, name: string): string | undefined {
+  const target = name.toLowerCase();
+  for (const [k, v] of Object.entries(event.headers ?? {})) {
+    if (k.toLowerCase() === target) return v;
+  }
+  return undefined;
+}
+
+/**
+ * Verify Slack's `v0=` HMAC over `v0:{timestamp}:{rawBody}`.
+ *
+ * Returns a reason string on failure rather than throwing, so the caller answers
+ * 401 for every rejection and an attacker learns nothing from the status code
+ * about which check failed.
+ */
+function verifySignature(
+  event: SlackEvent,
+  rawBody: string,
+  deps: SlackDeps,
+): string | null {
+  // Empty string is the "disabled" sentinel elsewhere in this Lambda (`hmacKey`),
+  // and an empty HMAC key still produces a valid signature — so a handler that
+  // signed with "" would accept anything an attacker signed with "" too. Fail
+  // closed, before any comparison.
+  if (!deps.signingSecret) return "signing secret is not configured";
+
+  const provided = header(event, "x-slack-signature");
+  const timestamp = header(event, "x-slack-request-timestamp");
+  if (!provided || !timestamp) return "missing signature headers";
+
+  // Checked by SHAPE before value, because `Number` is too permissive to guard the
+  // skew comparison below: `Number("abc")` is NaN and every NaN comparison is
+  // false, so `Math.abs(now - NaN) > MAX` is false and a value-only check ACCEPTS
+  // garbage. That case alone is why this line has to exist.
+  //
+  // It is deliberately narrower than that one case needs, and the extra width buys
+  // a REASON rather than a rejection: `""`, `"1e999"`, `"-1"` and a 20-digit value
+  // would all be refused by the skew check anyway, but refused as `stale
+  // timestamp` — sending an operator to hunt a clock skew that does not exist.
+  // `" 1754395200 "` is the sharpest: `Number` trims, so a trimmed-but-in-window
+  // value is the one input the skew check genuinely cannot see. Twelve digits
+  // covers Unix seconds past the year 33000, so the bound costs nothing real, and
+  // it keeps the millisecond product under 1e15 — inside the safe-integer range by
+  // construction, which is why no `Number.isSafeInteger` check follows.
+  if (!/^\d{1,12}$/u.test(timestamp)) return "malformed timestamp";
+  const tsMs = Number(timestamp) * 1000;
+  // Two-sided on purpose: a one-sided check accepts a signature minted against a
+  // clock the attacker controls and keeps it valid indefinitely.
+  if (Math.abs(deps.now() - tsMs) > MAX_TIMESTAMP_SKEW_MS) return "stale timestamp";
+
+  const expected = `v0=${createHmac("sha256", deps.signingSecret)
+    .update(`v0:${timestamp}:${rawBody}`)
+    .digest("hex")}`;
+  const a = Buffer.from(provided, "utf8");
+  const b = Buffer.from(expected, "utf8");
+  // Length first: `timingSafeEqual` THROWS on a length mismatch (the
+  // `state.ts` precedent), and an unhandled throw here is a 500 that tells an
+  // attacker their input reached the comparator.
+  if (a.length !== b.length) return "signature mismatch";
+  if (!timingSafeEqual(a, b)) return "signature mismatch";
+  return null;
+}
+
+interface OfferedRecord {
+  stage: string;
+  hash: string;
+  ids: string[];
+}
+
+/** Parse a stored record, returning null for anything malformed. */
+function parseRecord(raw: string | null): Record<string, unknown> | null {
+  if (!raw) return null;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The offered list, or null if it cannot be trusted for this click.
+ *
+ * A read failure, a malformed record, a hash that does not match, and a record
+ * naming another stage all resolve to the same answer. That is the point: a
+ * failure to read must never WIDEN what is accepted, and a stage mismatch is the
+ * same class of error as #102's decision-file stage guard — a preview approval
+ * must never apply to prod.
+ */
+async function loadOffered(
+  hash: string,
+  deps: SlackDeps,
+): Promise<{ record: OfferedRecord } | { error: string }> {
+  let raw: string | null;
+  try {
+    raw = await deps.getParameter(`${deps.ssmPrefix}/approvals/offered`);
+  } catch (err) {
+    deps.log(`approvals/offered could not be read: ${(err as Error).message}`);
+    return { error: "The approval list could not be read. Nothing was applied." };
+  }
+  const record = parseRecord(raw);
+  if (!record || !Array.isArray(record.ids) || typeof record.hash !== "string") {
+    return { error: "There is no current approval list. It may have been regenerated." };
+  }
+  if (record.stage !== deps.stage) {
+    return {
+      error: `That approval names stage ${JSON.stringify(String(record.stage))}, not ${JSON.stringify(deps.stage)}. Nothing was applied.`,
+    };
+  }
+  if (record.hash !== hash) {
+    return { error: "That list has been regenerated since it was posted. Nothing was applied." };
+  }
+  return {
+    record: {
+      stage: record.stage,
+      hash: record.hash,
+      ids: record.ids.filter((id): id is string => typeof id === "string"),
+    },
+  };
+}
+
+/**
+ * Claim the approval and start the apply, or explain why this delivery is not
+ * the one that should.
+ *
+ * The three branches on a losing claim are the whole redelivery design; see the
+ * table in docs/test-cases/slack-approval-loop.md.
+ */
+async function claimAndRun(
+  offered: OfferedRecord,
+  deps: SlackDeps,
+): Promise<SlackResponse> {
+  const claimName = `${deps.ssmPrefix}/approvals/approved-${offered.hash}`;
+  const claim = {
+    stage: offered.stage,
+    hash: offered.hash,
+    ids: offered.ids,
+    claimedAt: new Date(deps.now()).toISOString(),
+  };
+
+  let won = true;
+  try {
+    // `Overwrite: false` is the atomic primitive. A read-then-write would race
+    // two redeliveries against each other and double-apply.
+    await deps.putParameter(claimName, JSON.stringify(claim), { overwrite: false });
+  } catch (err) {
+    const name = (err as Error).name;
+    const message = (err as Error).message;
+    if (name !== "ParameterAlreadyExists" && !message.includes("ParameterAlreadyExists")) {
+      // The NAME, not just the message: this branch exists to separate "someone
+      // else won" from every other failure, and the name is the only part that
+      // names the class. `AccessDeniedException` here means the workload
+      // permissions boundary has not been rolled out yet — a deploy-order problem
+      // whose message ("User is not authorized to perform ssm:PutParameter") reads
+      // like a policy bug if the class is missing.
+      deps.log(`approval claim failed for ${offered.hash}: ${name}: ${message}`);
+      return reply("The approval could not be recorded, so the apply did not start.");
+    }
+    won = false;
+  }
+
+  if (!won) {
+    // A read FAILURE is not an absent claim, and the difference decides whether a
+    // destructive task starts. Collapsing them (`.catch(() => null)`) made
+    // `parseRecord` return null, `Date.parse(String(undefined))` return NaN, and
+    // `!Number.isFinite(NaN)` make `stale` TRUE — so a losing delivery whose read
+    // was merely throttled took the RECOVERY path and started a second apply of the
+    // same ids. Two redeliveries hitting one parameter within Slack's 3-second
+    // window is exactly when a `ThrottlingException` is likely.
+    //
+    // We already know the claim EXISTS (the `Overwrite: false` write lost to it), so
+    // an unreadable claim is unknown, not stale — and unknown is precisely when
+    // starting an apply is unsafe. Refuse and let the operator re-click.
+    let existing: Record<string, unknown> | null;
+    try {
+      existing = parseRecord(await deps.getParameter(claimName));
+    } catch (err) {
+      deps.log(
+        `ERROR could not read the existing claim for ${offered.hash}: ` +
+          `${(err as Error).name}: ${(err as Error).message}`,
+      );
+      return reply(
+        "Another delivery already claimed this approval and we could not " +
+          "confirm whether its apply started. Nothing further was started; " +
+          "re-click if no apply appears.",
+      );
+    }
+    if (existing?.taskArn) {
+      return reply("That approval has already been applied. Nothing further was started.");
+    }
+    const claimedAt = Date.parse(String(existing?.claimedAt ?? ""));
+    // A successfully read record with an unparseable `claimedAt` IS treated as
+    // stale: the claim is corrupt, so the stale window is the only way it is ever
+    // recoverable. That is a different case from a read that failed, where the
+    // record may be perfectly valid and merely unread.
+    const stale =
+      !Number.isFinite(claimedAt) || deps.now() - claimedAt > CLAIM_STALE_MS;
+    if (!stale) {
+      // The ONLY interleaving that can lose an approval, and only if the winning
+      // invocation dies inside this window. Logged at error level with the hash
+      // so the operator can re-click; starting a second task whenever a claim
+      // merely looks unfinished would risk a double apply instead.
+      deps.log(
+        `ERROR another delivery holds an unfinished claim for ${offered.hash}; ` +
+          `if no apply appears, re-click to retry`,
+      );
+      return reply("That approval is already being applied.");
+    }
+    deps.log(
+      `recovering a stale claim for ${offered.hash} (no taskArn after ${CLAIM_STALE_MS}ms)`,
+    );
+  }
+
+  let taskArn: string;
+  try {
+    taskArn = await deps.runTask({ ids: offered.ids, hash: offered.hash, stage: offered.stage });
+  } catch (err) {
+    // Surfaced, never swallowed: "recorded the approval and told the operator it
+    // worked" is the worst available outcome. The claim REMAINS, so a retry
+    // recovers through the stale-claim branch above. The message is logged
+    // without the request body, which carries the payload and the ids.
+    deps.log(`RunTask failed for ${offered.hash}: ${(err as Error).message}`);
+    return reply(
+      `The approval was recorded but the apply did not start. Retry the click, or run the apply manually.`,
+    );
+  }
+
+  // Stamped after RunTask returns, so a later delivery takes the taskArn branch
+  // rather than starting a second apply. `Overwrite: true` because the claim
+  // already exists — this is the same record gaining a field.
+  try {
+    await deps.putParameter(
+      claimName,
+      JSON.stringify({ ...claim, taskArn }),
+      { overwrite: true },
+    );
+  } catch (err) {
+    // A stamp failure does not undo a started apply, so it is reported rather
+    // than treated as a failure of the run: the risk it leaves is a redelivery
+    // taking the stale-claim path and starting a second task, which is why it is
+    // logged loudly.
+    deps.log(
+      `ERROR apply started (${taskArn}) but the claim could not be stamped: ` +
+        `${(err as Error).message}; a redelivery may start a second apply`,
+    );
+  }
+  return reply(`Apply started for ${offered.ids.length} memories.`);
+}
+
+/**
+ * Handle `POST /slack/interactions`.
+ *
+ * Verification comes before ANY parsing: parsing an unauthenticated body is the
+ * attack surface this endpoint exists to close.
+ */
+export async function handleSlackInteraction(
+  event: SlackEvent,
+  deps: SlackDeps,
+): Promise<SlackResponse> {
+  if ((event.requestContext?.http?.method ?? "POST").toUpperCase() !== "POST") {
+    return status(405, "method not allowed");
+  }
+
+  // The signature covers the RAW body, so base64 must be decoded before
+  // verification and never re-encoded. API Gateway base64-encodes when the
+  // content type is not recognised as text.
+  const rawBody = event.isBase64Encoded
+    ? Buffer.from(event.body ?? "", "base64").toString("utf8")
+    : (event.body ?? "");
+
+  const bad = verifySignature(event, rawBody, deps);
+  if (bad) {
+    // One status for every rejection reason: the reason goes to the log, not to
+    // the caller.
+    deps.log(`rejected a /slack/interactions request: ${bad}`);
+    return status(401, "unauthorized");
+  }
+
+  // Slack posts `application/x-www-form-urlencoded` with the JSON in a `payload`
+  // field, NOT a JSON body.
+  // `response_url` is deliberately NOT read. Slack sends one, and posting to it is
+  // the documented way to update a message later — but it is a caller-supplied URL
+  // in a payload whose only validation is the signature, so following it is an SSRF
+  // primitive unless the host is checked against Slack's own. Everything this
+  // endpoint needs to say fits in the synchronous 200, so the capability is absent
+  // rather than present-and-unused.
+  let action: { action_id?: string; value?: string };
+  try {
+    const form = new URLSearchParams(rawBody);
+    const raw = form.get("payload");
+    if (!raw) throw new Error("no payload field");
+    const parsed = JSON.parse(raw) as {
+      actions?: Array<{ action_id?: string; value?: string }>;
+    };
+    const first = parsed.actions?.[0];
+    if (!first) throw new Error("no actions");
+    action = first;
+  } catch (err) {
+    deps.log(`unparseable /slack/interactions payload: ${(err as Error).message}`);
+    return status(400, "bad request");
+  }
+
+  // The default is INERT. Treating "not reject" as approve would turn any future
+  // button — or a typo in the message template — into a deletion trigger.
+  if (action.action_id === "cleanup_reject") {
+    return reply("Rejected. Nothing was deleted and no approval was recorded.");
+  }
+  if (action.action_id !== "cleanup_approve") {
+    deps.log(`ignoring unrecognised action_id ${JSON.stringify(action.action_id ?? null)}`);
+    return reply("That button is not one this app knows how to handle.");
+  }
+
+  // The hash from the button; the ids come from SSM. Never from the payload — the
+  // signature proves the request came from the workspace, not that the ids in it
+  // are the ids the classifier chose.
+  const hash = action.value;
+  if (typeof hash !== "string" || !hash) {
+    return reply("That approval carried no list reference. Nothing was applied.");
+  }
+
+  const loaded = await loadOffered(hash, deps);
+  if ("error" in loaded) return reply(loaded.error);
+
+  return claimAndRun(loaded.record, deps);
+}

--- a/infra/sst-types.d.ts
+++ b/infra/sst-types.d.ts
@@ -669,6 +669,11 @@ declare namespace sst {
       readonly name: Output<string>;
       readonly nodes: {
         function: { name: Output<string>; arn: Output<string> };
+        // The execution role. infra/slack-approval.ts attaches the approval
+        // grants to the façade Function's existing role by NAME (which is what
+        // aws.iam.RolePolicy takes) rather than creating a second Lambda role
+        // that would need its own workload-boundary exception.
+        role: { name: Output<string>; arn: Output<string> };
       };
     }
 

--- a/infra/task-failure-alarm.test-fixtures.ts
+++ b/infra/task-failure-alarm.test-fixtures.ts
@@ -1,0 +1,66 @@
+/**
+ * Pulumi `aws.cloudwatch` stubs for the six resources `taskFailureAlarm` creates.
+ *
+ * Shared by `consolidation.test.ts` and `slack-approval.test.ts` because the stub
+ * SET is exactly that helper's resource set: a seventh resource added there needs
+ * one stub added here, not two identical blocks kept in sync. The two harnesses
+ * keep their own `record`/`out` (each owns its own resource log), so those are
+ * passed in rather than imported.
+ *
+ * Only `EventRule` and `LogGroup` expose attributes, and only the ones the helper
+ * reads back — `logGroup.arn` for the resource policy, `rule.name` for the target.
+ * A stub with more attributes than the real code consumes invites an assertion on
+ * a value nothing produces.
+ */
+export interface TaskFailureAlarmStubOptions {
+  /** Recorder the host harness uses to log created resources. */
+  record: (kind: string, logicalName: string, args: Record<string, unknown>) => void;
+  /** The host harness's `Output` wrapper. */
+  out: <T>(value: T) => unknown;
+  /** Stand-in rule ARN/name; only the name is read (by the event target). */
+  ruleName: string;
+  /** Stand-in log group name; its ARN is read by the resource policy. */
+  logGroupName: string;
+}
+
+export function cloudwatchStubs(options: TaskFailureAlarmStubOptions) {
+  const { record, out, ruleName, logGroupName } = options;
+  return {
+    EventRule: class {
+      arn = out(`arn:aws:events:ap-northeast-1:123456789012:rule/${ruleName}`);
+      name = out(ruleName);
+      constructor(logicalName: string, args: Record<string, unknown>) {
+        record("EventRule", logicalName, args);
+      }
+    },
+    EventTarget: class {
+      constructor(logicalName: string, args: Record<string, unknown>) {
+        record("EventTarget", logicalName, args);
+      }
+    },
+    LogGroup: class {
+      arn = out(
+        `arn:aws:logs:ap-northeast-1:123456789012:log-group:${logGroupName}`,
+      );
+      name = out(logGroupName);
+      constructor(logicalName: string, args: Record<string, unknown>) {
+        record("LogGroup", logicalName, args);
+      }
+    },
+    LogResourcePolicy: class {
+      constructor(logicalName: string, args: Record<string, unknown>) {
+        record("LogResourcePolicy", logicalName, args);
+      }
+    },
+    LogMetricFilter: class {
+      constructor(logicalName: string, args: Record<string, unknown>) {
+        record("LogMetricFilter", logicalName, args);
+      }
+    },
+    MetricAlarm: class {
+      constructor(logicalName: string, args: Record<string, unknown>) {
+        record("MetricAlarm", logicalName, args);
+      }
+    },
+  };
+}

--- a/infra/task-failure-alarm.ts
+++ b/infra/task-failure-alarm.ts
@@ -1,0 +1,174 @@
+import { boundedNamePrefix } from "./consolidation";
+
+// The failure alarm shared by the two scheduled/triggered ECS tasks: the weekly
+// consolidation (#113) and the Slack-approved cleanup apply (#123).
+//
+// Both tasks have the same problem. They run unattended, every error path inside
+// them ends in a log line, and a log line pages nobody — for cleanup the operator
+// has already been told "Apply started", and for consolidation nobody is watching
+// at all. The next signal without an alarm is a human noticing months of
+// un-consolidated or un-tidied memories.
+//
+// An EventBridge rule on ECS task state change is used rather than a metric filter
+// over the task's OWN logs because the most likely first-deploy failure produces no
+// application log whatsoever: a task killed in the ECS agent's secret-fetch phase
+// never runs its entrypoint. That is also why the exit-code filter is
+// `anything-but: 0` and not a `> 0` comparison — such a task reports NO exitCode,
+// which is exactly what a numeric filter drops.
+//
+// The rule is pinned to the task definition REVISION, never to the cluster: the
+// cluster is shared with the server and the other task, so a cluster-wide rule
+// would alarm one feature's topic on every unrelated task failure.
+//
+// Extracted because the two copies had already drifted — the cleanup copy carries
+// `stoppedReason` (see `includeStoppedReason`) and the consolidation copy does not
+// — and a third copy of ~110 lines of resource wiring is how the next one drifts
+// further. The logical names stay caller-supplied so that extracting this changed
+// no deployed resource's URN.
+
+export interface TaskFailureAlarmArgs {
+  /**
+   * Logical-name stem, e.g. `ConsolidationTaskFailure`. Concatenated with
+   * `Events`/`Rule`/`LogPolicy`/`LogTarget`/`Filter`/`Alarm` to reproduce the
+   * exact logical names the two stacks already deployed. Changing a stem
+   * RENAMES resources, which for the log group and the rule means Pulumi
+   * replaces them and the alarm goes briefly blind.
+   */
+  stem: string;
+  /** Log group name, e.g. `/sst/consolidation/{stage}/task-failures`. */
+  logGroupName: string;
+  /** `namePrefix` for the rule, budgeted against Pulumi's 26-char suffix. */
+  rulePrefix: string;
+  /** What the prefix is, for `boundedNamePrefix`'s error message. */
+  ruleWhat: string;
+  ruleDescription: string;
+  /** `LogResourcePolicy` policy name — a NAME, so it must be stage-unique. */
+  policyName: string;
+  /** The `event` field, matched by the metric filter, e.g. `..._task_failed`. */
+  eventName: string;
+  metricName: string;
+  alarmDescription: string;
+  /** The task definition revision ARN this rule is pinned to. */
+  taskDefinitionArn: Input<string>;
+  alertsTopicArn: Input<string>;
+  tags: Record<string, Input<string>>;
+  /**
+   * Carry `stoppedReason` into the log event. It is the ONLY field where a
+   * startup failure names itself (`ResourceInitializationError` on the secret
+   * fetch), so it is on for the cleanup task, whose execution role sits outside
+   * the boundary's secret-decrypt exception list.
+   *
+   * Off for consolidation only because turning it on would change that stack's
+   * deployed `inputTransformer` — a diff unrelated to whatever change is being
+   * shipped. Worth doing on its own.
+   */
+  includeStoppedReason?: boolean;
+}
+
+const FAILURE_NAMESPACE = "mem9-on-aws";
+
+/** EventBridge caps a rule NAME at 64 characters. */
+const EVENT_RULE_NAME_MAX = 64;
+
+export function taskFailureAlarm(args: TaskFailureAlarmArgs): void {
+  const logGroup = new aws.cloudwatch.LogGroup(`${args.stem}Events`, {
+    name: args.logGroupName,
+    retentionInDays: 30,
+    tags: args.tags,
+  });
+
+  const rule = new aws.cloudwatch.EventRule(`${args.stem}Rule`, {
+    namePrefix: boundedNamePrefix(
+      args.rulePrefix,
+      EVENT_RULE_NAME_MAX,
+      args.ruleWhat,
+    ),
+    description: args.ruleDescription,
+    eventPattern: $jsonStringify({
+      source: ["aws.ecs"],
+      "detail-type": ["ECS Task State Change"],
+      detail: {
+        lastStatus: ["STOPPED"],
+        taskDefinitionArn: [args.taskDefinitionArn],
+        containers: { exitCode: [{ "anything-but": 0 }] },
+      },
+    }),
+    tags: args.tags,
+  });
+
+  const logPolicy = new aws.cloudwatch.LogResourcePolicy(
+    `${args.stem}LogPolicy`,
+    {
+      policyName: args.policyName,
+      policyDocument: $jsonStringify({
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Principal: {
+              Service: ["events.amazonaws.com", "delivery.logs.amazonaws.com"],
+            },
+            Action: ["logs:CreateLogStream", "logs:PutLogEvents"],
+            Resource: $interpolate`${logGroup.arn}:*`,
+          },
+        ],
+      }),
+    },
+  );
+
+  new aws.cloudwatch.EventTarget(
+    `${args.stem}LogTarget`,
+    {
+      arn: logGroup.arn,
+      rule: rule.name,
+      inputTransformer: {
+        inputPaths: {
+          exitCode: "$.detail.containers[0].exitCode",
+          ...(args.includeStoppedReason
+            ? { stoppedReason: "$.detail.stoppedReason" }
+            : {}),
+        },
+        inputTemplate: JSON.stringify({
+          event: args.eventName,
+          stage: $app.stage,
+          exitCode: "<exitCode>",
+          ...(args.includeStoppedReason
+            ? { stoppedReason: "<stoppedReason>" }
+            : {}),
+        }),
+      },
+    },
+    // The policy must exist before EventBridge is asked to deliver to the group,
+    // or the first PutTargets is rejected.
+    { dependsOn: [logPolicy] },
+  );
+
+  new aws.cloudwatch.LogMetricFilter(`${args.stem}Filter`, {
+    logGroupName: logGroup.name,
+    pattern:
+      `{ $.event = "${args.eventName}" && ` + `$.stage = "${$app.stage}" }`,
+    metricTransformation: {
+      name: args.metricName,
+      namespace: FAILURE_NAMESPACE,
+      value: "1",
+      dimensions: { stage: "$.stage" },
+    },
+  });
+
+  new aws.cloudwatch.MetricAlarm(`${args.stem}Alarm`, {
+    alarmDescription: args.alarmDescription,
+    namespace: FAILURE_NAMESPACE,
+    metricName: args.metricName,
+    dimensions: { stage: $app.stage },
+    statistic: "Sum",
+    period: 300,
+    evaluationPeriods: 1,
+    datapointsToAlarm: 1,
+    threshold: 1,
+    comparisonOperator: "GreaterThanOrEqualToThreshold",
+    // A stage with no failures emits no datapoints at all, and `missing` would
+    // hold the alarm in INSUFFICIENT_DATA forever rather than OK.
+    treatMissingData: "notBreaching",
+    alarmActions: [args.alertsTopicArn],
+  });
+}

--- a/infra/workload-permissions-boundary.roles.test.ts
+++ b/infra/workload-permissions-boundary.roles.test.ts
@@ -7,6 +7,7 @@ import { WORKLOAD_BOUNDARY_POLICY_NAME } from "./workload-permissions-boundary";
 import {
   CONSOLIDATION_SCHEDULER_ROLE_NAME,
   EXPECTED_WORKLOAD_ROLE_NAMES,
+  SLACK_APPROVAL_ROLE_NAMES,
 } from "./workload-permissions-boundary.test-fixtures";
 
 interface MockCallArgs {
@@ -236,15 +237,23 @@ describe("workload role coverage from the real SST graph", () => {
       authorizerEnabled: false,
       label: "authorizer disabled, scheduler disabled",
       scheduleEnabled: false,
+      slackApprovalEnabled: false,
     },
     {
       authorizerEnabled: true,
       label: "authorizer enabled, scheduler enabled",
       scheduleEnabled: true,
+      slackApprovalEnabled: false,
+    },
+    {
+      authorizerEnabled: true,
+      label: "authorizer enabled, scheduler enabled, Slack approval enabled",
+      scheduleEnabled: true,
+      slackApprovalEnabled: true,
     },
   ])(
-    "TC-FACADEAUTH-004/TC-CONSOL-026: keeps the $label graph inside the workload boundary",
-    async ({ authorizerEnabled, scheduleEnabled }) => {
+    "TC-FACADEAUTH-004/TC-CONSOL-026/TC-SLACKAPP-082: keeps the $label graph inside the workload boundary",
+    async ({ authorizerEnabled, scheduleEnabled, slackApprovalEnabled }) => {
       vi.resetModules();
       const rpcServer = await startSstRpcServer();
       const previousSstServer = process.env.SST_SERVER;
@@ -255,6 +264,13 @@ describe("workload role coverage from the real SST graph", () => {
       const previousSlackWebhook = process.env.SST_SECRET_SlackWebhookUrl;
       const previousScheduleEnabled =
         process.env.MEM9_CONSOLIDATION_SCHEDULE_ENABLED;
+      const previousSlackApprovalEnabled =
+        process.env.MEM9_SLACK_APPROVAL_ENABLED;
+      const previousSlackApprovalChannel =
+        process.env.MEM9_SLACK_APPROVAL_CHANNEL;
+      const previousSlackBotToken = process.env.SST_SECRET_SlackBotToken;
+      const previousSlackSigningSecret =
+        process.env.SST_SECRET_SlackSigningSecret;
       process.env.SST_SERVER = rpcServer.url;
       process.env.WORKLOAD_BOUNDARY_PROD_ENABLED = "true";
       if (authorizerEnabled) {
@@ -269,6 +285,17 @@ describe("workload role coverage from the real SST graph", () => {
         process.env.MEM9_CONSOLIDATION_SCHEDULE_ENABLED = "1";
       } else {
         delete process.env.MEM9_CONSOLIDATION_SCHEDULE_ENABLED;
+      }
+      if (slackApprovalEnabled) {
+        process.env.MEM9_SLACK_APPROVAL_ENABLED = "1";
+        process.env.MEM9_SLACK_APPROVAL_CHANNEL = "C0123456789";
+        process.env.SST_SECRET_SlackBotToken = "xoxb-mock-bot-token";
+        process.env.SST_SECRET_SlackSigningSecret = "mock-signing-secret";
+      } else {
+        delete process.env.MEM9_SLACK_APPROVAL_ENABLED;
+        delete process.env.MEM9_SLACK_APPROVAL_CHANNEL;
+        delete process.env.SST_SECRET_SlackBotToken;
+        delete process.env.SST_SECRET_SlackSigningSecret;
       }
       Object.assign(globalThis, {
         $app: {
@@ -350,8 +377,12 @@ describe("workload role coverage from the real SST graph", () => {
           : [...EXPECTED_WORKLOAD_ROLE_NAMES];
         if (scheduleEnabled) {
           expectedRoleNames.push(CONSOLIDATION_SCHEDULER_ROLE_NAME);
-          expectedRoleNames.sort();
         }
+        if (slackApprovalEnabled) {
+          // One `sst.aws.Task` creates BOTH a task role and an execution role.
+          expectedRoleNames.push(...SLACK_APPROVAL_ROLE_NAMES);
+        }
+        expectedRoleNames.sort();
         await pulumi.runtime.runInPulumiStack(async () => {
           const configModule = await import(
             /* @vite-ignore */ moduleUrl("sst.config.ts")
@@ -502,6 +533,10 @@ describe("workload role coverage from the real SST graph", () => {
             "MEM9_CONSOLIDATION_SCHEDULE_ENABLED",
             previousScheduleEnabled,
           ],
+          ["MEM9_SLACK_APPROVAL_ENABLED", previousSlackApprovalEnabled],
+          ["MEM9_SLACK_APPROVAL_CHANNEL", previousSlackApprovalChannel],
+          ["SST_SECRET_SlackBotToken", previousSlackBotToken],
+          ["SST_SECRET_SlackSigningSecret", previousSlackSigningSecret],
         ] as const) {
           if (value === undefined) {
             delete process.env[name];

--- a/infra/workload-permissions-boundary.test-fixtures.ts
+++ b/infra/workload-permissions-boundary.test-fixtures.ts
@@ -13,3 +13,21 @@ export const EXPECTED_WORKLOAD_ROLE_NAMES = [
 
 export const CONSOLIDATION_SCHEDULER_ROLE_NAME =
   "Mem9ConsolidationSchedulerRole";
+
+/**
+ * The roles `infra/slack-approval.ts` adds when `MEM9_SLACK_APPROVAL_ENABLED=1`
+ * (#123). One `sst.aws.Task` always creates BOTH a task role and an execution
+ * role, so both must be admitted or the exact-set assertion in
+ * `workload-permissions-boundary.roles.test.ts` fails.
+ *
+ * Neither name appears in the operator-owned boundary's
+ * `ECS_EXECUTION_ROLE_TOKENS`, and it does not need to: the task's SecureString
+ * reads are gated on `kms:ViaService`, and its Secrets Manager reads resolve
+ * under the default `aws/secretsmanager` key, which needs no identity
+ * `kms:Decrypt`. Moving either secret to a customer managed key would require
+ * adding `Mem9CleanupExecutionRole-` to that deny's exception list.
+ */
+export const SLACK_APPROVAL_ROLE_NAMES = [
+  "Mem9CleanupExecutionRole",
+  "Mem9CleanupTaskRole",
+] as const;

--- a/scripts/cleanup-image-contract.test.mjs
+++ b/scripts/cleanup-image-contract.test.mjs
@@ -1,0 +1,116 @@
+// The llm-proxy image is the runtime for BOTH the weekly consolidation task and
+// the Slack-triggered cleanup apply task (#123). Those entrypoints are COPYd in
+// from scripts/, so their import graph is a contract with
+// docker/llm-proxy/package.json that nothing else checks: a `node_modules` that
+// satisfies the sidecar can still be missing a client the entrypoint reaches, and
+// the failure is a MODULE_NOT_FOUND at task start — after the operator's click has
+// already been claimed and spent.
+//
+// Kin to TC-CONSOL-045 (scripts/run-consolidation-task.test.mjs), which pins the
+// entrypoint PATHS across the same three files. This pins the DEPENDENCIES.
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const root = new URL("..", import.meta.url);
+const read = (rel) => readFileSync(new URL(rel, root), "utf8");
+
+const imagePackage = JSON.parse(read("docker/llm-proxy/package.json"));
+const imageLock = JSON.parse(read("docker/llm-proxy/package-lock.json"));
+const dockerfile = read("docker/llm-proxy/Dockerfile");
+
+/**
+ * Every bare module specifier a source file can import, static or dynamic.
+ *
+ * Dynamic `import()` is the shape that matters most here: every AWS client in
+ * these entrypoints is imported lazily so the operator CLI pays for only the ones
+ * its flags reach, which also means a missing one is invisible until the exact
+ * code path runs. A static-import-only check would have passed while the apply
+ * task died on `await import("@aws-sdk/client-ssm")`.
+ *
+ * Bare = not relative, not absolute, not `node:` — i.e. resolved from
+ * node_modules, which is the only thing `npm ci` in the image controls.
+ */
+function bareSpecifiers(source) {
+  const specifiers = new Set();
+  for (const match of source.matchAll(
+    /(?:\bfrom\s*|\bimport\s*\(\s*)["']([^"']+)["']/gu,
+  )) {
+    const specifier = match[1];
+    if (/^[./]/u.test(specifier) || specifier.startsWith("node:")) continue;
+    // The pattern matches inside comments too, which is deliberate — over-inclusion
+    // only ever asks the image to ship one more package — but prose reaches it that
+    // way as well (`// from "a concurrent write protected me"`). Keep only strings
+    // shaped like a module specifier; anything a package name cannot contain is not
+    // one, and no valid specifier is excluded by this.
+    if (!/^(?:@[\w.-]+\/)?[\w.-]+(?:\/[\w.-]+)*$/u.test(specifier)) continue;
+    // A subpath import (`pkg/sub`) is satisfied by the PACKAGE, so compare on the
+    // package name. Scoped names carry one slash before the package name.
+    const parts = specifier.split("/");
+    specifiers.add(
+      specifier.startsWith("@") ? parts.slice(0, 2).join("/") : parts[0],
+    );
+  }
+  return specifiers;
+}
+
+/**
+ * The files the image runs: the sidecar plus everything copied under
+ * /app/scripts/. Derived from the Dockerfile rather than hardcoded, so a new
+ * entrypoint is covered the moment it is copied in.
+ */
+function copiedEntrypoints() {
+  return [
+    ...dockerfile.matchAll(/^COPY\s+(scripts\/\S+\.mjs)\s+\/app\/scripts\/\S+$/gmu),
+  ].map((match) => match[1]);
+}
+
+describe("the llm-proxy image can run the entrypoints copied into it (TC-SLACKAPP-099)", () => {
+  it("ships every module the copied entrypoints import", () => {
+    const entrypoints = copiedEntrypoints();
+    // A vacuous pass is the failure mode of a Dockerfile-derived list: if the COPY
+    // regex ever stops matching, an empty list satisfies every assertion below.
+    expect(entrypoints).toContain("scripts/memory-cleanup.mjs");
+    expect(entrypoints).toContain("scripts/memory-consolidation.mjs");
+
+    const shipped = new Set(Object.keys(imagePackage.dependencies));
+    const missing = [];
+    for (const relative of [...entrypoints, "docker/llm-proxy/server.mjs"]) {
+      for (const specifier of bareSpecifiers(read(relative))) {
+        if (!shipped.has(specifier)) missing.push(`${relative} -> ${specifier}`);
+      }
+    }
+    // Asserted over EVERY specifier rather than only the ones the task's own argv
+    // reaches. Reachability is the wrong question because the two errors are not
+    // symmetric: shipping a client no code path takes costs image bytes, while
+    // omitting one a path does take kills the run after the approval is spent. The
+    // cheap rule is "if the file can name it, the image has it".
+    expect(missing).toEqual([]);
+  });
+
+  it("keeps the lockfile in agreement so `npm ci` cannot fail the image build", () => {
+    // `npm ci` REFUSES to install when package.json and the lockfile disagree, so
+    // adding a dependency without regenerating the lock does not produce a thinner
+    // image — it produces no image at all, discovered in CI rather than here.
+    expect(imageLock.packages[""].dependencies).toEqual(
+      imagePackage.dependencies,
+    );
+  });
+
+  it("fails the image build, not the run, when an entrypoint's static graph breaks", () => {
+    // The existing guard covers consolidation only. It catches the class of bug
+    // that produced it (a flattened COPY breaking `../docker/llm-proxy/server.mjs`),
+    // and that import is shared by both entrypoints — but the guard is per-file, so
+    // an entrypoint without one is unverified at build time.
+    //
+    // Static graph only: a `RUN node -e "await import(...)"` never executes the
+    // lazy `import()` calls, which is exactly why the dependency assertion above
+    // exists alongside it.
+    for (const relative of copiedEntrypoints()) {
+      const containerPath = `/app/${relative}`;
+      expect(
+        dockerfile.includes(`await import('${containerPath}')`),
+        `${relative} has no build-time import guard`,
+      ).toBe(true);
+    }
+  });
+});

--- a/scripts/deployment-workflow.test.mjs
+++ b/scripts/deployment-workflow.test.mjs
@@ -399,6 +399,55 @@ describe("workflow integration", () => {
     expect(runner).not.toContain("logs get-log-events");
   });
 
+  it("TC-SLACKAPP-090: runs the Slack approval E2E on preview only, never prod", () => {
+    const source = readFileSync(workflowPath, "utf8");
+    const workflow = parse(source);
+    const previewSteps = workflow.jobs["deploy-preview"].steps;
+    const prodSteps = workflow.jobs["deploy-prod"].steps;
+    const previewDeploy = previewSteps.find(({ name }) => name === "Deploy PR stage");
+    const e2eIndex = previewSteps.findIndex(
+      ({ name }) => name === "Slack approval E2E (preview)",
+    );
+    const deployIndex = previewSteps.findIndex(({ name }) => name === "Deploy PR stage");
+
+    // After the deploy, because it POSTs to the façade the deploy creates.
+    expect(e2eIndex).toBeGreaterThan(deployIndex);
+    expect(previewSteps[e2eIndex].run).toBe("bash scripts/run-slack-approval-e2e.sh");
+    expect(previewSteps[e2eIndex].env.STAGE).toBe("${{ steps.deploy.outputs.stage }}");
+    expect(source).toContain("shellcheck scripts/run-slack-approval-e2e.sh");
+
+    // NOT on prod. The harness overwrites `approvals/offered`, so a prod run would
+    // destroy a pending human approval and approve a deletion against the live
+    // database. Asserted on the job rather than left to the comment, because
+    // copying a green preview step into deploy-prod is the obvious next edit.
+    expect(prodSteps.some(({ run }) => String(run).includes("run-slack-approval-e2e.sh"))).toBe(
+      false,
+    );
+
+    // The synth flag comes from a repo VARIABLE, not a literal "1":
+    // infra/slack-approval.ts throws when the flag is set and either secret is
+    // unseeded, and GitHub passes an unset secret as an empty string — so a
+    // hardcoded flag would fail synthesis on every PR in a repo without a Slack app.
+    expect(previewDeploy.env.MEM9_SLACK_APPROVAL_ENABLED).toBe(
+      "${{ vars.MEM9_SLACK_APPROVAL_ENABLED }}",
+    );
+    expect(previewDeploy.env.MEM9_SLACK_APPROVAL_CHANNEL).toBe(
+      "${{ vars.MEM9_SLACK_APPROVAL_CHANNEL }}",
+    );
+    expect(previewDeploy.env.SST_SECRET_SlackBotToken).toBe(
+      "${{ secrets.SLACK_BOT_TOKEN }}",
+    );
+    expect(previewDeploy.env.SST_SECRET_SlackSigningSecret).toBe(
+      "${{ secrets.SLACK_SIGNING_SECRET }}",
+    );
+
+    // And no secret is inlined into a `run:` script, where it would land in the
+    // step's rendered command rather than only in the process environment.
+    for (const step of previewSteps) {
+      expect(String(step.run ?? "")).not.toContain("secrets.SLACK_");
+    }
+  });
+
   it("uses the tested tag selector and reconciles preview and prod deployments", () => {
     const workflow = readFileSync(workflowPath, "utf8");
 

--- a/scripts/memory-cleanup.mjs
+++ b/scripts/memory-cleanup.mjs
@@ -22,20 +22,22 @@
 //        [--protected-topics personal-finance,operations]
 //        [--consensus-passes 2]
 //
-// --protected-topics names subject areas this tool may not mutate AT ALL: not
-// deleted, not absorbed into a merge, not rewritten as a merge survivor. Default
-// `personal-finance`; pass an empty value to protect nothing. A protected memory
-// the classifier judged deletable is reported as RETAIN with the original
-// verdict, so the report shows policy overriding the classifier rather than the
-// classifier having decided to keep it.
+// What every flag DOES lives in `USAGE` (`--help`), which derives its defaults
+// from the constants rather than restating them. Recorded here is only the part
+// `--help` is the wrong place for — why the two #123 flags exist at all:
 //
-// --consensus-passes N runs the classifier N independent times over ONE scan and
-// offers only the ids EVERY pass judged DELETE. The measured motivation: a pass
-// reproduced 66% of its own DELETE set on a re-run, which is not reproducible
-// enough to authorize deletions from. This only ever NARROWS: a contested id is
-// reported as UNSTABLE and acted on by nobody. Minimum 2 (one pass is not a
-// quorum of itself); omitted means single-pass. N passes cost N times the
-// inference.
+// --protected-topics, because the cost of the retention default is finance
+// memories that never get tidied, and the cost of no default is finance memories
+// that get deleted. Protection is a policy invariant, not a verdict: a protected
+// memory the classifier judged deletable is reported as RETAIN carrying the
+// original verdict, so the report shows policy overriding the classifier rather
+// than the classifier having decided to keep it.
+//
+// --consensus-passes, because of a measurement: one pass reproduced only 66% of
+// its own DELETE set on a re-run, which is not reproducible enough to authorize
+// deletions from. Intersecting passes only ever NARROWS — a contested id is
+// reported as UNSTABLE and acted on by nobody — so the flag trades inference cost
+// for a smaller, more reproducible offered set, never a larger one.
 //
 // The decision log and the restore log contain memory snippets — instance-private
 // data. Both are written OUTSIDE the repository (default ~/.mem9-cleanup/<stage>/)
@@ -869,21 +871,6 @@ async function discoverBaseUrl(opts, deps) {
 }
 
 /**
- * Count every verdict, including the ones that did not occur.
- *
- * Zeros are printed on purpose: a run where protection matched nothing must say
- * `"RETAIN":0`, because an omitted key is indistinguishable from a build with no
- * protection rule at all — which is how a dropped `--protected-topics` would go
- * unnoticed. And the key set is CLOSED: an unrecognised verdict is a routing
- * bug (a memory on a path nothing audits), so it throws rather than quietly
- * inventing a bucket that reads as a data oddity.
- *
- * Exported because that second property cannot be reached through any input:
- * `validateDecisions` rejects an unknown verdict in a replayed file before this
- * runs, so the only way in is a planner push site — an internal invariant, and
- * TC-SLACKAPP-066 asserts it directly rather than leaving the guard unproven.
- */
-/**
  * The `{prefix}/approvals/offered` record: what the callback Lambda compares a
  * button click against, and where the apply task reads its ids from (#123).
  *
@@ -1393,6 +1380,21 @@ export async function materializeApprovedIds({
   };
 }
 
+/**
+ * Count every verdict, including the ones that did not occur.
+ *
+ * Zeros are printed on purpose: a run where protection matched nothing must say
+ * `"RETAIN":0`, because an omitted key is indistinguishable from a build with no
+ * protection rule at all — which is how a dropped `--protected-topics` would go
+ * unnoticed. And the key set is CLOSED: an unrecognised verdict is a routing
+ * bug (a memory on a path nothing audits), so it throws rather than quietly
+ * inventing a bucket that reads as a data oddity.
+ *
+ * Exported because that second property cannot be reached through any input:
+ * `validateDecisions` rejects an unknown verdict in a replayed file before this
+ * runs, so the only way in is a planner push site — an internal invariant, and
+ * TC-SLACKAPP-066 asserts it directly rather than leaving the guard unproven.
+ */
 export function verdictSummary(decisions) {
   const summary = { KEEP: 0, DELETE: 0, MERGE: 0, SKIP: 0, RETAIN: 0, UNSTABLE: 0 };
   for (const d of decisions) {
@@ -2773,11 +2775,12 @@ export function parseArgs(argv) {
     // Two ways a fractional value goes wrong, and neither is a smaller version of
     // a valid run. A row count binds a bigint — `--limit 5.5` fails at the server,
     // after the SSM reads, the secret fetch, and the connection. A fractional
-    // `--consensus-passes` would run `Math.trunc`-many passes while the log and the
-    // report quoted the fraction, so the run's summary would disagree with its own
-    // invocation. `isSafeInteger`, not `isInteger`, because `1e30` is an integer
-    // that no bigint bind or pass loop can honor. `--lock-ttl` is deliberately NOT
-    // integer-checked — half an hour is a meaningful TTL.
+    // `--consensus-passes` runs `Math.trunc`-many passes while the progress log
+    // quotes the fraction ("pass 2 of 2.5"), so a run's own log disagrees with the
+    // pass count its consensus report goes on to state. `isSafeInteger`, not
+    // `isInteger`, because `1e30` is an integer that no bigint bind or pass loop
+    // can honor. `--lock-ttl` is deliberately NOT integer-checked — half an hour
+    // is a meaningful TTL.
     if (spec.integer && !Number.isSafeInteger(value)) {
       throw new Error(`${name} must be a whole integer, got ${raw}`);
     }
@@ -2975,7 +2978,14 @@ async function readSecret(secretId, region, runtime) {
   }
 }
 
-async function productionDatabaseMutex(stage, region, runtime) {
+// `runtime` defaults here, not just at `createCleanupDeps`: the recovery path
+// (`recoveryDeps`) injects nothing, and the helpers this delegates to reach into
+// `runtime` unguarded (`ssmClient`'s `runtime.ssm`, `readSecret`'s
+// `runtime.secrets`, and `runtime.Client` just below), so an omitted argument is a
+// TypeError before the first AWS call rather than a missing-credentials error an
+// operator could act on. Defaulting at the boundary makes the CLI's two callers
+// agree without either having to remember (TC-MEMRESTORE-071).
+async function productionDatabaseMutex(stage, region, runtime = {}) {
   const config = await resolveDatabaseConfig(stage, region, runtime);
   const Client = runtime.Client ?? (await import("pg")).Client;
   const db = new Client({

--- a/scripts/memory-cleanup.mjs
+++ b/scripts/memory-cleanup.mjs
@@ -175,6 +175,52 @@ export function contentHash(content) {
 }
 
 /**
+ * The SSM parameter name of one approval claim, derived from the offered list's
+ * content hash (#123).
+ *
+ * The `:` in `sha256:...` CANNOT appear in an SSM parameter name: `PutParameter`
+ * answers `ValidationException` ("each sub-path can be formed as a mix of letters,
+ * numbers and the following 3 symbols .-_"), and on the READ side a colon is
+ * parsed as the version/label selector instead — so the two operations disagree
+ * about what the name even is. Probed live in ap-northeast-1: the colon form is
+ * rejected on write, the dash form accepted.
+ *
+ * That made the whole loop dead on arrival, invisibly: `claimAndRun`'s catch
+ * separates "someone else won" from every other failure by the error NAME, so a
+ * `ValidationException` fell to the generic branch and answered "The approval
+ * could not be recorded" on every click, forever. Nothing caught it because every
+ * SSM test double is a Map keyed on the name string, so no double validates the
+ * name's SHAPE. `assertClaimParameterName` below is that missing validation, and
+ * the fakes call it (TC-SLACKAPP-131).
+ *
+ * The transformation replaces the separator rather than dropping the `sha256`
+ * prefix: the algorithm stays legible in the name, which is what an operator
+ * reading `describe-parameters` output needs in order to recompute it.
+ */
+export function claimParameterName(ssmPrefix, hash) {
+  return `${ssmPrefix}/approvals/approved-${String(hash).replace(/:/gu, "-")}`;
+}
+
+/**
+ * Throw unless `name` is a name SSM will actually accept on WRITE.
+ *
+ * Exported for the test doubles to call. A fake that accepts any string cannot
+ * fail the way the service does, and that gap is exactly what let the colon reach
+ * a deployed stage — so the doubles borrow the real constraint from here rather
+ * than restating it.
+ */
+export function assertClaimParameterName(name) {
+  if (!/^(?:\/[A-Za-z0-9_.-]+)+$/u.test(name)) {
+    throw new Error(
+      `ValidationException: Parameter name: if formed as a path, it can consist ` +
+        `of sub-paths divided by slash symbol; each sub-path can be formed as a ` +
+        `mix of letters, numbers and the following 3 symbols .-_ (got ${name})`,
+    );
+  }
+  return name;
+}
+
+/**
  * Parse + validate one LLM classification response. Throws MalformedResponse
  * on any malformed shape — field types included, so a hallucinated
  * `absorbs: "id"` (non-array) is caught here and handled by the retry/SKIP
@@ -1153,6 +1199,17 @@ export function buildOutcomeMessage({
   if (result.skippedByFilter > 0) {
     notes.push(`${result.skippedByFilter} not in the approved list`);
   }
+  // Distinct from the line above, and the distinction is the operator's: "not in
+  // the approved list" is the guard doing its job on something they did not
+  // approve, while this is something they DID approve that the classifier has
+  // since changed its mind about. Both leave the headline short of `approved`,
+  // and without this note the shortfall has no stated cause.
+  if (result.reclassified > 0) {
+    notes.push(
+      `${result.reclassified} approved id(s) are no longer classified as ` +
+        `deletions and were left in place`,
+    );
+  }
   // Named by what the operator has to DO about it, not by the exit code: a capped
   // run leaves approved ids untouched and needs a fresh review, a partial one has
   // a failure in the log to read. An exit code in a Slack message is a lookup.
@@ -1273,7 +1330,7 @@ export async function materializeApprovedIds({
   fs,
   log = () => {},
 }) {
-  const name = `${ssmPrefix}/approvals/approved-${hash}`;
+  const name = claimParameterName(ssmPrefix, hash);
   const { GetParametersCommand } = await import("@aws-sdk/client-ssm");
   const response = await ssm.send(new GetParametersCommand({ Names: [name] }));
   // An absent name is echoed in `InvalidParameters` and simply MISSING from
@@ -1592,6 +1649,17 @@ function readApprovedIds(fs, idsFile) {
  * Execute the destructive legs under the cap. Every mutation is preceded by a
  * re-read whose content hash must still match the decision's anchor (LWW
  * guard), so a concurrently edited memory is skipped rather than clobbered.
+ *
+ * When `approved` is present, EVERY id this function deletes must be in it — not
+ * just the id the decision is keyed on. A MERGE deletes its `absorbs[]` ids and
+ * rewrites the survivor's content, and `buildOfferedRecord` offers DELETE verdicts
+ * only, so under `--ids` a MERGE can never be an approved operation: its absorbed
+ * ids were never shown to the operator and its survivor is not a deletion at all.
+ * Gating on `decision.id` alone let a MERGE through whose absorbed ids the operator
+ * had never seen (the Slack-triggered task re-classifies rather than replaying the
+ * reviewed artifact, so the verdicts it applies are not the verdicts that were
+ * approved). That is the one thing this loop exists to prevent, so a MERGE is
+ * refused outright here rather than partially honored.
  */
 async function applyDecisions({ decisions, client, cap, approved, counters, log }) {
   const deleteQueue = [];
@@ -1599,11 +1667,43 @@ async function applyDecisions({ decisions, client, cap, approved, counters, log 
   let skippedByFilter = 0;
   let exitCode = 0;
 
+  // Approved ids this run classified as something NON-destructive. Under `--ids`
+  // the approved set is the operator's list, and a re-classification that now
+  // returns KEEP for one of those ids drops out at `cost === 0` below — so without
+  // this the outcome message says "1 of 2 approved" and offers no note explaining
+  // the missing one, which reads as a partial failure rather than a changed
+  // verdict.
+  //
+  // Seeded from the intersection with `decisions`, not from `approved` itself: an
+  // approved id that appears in NO decision was never classified at all, and
+  // `runCleanup` already reports those by name ("matched no decision") because a
+  // typo'd approval is a different problem with a different fix. Counting them
+  // here would have the same id described two contradictory ways in one run.
+  const decided = new Set(decisions.map((decision) => decision.id));
+  const unclaimed = approved
+    ? new Set([...approved].filter((id) => decided.has(id)))
+    : null;
+
   try {
     for (const decision of decisions) {
       const cost = destructiveCost(decision);
       if (cost === 0) continue;
+      unclaimed?.delete(decision.id);
       if (approved && !approved.has(decision.id)) {
+        skippedByFilter += 1;
+        continue;
+      }
+      // Counted as filtered rather than as an error: an approved-ids run that met
+      // a MERGE has classified something the operator's list cannot cover, which
+      // is a normal consequence of re-classifying, not a corrupt input. It is
+      // LOGGED because the alternative — a silent skip — is how "1 of 2 applied"
+      // becomes unexplainable.
+      if (approved && decision.verdict === "MERGE") {
+        log(
+          `MERGE ${decision.id}: refused under an approved-ids run — the offered ` +
+            `list contains deletions only, so its ${decision.absorbs.length} ` +
+            `absorbed id(s) and its content rewrite were never approved`,
+        );
         skippedByFilter += 1;
         continue;
       }
@@ -1642,7 +1742,17 @@ async function applyDecisions({ decisions, client, cap, approved, counters, log 
     // against the cap — they must not be silently dropped.
     await flushDeletes(deleteQueue, client, log);
   }
-  return { capUsed, skippedByFilter, exitCode };
+  // Only meaningful on a run that finished its loop: a cap abort leaves the tail
+  // of `decisions` unexamined, so those ids are "unapplied because the cap was
+  // reached" (already its own note) rather than "no longer classified DELETE".
+  const reclassified = exitCode === 4 ? 0 : (unclaimed?.size ?? 0);
+  if (reclassified > 0) {
+    log(
+      `${reclassified} approved id(s) are no longer classified as deletions by ` +
+        `this run and were left in place`,
+    );
+  }
+  return { capUsed, skippedByFilter, reclassified, exitCode };
 }
 
 /**
@@ -3016,10 +3126,24 @@ async function buildPostApproval(opts, region, runtime) {
  * it would cost deletions the operator already authorized.
  */
 function buildReportOutcome(opts, claim, runtime) {
-  if (!claim?.messageTs || !claim?.messageChannel) return undefined;
-  const botToken = process.env.SLACK_BOT_TOKEN;
   const log = (message) =>
     console.error(`[memory-cleanup ${new Date().toISOString()}] ${message}`);
+  if (!claim?.messageTs || !claim?.messageChannel) {
+    // Logged for the same reason the token branch below is: skipping the update
+    // leaves the review message showing its Approve button and the PRE-apply
+    // list, so the operator sees an un-actioned request for memories that are
+    // already deleted, and a re-click answers "already applied". The coordinates
+    // can legitimately be absent — `postApprovalRequest` only warns when the
+    // stamp fails — so this stays non-fatal, but it must not be invisible.
+    log(
+      `the approval claim carries no Slack message coordinates ` +
+        `(ts=${claim?.messageTs ?? "unset"}, channel=${claim?.messageChannel ?? "unset"}), ` +
+        `so the outcome cannot be posted back and the original message keeps its ` +
+        `button and pre-apply list; the apply is unaffected`,
+    );
+    return undefined;
+  }
+  const botToken = process.env.SLACK_BOT_TOKEN;
   if (!botToken) {
     log(
       `the approval was claimed against a Slack message but SLACK_BOT_TOKEN is ` +

--- a/scripts/memory-cleanup.mjs
+++ b/scripts/memory-cleanup.mjs
@@ -77,6 +77,18 @@ const DEFAULT_CAP = 50;
 // deliberately not an option: it incurs a charge and cannot be reverted to
 // standard without data loss, so the record has to fit here (#123).
 const MAX_PARAMETER_BYTES = 4096;
+// Slack's own hard ceilings on a `chat.postMessage` payload
+// (api.slack.com/reference/block-kit/blocks). A message over ANY of them is
+// rejected wholesale, so the operator sees nothing — which is why
+// `buildApprovalMessage` refuses to build one rather than letting Slack refuse
+// to render it.
+const SLACK_API_BASE = "https://slack.com/api";
+const SLACK_MAX_BLOCKS = 50;
+const SLACK_MAX_SECTION_CHARS = 3000;
+const SLACK_MAX_HEADER_CHARS = 150;
+const SLACK_TIMEOUT_MS = 15_000;
+/** Set by infra/slack-approval.ts; its presence is what enables the offer. */
+const MEM9_SLACK_CHANNEL_ENV = "MEM9_SLACK_APPROVAL_CHANNEL";
 const REQUEST_TIMEOUT_MS = 30_000; // REST calls; the LLM call sets its own
 const LLM_TIMEOUT_MS = 120_000;
 // Reasoning models consume output tokens on hidden reasoning BEFORE emitting
@@ -866,6 +878,373 @@ export function buildOfferedRecord({ stage, decisions, generatedAt }) {
 }
 
 /**
+ * The Block Kit message the operator reviews and clicks (#123).
+ *
+ * Pure and separately exported, because the interesting failures are all in the
+ * SHAPE rather than in the transport: the two `action_id`s the deployed handler
+ * branches on, the hash in both action values, and the block limits that decide
+ * whether Slack renders the message at all.
+ *
+ * Over any limit it THROWS, the same argument as `buildOfferedRecord`'s
+ * parameter fence: a message that dropped its overflow would show the operator
+ * part of a list and attach an Approve button whose hash covers all of it, which
+ * is a wrong apply rather than a failed one. Slack rejects an over-limit message
+ * wholesale anyway, so the only thing lost is a clear error.
+ */
+export function buildApprovalMessage({ record, decisions, channel }) {
+  const withheld = { RETAIN: 0, UNSTABLE: 0 };
+  const byId = new Map();
+  for (const d of decisions) {
+    byId.set(d.id, d);
+    if (d.verdict in withheld) withheld[d.verdict] += 1;
+  }
+
+  const header = `Memory cleanup review — ${record.ids.length} deletion(s) for ${record.stage}`;
+  const lines = record.ids.map((id) => {
+    const decision = byId.get(id);
+    // The snippet is the review: an id alone is not something an operator can
+    // judge. Slack and CloudWatch Logs are the approved destinations for memory
+    // content — the SSM record and the repository are not.
+    const snippet = (decision?.snippet ?? "").replace(/\s+/gu, " ").trim();
+    return `• \`${id}\` — ${decision?.reason ?? "no reason recorded"}${snippet ? `: ${snippet}` : ""}`;
+  });
+
+  const blocks = [
+    { type: "header", text: { type: "plain_text", text: header } },
+    // Counted even at zero, for the same reason `verdictSummary` prints its
+    // zeros: a protected-topic rule that started matching everything, or a
+    // consensus that collapsed, would otherwise read as a clean corpus.
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text:
+          `*Withheld from this approval:* RETAIN ${withheld.RETAIN} ` +
+          `(protected topic), UNSTABLE ${withheld.UNSTABLE} (passes disagreed). ` +
+          `Generated ${record.generatedAt}.`,
+      },
+    },
+    ...chunkSections(lines),
+    {
+      type: "actions",
+      elements: [
+        {
+          type: "button",
+          action_id: "cleanup_approve",
+          text: { type: "plain_text", text: `Approve ${record.ids.length} deletion(s)` },
+          style: "danger",
+          // The hash ONLY. A Slack action value is capped at 2000 characters so
+          // it cannot carry the ids — and must not: the signature proves a click
+          // came from the workspace, never that ids inside the payload are the
+          // ones the classifier chose. The apply task reads them from SSM.
+          value: record.hash,
+          confirm: {
+            title: { type: "plain_text", text: "Apply these deletions?" },
+            text: {
+              type: "mrkdwn",
+              text: `${record.ids.length} memories will be soft-deleted in *${record.stage}*.`,
+            },
+            confirm: { type: "plain_text", text: "Apply" },
+            deny: { type: "plain_text", text: "Cancel" },
+            style: "danger",
+          },
+        },
+        {
+          type: "button",
+          action_id: "cleanup_reject",
+          text: { type: "plain_text", text: "Reject" },
+          value: record.hash,
+        },
+      ],
+    },
+  ];
+
+  if (blocks.length > SLACK_MAX_BLOCKS) {
+    throw new Error(
+      `the review list needs ${blocks.length} Block Kit blocks, over Slack's ` +
+        `${SLACK_MAX_BLOCKS}-block message limit for ${record.ids.length} ids — ` +
+        `lower --cap rather than posting a list the operator cannot see whole`,
+    );
+  }
+  const long = blocks.find(
+    (b) => b.type === "header" && b.text.text.length > SLACK_MAX_HEADER_CHARS,
+  );
+  if (long) {
+    throw new Error(`the review header does not fit Slack's ${SLACK_MAX_HEADER_CHARS}-character limit`);
+  }
+  return { channel, text: header, blocks };
+}
+
+/**
+ * Pack the id lines into as few section blocks as Slack's per-section character
+ * limit allows.
+ *
+ * One section per id would hit the 50-block message limit at ~46 ids — below
+ * #102's default cap of 50 — so the natural spelling breaks the loop's own
+ * default. Packing keeps a cap-50 list inside a handful of blocks. A single line
+ * longer than the limit is truncated with a marker rather than dropped: the ids
+ * shown must still be the ids the hash covers, and the snippet is already a
+ * 120-character slice of the memory, so only a pathological reason string can
+ * reach this.
+ */
+function chunkSections(lines) {
+  const sections = [];
+  let current = "";
+  for (const line of lines) {
+    const clipped =
+      line.length > SLACK_MAX_SECTION_CHARS
+        ? `${line.slice(0, SLACK_MAX_SECTION_CHARS - 3)}...`
+        : line;
+    if (current && current.length + 1 + clipped.length > SLACK_MAX_SECTION_CHARS) {
+      sections.push({ type: "section", text: { type: "mrkdwn", text: current } });
+      current = clipped;
+      continue;
+    }
+    current = current ? `${current}\n${clipped}` : clipped;
+  }
+  if (current) sections.push({ type: "section", text: { type: "mrkdwn", text: current } });
+  return sections;
+}
+
+/** One Slack Web API call, with the failure mode the HTTP status does not show. */
+async function slackCall(method, body, { botToken, fetchImpl }) {
+  let response;
+  try {
+    response = await fetchImpl(`${SLACK_API_BASE}/${method}`, {
+      method: "POST",
+      // The alert-router precedent: a redirect from an API host is never worth
+      // following with a bearer token attached.
+      redirect: "manual",
+      headers: {
+        Authorization: `Bearer ${botToken}`,
+        "content-type": "application/json; charset=utf-8",
+      },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(SLACK_TIMEOUT_MS),
+    });
+  } catch (err) {
+    // Never the request body: it carries the memory snippets. Never the error's
+    // own `cause` chain either, which can hold the request headers.
+    throw new Error(`Slack ${method} request failed: ${err.name}`);
+  }
+  if (!response.ok) {
+    throw new Error(`Slack ${method} returned HTTP ${response.status}`);
+  }
+  // EVERY Slack Web API method answers HTTP 200 for application errors and puts
+  // the failure in `{ok: false, error}`. A `response.ok` check alone reports a
+  // message that was never delivered, and the weekly loop would look healthy
+  // while no operator ever saw a review list.
+  const payload = await response.json();
+  if (!payload?.ok) {
+    throw new Error(`Slack ${method} refused the request: ${payload?.error ?? "unknown error"}`);
+  }
+  return payload;
+}
+
+/**
+ * Offer this run's deletions to the operator: write the record, then post the
+ * message whose button the callback Lambda validates against it (#123).
+ *
+ * ORDER IS LOAD-BEARING, and in the opposite direction from
+ * `createCleanupDeps`. The record is written FIRST because posting first leaves a
+ * live Approve button that the callback rejects with "there is no current
+ * approval list" — a click spent on an operator hunting a backend fault. The
+ * write is also what invalidates LAST week's button (the callback compares the
+ * click's hash against `offered.hash`), so it happens even when this run offers
+ * nothing and even when the post then fails: a stale click must never apply a
+ * list this run's audit no longer stands behind.
+ *
+ * The `messageTs` stamp is a second write because `ts` does not exist until the
+ * post returns, and the apply task needs it to `chat.update` the message it was
+ * approved from. A stamp failure is reported, not raised — losing the audit-trail
+ * update is strictly better than refusing an approval the operator can act on.
+ */
+export async function postApprovalRequest({
+  ssm,
+  ssmPrefix,
+  stage,
+  decisions,
+  generatedAt,
+  channel,
+  botToken,
+  fetchImpl,
+  log = () => {},
+}) {
+  const record = buildOfferedRecord({ stage, decisions, generatedAt });
+  const { PutParameterCommand } = await import("@aws-sdk/client-ssm");
+  const name = `${ssmPrefix}/approvals/offered`;
+  const write = (value) =>
+    ssm.send(
+      new PutParameterCommand({
+        Name: name,
+        // Plain `String` and `Overwrite: true`, both runtime-only failures like
+        // TC-SLACKAPP-047f's: the boundary denies a `SecureString` write (no
+        // `kms:Encrypt`, no `kms:GenerateDataKey`), and `Overwrite: false` would
+        // succeed once and then fail every later week with
+        // `ParameterAlreadyExists`, silently ending the loop.
+        Type: "String",
+        Overwrite: true,
+        Value: JSON.stringify(value),
+      }),
+    );
+
+  await write(record);
+  log(`offered ${record.ids.length} id(s) for approval as ${record.hash}`);
+  if (record.ids.length === 0) {
+    // Nothing to approve, so nothing to post — but the record above still
+    // overwrote last week's list, which is the point.
+    log("no deletions to offer; posted nothing to Slack");
+    return { record, posted: false };
+  }
+
+  const message = buildApprovalMessage({ record, decisions, channel });
+  const posted = await slackCall("chat.postMessage", message, { botToken, fetchImpl });
+
+  try {
+    await write({ ...record, messageTs: posted.ts, messageChannel: posted.channel });
+  } catch (err) {
+    log(
+      `WARNING the approval list was offered and posted but the message ` +
+        `timestamp could not be stamped onto the record: ${err.message}; ` +
+        `the apply will not be able to update the Slack message`,
+    );
+  }
+  return { record, posted: true, messageTs: posted.ts, messageChannel: posted.channel };
+}
+
+/**
+ * The Block Kit message that REPLACES the review message once the apply has run
+ * (#123), so the outcome lives on the thing the operator clicked.
+ *
+ * Two properties matter and neither is cosmetic:
+ *
+ *  - The count is what was DELETED (`capUsed`), never what was approved. An
+ *    apply that approved 3 and deleted 1 has lost two to the LWW guard, and this
+ *    message is the audit trail — nothing downstream would ever correct an
+ *    optimistic number, so the operator would believe memories are gone that are
+ *    still there.
+ *  - No `actions` block. `chat.update` REPLACES the blocks wholesale, which is
+ *    what removes the buttons; leaving them would offer a hash whose claim
+ *    already exists, and the callback answers that click with "someone else is
+ *    already applying" — a dead end rather than a record.
+ *
+ * Ids are accepted and deliberately unused: the caller has them (they are the
+ * claim's), and taking the parameter makes the omission explicit rather than an
+ * accident of the signature. The review message carries ids and snippets because
+ * it is what the operator reviews; the outcome needs none, and this runs in the
+ * apply task whose log already reaches CloudWatch.
+ */
+export function buildOutcomeMessage({
+  channel,
+  messageTs,
+  hash,
+  stage,
+  approved,
+  result,
+  appliedAt,
+}) {
+  const deleted = result.capUsed ?? 0;
+  const notes = [];
+  if (result.skippedLww > 0) {
+    notes.push(
+      `${result.skippedLww} skipped — changed after the list was generated (last-write-wins guard)`,
+    );
+  }
+  if (result.skippedByFilter > 0) {
+    notes.push(`${result.skippedByFilter} not in the approved list`);
+  }
+  // Named by what the operator has to DO about it, not by the exit code: a capped
+  // run leaves approved ids untouched and needs a fresh review, a partial one has
+  // a failure in the log to read. An exit code in a Slack message is a lookup.
+  if (result.exitCode === 4) {
+    notes.push(
+      `*stopped early: the run's cap was reached*, so approved ids were left ` +
+        `unapplied — they will reappear in the next review`,
+    );
+  } else if (result.exitCode === 6) {
+    notes.push(`*completed partially* — see the task log for the failures`);
+  } else if (result.exitCode !== 0) {
+    notes.push(`*the run exited ${result.exitCode}* — see the task log`);
+  }
+
+  const headline = `Applied: ${deleted} of ${approved} approved deletion(s) in ${stage}`;
+  const blocks = [
+    { type: "header", text: { type: "plain_text", text: "Memory cleanup applied" } },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `*${headline}*\nApproval \`${hash}\` applied ${appliedAt}.`,
+      },
+    },
+  ];
+  if (notes.length > 0) {
+    blocks.push({
+      type: "section",
+      text: { type: "mrkdwn", text: notes.map((n) => `• ${n}`).join("\n") },
+    });
+  }
+  // `text` is not required alongside `blocks`, but it is what a notification and
+  // a screen reader read — and the count is the part worth notifying.
+  return { channel, ts: messageTs, text: headline, blocks };
+}
+
+/**
+ * Update the review message with the outcome (#123). Returns whether it posted.
+ *
+ * NEVER throws and never touches the exit code. By the time this runs the
+ * deletions are done and irreversible: raising would alarm on a successful apply,
+ * and — under the callback's stale-claim recovery — a retried task would re-apply
+ * ids that are already gone. So every failure here is a loud log line and a
+ * `false`.
+ *
+ * The coordinates come from the CLAIM, which copied them from the offered record.
+ * Absent, this skips: `chat.update` requires both `channel` and `ts`, and calling
+ * with `undefined` earns a `channel_not_found` that reads like a misconfigured
+ * channel rather than an unstamped record.
+ */
+export async function updateApprovalMessage({
+  claim,
+  approved,
+  stage,
+  result,
+  appliedAt,
+  botToken,
+  fetchImpl,
+  log = () => {},
+}) {
+  if (!claim?.messageTs || !claim?.messageChannel) {
+    log(
+      `the approval claim carries no Slack message coordinates, so the outcome ` +
+        `could not update the review message; the apply itself is unaffected`,
+    );
+    return false;
+  }
+  const message = buildOutcomeMessage({
+    channel: claim.messageChannel,
+    messageTs: claim.messageTs,
+    hash: claim.hash,
+    stage,
+    // The COUNT is a parameter, not `claim.ids.length`: the container's claim
+    // carries a count and no ids by design (the ids live in the --ids file), and a
+    // signature that read them here would invite putting them back.
+    approved,
+    result,
+    appliedAt,
+  });
+  try {
+    await slackCall("chat.update", message, { botToken, fetchImpl });
+    return true;
+  } catch (err) {
+    log(
+      `WARNING the deletions were applied but the review message could not be ` +
+        `updated: ${err.message}; the message still shows the pre-apply list`,
+    );
+    return false;
+  }
+}
+
+/**
  * Materialize the `--ids` file the apply task consumes, from the approval CLAIM
  * the operator's click created (#123).
  *
@@ -944,7 +1323,17 @@ export async function materializeApprovedIds({
   // The COUNT, never the ids: an operator needs to know the apply matched the
   // approval, not which memories it names.
   log(`materialized ${record.ids.length} approved id(s) for ${hash}`);
-  return record.ids.length;
+  // The coordinates ride out of the read that was already happening. They are
+  // the only reason this returns a shape rather than a count: `chat.update` needs
+  // them and nothing else in the task does, so a second read of the same
+  // parameter would be the alternative. Ids deliberately do NOT come back — the
+  // file is where they belong, and the outcome message must not name them.
+  return {
+    count: record.ids.length,
+    messageTs: typeof record.messageTs === "string" ? record.messageTs : undefined,
+    messageChannel:
+      typeof record.messageChannel === "string" ? record.messageChannel : undefined,
+  };
 }
 
 export function verdictSummary(decisions) {
@@ -1051,6 +1440,10 @@ async function loadDecisions(opts, deps, { client, fs, clock, log, outDir }) {
     return {
       decisions: loaded.decisions,
       decisionPath: opts.decisionsFile,
+      // The FILE's stamp, not now: this run generated nothing, and an offered
+      // record claiming otherwise would date a list to the moment it was reposted.
+      // Falls back to now for a file written before the field existed.
+      generatedAt: loaded.generatedAt ?? new Date(clock()).toISOString(),
       classifierBroken: false,
       batches: 0,
       failedBatches: 0,
@@ -1119,6 +1512,9 @@ async function loadDecisions(opts, deps, { client, fs, clock, log, outDir }) {
   return {
     decisions,
     decisionPath,
+    // The SAME stamp the decision file carries, so the offered record and the
+    // artefact an operator falls back to name one moment.
+    generatedAt,
     classifierBroken,
     batches,
     failedBatches,
@@ -1296,13 +1692,15 @@ export async function runCleanup(opts, deps) {
   }
   const client = restClient(baseUrl, opts.tenantId, deps.fetchImpl, counters);
 
-  const { decisions, decisionPath, classifierBroken, batches, failedBatches, scanned } = await loadDecisions(opts, deps, {
-    client,
-    fs,
-    clock,
-    log,
-    outDir,
-  });
+  const {
+    decisions,
+    decisionPath,
+    generatedAt: decisionGeneratedAt,
+    classifierBroken,
+    batches,
+    failedBatches,
+    scanned,
+  } = await loadDecisions(opts, deps, { client, fs, clock, log, outDir });
   const summary = verdictSummary(decisions);
   const failureNote = classificationFailureNote({ batches, failedBatches, decisions, scanned });
 
@@ -1315,6 +1713,31 @@ export async function runCleanup(opts, deps) {
   }
   if (!opts.apply) {
     log(`dry-run: ${JSON.stringify(summary)}; writeCalls=${counters.writeCalls}${failureNote}`);
+    // The review run is the loop's ENTRY POINT, and only the review run: an
+    // --apply that re-offered would overwrite the very record its own claim was
+    // derived from, so a redelivered click mid-apply would be compared against a
+    // list the running task never saw. Absent when Slack is not configured, which
+    // keeps the #102 operator CLI working unchanged.
+    if (deps.postApproval) {
+      try {
+        const offer = await deps.postApproval({ decisions, generatedAt: decisionGeneratedAt });
+        log(
+          `offered ${offer.record.ids.length} id(s) to Slack as ${offer.record.hash}` +
+            (offer.posted ? "" : " (nothing posted)"),
+        );
+      } catch (err) {
+        // Exit 1, not 0. A scheduled review run whose post failed has done its
+        // audit and offered nothing, and exit 0 would make that indistinguishable
+        // from a healthy week — the operator would notice only by the absence of a
+        // message they were not expecting on any particular day. The decision list
+        // is named because it survives, and is what a manual `--apply --ids` reads.
+        log(
+          `failed to offer the review list to Slack: ${err.message}; ` +
+            `the decision list is kept at ${decisionPath}`,
+        );
+        return result({ exitCode: 1, decisions, decisionPath });
+      }
+    }
     return result({ exitCode: 0, decisions, decisionPath });
   }
 
@@ -1357,7 +1780,28 @@ export async function runCleanup(opts, deps) {
       `writeCalls=${counters.writeCalls}; skippedLww=${counters.skippedLww}; ` +
       `skippedByFilter=${applied.skippedByFilter}${failureNote}`,
   );
-  return result({ ...applied, decisions, decisionPath });
+  const outcome = result({ ...applied, decisions, decisionPath });
+  // Once, after the lock and the mutex are released, with the numbers the run
+  // ACHIEVED. Reporting inside the loop would show intermediate counts as if they
+  // were outcomes; reporting before the release would hold the shared mutex across
+  // a Slack round trip. Absent for a dry run (which POSTS instead) and for the
+  // #102 operator CLI, which has no Slack at all.
+  if (deps.reportOutcome) {
+    try {
+      await deps.reportOutcome({
+        result: outcome,
+        appliedAt: new Date(clock()).toISOString(),
+      });
+    } catch (err) {
+      // Never the exit code. The deletions are done and irreversible by now, so a
+      // non-zero exit would alarm on a successful apply — and under the callback's
+      // stale-claim recovery a retried task would re-apply ids already gone. Loud
+      // in the log instead, because a systematically broken report is otherwise
+      // invisible: the loop would keep working and keep losing its audit trail.
+      log(`WARNING the apply completed but its outcome could not be reported: ${err.message}`);
+    }
+  }
+  return outcome;
 }
 
 // ---------------------------------------------------------------------------
@@ -2482,6 +2926,121 @@ async function recoveryDeps(opts) {
 }
 
 /**
+ * The `postApproval` dep, or `undefined` when this stage has no Slack surface.
+ *
+ * ABSENT rather than present-and-inert when the channel is unset, which is what
+ * keeps #102's operator CLI working unchanged: a dep that existed
+ * unconditionally would have every hand-run dry run try to write an approval
+ * record the operator's identity may not be able to write, and would post a
+ * clickable Approve button for a list they ran locally just to look at.
+ *
+ * The token is env-first for the same reason the database config is
+ * (`resolveDatabaseConfig`): the apply task receives `SLACK_BOT_TOKEN` from ECS
+ * `ssm:`, already decrypted, and its task role holds `ssm:GetParameters` under
+ * `approvals/*` ONLY — so a read of `slack/bot-token` is an AccessDenied there.
+ * The review run has no such restriction and reads the parameter itself.
+ *
+ * A configured channel with no reachable token THROWS. Skipping the post would be
+ * the whole audit running, offering nothing, and exiting 0 — indistinguishable
+ * from a healthy week to the only person who would notice.
+ */
+async function buildPostApproval(opts, region, runtime) {
+  const channel = process.env[MEM9_SLACK_CHANNEL_ENV];
+  if (!channel) return undefined;
+
+  const ssmPrefix = process.env.MEM9_SSM_PREFIX || `/mem9-on-aws/${opts.stage}`;
+  const { ssm, release } = await ssmClient(region, runtime);
+  let botToken = process.env.SLACK_BOT_TOKEN;
+  try {
+    if (!botToken) {
+      const name = `${ssmPrefix}/slack/bot-token`;
+      const { GetParametersCommand } = await import("@aws-sdk/client-ssm");
+      // Plural, not `GetParameter`: the two are distinct IAM actions and the
+      // boundary's ceiling admits only this one (TC-SLACKAPP-047g).
+      const response = await ssm.send(
+        // The parameter is a SecureString; without decryption the value comes back
+        // as ciphertext and every post 401s with `invalid_auth`.
+        new GetParametersCommand({ Names: [name], WithDecryption: true }),
+      );
+      botToken = (response.Parameters ?? []).find((p) => p.Name === name)?.Value;
+      if (!botToken) {
+        throw new Error(
+          `${MEM9_SLACK_CHANNEL_ENV} is set but no bot token is available: ` +
+            `inject SLACK_BOT_TOKEN or seed ${name}`,
+        );
+      }
+    }
+  } catch (err) {
+    release();
+    throw err;
+  }
+
+  // The client outlives this call — it is the one every offer writes through —
+  // and is deliberately NOT threaded into `close()`, unlike the database mutex.
+  // The asymmetry is the resource: an open Postgres connection holds a server-side
+  // session and an advisory lock the next run needs released, while an SSM client
+  // holds local sockets that the entrypoint's `process.exit` reclaims. `release`
+  // is called only on the failure path above, where nothing gets to use it.
+  return async ({ decisions, generatedAt }) =>
+    postApprovalRequest({
+      ssm,
+      ssmPrefix,
+      stage: opts.stage,
+      decisions,
+      generatedAt,
+      channel,
+      botToken,
+      fetchImpl: runtime.fetchImpl ?? fetch,
+      log: (message) =>
+        console.error(`[memory-cleanup ${new Date().toISOString()}] ${message}`),
+    });
+}
+
+/**
+ * The `reportOutcome` dep, or `undefined` when there is nothing to report to.
+ *
+ * Three independent absences, all of which must DEGRADE rather than fail, because
+ * every one of them is discovered after the operator has already approved:
+ *
+ *  - No claim at all: a review run, which POSTS instead of updating. There is
+ *    nothing to update against — the message does not exist yet.
+ *  - A claim with no coordinates: a review run whose stamp write failed, or a
+ *    pre-#123 record.
+ *  - No bot token: the apply task takes it from ECS `ssm:`, already decrypted, and
+ *    its role holds `ssm:GetParameters` under `approvals/*` ONLY — so unlike
+ *    `buildPostApproval` this CANNOT read the parameter itself, and a missing
+ *    token means no update rather than an AccessDenied.
+ *
+ * The asymmetry with `buildPostApproval`, which throws on a missing token, is the
+ * point: there, failing loud costs an unposted list nobody has acted on yet; here,
+ * it would cost deletions the operator already authorized.
+ */
+function buildReportOutcome(opts, claim, runtime) {
+  if (!claim?.messageTs || !claim?.messageChannel) return undefined;
+  const botToken = process.env.SLACK_BOT_TOKEN;
+  const log = (message) =>
+    console.error(`[memory-cleanup ${new Date().toISOString()}] ${message}`);
+  if (!botToken) {
+    log(
+      `the approval was claimed against a Slack message but SLACK_BOT_TOKEN is ` +
+        `not set, so the outcome cannot be posted back; the apply is unaffected`,
+    );
+    return undefined;
+  }
+  return async ({ result, appliedAt }) =>
+    updateApprovalMessage({
+      claim,
+      approved: claim.count,
+      stage: opts.stage,
+      result,
+      appliedAt,
+      botToken,
+      fetchImpl: runtime.fetchImpl ?? fetch,
+      log,
+    });
+}
+
+/**
  * Build the real deps for one run — for the operator CLI and for the
  * Slack-triggered apply task, which are the same code on different IAM (#123).
  *
@@ -2511,6 +3070,8 @@ export async function createCleanupDeps(opts, runtime = {}) {
   // The approval hash is the ECS container override the callback Lambda sets, and
   // it is the ONLY thing that reaches the task from the click.
   const approvalHash = process.env.MEM9_APPROVAL_HASH;
+  /** What the claim said, for the outcome update. Absent on a review run. */
+  let claim;
   if (approvalHash) {
     // A hash with nowhere to write is the loop's worst failure mode, not a
     // degraded one: `readApprovedIds` returns null for an absent `--ids`, and null
@@ -2525,7 +3086,7 @@ export async function createCleanupDeps(opts, runtime = {}) {
     const ssmPrefix = process.env.MEM9_SSM_PREFIX || `/mem9-on-aws/${opts.stage}`;
     const { ssm, release } = await ssmClient(region, runtime);
     try {
-      await materializeApprovedIds({
+      claim = await materializeApprovedIds({
         ssm,
         stage: opts.stage,
         ssmPrefix,
@@ -2535,7 +3096,10 @@ export async function createCleanupDeps(opts, runtime = {}) {
         log: (message) =>
           console.error(`[memory-cleanup ${new Date().toISOString()}] ${message}`),
       });
+      claim.hash = approvalHash;
     } finally {
+      // Released here, unlike `buildPostApproval`'s client: this one has done its
+      // one read, and the outcome update goes over `fetch` rather than SSM.
       release();
     }
   }
@@ -2543,6 +3107,8 @@ export async function createCleanupDeps(opts, runtime = {}) {
   const databaseMutex = opts.apply
     ? await productionDatabaseMutex(opts.stage, region, runtime)
     : undefined;
+
+  const postApproval = await buildPostApproval(opts, region, runtime);
 
   const getToken =
     runtime.getToken ?? (await import("@aws/bedrock-token-generator")).getToken;
@@ -2584,6 +3150,8 @@ export async function createCleanupDeps(opts, runtime = {}) {
       outDir: opts.outDir,
       lockFile: opts.lockFile,
       acquireMutex: databaseMutex?.acquireMutex,
+      postApproval,
+      reportOutcome: buildReportOutcome(opts, claim, runtime),
     },
     close: async () => {
       await databaseMutex?.close();

--- a/scripts/memory-cleanup.mjs
+++ b/scripts/memory-cleanup.mjs
@@ -19,6 +19,23 @@
 //        [--apply] [--decisions file.json] [--ids approved.txt]
 //        [--cap 50] [--out dir] [--lock-file path] [--lock-ttl hours]
 //        [--model openai.gpt-5.6-terra] [--effort high] [--llm-region us-west-2]
+//        [--protected-topics personal-finance,operations]
+//        [--consensus-passes 2]
+//
+// --protected-topics names subject areas this tool may not mutate AT ALL: not
+// deleted, not absorbed into a merge, not rewritten as a merge survivor. Default
+// `personal-finance`; pass an empty value to protect nothing. A protected memory
+// the classifier judged deletable is reported as RETAIN with the original
+// verdict, so the report shows policy overriding the classifier rather than the
+// classifier having decided to keep it.
+//
+// --consensus-passes N runs the classifier N independent times over ONE scan and
+// offers only the ids EVERY pass judged DELETE. The measured motivation: a pass
+// reproduced 66% of its own DELETE set on a re-run, which is not reproducible
+// enough to authorize deletions from. This only ever NARROWS: a contested id is
+// reported as UNSTABLE and acted on by nobody. Minimum 2 (one pass is not a
+// quorum of itself); omitted means single-pass. N passes cost N times the
+// inference.
 //
 // The decision log and the restore log contain memory snippets — instance-private
 // data. Both are written OUTSIDE the repository (default ~/.mem9-cleanup/<stage>/)
@@ -101,6 +118,20 @@ D4. Rules 12-14 above do NOT apply. When in doubt about durability, return
     fewer facts. An empty facts array is the CORRECT output for a routine
     work session with no durable takeaways.`;
 
+/**
+ * The subject areas a memory can be assigned to (#123). Closed set: an
+ * unrecognised value is a MalformedResponse, because `protectedTopics` can only
+ * protect topics it knows about, and a silently accepted sixth topic would route
+ * finance memories somewhere the retain rule never looks.
+ */
+export const TOPICS = Object.freeze([
+  "personal-finance",
+  "engineering",
+  "content",
+  "operations",
+  "other",
+]);
+
 const CLASSIFY_SYSTEM_PROMPT = `You are auditing a shared long-lived memory store used by coding agents across sessions, machines, and tools. Judge each memory against these durability rules:
 
 ${DURABLE_ONLY_RULES}
@@ -112,9 +143,16 @@ For every memory in the input, output exactly one verdict:
   surviving id (merge_into), list the absorbed ids, and provide the merged
   content ("merged_content") that preserves all durable information.
 
+Also assign every memory exactly one "topic" from this closed set:
+${TOPICS.map((t) => `- "${t}"`).join("\n")}
+"personal-finance" covers anything about the operator's own money — holdings,
+positions, trading rules, insurance, budgets, cash planning — in any language,
+regardless of how time-sensitive it looks. Judge the subject matter, not the
+durability; the verdict already carries the durability judgment.
+
 Respond with ONLY a JSON object:
-{"verdicts":[{"id":"...","verdict":"KEEP|DELETE|MERGE","reason":"...","merge_into":"id?","absorbs":["id"...]?,"merged_content":"...?"}]}
-Every input id must appear exactly once. Never invent ids.`;
+{"verdicts":[{"id":"...","verdict":"KEEP|DELETE|MERGE","topic":"${TOPICS.join("|")}","reason":"...","merge_into":"id?","absorbs":["id"...]?,"merged_content":"...?"}]}
+Every input id must appear exactly once, with a topic. Never invent ids.`;
 
 export function contentHash(content) {
   return `sha256:${createHash("sha256").update(content ?? "").digest("hex")}`;
@@ -146,6 +184,15 @@ export function parseVerdicts(raw) {
     if (!v || typeof v.id !== "string") throw new MalformedResponse("verdict entry missing id");
     if (!["KEEP", "DELETE", "MERGE"].includes(v.verdict)) {
       throw new MalformedResponse("verdict entry has an invalid verdict value");
+    }
+    // Required on EVERY verdict, not only DELETE ones (#123). A topic consulted
+    // only where the code happens to need it protects finance memories exactly
+    // until a response arrives in a shape nobody predicted. Strictness costs a
+    // batch SKIP, which is non-destructive and reported; leniency costs the
+    // memories the operator asked to keep. Never defaulted to "other" — that is
+    // the unprotected topic.
+    if (!TOPICS.includes(v.topic)) {
+      throw new MalformedResponse("verdict entry has a missing or invalid topic");
     }
     if (v.merge_into !== undefined && typeof v.merge_into !== "string") {
       throw new MalformedResponse("merge_into must be a string");
@@ -255,11 +302,18 @@ function resolveMergeGroups(byId, verdictById, conflicted) {
  * Turn raw LLM verdicts into the persisted decision list, validating the merge
  * graph. Invalid merges (target missing/deleted/cyclic) downgrade to SKIP —
  * never to a destructive fallback.
+ *
+ * `opts.protectedTopics` names topics this tool may not mutate AT ALL (#123):
+ * not deleted, not absorbed into a merge, not rewritten as a merge survivor.
+ * One invariant rather than a per-verdict list, so a fourth verdict added later
+ * cannot silently escape it.
  */
-export function planDecisions(memories, verdicts) {
+export function planDecisions(memories, verdicts, opts = {}) {
+  const protectedTopics = opts.protectedTopics ?? DEFAULT_PROTECTED_TOPICS;
   const byId = new Map(memories.map((m) => [m.id, m]));
   const verdictById = new Map();
   const conflicted = new Set();
+  const retained = new Map();
   for (const v of verdicts) {
     if (!byId.has(v.id)) continue;
     const prior = verdictById.get(v.id);
@@ -267,6 +321,21 @@ export function planDecisions(memories, verdicts) {
     if (prior && prior.verdict !== v.verdict) conflicted.add(v.id);
     verdictById.set(v.id, v);
   }
+
+  // Withheld BEFORE the merge graph is resolved, not after: a protected id left
+  // in `verdictById` as a MERGE would consent to its own absorption, and being
+  // absorbed deletes it just as surely as DELETE does. Removing it here means the
+  // group it belonged to loses that member and — with no consenting absorbed ids
+  // left — degrades to SKIP through the existing path, so the survivor is not
+  // rewritten either. KEEP is exempt because KEEP mutates nothing: downgrading it
+  // would report policy as having overridden a decision that agreed with policy.
+  for (const [id, v] of verdictById) {
+    if (v.verdict === "KEEP") continue;
+    if (!protectedTopics.includes(v.topic)) continue;
+    retained.set(id, v);
+    verdictById.delete(id);
+  }
+
   const { mergeGroups, skip } = resolveMergeGroups(byId, verdictById, conflicted);
 
   // Only groups that will actually EMIT a MERGE decision may fold their
@@ -333,14 +402,130 @@ export function planDecisions(memories, verdicts) {
       absorbs: group.absorbs.map((a) => ({ id: a, ...anchor(byId.get(a)) })),
     });
   }
+  // `RETAIN` is its own verdict rather than a KEEP with a note: the summary
+  // counts it without special-casing, and `applyDecisions` cannot act on it by
+  // reaching a DELETE/MERGE branch. It records what the classifier actually
+  // judged, so the report shows policy overriding a deletable verdict rather
+  // than the classifier having decided to keep the memory.
+  for (const [id, v] of retained) {
+    decisions.push({
+      id,
+      verdict: "RETAIN",
+      reason: v.reason,
+      originalVerdict: v.verdict,
+      retainedReason: `protected topic ${v.topic}`,
+    });
+  }
   // Audit completeness: a memory the LLM returned no verdict for still gets a
   // row, so the decision log covers every scanned memory (TC-MEMCLEAN-021).
+  // `retained` counts as having a verdict — its ids were removed from
+  // `verdictById` above, so without this they would double-report as
+  // "no verdict returned" alongside their own RETAIN row.
   for (const [id] of byId) {
-    if (!verdictById.has(id) && !absorbedIds.has(id)) {
+    if (!verdictById.has(id) && !retained.has(id) && !absorbedIds.has(id)) {
       decisions.push({ id, verdict: "SKIP", reason: "no verdict returned" });
     }
   }
   return decisions;
+}
+
+/**
+ * Narrow N independent classification passes to the ids EVERY pass agreed to
+ * delete (#123).
+ *
+ * The measured motivation: one pass reproduced only 66% of its own DELETE set on
+ * a re-run, which is not reproducible enough to authorize deletions from. This is
+ * a narrowing operation and never a widening one — an id reaches `DELETE` only by
+ * being `DELETE` in every pass, and everything else is REPORTED rather than acted
+ * on. Each pass must already be a planned decision list (`planDecisions` output),
+ * so per-pass protection and merge-graph validation have run before the
+ * intersection: an intersection computed over raw verdicts would admit a
+ * protected id whenever one pass assigned it a different topic, and topic is a
+ * model judgment like any other (TC-SLACKAPP-075).
+ *
+ * @param passes decision arrays, or `null` for a pass that failed entirely
+ */
+export function consensusDecisions(passes) {
+  const usable = passes.filter(Boolean);
+  const report = {
+    passes: passes.length,
+    usablePasses: usable.length,
+    perPassDeletes: passes.map((p) => (p ? p.filter((d) => d.verdict === "DELETE").length : null)),
+    agreed: 0,
+    disagreed: 0,
+    mergesWithheld: 0,
+    // Consensus needs at least two usable passes BY DEFINITION. One pass is not
+    // a quorum of itself, so a run that loses a pass offers nothing and says so
+    // — "use the other pass" would quietly restore the single-pass behavior this
+    // exists to remove (TC-SLACKAPP-073).
+    consensusReached: usable.length >= 2 && usable.length === passes.length,
+  };
+
+  // Union of every id any pass judged, in first-seen order so the output is
+  // deterministic. Every id keeps a row: the decision log covers the whole scan.
+  const ids = [];
+  const seen = new Set();
+  for (const pass of usable) {
+    for (const d of pass) {
+      if (!seen.has(d.id)) {
+        seen.add(d.id);
+        ids.push(d.id);
+      }
+    }
+  }
+  const byPass = usable.map((pass) => new Map(pass.map((d) => [d.id, d])));
+
+  const decisions = [];
+  for (const id of ids) {
+    // `null` for a pass that did not judge this id at all. Absence is not
+    // agreement in either direction (TC-SLACKAPP-074).
+    const rows = byPass.map((m) => m.get(id) ?? null);
+    const verdicts = rows.map((d) => d?.verdict ?? null);
+
+    // MERGE is withheld from the offered set in v1 — the approval loop approves
+    // deletions only — and counted, so the withholding cannot read as "the
+    // classifier found no merges" (TC-SLACKAPP-076).
+    if (verdicts.includes("MERGE")) {
+      report.mergesWithheld += 1;
+      decisions.push({
+        id,
+        verdict: "UNSTABLE",
+        reason: "merge withheld from the approval loop in v1",
+        verdicts,
+      });
+      continue;
+    }
+
+    const anyDelete = verdicts.includes("DELETE");
+    const allDelete = report.consensusReached && verdicts.every((v) => v === "DELETE");
+    if (allDelete) {
+      report.agreed += 1;
+      // The FIRST pass's row carries the anchors the apply path fences against.
+      // Any pass's would do — they re-read the same store — but picking one
+      // deliberately beats picking whichever happened to be last.
+      decisions.push(rows[0]);
+      continue;
+    }
+    if (anyDelete) {
+      // Its own verdict rather than a KEEP: a KEEP would claim the classifier
+      // judged the memory durable, when in fact a pass wanted it gone and the
+      // passes disagreed — the exact number this design exists to surface.
+      report.disagreed += 1;
+      decisions.push({
+        id,
+        verdict: "UNSTABLE",
+        reason: report.consensusReached
+          ? "passes disagreed on deletion"
+          : "no consensus: a classification pass failed entirely",
+        verdicts,
+      });
+      continue;
+    }
+    // No pass wanted it deleted: keep the first pass's row as-is (KEEP, SKIP,
+    // RETAIN — all non-destructive, and each already means what it says).
+    decisions.push(rows.find(Boolean));
+  }
+  return { decisions, report };
 }
 
 function destructiveCost(decision) {
@@ -446,7 +631,7 @@ async function classifyBatch(batch, batchIndex, completeChat, log) {
   return null;
 }
 
-async function classifyAll(memories, completeChat, log) {
+async function classifyAll(memories, completeChat, log, opts = {}) {
   const decisions = [];
   let batches = 0;
   let failedBatches = 0;
@@ -468,7 +653,7 @@ async function classifyAll(memories, completeChat, log) {
       log(`discarding hallucinated verdict for unknown id ${v.id}`);
       return false;
     });
-    decisions.push(...planDecisions(batch, inBatch));
+    decisions.push(...planDecisions(batch, inBatch, opts));
   }
   return { decisions, batches, failedBatches };
 }
@@ -621,9 +806,29 @@ async function discoverBaseUrl(opts, deps) {
   throw new Error(`no healthy mnemo-server instance found for stage ${opts.stage} after ${DISCOVERY_RETRIES} attempts`);
 }
 
-function verdictSummary(decisions) {
-  const summary = { KEEP: 0, DELETE: 0, MERGE: 0, SKIP: 0 };
-  for (const d of decisions) summary[d.verdict] = (summary[d.verdict] || 0) + 1;
+/**
+ * Count every verdict, including the ones that did not occur.
+ *
+ * Zeros are printed on purpose: a run where protection matched nothing must say
+ * `"RETAIN":0`, because an omitted key is indistinguishable from a build with no
+ * protection rule at all — which is how a dropped `--protected-topics` would go
+ * unnoticed. And the key set is CLOSED: an unrecognised verdict is a routing
+ * bug (a memory on a path nothing audits), so it throws rather than quietly
+ * inventing a bucket that reads as a data oddity.
+ *
+ * Exported because that second property cannot be reached through any input:
+ * `validateDecisions` rejects an unknown verdict in a replayed file before this
+ * runs, so the only way in is a planner push site — an internal invariant, and
+ * TC-SLACKAPP-066 asserts it directly rather than leaving the guard unproven.
+ */
+export function verdictSummary(decisions) {
+  const summary = { KEEP: 0, DELETE: 0, MERGE: 0, SKIP: 0, RETAIN: 0, UNSTABLE: 0 };
+  for (const d of decisions) {
+    if (!(d.verdict in summary)) {
+      throw new Error(`decision for ${d.id} has an uncountable verdict`);
+    }
+    summary[d.verdict] += 1;
+  }
   return summary;
 }
 
@@ -726,11 +931,54 @@ async function loadDecisions(opts, deps, { client, fs, clock, log, outDir }) {
     };
   }
   const memories = await scanActiveMemories(client);
-  const { decisions, batches, failedBatches } = await classifyAll(memories, deps.completeChat, log);
+  // Each pass is a full independent classification of the SAME scan, so the
+  // passes differ only in model nondeterminism — which is exactly the variable
+  // being measured. One scan, N classifications: re-scanning per pass would let a
+  // concurrent ingest change the corpus between passes and show up as
+  // disagreement the model never had.
+  const passCount = Math.max(1, opts.consensusPasses ?? 1);
+  const runs = [];
+  for (let pass = 1; pass <= passCount; pass += 1) {
+    if (passCount > 1) log(`classification pass ${pass} of ${passCount}`);
+    runs.push(
+      await classifyAll(memories, deps.completeChat, log, {
+        protectedTopics: opts.protectedTopics,
+      }),
+    );
+  }
+  let { decisions, batches, failedBatches } = runs[0];
+  batches = runs.reduce((n, r) => n + r.batches, 0);
+  failedBatches = runs.reduce((n, r) => n + r.failedBatches, 0);
+  let consensus;
+  if (passCount > 1) {
+    // A pass whose every batch failed is passed as `null`, not as the list of SKIP
+    // rows `classifyAll` actually returned. The intersection is safe either way —
+    // a SKIP is not a DELETE — but the REPORT is not: SKIP rows read as "this pass
+    // judged the memory and declined to delete it", so the summary would blame a
+    // classifier that changed its mind for a transport that never answered.
+    const passes = runs.map((r) => (r.batches > 0 && r.failedBatches === r.batches ? null : r.decisions));
+    const result = consensusDecisions(passes);
+    decisions = result.decisions;
+    consensus = result.report;
+    log(
+      `CONSENSUS over ${consensus.passes} passes: ` +
+        consensus.perPassDeletes
+          .map((n, i) => `pass ${i + 1} DELETE=${n ?? "failed"}`)
+          .join("; ") +
+        `; agreed=${consensus.agreed}; disagreed=${consensus.disagreed}` +
+        `; merges withheld=${consensus.mergesWithheld}` +
+        reproducibility(consensus) +
+        (consensus.consensusReached
+          ? ""
+          : " — NO CONSENSUS: a pass failed entirely, so nothing is offered for deletion"),
+    );
+  }
   // Zero successful batches on a non-empty store = the classifier path is
   // broken (IAM, model id, endpoint), not "nothing to clean". Surfaced as a
   // distinct exit code so CI cannot report a green E2E for a run that never
-  // classified anything.
+  // classified anything. Summed across passes deliberately: one pass classifying
+  // the whole corpus proves the path works, so a later pass losing every batch is
+  // a transport outage the CONSENSUS line reports, not a broken classifier.
   const classifierBroken = batches > 0 && failedBatches === batches;
 
   const generatedAt = new Date(clock()).toISOString();
@@ -749,7 +997,23 @@ async function loadDecisions(opts, deps, { client, fs, clock, log, outDir }) {
     batches,
     failedBatches,
     scanned: memories.length,
+    consensus,
   };
+}
+
+/**
+ * The agreement rate, as a share of the ids ANY pass wanted deleted.
+ *
+ * Denominator choice matters and is not obvious: over the whole corpus the rate
+ * would be dominated by the KEEPs every pass trivially agrees on, so a
+ * classifier that became far less reproducible about deletions would still
+ * report ~99%. Over the contested set, the number moves when reproducibility
+ * moves — which is the only reason to report it.
+ */
+function reproducibility({ agreed, disagreed }) {
+  const contested = agreed + disagreed;
+  if (contested === 0) return "";
+  return `; agreement=${Math.round((agreed / contested) * 100)}% of ${contested} contested ids`;
 }
 
 /**
@@ -763,7 +1027,17 @@ function validateDecisions(decisions) {
       throw new Error(`decision file entry ${i} invalid: ${why}`);
     };
     if (!d || typeof d.id !== "string") fail("missing id");
-    if (!["KEEP", "DELETE", "MERGE", "SKIP"].includes(d.verdict)) fail("invalid verdict");
+    // `RETAIN` is accepted here because the planner WRITES it (#123): a dry run
+    // over a protected memory persists a RETAIN row, and rejecting it on replay
+    // would make every --apply that follows such a run fail at load — the
+    // protection rule breaking the tool it protects memories in. It carries no
+    // anchor because it is non-destructive by construction.
+    // `UNSTABLE` is admitted for the same reason as `RETAIN`: the planner WRITES
+    // it (a consensus dry run persists one row per contested id), so rejecting it
+    // would make every `--apply` replaying a consensus run fail at load — the
+    // safety mechanism breaking the tool it exists to make safe. Like RETAIN it
+    // carries no anchor, because it is non-destructive by construction.
+    if (!["KEEP", "DELETE", "MERGE", "SKIP", "RETAIN", "UNSTABLE"].includes(d.verdict)) fail("invalid verdict");
     if (d.verdict === "DELETE" && typeof d.contentHash !== "string") fail("DELETE without contentHash");
     if (d.verdict === "MERGE") {
       if (typeof d.contentHash !== "string") fail("MERGE without contentHash");
@@ -1655,8 +1929,10 @@ const MODES = ["cleanup", "list", "restore"];
 
 // --flag -> the opts key it sets. `flag: true` takes no value; `number: true`
 // values must parse to a positive number (a NaN cap would disable the cap);
-// `integer: true` additionally requires a whole number. `choices` restricts the
-// accepted values; `iso` requires a parseable ISO timestamp.
+// `integer: true` additionally requires a whole number, and `min` raises the
+// floor above the blanket `> 0`. `choices` restricts the accepted values;
+// `iso` requires a parseable ISO timestamp; `list` splits a comma-separated
+// value and validates each entry against `of`.
 //
 // `mode` lists the run modes the flag belongs to, and anything outside them is
 // REJECTED rather than ignored: an operator who believes --state narrowed a
@@ -1678,6 +1954,16 @@ export const ARG_SPECS = {
   "--model": { key: "model", mode: ["cleanup"] },
   "--effort": { key: "effort", choices: REASONING_EFFORTS, mode: ["cleanup"] },
   "--llm-region": { key: "llmRegion", mode: ["cleanup"] },
+  // Topic retention and consensus (issue #123). Both shape how the classifier
+  // decides, so both belong to the audit mode only.
+  "--protected-topics": { key: "protectedTopics", list: true, of: TOPICS, mode: ["cleanup"] },
+  "--consensus-passes": {
+    key: "consensusPasses",
+    number: true,
+    integer: true,
+    min: 2,
+    mode: ["cleanup"],
+  },
   // Recovery modes (issue #124).
   "--list-inactive": { key: "listInactive", flag: true, mode: ["list"] },
   "--restore": { key: "restore", flag: true, mode: ["restore"] },
@@ -1687,6 +1973,9 @@ export const ARG_SPECS = {
   "--limit": { key: "limit", integer: true, mode: ["list"] },
   "--help": { key: "help", flag: true, mode: MODES },
 };
+
+/** Topics this tool refuses to mutate unless the operator says otherwise (#123). */
+export const DEFAULT_PROTECTED_TOPICS = Object.freeze(["personal-finance"]);
 
 export const USAGE = `memory-cleanup.mjs — audit, clean, and recover the mem9 memory store
 
@@ -1706,6 +1995,21 @@ Audit and clean (issue #102) — dry-run by default, --apply writes:
   --model <id>                classifier model
   --effort <${REASONING_EFFORTS.join("|")}>
   --llm-region <region>       region for the reasoning-model route
+  --protected-topics <a,b>    subject areas this tool may not mutate AT ALL —
+                              not deleted, not absorbed into a merge, not
+                              rewritten as a survivor (default
+                              ${DEFAULT_PROTECTED_TOPICS.join(",")}; pass an empty value to
+                              protect nothing). A protected memory the
+                              classifier judged deletable is reported as RETAIN
+                              with the original verdict, so the report shows
+                              policy overriding the classifier.
+                              Known topics: ${TOPICS.join(", ")}
+  --consensus-passes <n>      run the classifier n independent times over ONE
+                              scan and offer only the ids EVERY pass judged
+                              DELETE. Minimum 2 — one pass is not a quorum of
+                              itself; omitted means single-pass. Only ever
+                              NARROWS: a contested id is reported UNSTABLE and
+                              acted on by nobody. Costs n times the inference.
 
 Recover soft-deleted and archived memories (issue #124):
   --list-inactive             read-only listing; takes no lock
@@ -1760,6 +2064,24 @@ export function parseArgs(argv) {
       opts[spec.key] = raw;
       continue;
     }
+    if (spec.list) {
+      // An empty string is a DELIBERATE empty list ("protect nothing"), which is
+      // why the default is applied after the loop rather than as an initial
+      // value: `opts.protectedTopics = []` must survive as an opt-out. Unknown
+      // entries are rejected by name — a typo like `personal_finance` matches no
+      // topic and would silently protect nothing, and the operator would not
+      // find out until finance memories were deleted.
+      const entries = raw === "" ? [] : raw.split(",").map((t) => t.trim());
+      const unknown = entries.filter((t) => !spec.of.includes(t));
+      if (unknown.length > 0) {
+        throw new Error(
+          `${name} has unknown ${unknown.length === 1 ? "topic" : "topics"} ` +
+            `${unknown.join(", ")}; known topics are ${spec.of.join(", ")}`,
+        );
+      }
+      opts[spec.key] = entries;
+      continue;
+    }
     if (!spec.number && !spec.integer) {
       opts[spec.key] = raw;
       continue;
@@ -1768,12 +2090,23 @@ export function parseArgs(argv) {
     if (!Number.isFinite(value) || value <= 0) {
       throw new Error(`${name} must be a positive number`);
     }
-    // A row count is a whole number, and `LIMIT $n` binds a bigint: `--limit 5.5`
-    // would fail at the server, after the SSM reads, the secret fetch, and the
-    // connection. `--lock-ttl` is deliberately not integer-checked — half an hour
-    // is a meaningful TTL.
+    // Two ways a fractional value goes wrong, and neither is a smaller version of
+    // a valid run. A row count binds a bigint — `--limit 5.5` fails at the server,
+    // after the SSM reads, the secret fetch, and the connection. A fractional
+    // `--consensus-passes` would run `Math.trunc`-many passes while the log and the
+    // report quoted the fraction, so the run's summary would disagree with its own
+    // invocation. `isSafeInteger`, not `isInteger`, because `1e30` is an integer
+    // that no bigint bind or pass loop can honor. `--lock-ttl` is deliberately NOT
+    // integer-checked — half an hour is a meaningful TTL.
     if (spec.integer && !Number.isSafeInteger(value)) {
-      throw new Error(`${name} must be a whole number, got ${raw}`);
+      throw new Error(`${name} must be a whole integer, got ${raw}`);
+    }
+    // `min` is separate from the `> 0` check because "positive" is not the
+    // constraint for every numeric flag — one consensus pass is not a quorum of
+    // itself, so accepting 1 and quietly running single-pass would restore exactly
+    // the behavior the flag exists to replace.
+    if (spec.min !== undefined && value < spec.min) {
+      throw new Error(`${name} must be at least ${spec.min}`);
     }
     opts[spec.key] = value;
   }
@@ -1805,6 +2138,13 @@ export function parseArgs(argv) {
       `${name} applies only to ${spec.mode.map((m) => `--${m === "cleanup" ? "apply/--decisions (audit)" : m === "list" ? "list-inactive" : "restore"}`).join(" or ")}`,
     );
   }
+  // Applied here, not as an initial value, so `--protected-topics ""` stays an
+  // empty list. Defaulting a *retention* rule is the safe direction: the cost of
+  // the default is finance memories that never get tidied, and the cost of no
+  // default is finance memories that get deleted. It is unconditional rather than
+  // cleanup-only because the retention rule is a property of the tool, and a
+  // reader of `opts` should not have to know the mode to know what is protected.
+  opts.protectedTopics ??= [...DEFAULT_PROTECTED_TOPICS];
   return opts;
 }
 

--- a/scripts/memory-cleanup.mjs
+++ b/scripts/memory-cleanup.mjs
@@ -73,6 +73,10 @@ const CLASSIFY_ATTEMPTS = 2;
 const LOCK_ACQUIRE_ATTEMPTS = 2;
 const DISCOVERY_RETRIES = 3;
 const DEFAULT_CAP = 50;
+// The STANDARD Parameter Store tier's content limit. The advanced tier's 8 KB is
+// deliberately not an option: it incurs a charge and cannot be reverted to
+// standard without data loss, so the record has to fit here (#123).
+const MAX_PARAMETER_BYTES = 4096;
 const REQUEST_TIMEOUT_MS = 30_000; // REST calls; the LLM call sets its own
 const LLM_TIMEOUT_MS = 120_000;
 // Reasoning models consume output tokens on hidden reasoning BEFORE emitting
@@ -821,6 +825,46 @@ async function discoverBaseUrl(opts, deps) {
  * runs, so the only way in is a planner push site — an internal invariant, and
  * TC-SLACKAPP-066 asserts it directly rather than leaving the guard unproven.
  */
+/**
+ * The `{prefix}/approvals/offered` record: what the callback Lambda compares a
+ * button click against, and where the apply task reads its ids from (#123).
+ *
+ * Ids and a hash only, never memory content. The parameter is a plain `String`
+ * because the workload permissions boundary admits neither `kms:Encrypt` nor
+ * `kms:GenerateDataKey`, so a `SecureString` write would be denied at runtime —
+ * which makes this record readable by anything holding `ssm:GetParameters` on
+ * the stage tree, and bounds what may go in it (TC-SLACKAPP-023b).
+ *
+ * Over the limit it THROWS. Truncating would ask the operator to approve a list
+ * that is not the list they were shown, and the ids are exactly what the apply
+ * task deletes — the one failure mode here that produces a *wrong* apply rather
+ * than a failed one (TC-SLACKAPP-024).
+ */
+export function buildOfferedRecord({ stage, decisions, generatedAt }) {
+  const ids = decisions.filter((d) => d.verdict === "DELETE").map((d) => d.id);
+  const record = {
+    stage,
+    // Over the ids, so a click carrying an earlier list's hash no longer matches
+    // once the list is regenerated. Joined with a separator no id can contain, so
+    // `["ab","c"]` and `["a","bc"]` cannot collide into one hash.
+    hash: contentHash(ids.join("\n")),
+    ids,
+    generatedAt,
+  };
+  const serialized = JSON.stringify(record);
+  if (serialized.length > MAX_PARAMETER_BYTES) {
+    // Measured on the SERIALIZED value rather than the id count: a limit
+    // expressed as "N ids" drifts from the real constraint as soon as ids get
+    // longer, and bytes are what SSM rejects. `--cap` is the knob to lower.
+    throw new Error(
+      `the offered approval list is ${serialized.length} bytes, over the ` +
+        `${MAX_PARAMETER_BYTES}-byte standard parameter limit for ${ids.length} ids — ` +
+        `lower --cap rather than truncating the list the operator approves`,
+    );
+  }
+  return record;
+}
+
 export function verdictSummary(decisions) {
   const summary = { KEEP: 0, DELETE: 0, MERGE: 0, SKIP: 0, RETAIN: 0, UNSTABLE: 0 };
   for (const d of decisions) {

--- a/scripts/memory-cleanup.mjs
+++ b/scripts/memory-cleanup.mjs
@@ -865,6 +865,88 @@ export function buildOfferedRecord({ stage, decisions, generatedAt }) {
   return record;
 }
 
+/**
+ * Materialize the `--ids` file the apply task consumes, from the approval CLAIM
+ * the operator's click created (#123).
+ *
+ * The task receives only the list's content HASH, as an ECS container override.
+ * That is deliberate: an override is echoed by `DescribeTasks` and recorded in
+ * CloudTrail, so ids there would put memory identifiers in an audit log — and
+ * more importantly the callback's signature proves the click came from the
+ * workspace, never that any ids in the request are the ids the classifier chose.
+ * So the ids come from `approvals/approved-{hash}`, which is immutable once
+ * written (`Overwrite: false` is the claim's atomic primitive).
+ *
+ * NOT from `approvals/offered`: that record is overwritten by every run, so
+ * reading it would apply the CURRENT run's list under an approval the operator
+ * gave for an earlier one.
+ *
+ * Every guard here throws. An `--ids` file that is absent, empty, or short means
+ * "approve fewer things" to the caller, so a permissive path does not fail — it
+ * reports a clean apply that deleted nothing (or the wrong thing).
+ */
+export async function materializeApprovedIds({
+  ssm,
+  stage,
+  ssmPrefix,
+  hash,
+  idsFile,
+  fs,
+  log = () => {},
+}) {
+  const name = `${ssmPrefix}/approvals/approved-${hash}`;
+  const { GetParametersCommand } = await import("@aws-sdk/client-ssm");
+  const response = await ssm.send(new GetParametersCommand({ Names: [name] }));
+  // An absent name is echoed in `InvalidParameters` and simply MISSING from
+  // `Parameters`, so there is no empty-value case to distinguish — `?.Value` is
+  // `undefined` and must not fall through to an empty ids file.
+  const raw = (response.Parameters ?? []).find((p) => p.Name === name)?.Value;
+  if (!raw) {
+    throw new Error(`no approval record for the requested hash at ${name}`);
+  }
+
+  let record;
+  try {
+    record = JSON.parse(raw);
+  } catch {
+    // The message never quotes the value: this parameter is the one place ids
+    // legitimately live, and a stack that echoed it would copy them to the log.
+    throw new Error(`the approval record at ${name} is not valid JSON`);
+  }
+  if (!record || typeof record !== "object" || !Array.isArray(record.ids)) {
+    throw new Error(`the approval record at ${name} has no id list`);
+  }
+  // Stage-bound, like #102's decision-file guard: a preview approval must never
+  // apply to prod.
+  if (record.stage !== stage) {
+    throw new Error(
+      `the approval record names stage ${record.stage}, not ${stage}`,
+    );
+  }
+  if (record.ids.length === 0) {
+    throw new Error(`the approval record at ${name} approved no ids`);
+  }
+  // Re-derived over the IDS, not compared against the record's own `hash` field:
+  // a tampered record carries a `hash` that agrees with itself, so only
+  // recomputing makes the ids the thing the hash vouches for. Same join as
+  // `buildOfferedRecord`, with a separator no id can contain.
+  const derived = contentHash(record.ids.join("\n"));
+  if (derived !== hash) {
+    throw new Error(
+      `the approval record's ids do not match the requested hash — refusing to apply`,
+    );
+  }
+
+  // Ids only, one per line, because `readApprovedIds` splits on "\n" and trims.
+  // A JSON array or a comma-joined line would parse as a single id and silently
+  // approve nothing.
+  fs.writeFileSync(idsFile, `${record.ids.join("\n")}\n`, { mode: 0o600 });
+  // The COUNT, never the ids: an operator needs to know the apply matched the
+  // approval, not which memories it names.
+  log(`materialized ${record.ids.length} approved id(s) for ${hash}`);
+  return record.ids.length;
+}
+
 export function verdictSummary(decisions) {
   const summary = { KEEP: 0, DELETE: 0, MERGE: 0, SKIP: 0, RETAIN: 0, UNSTABLE: 0 };
   for (const d of decisions) {
@@ -2192,11 +2274,51 @@ export function parseArgs(argv) {
   return opts;
 }
 
-async function productionDatabaseMutex(stage, region) {
-  const { SSMClient, GetParametersCommand } =
-    await import("@aws-sdk/client-ssm");
-  const { SecretsManagerClient, GetSecretValueCommand } =
-    await import("@aws-sdk/client-secrets-manager");
+/**
+ * Where the database connection details come from — the environment when the
+ * runtime supplies them, otherwise the stage's own SSM tree.
+ *
+ * TWO callers with different IAM (#123). The operator CLI runs under a human
+ * identity that can read `/mem9-on-aws/{stage}/db/*` and the cluster secret, so it
+ * discovers everything itself. The Slack-triggered apply task cannot: its task
+ * role holds `ssm:GetParameters` ONLY under `approvals/*`, because a task that
+ * could read the stage tree could read the four `cleanup/*` inputs that decide
+ * which cluster and task definition an apply runs on. So ECS resolves the secret
+ * for it — `MEM9_DB_SECRET` arrives as the secret's JSON, already decrypted by the
+ * EXECUTION role at task start — and the endpoint arrives as plain `environment`.
+ * Mirrors `memory-consolidation.mjs`'s `createProductionDeps`, which is the same
+ * split for the same reason.
+ *
+ * The env path is preferred when it is COMPLETE, not when it is merely partly
+ * present: a half-set environment falling through to SSM is the behavior an
+ * operator can reason about, whereas a half-set environment used as-is hands `pg`
+ * an undefined host.
+ */
+async function resolveDatabaseConfig(stage, region, runtime) {
+  const injectedSecret = process.env.MEM9_DB_SECRET;
+  if (injectedSecret && process.env.MEM9_DB_HOST && process.env.MEM9_DB_NAME) {
+    let credentials;
+    try {
+      credentials = JSON.parse(injectedSecret);
+    } catch {
+      // Never quotes the value: this variable IS the database password.
+      throw new Error("MEM9_DB_SECRET is not valid JSON");
+    }
+    if (
+      typeof credentials.username !== "string" ||
+      typeof credentials.password !== "string"
+    ) {
+      throw new Error("MEM9_DB_SECRET is missing credentials");
+    }
+    return {
+      host: process.env.MEM9_DB_HOST,
+      port: Number(process.env.MEM9_DB_PORT || 5432),
+      database: process.env.MEM9_DB_NAME,
+      user: credentials.username,
+      password: credentials.password,
+    };
+  }
+
   const prefix = `/mem9-on-aws/${stage}/db`;
   const parameterNames = {
     host: `${prefix}/host`,
@@ -2205,11 +2327,16 @@ async function productionDatabaseMutex(stage, region) {
     secretArn: `${prefix}/secret-arn`,
   };
 
-  const ssm = new SSMClient({ region });
-  const parameterResponse = await ssm.send(
-    new GetParametersCommand({ Names: Object.values(parameterNames) }),
-  );
-  ssm.destroy();
+  const { GetParametersCommand } = await import("@aws-sdk/client-ssm");
+  const { ssm, release: releaseSsm } = await ssmClient(region, runtime);
+  let parameterResponse;
+  try {
+    parameterResponse = await ssm.send(
+      new GetParametersCommand({ Names: Object.values(parameterNames) }),
+    );
+  } finally {
+    releaseSsm();
+  }
   if (parameterResponse.InvalidParameters?.length) {
     throw new Error("database connection parameters are incomplete");
   }
@@ -2235,14 +2362,10 @@ async function productionDatabaseMutex(stage, region) {
     throw new Error("database connection parameters are incomplete");
   }
 
-  const secrets = new SecretsManagerClient({ region });
-  const secretResponse = await secrets.send(
-    new GetSecretValueCommand({ SecretId: config.secretArn }),
-  );
-  secrets.destroy();
+  const secretString = await readSecret(config.secretArn, region, runtime);
   let credentials;
   try {
-    credentials = JSON.parse(secretResponse.SecretString ?? "");
+    credentials = JSON.parse(secretString ?? "");
   } catch {
     throw new Error("database secret is not valid JSON");
   }
@@ -2252,14 +2375,57 @@ async function productionDatabaseMutex(stage, region) {
   ) {
     throw new Error("database secret is missing credentials");
   }
-
-  const { Client } = await import("pg");
-  const db = new Client({
+  return {
     host: config.host,
     port,
     database: config.database,
     user: credentials.username,
     password: credentials.password,
+  };
+}
+
+/**
+ * An SSM client plus the call that disposes it — but only when this function is
+ * the one that built it. A caller-injected client outlives this call (the same
+ * client serves the approval read and the db discovery), so destroying it here
+ * would break the second use.
+ */
+async function ssmClient(region, runtime) {
+  if (runtime.ssm) return { ssm: runtime.ssm, release: () => {} };
+  const { SSMClient } = await import("@aws-sdk/client-ssm");
+  const ssm = new SSMClient({ region });
+  return { ssm, release: () => ssm.destroy() };
+}
+
+async function readSecret(secretId, region, runtime) {
+  const { GetSecretValueCommand } = await import(
+    "@aws-sdk/client-secrets-manager"
+  );
+  if (runtime.secrets) {
+    const response = await runtime.secrets.send(
+      new GetSecretValueCommand({ SecretId: secretId }),
+    );
+    return response.SecretString;
+  }
+  const { SecretsManagerClient } = await import(
+    "@aws-sdk/client-secrets-manager"
+  );
+  const secrets = new SecretsManagerClient({ region });
+  try {
+    const response = await secrets.send(
+      new GetSecretValueCommand({ SecretId: secretId }),
+    );
+    return response.SecretString;
+  } finally {
+    secrets.destroy();
+  }
+}
+
+async function productionDatabaseMutex(stage, region, runtime) {
+  const config = await resolveDatabaseConfig(stage, region, runtime);
+  const Client = runtime.Client ?? (await import("pg")).Client;
+  const db = new Client({
+    ...config,
     ssl: { rejectUnauthorized: true },
     application_name: `mem9-cleanup-${stage}`,
   });
@@ -2290,7 +2456,7 @@ async function productionDatabaseMutex(stage, region) {
 }
 
 /**
- * Deps for `--list-inactive` / `--restore`. Deliberately NOT `productionDeps`:
+ * Deps for `--list-inactive` / `--restore`. Deliberately NOT `createCleanupDeps`:
  * recovery needs no tenant key, no service discovery, and no LLM, so requiring
  * them would make a read-only listing fail on unrelated configuration. The
  * shared mutex is passed only for an actual `--apply`, matching cleanup.
@@ -2315,27 +2481,74 @@ async function recoveryDeps(opts) {
   };
 }
 
-async function productionDeps(opts) {
+/**
+ * Build the real deps for one run — for the operator CLI and for the
+ * Slack-triggered apply task, which are the same code on different IAM (#123).
+ *
+ * `runtime` exists for the tests: every AWS client and `pg` itself is injectable,
+ * which is what lets the container path be asserted without an account. Nothing in
+ * production passes it.
+ *
+ * ORDER IS LOAD-BEARING. When `MEM9_APPROVAL_HASH` is set the ids are materialized
+ * FIRST, before the database is opened and before the advisory lock is taken:
+ * that read is the cheapest guard and the only one that can prove the ids are the
+ * approved ids, and a tampered claim that failed later would hold the shared mutex
+ * for the length of its own failure, blocking the weekly consolidation.
+ */
+export async function createCleanupDeps(opts, runtime = {}) {
   const region = process.env.AWS_REGION || "ap-northeast-1";
 
   // The explicit flag WINS over the env var: a stale MEM9_TENANT_ID from a
   // preview shell must not silently redirect an --apply aimed at another stage.
   let tenantId;
   if (opts.tenantSecretArn) {
-    const { SecretsManagerClient, GetSecretValueCommand } = await import("@aws-sdk/client-secrets-manager");
-    const sm = new SecretsManagerClient({ region });
-    const res = await sm.send(new GetSecretValueCommand({ SecretId: opts.tenantSecretArn }));
-    tenantId = res.SecretString;
+    tenantId = await readSecret(opts.tenantSecretArn, region, runtime);
   } else {
     tenantId = process.env.MEM9_TENANT_ID;
   }
   if (!tenantId) throw new Error("tenant id required: set MEM9_TENANT_ID or --tenant-secret-arn");
+
+  // The approval hash is the ECS container override the callback Lambda sets, and
+  // it is the ONLY thing that reaches the task from the click.
+  const approvalHash = process.env.MEM9_APPROVAL_HASH;
+  if (approvalHash) {
+    // A hash with nowhere to write is the loop's worst failure mode, not a
+    // degraded one: `readApprovedIds` returns null for an absent `--ids`, and null
+    // means "no filter" — so the run would delete every DELETE verdict it found
+    // rather than the ones the operator approved, and exit 0 reporting success.
+    if (!opts.idsFile) {
+      throw new Error(
+        "MEM9_APPROVAL_HASH is set but --ids is not; refusing to apply " +
+          "without the approved-id filter",
+      );
+    }
+    const ssmPrefix = process.env.MEM9_SSM_PREFIX || `/mem9-on-aws/${opts.stage}`;
+    const { ssm, release } = await ssmClient(region, runtime);
+    try {
+      await materializeApprovedIds({
+        ssm,
+        stage: opts.stage,
+        ssmPrefix,
+        hash: approvalHash,
+        idsFile: opts.idsFile,
+        fs: await import("node:fs"),
+        log: (message) =>
+          console.error(`[memory-cleanup ${new Date().toISOString()}] ${message}`),
+      });
+    } finally {
+      release();
+    }
+  }
+
   const databaseMutex = opts.apply
-    ? await productionDatabaseMutex(opts.stage, region)
+    ? await productionDatabaseMutex(opts.stage, region, runtime)
     : undefined;
 
-  const { getToken } = await import("@aws/bedrock-token-generator");
-  const { fromNodeProviderChain } = await import("@aws-sdk/credential-providers");
+  const getToken =
+    runtime.getToken ?? (await import("@aws/bedrock-token-generator")).getToken;
+  const fromNodeProviderChain =
+    runtime.fromNodeProviderChain ??
+    (await import("@aws-sdk/credential-providers")).fromNodeProviderChain;
   const completeChat = buildCompleteChat(
     { ...opts, region },
     {
@@ -2403,7 +2616,7 @@ if (isMain) {
         : await runListInactive(opts, production.deps);
       process.exitCode = result.exitCode;
     } else {
-      production = await productionDeps(opts);
+      production = await createCleanupDeps(opts);
       const result = await runCleanup(
         { ...opts, tenantId: production.tenantId },
         production.deps,

--- a/scripts/memory-cleanup.test.mjs
+++ b/scripts/memory-cleanup.test.mjs
@@ -9,10 +9,12 @@ import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  assertClaimParameterName,
   buildApprovalMessage,
   buildCompleteChat,
   buildOfferedRecord,
   buildOutcomeMessage,
+  claimParameterName,
   contentHash,
   createCleanupDeps,
   inactiveMemoryAdapter,
@@ -149,6 +151,41 @@ function fakeLlm(verdictsByBatch) {
 }
 
 const withTopic = (v) => ("topic" in v ? v : { ...v, topic: "engineering" });
+
+/**
+ * SSM/Secrets Manager double, keyed by parameter name.
+ *
+ * `GetParameters` is the only read the workload boundary admits, so an absent name
+ * is echoed in `InvalidParameters` and simply MISSING from `Parameters` — never an
+ * exception. Fakes that threw would let a script relying on a throw pass here and
+ * silently read `undefined` in production.
+ *
+ * The name constraint is borrowed from the SERVICE (`assertClaimParameterName`)
+ * rather than accepting any string: a Map-keyed fake is precisely why a claim name
+ * carrying the `:` of `sha256:` passed this whole suite while PutParameter would
+ * have rejected it on every real click (TC-SLACKAPP-131).
+ */
+function fakeAwsClient(values = {}) {
+  const client = {
+    sent: [],
+    send: vi.fn(async (command) => {
+      client.sent.push(command.input);
+      if (command.input.Names) {
+        for (const name of command.input.Names) assertClaimParameterName(name);
+        const names = command.input.Names;
+        return {
+          Parameters: names
+            .filter((name) => name in values)
+            .map((name) => ({ Name: name, Value: values[name] })),
+          InvalidParameters: names.filter((name) => !(name in values)),
+        };
+      }
+      return { SecretString: values[command.input.SecretId] };
+    }),
+    destroy: () => {},
+  };
+  return client;
+}
 
 function baseDeps(server, llm, dir) {
   return {
@@ -415,6 +452,120 @@ describe("apply, cap, --ids", () => {
     expect(server.store.get("d1").state).toBe("deleted");
     expect(server.store.get("d2").state).toBe("active");
     expect(result.skippedByFilter).toBe(1);
+  });
+
+  it("TC-SLACKAPP-132 --ids refuses a MERGE outright, absorbed ids included", async () => {
+    // The privilege-escalation hole this closes. `buildOfferedRecord` offers
+    // DELETE verdicts only, so no MERGE can ever be in an approved list — but the
+    // filter checked `approved.has(decision.id)` on the SURVIVOR only, and a
+    // MERGE deletes its `absorbs[]` and rewrites the survivor's content. The
+    // Slack-triggered task re-classifies instead of replaying the reviewed
+    // artifact, so a fresh MERGE naming an approved id as its survivor deleted two
+    // memories the operator never saw and exited 0 reporting success.
+    const dir = tempDir();
+    const server = fakeServer([
+      memory("surv", "survivor"),
+      memory("frag-1", "fragment one"),
+      memory("frag-2", "fragment two"),
+    ]);
+    const llm = fakeLlm([
+      [
+        { id: "surv", verdict: "MERGE", reason: "r", merge_into: "surv", absorbs: ["frag-1", "frag-2"], merged_content: "MERGED" },
+        { id: "frag-1", verdict: "MERGE", reason: "r", merge_into: "surv" },
+        { id: "frag-2", verdict: "MERGE", reason: "r", merge_into: "surv" },
+      ],
+    ]);
+    const idsFile = join(dir, "approved.txt");
+    // The operator approved exactly the survivor id, as a DELETION.
+    writeFileSync(idsFile, "surv\n");
+    const deps = baseDeps(server, llm, dir);
+    const result = await runCleanup(baseOpts({ apply: true, idsFile }), deps);
+
+    // Nothing destroyed and nothing rewritten.
+    expect(server.store.get("frag-1").state).toBe("active");
+    expect(server.store.get("frag-2").state).toBe("active");
+    expect(server.store.get("surv").state).toBe("active");
+    expect(server.store.get("surv").content).toBe("survivor");
+    expect(result.capUsed).toBe(0);
+    // No write of ANY kind reached the server: asserted on the request log rather
+    // than only on the store, because a PUT that happened to write identical
+    // content would leave the store looking untouched.
+    expect(server.calls.filter((c) => c.method !== "GET")).toEqual([]);
+    // Counted AND logged: a silent skip is how a shortfall in the Slack outcome
+    // message becomes unexplainable.
+    expect(result.skippedByFilter).toBe(1);
+    const logged = deps.log.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(logged).toMatch(/refused under an approved-ids run/u);
+  });
+
+  it("TC-SLACKAPP-132 an approved id the re-classifier now KEEPs is reported, not silently dropped", async () => {
+    // The converse gap. An approved id whose fresh verdict is KEEP falls out at
+    // `destructiveCost === 0`, so it incremented nothing: the outcome message said
+    // "1 of 2 approved deletion(s)" with no note, which reads as a partial failure
+    // rather than a changed verdict.
+    const dir = tempDir();
+    const server = fakeServer([memory("d1", "x"), memory("d2", "y")]);
+    const llm = fakeLlm([
+      [
+        { id: "d1", verdict: "DELETE", reason: "noise" },
+        { id: "d2", verdict: "KEEP", reason: "durable now" },
+      ],
+    ]);
+    const idsFile = join(dir, "approved.txt");
+    writeFileSync(idsFile, "d1\nd2\n");
+    const result = await runCleanup(baseOpts({ apply: true, idsFile }), baseDeps(server, llm, dir));
+
+    expect(server.store.get("d1").state).toBe("deleted");
+    expect(server.store.get("d2").state).toBe("active");
+    expect(result.reclassified).toBe(1);
+    // Distinct from skippedByFilter: that counts things the operator did NOT
+    // approve, this counts things they DID.
+    expect(result.skippedByFilter).toBe(0);
+
+    const message = buildOutcomeMessage({
+      channel: "C1",
+      messageTs: "1.1",
+      hash: contentHash("d1\nd2"),
+      stage: "test",
+      approved: 2,
+      result,
+      appliedAt: "2026-08-05T04:00:00.000Z",
+    });
+    expect(JSON.stringify(message)).toMatch(/no longer classified as deletions/u);
+  });
+
+  it("TC-SLACKAPP-132 an approved id that matched no decision is not counted as reclassified", async () => {
+    // The two counts must not describe one id two contradictory ways. An id that
+    // appears in NO decision was never classified, so calling it "no longer
+    // classified as deletions" tells the operator the classifier changed its mind
+    // when in fact their list named something this run never saw — a typo, or an id
+    // from a different stage. `runCleanup` already reports those BY NAME, and that
+    // message is the one with the actionable fix.
+    const dir = tempDir();
+    const server = fakeServer([memory("d1", "x")]);
+    const llm = fakeLlm([[{ id: "d1", verdict: "DELETE", reason: "noise" }]]);
+    const idsFile = join(dir, "approved.txt");
+    writeFileSync(idsFile, "d1\nd-typo\n");
+    const deps = baseDeps(server, llm, dir);
+    const result = await runCleanup(baseOpts({ apply: true, idsFile }), deps);
+
+    expect(server.store.get("d1").state).toBe("deleted");
+    expect(result.reclassified).toBe(0);
+    expect(result.skippedByFilter).toBe(0);
+    const logged = deps.log.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(logged).toMatch(/1 approved id\(s\) matched no decision: d-typo/u);
+    expect(logged).not.toMatch(/no longer classified as deletions/u);
+
+    const message = buildOutcomeMessage({
+      channel: "C1",
+      messageTs: "1.1",
+      hash: contentHash("d1\nd-typo"),
+      stage: "test",
+      approved: 2,
+      result,
+      appliedAt: "2026-08-05T04:00:00.000Z",
+    });
+    expect(JSON.stringify(message)).not.toMatch(/no longer classified as deletions/u);
   });
 
   it("TC-MEMCLEAN-033 MERGE recovery is hash-anchored (three-way)", async () => {
@@ -3658,7 +3809,7 @@ describe("the offered approval record (#123)", () => {
 
 describe("materializing the approved ids in the apply task (#123)", () => {
   const OFFERED = "/mem9-on-aws/prod/approvals/offered";
-  const claimName = (hash) => `/mem9-on-aws/prod/approvals/approved-${hash}`;
+  const claimName = (hash) => claimParameterName("/mem9-on-aws/prod", hash);
 
   /**
    * Fake SSM whose `send` answers `GetParametersCommand` from a name→value map.
@@ -3694,6 +3845,51 @@ describe("materializing the approved ids in the apply task (#123)", () => {
       generatedAt: "2026-08-05T00:00:00.000Z",
       ...extra,
     });
+
+  it("TC-SLACKAPP-131 the claim name is one SSM will accept on WRITE, and matches the facade's copy", async () => {
+    // The defect this pins was total and silent: `contentHash` returns
+    // `sha256:<hex>`, and a `:` cannot appear in an SSM parameter name.
+    // PutParameter answers ValidationException, which `claimAndRun` classifies by
+    // error NAME — not `ParameterAlreadyExists`, so it fell to the generic branch
+    // and answered "The approval could not be recorded" for EVERY click on every
+    // stage. Probed live in ap-northeast-1: colon rejected on write, dash
+    // accepted. Nothing caught it because every SSM double was a Map keyed on the
+    // name string, so no double could reject a name's SHAPE.
+    const hash = contentHash("m-1");
+    expect(hash).toMatch(/^sha256:/u);
+    const name = claimParameterName("/mem9-on-aws/prod", hash);
+    expect(name).not.toContain(":");
+    expect(() => assertClaimParameterName(name)).not.toThrow();
+    // The prefix is kept rather than stripped so an operator reading
+    // describe-parameters output can still tell which algorithm produced it.
+    expect(name).toBe(`/mem9-on-aws/prod/approvals/approved-${hash.replace(":", "-")}`);
+    // And the guard has to actually reject the old form, or it is decoration.
+    expect(() =>
+      assertClaimParameterName(`/mem9-on-aws/prod/approvals/approved-${hash}`),
+    ).toThrow(/ValidationException/u);
+
+    // The WRITER of this record is the facade Lambda, which shares no module with
+    // this script — so the derivation is duplicated and this is the only thing
+    // keeping the two in agreement. A drift here means the task looks for a claim
+    // at a name the Lambda never wrote and dies with "no approval record", which
+    // is the same symptom as a tampered claim from a cause nobody would guess.
+    //
+    // Both functions are CALLED rather than their sources compared: comparing
+    // source text passes as long as the facade matches a literal in this file,
+    // which is not the property that matters and does not notice the script side
+    // changing at all. Only this direction is importable — vitest transforms the
+    // TS for an .mjs test, while an infra/*.test.ts importing the .mjs fails
+    // typecheck (TS7016), the same asymmetry noted at slack-approval.test.ts's
+    // boundaryStatements().
+    const { claimParameterName: facadeClaimParameterName } = await import(
+      "../infra/src/oauth-facade/slack-interactions.ts"
+    );
+    for (const prefix of ["/mem9-on-aws/prod", "/mem9-on-aws/pr-123"]) {
+      expect(facadeClaimParameterName(prefix, hash)).toBe(
+        claimParameterName(prefix, hash),
+      );
+    }
+  });
 
   it("TC-SLACKAPP-091 the ids come from the CLAIM named by the hash, not from the offered record", async () => {
     // The claim is what the operator's click actually approved. `offered` is
@@ -4079,27 +4275,6 @@ describe("the apply task's in-container runtime (#123)", () => {
     };
   }
 
-  function fakeAwsClient(values = {}) {
-    const client = {
-      sent: [],
-      send: vi.fn(async (command) => {
-        client.sent.push(command.input);
-        if (command.input.Names) {
-          const names = command.input.Names;
-          return {
-            Parameters: names
-              .filter((name) => name in values)
-              .map((name) => ({ Name: name, Value: values[name] })),
-            InvalidParameters: names.filter((name) => !(name in values)),
-          };
-        }
-        return { SecretString: values[command.input.SecretId] };
-      }),
-      destroy: () => {},
-    };
-    return client;
-  }
-
   it("TC-SLACKAPP-100 takes its database configuration from the environment, with no SSM or Secrets Manager read", async () => {
     // The image ships @aws-sdk/client-ssm now, so this is no longer about a
     // missing module — it is about grants. The task role holds ssm:GetParameters
@@ -4184,7 +4359,7 @@ describe("the apply task's in-container runtime (#123)", () => {
     const idsFile = join(dir, "approved.txt");
     containerEnv({ MEM9_APPROVAL_HASH: hash });
     const ssm = fakeAwsClient({
-      [`/mem9-on-aws/prod/approvals/approved-${hash}`]: JSON.stringify({
+      [claimParameterName("/mem9-on-aws/prod", hash)]: JSON.stringify({
         stage: "prod",
         hash,
         ids,
@@ -4239,7 +4414,7 @@ describe("the apply task's in-container runtime (#123)", () => {
     containerEnv({ MEM9_APPROVAL_HASH: hash });
     const calls = [];
     const ssm = fakeAwsClient({
-      [`/mem9-on-aws/prod/approvals/approved-${hash}`]: JSON.stringify({
+      [claimParameterName("/mem9-on-aws/prod", hash)]: JSON.stringify({
         stage: "prod",
         // Agrees with the request, so a string comparison of the two would pass.
         hash,
@@ -4962,28 +5137,6 @@ describe("closing the loop on the message (#123)", () => {
 });
 
 describe("wiring the outcome update into the apply run (#123)", () => {
-  /** SSM/Secrets double keyed by parameter name (the sibling describe's shape). */
-  function fakeAwsClient(values = {}) {
-    const client = {
-      sent: [],
-      send: vi.fn(async (command) => {
-        client.sent.push(command.input);
-        if (command.input.Names) {
-          const names = command.input.Names;
-          return {
-            Parameters: names
-              .filter((name) => name in values)
-              .map((name) => ({ Name: name, Value: values[name] })),
-            InvalidParameters: names.filter((name) => !(name in values)),
-          };
-        }
-        return { SecretString: values[command.input.SecretId] };
-      }),
-      destroy: () => {},
-    };
-    return client;
-  }
-
   const environmentKeys = [
     "AWS_REGION",
     "MEM9_APPROVAL_HASH",
@@ -5122,7 +5275,7 @@ describe("wiring the outcome update into the apply run (#123)", () => {
     const ssm = {
       send: vi.fn(async (command) => ({
         Parameters: (command.input.Names ?? [])
-          .filter((n) => n.endsWith(`approvals/approved-${hash}`))
+          .filter((n) => n === claimParameterName("/mem9-on-aws/prod", hash))
           .map((name) => ({
             Name: name,
             Value: JSON.stringify({
@@ -5217,7 +5370,7 @@ describe("wiring the outcome update into the apply run (#123)", () => {
     });
     delete process.env.SLACK_BOT_TOKEN;
     const ssm = fakeAwsClient({
-      [`/mem9-on-aws/prod/approvals/approved-${hash}`]: JSON.stringify({
+      [claimParameterName("/mem9-on-aws/prod", hash)]: JSON.stringify({
         stage: "prod",
         hash,
         ids,

--- a/scripts/memory-cleanup.test.mjs
+++ b/scripts/memory-cleanup.test.mjs
@@ -9,13 +9,17 @@ import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  buildApprovalMessage,
   buildCompleteChat,
   buildOfferedRecord,
+  buildOutcomeMessage,
   contentHash,
   createCleanupDeps,
   inactiveMemoryAdapter,
   materializeApprovedIds,
   parseArgs,
+  postApprovalRequest,
+  updateApprovalMessage,
   consensusDecisions,
   parseVerdicts,
   planDecisions,
@@ -3958,6 +3962,63 @@ describe("materializing the approved ids in the apply task (#123)", () => {
       expect(String(call[0])).not.toContain("m-1");
     }
   });
+
+  it("TC-SLACKAPP-098b what is returned to the caller is a count and the coordinates, never the ids", async () => {
+    // The return value is what the outcome update closes over, and it travels to
+    // `chat.update`. Ids on it would reach a Slack message the moment anything
+    // spread the claim into a payload — so the file is the ONLY place they go.
+    const ids = ["m-1", "m-2"];
+    const hash = contentHash(ids.join("\n"));
+    const ssm = fakeSsm({
+      [claimName(hash)]: JSON.stringify({
+        stage: "prod",
+        hash,
+        ids,
+        claimedAt: "2026-08-05T00:05:00.000Z",
+        messageTs: "1754400000.000100",
+        messageChannel: "C0APPROVAL",
+      }),
+    });
+    const dir = tempDir();
+    const idsFile = join(dir, "approved.txt");
+
+    const claim = await materializeApprovedIds({
+      ssm,
+      stage: "prod",
+      ssmPrefix: "/mem9-on-aws/prod",
+      hash,
+      idsFile,
+      fs: { writeFileSync },
+    });
+
+    expect(claim.count).toBe(2);
+    expect(claim.messageTs).toBe("1754400000.000100");
+    expect(claim.messageChannel).toBe("C0APPROVAL");
+    expect(JSON.stringify(claim)).not.toContain("m-1");
+    // The ids DID land, in the file, which is the other half of the same property.
+    expect(readFileSync(idsFile, "utf8")).toBe("m-1\nm-2\n");
+
+    // A record with no coordinates yields none rather than `undefined` values that
+    // would reach `chat.update` as a `channel_not_found`.
+    const bare = fakeSsm({
+      [claimName(hash)]: JSON.stringify({
+        stage: "prod",
+        hash,
+        ids,
+        claimedAt: "2026-08-05T00:05:00.000Z",
+      }),
+    });
+    const plain = await materializeApprovedIds({
+      ssm: bare,
+      stage: "prod",
+      ssmPrefix: "/mem9-on-aws/prod",
+      hash,
+      idsFile,
+      fs: { writeFileSync },
+    });
+    expect(plain.messageTs).toBeUndefined();
+    expect(plain.messageChannel).toBeUndefined();
+  });
 });
 
 describe("the apply task's in-container runtime (#123)", () => {
@@ -4195,5 +4256,995 @@ describe("the apply task's in-container runtime (#123)", () => {
     ).rejects.toThrow(/hash/u);
     expect(calls).toEqual([]);
     expect(existsSync(idsFile)).toBe(false);
+  });
+});
+
+describe("offering the list to Slack (#123)", () => {
+  const BOT_TOKEN = "xoxb-fixture-not-a-real-token";
+  const CHANNEL = "C0APPROVAL";
+  const OFFERED = "/mem9-on-aws/prod/approvals/offered";
+  const SNIPPET = "SENTINEL-MEMORY-SNIPPET";
+
+  const del = (id, snippet = `${SNIPPET}-${id}`) => ({
+    id,
+    verdict: "DELETE",
+    reason: "session-state",
+    version: 1,
+    contentHash: contentHash(`c-${id}`),
+    snippet,
+  });
+
+  /**
+   * SSM and Slack sharing ONE event log, because the ordering between them is a
+   * correctness property and not an implementation detail: a button that exists
+   * before the record it is validated against is a promise the backend cannot
+   * keep.
+   */
+  function offerFakes(slackBodies = {}) {
+    const events = [];
+    const ssm = {
+      puts: [],
+      send: vi.fn(async (command) => {
+        events.push(["ssm", command.input.Name]);
+        ssm.puts.push(command.input);
+        return {};
+      }),
+    };
+    const slack = {
+      calls: [],
+      fetchImpl: vi.fn(async (url, options = {}) => {
+        const method = String(url).split("/").pop();
+        events.push(["slack", method]);
+        slack.calls.push({
+          url: String(url),
+          method: options.method,
+          headers: options.headers,
+          redirect: options.redirect,
+          body: JSON.parse(options.body),
+        });
+        const body = slackBodies[method] ?? {
+          ok: true,
+          channel: CHANNEL,
+          ts: "1754400000.000100",
+        };
+        return new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }),
+    };
+    return { events, ssm, slack };
+  }
+
+  function offer(overrides = {}) {
+    const { ssm, slack, events } = overrides.fakes ?? offerFakes();
+    return {
+      events,
+      ssm,
+      slack,
+      log: overrides.log,
+      promise: postApprovalRequest({
+        ssm,
+        ssmPrefix: "/mem9-on-aws/prod",
+        stage: "prod",
+        decisions: overrides.decisions ?? [del("m-1"), del("m-2")],
+        generatedAt: "2026-08-05T03:00:00.000Z",
+        channel: CHANNEL,
+        botToken: BOT_TOKEN,
+        fetchImpl: slack.fetchImpl,
+        log: overrides.log ?? vi.fn(),
+      }),
+    };
+  }
+
+  it("TC-SLACKAPP-105 writes the offered record before the button exists, as an overwritable plain String", async () => {
+    const fakes = offerFakes();
+    const log = vi.fn();
+    const { promise } = offer({ fakes, log });
+    const result = await promise;
+
+    // ORDER. Posting first leaves a live Approve button whose click the callback
+    // rejects with "there is no current approval list" — a spent click and an
+    // operator hunting a backend fault. The write is also what INVALIDATES last
+    // week's button, so it must not be reachable only through the post.
+    expect(fakes.events).toEqual([
+      ["ssm", OFFERED],
+      ["slack", "chat.postMessage"],
+      ["ssm", OFFERED],
+    ]);
+    const [first] = fakes.ssm.puts;
+    expect(first.Name).toBe(OFFERED);
+    // Runtime-only, exactly like TC-SLACKAPP-047f: `SecureString` is denied by the
+    // workload boundary (no `kms:Encrypt`, no `kms:GenerateDataKey`), and
+    // `Overwrite: false` would succeed once and then fail every subsequent week
+    // with `ParameterAlreadyExists` — the loop would silently stop offering.
+    expect(first.Type).toBe("String");
+    expect(first.Overwrite).toBe(true);
+    const record = JSON.parse(first.Value);
+    expect(Object.keys(record).sort()).toEqual(["generatedAt", "hash", "ids", "stage"]);
+    expect(record.ids).toEqual(["m-1", "m-2"]);
+    expect(record.hash).toBe(contentHash("m-1\nm-2"));
+    expect(result.record.hash).toBe(record.hash);
+    expect(result.messageTs).toBe("1754400000.000100");
+  });
+
+  it("TC-SLACKAPP-106 carries that exact hash in both action values and shows every id it asks about", async () => {
+    const { promise, slack } = offer();
+    const { record } = await promise;
+    const [call] = slack.calls;
+
+    expect(call.url).toBe("https://slack.com/api/chat.postMessage");
+    expect(call.method).toBe("POST");
+    expect(call.headers.Authorization).toBe(`Bearer ${BOT_TOKEN}`);
+    // The alert-router precedent: a redirect from an API host is never something
+    // to follow with a bearer token attached.
+    expect(call.redirect).toBe("manual");
+    expect(call.body.channel).toBe(CHANNEL);
+
+    const actions = call.body.blocks.filter((b) => b.type === "actions");
+    expect(actions).toHaveLength(1);
+    const ids = actions[0].elements.map((e) => e.action_id).sort();
+    // The action ids the deployed handler branches on. A rename here is a click
+    // the callback answers with "that button is not one this app knows how to
+    // handle" — after the operator has reviewed the whole list.
+    expect(ids).toEqual(["cleanup_approve", "cleanup_reject"]);
+    for (const element of actions[0].elements) {
+      // The hash is the ONLY thing the click carries. Ids cannot ride here (the
+      // 2000-character value cap), and must not: the signature proves the request
+      // came from the workspace, never that ids inside it are the classifier's.
+      expect(element.value).toBe(record.hash);
+    }
+
+    // Every offered id appears in the message. Approving a list longer than the
+    // list shown is the one failure mode that produces a WRONG apply rather than
+    // a failed one — the same argument as TC-SLACKAPP-024, on the other surface.
+    const rendered = JSON.stringify(call.body.blocks);
+    for (const id of record.ids) expect(rendered).toContain(id);
+    // Snippets are the point of the review, and Slack is an approved destination
+    // for them (unlike the repository or the SSM record).
+    expect(rendered).toContain(SNIPPET);
+  });
+
+  it("TC-SLACKAPP-107 refuses to post a list Block Kit would not carry whole", async () => {
+    // Slack's own ceilings: 50 blocks per message, 3000 characters per section
+    // text, 2000 per button value, 150 per header. A message over any of them is
+    // rejected wholesale, so the operator sees nothing at all — but a message
+    // that silently dropped the overflow would be worse: they would approve a
+    // hash covering ids they never saw.
+    const many = Array.from({ length: 4000 }, (_, i) => del(`memory-${i}`));
+    const record = {
+      stage: "prod",
+      hash: contentHash(many.map((d) => d.id).join("\n")),
+      ids: many.map((d) => d.id),
+      generatedAt: "2026-08-05T03:00:00.000Z",
+    };
+    expect(() => buildApprovalMessage({ record, decisions: many, channel: CHANNEL })).toThrow(
+      /block|too large|does not fit/iu,
+    );
+
+    const small = [del("m-1"), del("m-2")];
+    const message = buildApprovalMessage({
+      record: buildOfferedRecord({
+        stage: "prod",
+        decisions: small,
+        generatedAt: "2026-08-05T03:00:00.000Z",
+      }),
+      decisions: small,
+      channel: CHANNEL,
+    });
+    expect(message.blocks.length).toBeLessThanOrEqual(50);
+    for (const block of message.blocks) {
+      if (block.type === "header") expect(block.text.text.length).toBeLessThanOrEqual(150);
+      if (block.type === "section") expect(block.text.text.length).toBeLessThanOrEqual(3000);
+      for (const element of block.elements ?? []) {
+        if (element.value) expect(element.value.length).toBeLessThanOrEqual(2000);
+      }
+    }
+  });
+
+  it("TC-SLACKAPP-108 treats Slack's HTTP 200 application errors as failures, without echoing the token", async () => {
+    // Every Slack Web API method answers HTTP 200 for application errors and puts
+    // the failure in `{ok: false, error}`. A `response.ok` check alone reports a
+    // message that was never delivered — and the loop would appear healthy while
+    // no operator ever sees a review list.
+    const fakes = offerFakes({
+      "chat.postMessage": { ok: false, error: "channel_not_found" },
+    });
+    const log = vi.fn();
+    await expect(offer({ fakes, log }).promise).rejects.toThrow(/channel_not_found/u);
+
+    const logged = log.mock.calls.flat().join("\n");
+    expect(logged).not.toContain(BOT_TOKEN);
+    expect(logged).not.toContain(SNIPPET);
+    // The record was already written, which is deliberate: it invalidates the
+    // previous week's button even when this week's post fails, so no stale click
+    // can apply an old list.
+    expect(fakes.ssm.puts).toHaveLength(1);
+  });
+
+  it("TC-SLACKAPP-109 overwrites the record but posts nothing when the run offers no deletions", async () => {
+    // The write is NOT conditional on there being something to post. Last week's
+    // Approve button is still live in the channel and its hash still matches the
+    // record it was posted with, so a run that skipped the write entirely would
+    // leave a click that applies a list this run's audit no longer stands behind.
+    const fakes = offerFakes();
+    const result = await offer({
+      fakes,
+      decisions: [
+        { id: "m-keep", verdict: "KEEP", reason: "durable" },
+        { id: "m-unstable", verdict: "UNSTABLE", reason: "passes disagreed on deletion" },
+      ],
+    }).promise;
+
+    expect(fakes.ssm.puts).toHaveLength(1);
+    expect(JSON.parse(fakes.ssm.puts[0].Value).ids).toEqual([]);
+    expect(fakes.slack.fetchImpl).not.toHaveBeenCalled();
+    expect(result.posted).toBe(false);
+    expect(result.messageTs).toBeUndefined();
+  });
+
+  it("TC-SLACKAPP-110 stamps the message timestamp onto the record without failing the offer", async () => {
+    // The apply task has to `chat.update` the message it was approved from, and
+    // the only durable place that `ts` can reach it is the approval record. The
+    // stamp is a SECOND write on purpose — the first has to precede the post, and
+    // `ts` does not exist until the post returns.
+    const fakes = offerFakes();
+    const result = await offer({ fakes }).promise;
+    expect(fakes.ssm.puts).toHaveLength(2);
+    const stamped = JSON.parse(fakes.ssm.puts[1].Value);
+    expect(stamped.messageTs).toBe("1754400000.000100");
+    expect(stamped.messageChannel).toBe(CHANNEL);
+    expect(stamped.hash).toBe(result.record.hash);
+    expect(stamped.ids).toEqual(["m-1", "m-2"]);
+
+    // A stamp failure does not undo a posted message or an offered list, so it is
+    // reported and the offer stands: losing the audit-trail update is strictly
+    // better than refusing an approval the operator can act on.
+    const flaky = offerFakes();
+    let put = 0;
+    flaky.ssm.send = vi.fn(async (command) => {
+      put += 1;
+      if (put === 2) throw new Error("ThrottlingException");
+      flaky.ssm.puts.push(command.input);
+      return {};
+    });
+    const log = vi.fn();
+    const survived = await offer({ fakes: flaky, log }).promise;
+    expect(survived.posted).toBe(true);
+    expect(log.mock.calls.flat().join("\n")).toMatch(/stamp|timestamp/iu);
+  });
+
+  it("TC-SLACKAPP-111 reports what policy withheld, so a shrinking approve set is visible", async () => {
+    // A RETAIN is a deletion the protected-topic rule refused and an UNSTABLE is
+    // one the passes disagreed on. Neither is offered — but a message that showed
+    // only the approve set would make a rule that started matching everything
+    // look like a clean corpus.
+    const { promise, slack } = offer({
+      decisions: [
+        del("m-1"),
+        { id: "m-protected", verdict: "RETAIN", reason: "stale", retainedReason: "protected topic personal-finance" },
+        { id: "m-unstable", verdict: "UNSTABLE", reason: "passes disagreed on deletion" },
+        { id: "m-keep", verdict: "KEEP", reason: "durable" },
+      ],
+    });
+    await promise;
+    const rendered = JSON.stringify(slack.calls[0].body.blocks);
+    expect(rendered).toMatch(/RETAIN[^0-9]*1/u);
+    expect(rendered).toMatch(/UNSTABLE[^0-9]*1/u);
+  });
+
+  it("TC-SLACKAPP-112 offers from a dry run and never from an apply", async () => {
+    // An apply that re-offered would overwrite the very record its own claim was
+    // derived from, so a redelivered click mid-apply would compare against a list
+    // the running task never saw.
+    const server = fakeServer([memory("del-1", "session noise")]);
+    const llm = fakeLlm([[{ id: "del-1", verdict: "DELETE", reason: "session-state" }]]);
+    const postApproval = vi.fn(async () => ({ posted: true, record: { hash: "sha256:x", ids: ["del-1"] } }));
+
+    const dry = await runCleanup(baseOpts(), {
+      ...baseDeps(server, llm, tempDir()),
+      postApproval,
+    });
+    expect(dry.exitCode).toBe(0);
+    expect(postApproval).toHaveBeenCalledTimes(1);
+    const [{ decisions, generatedAt }] = postApproval.mock.calls[0];
+    expect(decisions.map((d) => d.id)).toEqual(["del-1"]);
+    expect(generatedAt).toBe("2026-07-31T00:00:00.000Z");
+
+    postApproval.mockClear();
+    const applyServer = fakeServer([memory("del-1", "session noise")]);
+    const applied = await runCleanup(baseOpts({ apply: true }), {
+      ...baseDeps(applyServer, fakeLlm([[{ id: "del-1", verdict: "DELETE", reason: "session-state" }]]), tempDir()),
+      postApproval,
+    });
+    expect(applied.exitCode).toBe(0);
+    expect(postApproval).not.toHaveBeenCalled();
+  });
+
+  it("TC-SLACKAPP-113 fails the run when the offer fails, naming the decision list it kept", async () => {
+    // A scheduled review run whose post failed has done its audit and offered
+    // nothing. Exit 0 would make that indistinguishable from a healthy week, and
+    // the operator would notice only by the absence of a Slack message they were
+    // not expecting on any particular day.
+    const server = fakeServer([memory("del-1", "session noise")]);
+    const llm = fakeLlm([[{ id: "del-1", verdict: "DELETE", reason: "session-state" }]]);
+    const deps = {
+      ...baseDeps(server, llm, tempDir()),
+      postApproval: vi.fn(async () => {
+        throw new Error("channel_not_found");
+      }),
+    };
+    const result = await runCleanup(baseOpts(), deps);
+    expect(result.exitCode).toBe(1);
+    // The decision list survives the failed offer: it is the artefact the
+    // operator falls back to for a manual `--apply --ids`.
+    expect(result.decisionPath).toBeTruthy();
+    expect(existsSync(result.decisionPath)).toBe(true);
+    const logged = deps.log.mock.calls.flat().join("\n");
+    expect(logged).toMatch(/channel_not_found/u);
+    expect(logged).toContain(result.decisionPath);
+  });
+
+  it("TC-SLACKAPP-119 re-offers a replayed decision file under the FILE's stamp, not the moment it was reposted", async () => {
+    // A `--decisions <file>` dry run with Slack configured re-offers that list —
+    // the path an operator takes to repost a review after a failed offer. The
+    // record's `generatedAt` is what dates the list, so stamping it `now` would
+    // claim a fresh audit for a classification that may be days old, and the
+    // operator's only cue that they are approving stale judgments would be gone.
+    const dir = tempDir();
+    const decisionsFile = join(dir, "decisions.json");
+    writeFileSync(
+      decisionsFile,
+      JSON.stringify({
+        stage: "test",
+        generatedAt: "2026-07-24T00:00:00.000Z",
+        decisions: [
+          {
+            id: "del-1",
+            verdict: "DELETE",
+            reason: "session-state",
+            version: 1,
+            contentHash: contentHash("session noise"),
+          },
+        ],
+      }),
+    );
+    const server = fakeServer([memory("del-1", "session noise")]);
+    const postApproval = vi.fn(async () => ({ posted: true, record: { hash: "sha256:x", ids: ["del-1"] } }));
+
+    const result = await runCleanup(baseOpts({ decisionsFile }), {
+      ...baseDeps(server, fakeLlm([]), dir),
+      postApproval,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(postApproval.mock.calls[0][0].generatedAt).toBe("2026-07-24T00:00:00.000Z");
+  });
+});
+
+
+describe("wiring the offer into the review run (#123)", () => {
+  const environmentKeys = [
+    "AWS_REGION",
+    "MEM9_DB_HOST",
+    "MEM9_DB_NAME",
+    "MEM9_DB_PORT",
+    "MEM9_DB_SECRET",
+    "MEM9_SLACK_APPROVAL_CHANNEL",
+    "MEM9_SSM_PREFIX",
+    "MEM9_TENANT_ID",
+    "SLACK_BOT_TOKEN",
+  ];
+  afterEach(() => {
+    for (const key of environmentKeys) delete process.env[key];
+  });
+
+  function reviewEnv(extra = {}) {
+    Object.assign(process.env, {
+      AWS_REGION: "ap-northeast-1",
+      MEM9_SSM_PREFIX: "/mem9-on-aws/prod",
+      MEM9_TENANT_ID: TENANT,
+      ...extra,
+    });
+  }
+
+  function ssmFake(values = {}) {
+    const client = {
+      sent: [],
+      send: vi.fn(async (command) => {
+        client.sent.push(command.input);
+        if (command.input.Names) {
+          return {
+            Parameters: command.input.Names.filter((n) => n in values).map((name) => ({
+              Name: name,
+              Value: values[name],
+            })),
+            InvalidParameters: command.input.Names.filter((n) => !(n in values)),
+          };
+        }
+        return {};
+      }),
+      destroy: () => {},
+    };
+    return client;
+  }
+
+  it("TC-SLACKAPP-114 builds no offer dep when Slack is not configured, so the #102 CLI is unchanged", async () => {
+    // The operator CLI at #102 has no Slack anything. An offer dep that existed
+    // unconditionally would make every hand-run dry run try to write an approval
+    // record the operator's identity may not be able to write — and would post a
+    // clickable Approve button for a list they ran locally to look at.
+    reviewEnv();
+    const production = await createCleanupDeps(
+      { stage: "prod", apply: false, cap: 50 },
+      { ssm: ssmFake(), getToken: vi.fn(), fromNodeProviderChain: vi.fn() },
+    );
+    expect(production.deps.postApproval).toBeUndefined();
+    await production.close();
+  });
+
+  it("TC-SLACKAPP-115 reads the bot token from the stage tree DECRYPTED when the channel is configured", async () => {
+    reviewEnv({ MEM9_SLACK_APPROVAL_CHANNEL: "C0APPROVAL" });
+    const ssm = ssmFake({ "/mem9-on-aws/prod/slack/bot-token": "xoxb-from-ssm" });
+    const production = await createCleanupDeps(
+      { stage: "prod", apply: false, cap: 50 },
+      { ssm, getToken: vi.fn(), fromNodeProviderChain: vi.fn() },
+    );
+    expect(typeof production.deps.postApproval).toBe("function");
+    const read = ssm.sent.find((input) => input.Names);
+    expect(read.Names).toEqual(["/mem9-on-aws/prod/slack/bot-token"]);
+    // The parameter is a SecureString, so without this the value comes back as
+    // ciphertext and every post 401s with `invalid_auth`.
+    expect(read.WithDecryption).toBe(true);
+    await production.close();
+  });
+
+  it("TC-SLACKAPP-116 prefers an injected token over the stage tree, reading no parameter at all", async () => {
+    // The apply task gets `SLACK_BOT_TOKEN` from ECS `ssm:`, and its task role
+    // holds `ssm:GetParameters` under `approvals/*` ONLY — a read of
+    // `slack/bot-token` is an AccessDenied there. Env-first is what lets one
+    // function serve both identities, exactly as `resolveDatabaseConfig` does.
+    reviewEnv({ MEM9_SLACK_APPROVAL_CHANNEL: "C0APPROVAL", SLACK_BOT_TOKEN: "xoxb-injected" });
+    const ssm = ssmFake();
+    const production = await createCleanupDeps(
+      { stage: "prod", apply: false, cap: 50 },
+      { ssm, getToken: vi.fn(), fromNodeProviderChain: vi.fn() },
+    );
+    expect(typeof production.deps.postApproval).toBe("function");
+    expect(ssm.sent.filter((input) => input.Names)).toEqual([]);
+    await production.close();
+  });
+
+  it("TC-SLACKAPP-117 refuses a configured channel it has no token for, rather than offering nothing", async () => {
+    // Silently skipping the post is the TC-SLACKAPP-113 failure with the alarm
+    // removed: the run does its whole audit, offers nothing, and exits 0 — and the
+    // operator finds out by never receiving a message they were not expecting on
+    // any particular day.
+    reviewEnv({ MEM9_SLACK_APPROVAL_CHANNEL: "C0APPROVAL" });
+    await expect(
+      createCleanupDeps(
+        { stage: "prod", apply: false, cap: 50 },
+        { ssm: ssmFake(), getToken: vi.fn(), fromNodeProviderChain: vi.fn() },
+      ),
+    ).rejects.toThrow(/bot-token|bot token/u);
+  });
+
+  it("TC-SLACKAPP-118 passes the stage, prefix and channel through to a real offer", async () => {
+    reviewEnv({ MEM9_SLACK_APPROVAL_CHANNEL: "C0APPROVAL", SLACK_BOT_TOKEN: "xoxb-injected" });
+    const ssm = ssmFake();
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ ok: true, channel: "C0APPROVAL", ts: "1754400000.000200" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    const production = await createCleanupDeps(
+      { stage: "prod", apply: false, cap: 50 },
+      { ssm, getToken: vi.fn(), fromNodeProviderChain: vi.fn(), fetchImpl },
+    );
+
+    const offer = await production.deps.postApproval({
+      decisions: [
+        {
+          id: "m-1",
+          verdict: "DELETE",
+          reason: "session-state",
+          version: 1,
+          contentHash: contentHash("c-m-1"),
+          snippet: "a session detail",
+        },
+      ],
+      generatedAt: "2026-08-05T03:00:00.000Z",
+    });
+
+    expect(offer.posted).toBe(true);
+    const put = ssm.sent.find((input) => input.Name);
+    // Built from the injected prefix, not a constant: a preview run writing prod's
+    // record would hand prod's callback a list preview generated.
+    expect(put.Name).toBe("/mem9-on-aws/prod/approvals/offered");
+    expect(JSON.parse(put.Value).stage).toBe("prod");
+    expect(JSON.parse(fetchImpl.mock.calls[0][1].body).channel).toBe("C0APPROVAL");
+    await production.close();
+  });
+});
+
+describe("closing the loop on the message (#123)", () => {
+  const BOT_TOKEN = "xoxb-fixture-not-a-real-token";
+  const CHANNEL = "C0APPROVAL";
+  const TS = "1754400000.000100";
+  const HASH = "sha256:whatever-the-claim-said";
+
+  function updateFakes(body = { ok: true, channel: CHANNEL, ts: TS }) {
+    const calls = [];
+    const fetchImpl = vi.fn(async (url, options = {}) => {
+      calls.push({
+        url: String(url),
+        headers: options.headers,
+        redirect: options.redirect,
+        body: JSON.parse(options.body),
+      });
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    return { calls, fetchImpl };
+  }
+
+  it("TC-SLACKAPP-120 the outcome update reports what was DELETED, not what was approved", async () => {
+    // The single number an operator reads off this message is the one that must
+    // not be optimistic. An apply that approved 3 and deleted 1 (two lost to the
+    // LWW guard) has to say 1 deleted and 2 skipped — reporting the approved
+    // count would tell them the memories are gone when they are still there, and
+    // this message IS the audit trail, so nothing else would ever correct it.
+    const fakes = updateFakes();
+    const message = buildOutcomeMessage({
+      channel: CHANNEL,
+      messageTs: TS,
+      hash: HASH,
+      stage: "prod",
+      approved: 3,
+      result: { capUsed: 1, skippedLww: 2, skippedByFilter: 0, exitCode: 0 },
+      appliedAt: "2026-08-05T04:00:00.000Z",
+    });
+    const flat = JSON.stringify(message);
+    expect(message.channel).toBe(CHANNEL);
+    expect(message.ts).toBe(TS);
+    // The ACHIEVED count first, the approved count second. Asserted as an
+    // ordering rather than against a phrase so it does not pin the wording: the
+    // defect this exists to catch is reporting 3 where 1 is true, and "3 of 3"
+    // fails the first of these while a swapped "3 of 1" fails the second.
+    expect(message.text).toMatch(/\b1\b[^0-9]*\b3\b/u);
+    expect(message.text).not.toMatch(/\b3\b[^0-9]*\b1\b/u);
+    expect(flat).toMatch(/2\b[^"]*(skip|unchanged|changed)/iu);
+    // The buttons are GONE. A live Approve button under an applied outcome is an
+    // invitation to click a hash whose claim already exists, which the callback
+    // answers with "someone else is already applying" — a confusing dead end
+    // rather than the record of what happened.
+    expect(flat).not.toContain("cleanup_approve");
+    expect(flat).not.toContain("cleanup_reject");
+    expect(message.blocks.some((b) => b.type === "actions")).toBe(false);
+    // `text` is not required alongside `blocks` but IS what a notification and a
+    // screen reader read, and the outcome is the part worth notifying.
+    expect(message.text).toMatch(/1\b/u);
+    void fakes;
+  });
+
+  it("TC-SLACKAPP-121 a partial or capped apply says so on the message rather than reading as clean", async () => {
+    // exitCode 4 (cap exceeded) and 6 (partial) are the two ways an apply stops
+    // early with real deletions already done. A message that showed only the
+    // count would read identically to a complete run, and the operator's next
+    // move differs: a capped run has approved ids that were never touched and
+    // needs a re-offer, a clean one does not.
+    const capped = buildOutcomeMessage({
+      channel: CHANNEL,
+      messageTs: TS,
+      hash: HASH,
+      stage: "prod",
+      approved: 60,
+      result: { capUsed: 50, skippedLww: 0, skippedByFilter: 0, exitCode: 4 },
+      appliedAt: "2026-08-05T04:00:00.000Z",
+    });
+    expect(JSON.stringify(capped)).toMatch(/cap/iu);
+
+    const clean = buildOutcomeMessage({
+      channel: CHANNEL,
+      messageTs: TS,
+      hash: HASH,
+      stage: "prod",
+      approved: 2,
+      result: { capUsed: 2, skippedLww: 0, skippedByFilter: 0, exitCode: 0 },
+      appliedAt: "2026-08-05T04:00:00.000Z",
+    });
+    expect(JSON.stringify(clean)).not.toMatch(/cap exceeded|incomplete|partial/iu);
+    // Distinguishable from each other, which is the actual requirement — two
+    // outcomes that serialize the same would make the assertion above vacuous.
+    expect(JSON.stringify(capped)).not.toBe(JSON.stringify(clean));
+  });
+
+  it("TC-SLACKAPP-122 the outcome message names no memory id and no content", async () => {
+    // The review message legitimately carries ids and snippets: it is what the
+    // operator reviews. The outcome does not need them, and this message is
+    // posted by the APPLY task, whose log already goes to CloudWatch — adding
+    // them here widens where memory identifiers live for no operator benefit.
+    const message = buildOutcomeMessage({
+      channel: CHANNEL,
+      messageTs: TS,
+      hash: HASH,
+      stage: "prod",
+      approved: 1,
+      result: { capUsed: 1, skippedLww: 0, skippedByFilter: 0, exitCode: 0 },
+      appliedAt: "2026-08-05T04:00:00.000Z",
+      ids: ["SENTINEL-MEMORY-ID"],
+    });
+    expect(JSON.stringify(message)).not.toContain("SENTINEL-MEMORY-ID");
+  });
+
+  it("TC-SLACKAPP-123 the update targets the claim's coordinates and is skipped when they are absent", async () => {
+    const fakes = updateFakes();
+    const posted = await updateApprovalMessage({
+      claim: { messageChannel: CHANNEL, messageTs: TS, hash: HASH, stage: "prod" },
+      approved: 1,
+      stage: "prod",
+      result: { capUsed: 1, skippedLww: 0, skippedByFilter: 0, exitCode: 0 },
+      appliedAt: "2026-08-05T04:00:00.000Z",
+      botToken: BOT_TOKEN,
+      fetchImpl: fakes.fetchImpl,
+    });
+    expect(posted).toBe(true);
+    expect(fakes.calls).toHaveLength(1);
+    expect(fakes.calls[0].url).toBe("https://slack.com/api/chat.update");
+    expect(fakes.calls[0].headers.Authorization).toBe(`Bearer ${BOT_TOKEN}`);
+    // Both required arguments, from the CLAIM. `chat.update` needs channel AND
+    // ts; either missing is `channel_not_found` or `message_not_found`.
+    expect(fakes.calls[0].body.channel).toBe(CHANNEL);
+    expect(fakes.calls[0].body.ts).toBe(TS);
+
+    // A claim with no coordinates (a review run whose stamp write failed, or a
+    // pre-#123 record) calls NOTHING rather than calling with undefined. The
+    // deletions still happened, so this is not an error — but it must not be
+    // silent either, or a systematically unstamped record would look like a
+    // working loop forever.
+    // HALF a pair is included, and is the sharper case: `chat.update` needs both,
+    // so one coordinate is not a usable coordinate — a guard that required both to
+    // be missing would call Slack with `ts: undefined` and earn a
+    // `channel_not_found` that reads like a misconfigured channel. The Lambda's
+    // `loadOffered` already refuses to carry half a pair into the claim, so this is
+    // the second of two independent guards, in the process that would have to
+    // report the confusing error.
+    for (const claim of [
+      { hash: HASH, stage: "prod" },
+      { hash: HASH, stage: "prod", messageTs: TS },
+      { hash: HASH, stage: "prod", messageChannel: CHANNEL },
+    ]) {
+      const none = updateFakes();
+      const log = vi.fn();
+      const skipped = await updateApprovalMessage({
+        claim,
+        approved: 1,
+        stage: "prod",
+        result: { capUsed: 1, skippedLww: 0, skippedByFilter: 0, exitCode: 0 },
+        appliedAt: "2026-08-05T04:00:00.000Z",
+        botToken: BOT_TOKEN,
+        fetchImpl: none.fetchImpl,
+        log,
+      });
+      expect(skipped, JSON.stringify(claim)).toBe(false);
+      expect(none.fetchImpl, JSON.stringify(claim)).not.toHaveBeenCalled();
+      expect(log.mock.calls.map(String).join("\n")).toMatch(/coordinate|messageTs|not update/iu);
+    }
+  });
+
+  it("TC-SLACKAPP-124 a refused update never turns a completed apply into a failure", async () => {
+    // The deletions are DONE and irreversible by the time this runs. An
+    // `edit_window_closed` or a revoked token must not make the task exit
+    // non-zero: that would alarm on a successful apply, and — worse under the
+    // callback's recovery path — a retried task would re-apply ids already gone.
+    // It must be LOUD in the log and harmless to the exit code.
+    const fakes = updateFakes({ ok: false, error: "edit_window_closed" });
+    const log = vi.fn();
+    const posted = await updateApprovalMessage({
+      claim: { messageChannel: CHANNEL, messageTs: TS, hash: HASH, stage: "prod" },
+      approved: 1,
+      stage: "prod",
+      result: { capUsed: 1, skippedLww: 0, skippedByFilter: 0, exitCode: 0 },
+      appliedAt: "2026-08-05T04:00:00.000Z",
+      botToken: BOT_TOKEN,
+      fetchImpl: fakes.fetchImpl,
+      log,
+    });
+    expect(posted).toBe(false);
+    const logged = log.mock.calls.map(String).join("\n");
+    expect(logged).toMatch(/edit_window_closed/u);
+    expect(logged).toMatch(/deletion|applied|already/iu);
+  });
+});
+
+describe("wiring the outcome update into the apply run (#123)", () => {
+  /** SSM/Secrets double keyed by parameter name (the sibling describe's shape). */
+  function fakeAwsClient(values = {}) {
+    const client = {
+      sent: [],
+      send: vi.fn(async (command) => {
+        client.sent.push(command.input);
+        if (command.input.Names) {
+          const names = command.input.Names;
+          return {
+            Parameters: names
+              .filter((name) => name in values)
+              .map((name) => ({ Name: name, Value: values[name] })),
+            InvalidParameters: names.filter((name) => !(name in values)),
+          };
+        }
+        return { SecretString: values[command.input.SecretId] };
+      }),
+      destroy: () => {},
+    };
+    return client;
+  }
+
+  const environmentKeys = [
+    "AWS_REGION",
+    "MEM9_APPROVAL_HASH",
+    "MEM9_DB_HOST",
+    "MEM9_DB_NAME",
+    "MEM9_DB_PORT",
+    "MEM9_DB_SECRET",
+    "MEM9_SLACK_APPROVAL_CHANNEL",
+    "MEM9_SSM_PREFIX",
+    "MEM9_TENANT_ID",
+    "SLACK_BOT_TOKEN",
+  ];
+  afterEach(() => {
+    for (const key of environmentKeys) delete process.env[key];
+  });
+
+  it("TC-SLACKAPP-125 the apply run reports its outcome once, with the numbers it actually achieved", async () => {
+    // Three approved, one edited between the scan and the re-read. The apply
+    // deletes two and skips one, and the message has to say two — the count the
+    // operator would otherwise take on faith.
+    const dir = tempDir();
+    const idsFile = join(dir, "approved.txt");
+    writeFileSync(idsFile, "d1\nd2\nd3\n");
+    const server = fakeServer([memory("d1", "a"), memory("d2", "b"), memory("d3", "c")]);
+    const llm = fakeLlm([
+      [
+        { id: "d1", verdict: "DELETE", reason: "stale" },
+        { id: "d2", verdict: "DELETE", reason: "stale" },
+        { id: "d3", verdict: "DELETE", reason: "stale" },
+      ],
+    ]);
+    const deps = baseDeps(server, llm, dir);
+    const realFetch = server.fetchImpl;
+    let mutated = false;
+    deps.fetchImpl = vi.fn(async (url, opts = {}) => {
+      if (!mutated && /memories\/[^/?]+$/.test(String(url))) {
+        mutated = true;
+        const d = server.store.get("d1");
+        d.content = "edited concurrently";
+        d.version += 1;
+      }
+      return realFetch(url, opts);
+    });
+    const reportOutcome = vi.fn(async () => true);
+    const result = await runCleanup(
+      baseOpts({ apply: true, idsFile }),
+      { ...deps, reportOutcome },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.capUsed).toBe(2);
+    expect(result.skippedLww).toBe(1);
+    // Once — not per decision and not per flush. A message updated three times
+    // would show intermediate counts as if they were outcomes.
+    expect(reportOutcome).toHaveBeenCalledTimes(1);
+    const reported = reportOutcome.mock.calls[0][0];
+    expect(reported.result.capUsed).toBe(2);
+    expect(reported.result.skippedLww).toBe(1);
+    expect(reported.result.exitCode).toBe(0);
+    // The stamp is the run's clock, not `Date.now()`: a container whose report is
+    // dated by wall time while everything else uses the injected clock makes two
+    // timestamps on one run disagree.
+    expect(reported.appliedAt).toBe("2026-07-31T00:00:00.000Z");
+  });
+
+  it("TC-SLACKAPP-126 a dry run and an unreported apply both leave the message alone", async () => {
+    // The review run posts; it must not also UPDATE, and the #102 operator CLI has
+    // no Slack at all — an apply with no dep must run to completion rather than
+    // throwing on a missing function.
+    const dir = tempDir();
+    const server = fakeServer([memory("d1", "a")]);
+    const llm = fakeLlm([[{ id: "d1", verdict: "DELETE", reason: "stale" }]]);
+    const reportOutcome = vi.fn(async () => true);
+    const dry = await runCleanup(baseOpts({ apply: false }), {
+      ...baseDeps(server, llm, dir),
+      reportOutcome,
+    });
+    expect(dry.exitCode).toBe(0);
+    expect(reportOutcome).not.toHaveBeenCalled();
+
+    const dir2 = tempDir();
+    const server2 = fakeServer([memory("d1", "a")]);
+    const llm2 = fakeLlm([[{ id: "d1", verdict: "DELETE", reason: "stale" }]]);
+    const plain = await runCleanup(
+      baseOpts({ apply: true }),
+      baseDeps(server2, llm2, dir2),
+    );
+    expect(plain.exitCode).toBe(0);
+    expect(server2.store.get("d1").state).toBe("deleted");
+  });
+
+  it("TC-SLACKAPP-127 a failed report does not change the exit code of a completed apply", async () => {
+    // The deletions are done and irreversible. A non-zero exit here would alarm on
+    // a successful apply, and the callback's stale-claim recovery would let a
+    // retried task re-apply ids that are already gone.
+    const dir = tempDir();
+    const server = fakeServer([memory("d1", "a")]);
+    const llm = fakeLlm([[{ id: "d1", verdict: "DELETE", reason: "stale" }]]);
+    const log = vi.fn();
+    const result = await runCleanup(baseOpts({ apply: true }), {
+      ...baseDeps(server, llm, dir),
+      log,
+      reportOutcome: vi.fn(async () => {
+        throw new Error("SENTINEL-REPORT-EXPLODED");
+      }),
+    });
+    expect(result.exitCode).toBe(0);
+    expect(server.store.get("d1").state).toBe("deleted");
+    // Loud, though: a systematically broken report must not be invisible.
+    expect(log.mock.calls.map(String).join("\n")).toMatch(/SENTINEL-REPORT-EXPLODED/u);
+  });
+
+  it("TC-SLACKAPP-128 the claim's coordinates reach the report dep the container builds", async () => {
+    // End of the chain the offer started: offered record → claim → materialize →
+    // this dep → `chat.update`. Every other link is tested; this one carries the
+    // coordinates out of the read that was already happening, which is the link
+    // most likely to be forgotten because nothing else needs them.
+    const ids = ["m-1", "m-2"];
+    const hash = contentHash(ids.join("\n"));
+    const dir = tempDir();
+    const idsFile = join(dir, "approved.txt");
+    Object.assign(process.env, {
+      AWS_REGION: "ap-northeast-1",
+      MEM9_DB_HOST: "writer.example.com",
+      MEM9_DB_NAME: "mem9",
+      MEM9_DB_PORT: "5432",
+      MEM9_DB_SECRET: JSON.stringify({ username: "mem9", password: "fixture-password" }),
+      MEM9_SSM_PREFIX: "/mem9-on-aws/prod",
+      MEM9_TENANT_ID: TENANT,
+      MEM9_APPROVAL_HASH: hash,
+      // The apply task's role holds ssm:GetParameters under approvals/* ONLY, so
+      // the token arrives through the task definition's `ssm:` block, already
+      // decrypted. A GetParameters read of slack/bot-token here is AccessDenied.
+      SLACK_BOT_TOKEN: "xoxb-fixture-not-a-real-token",
+    });
+    const ssm = {
+      send: vi.fn(async (command) => ({
+        Parameters: (command.input.Names ?? [])
+          .filter((n) => n.endsWith(`approvals/approved-${hash}`))
+          .map((name) => ({
+            Name: name,
+            Value: JSON.stringify({
+              stage: "prod",
+              hash,
+              ids,
+              claimedAt: "2026-08-05T00:05:00.000Z",
+              messageTs: "1754400000.000100",
+              messageChannel: "C0APPROVAL",
+            }),
+          })),
+        InvalidParameters: [],
+      })),
+      destroy: () => {},
+    };
+    const slackCalls = [];
+    const fetchImpl = vi.fn(async (url, options = {}) => {
+      slackCalls.push({ url: String(url), body: JSON.parse(options.body) });
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const production = await createCleanupDeps(
+      { stage: "prod", apply: true, cap: 50, idsFile },
+      {
+        Client: class {
+          async connect() {}
+          async query() {
+            return { rows: [{ locked: true }] };
+          }
+          async end() {}
+        },
+        ssm,
+        secrets: fakeAwsClient(),
+        getToken: vi.fn(),
+        fromNodeProviderChain: vi.fn(),
+        fetchImpl,
+      },
+    );
+
+    expect(production.deps.reportOutcome).toBeTypeOf("function");
+    await production.deps.reportOutcome({
+      result: { capUsed: 2, skippedLww: 0, skippedByFilter: 0, exitCode: 0 },
+      appliedAt: "2026-08-05T04:00:00.000Z",
+    });
+    expect(slackCalls).toHaveLength(1);
+    expect(slackCalls[0].url).toBe("https://slack.com/api/chat.update");
+    expect(slackCalls[0].body.ts).toBe("1754400000.000100");
+    expect(slackCalls[0].body.channel).toBe("C0APPROVAL");
+    // No ids ANYWHERE on the way through, not just on the message. The claim the
+    // container carries is the object this dep closes over, so an id list added to
+    // `materializeApprovedIds`'s return would reach the message body the moment
+    // anything spread the claim into it — asserted on both so the omission is a
+    // property of the data, not of one call site's field list.
+    expect(JSON.stringify(slackCalls[0].body)).not.toContain("m-1");
+    expect(slackCalls[0].body.text).toMatch(/2\b[^0-9]*2\b/u);
+    // The hash identifies WHICH approval was applied, and it is the only handle an
+    // operator has for correlating this message with the task log and the claim
+    // parameter. A message without it says a cleanup happened but not which one.
+    expect(JSON.stringify(slackCalls[0].body)).toContain(hash);
+    await production.close();
+  });
+
+  it("TC-SLACKAPP-129 a review run builds no report dep, and a hash-driven run with no token still applies", async () => {
+    // Two independent absences, both of which must degrade rather than fail: a
+    // review run has no claim to update against, and a token misconfiguration must
+    // not stop deletions the operator already approved — it must cost the audit
+    // update and say so.
+    Object.assign(process.env, {
+      AWS_REGION: "ap-northeast-1",
+      MEM9_SSM_PREFIX: "/mem9-on-aws/prod",
+      MEM9_TENANT_ID: TENANT,
+    });
+    const review = await createCleanupDeps(
+      { stage: "prod", apply: false, cap: 50 },
+      { ssm: fakeAwsClient(), getToken: vi.fn(), fromNodeProviderChain: vi.fn() },
+    );
+    expect(review.deps.reportOutcome).toBeUndefined();
+    await review.close();
+
+    const ids = ["m-1"];
+    const hash = contentHash(ids.join("\n"));
+    const dir = tempDir();
+    const idsFile = join(dir, "approved.txt");
+    Object.assign(process.env, {
+      MEM9_DB_HOST: "writer.example.com",
+      MEM9_DB_NAME: "mem9",
+      MEM9_DB_PORT: "5432",
+      MEM9_DB_SECRET: JSON.stringify({ username: "mem9", password: "fixture-password" }),
+      MEM9_APPROVAL_HASH: hash,
+    });
+    delete process.env.SLACK_BOT_TOKEN;
+    const ssm = fakeAwsClient({
+      [`/mem9-on-aws/prod/approvals/approved-${hash}`]: JSON.stringify({
+        stage: "prod",
+        hash,
+        ids,
+        claimedAt: "2026-08-05T00:05:00.000Z",
+        messageTs: "1754400000.000100",
+        messageChannel: "C0APPROVAL",
+      }),
+    });
+    const production = await createCleanupDeps(
+      { stage: "prod", apply: true, cap: 50, idsFile },
+      {
+        Client: class {
+          async connect() {}
+          async query() {
+            return { rows: [{ locked: true }] };
+          }
+          async end() {}
+        },
+        ssm,
+        secrets: fakeAwsClient(),
+        getToken: vi.fn(),
+        fromNodeProviderChain: vi.fn(),
+      },
+    );
+    // The ids were still materialized — the apply is unaffected.
+    expect(readFileSync(idsFile, "utf8")).toBe("m-1\n");
+    expect(production.deps.reportOutcome).toBeUndefined();
+    await production.close();
   });
 });

--- a/scripts/memory-cleanup.test.mjs
+++ b/scripts/memory-cleanup.test.mjs
@@ -13,14 +13,17 @@ import {
   contentHash,
   inactiveMemoryAdapter,
   parseArgs,
+  consensusDecisions,
   parseVerdicts,
   planDecisions,
   runCleanup,
   runListInactive,
   runRestore,
   snippetLogDir,
+  verdictSummary,
   ARG_SPECS,
   DURABLE_ONLY_RULES,
+  TOPICS,
   USAGE,
 } from "./memory-cleanup.mjs";
 
@@ -117,15 +120,28 @@ function fakeServer(initial) {
   return { store, calls, fetchImpl };
 }
 
-/** LLM fake: verdictsByBatch is an array of responses (JSON string or object) per call. */
+/**
+ * LLM fake: verdictsByBatch is an array of responses (JSON string or object) per
+ * call.
+ *
+ * Object-form verdicts get `topic: "engineering"` when the key is ABSENT, so the
+ * fake models a classifier that honours the #123 contract and the pre-existing
+ * cases stay about what they were written to test. Present-but-wrong is passed
+ * through untouched (`topic: null`, `topic: "bogus"`), which is how a case
+ * expresses a non-compliant response in object form; a raw JSON string is passed
+ * through verbatim either way.
+ */
 function fakeLlm(verdictsByBatch) {
   let call = 0;
   return vi.fn(async () => {
     const v = verdictsByBatch[Math.min(call, verdictsByBatch.length - 1)];
     call += 1;
-    return typeof v === "string" ? v : JSON.stringify({ verdicts: v });
+    if (typeof v === "string") return v;
+    return JSON.stringify({ verdicts: v.map(withTopic) });
   });
 }
+
+const withTopic = (v) => ("topic" in v ? v : { ...v, topic: "engineering" });
 
 function baseDeps(server, llm, dir) {
   return {
@@ -149,7 +165,12 @@ function baseOpts(overrides = {}) {
   };
 }
 
-const keepAll = (memories) => memories.map((m) => ({ id: m.id, verdict: "KEEP", reason: "durable" }));
+// `topic` is required on every verdict (#123 / TC-SLACKAPP-051), so the fakes
+// emit it exactly as the real classifier now must. "engineering" is the neutral
+// default here: it is NOT protected, so a case that means to exercise the
+// protected-topic rule has to say so explicitly rather than inherit it.
+const keepAll = (memories) =>
+  memories.map((m) => ({ id: m.id, verdict: "KEEP", reason: "durable", topic: "engineering" }));
 
 describe("scan & pagination", () => {
   it("TC-MEMCLEAN-001 pages through windows and sees every memory once", async () => {
@@ -447,7 +468,9 @@ describe("apply, cap, --ids", () => {
     const server = fakeServer(mems);
     const llm = fakeLlm([]);
     llm.mockImplementation(async (_p, batch) =>
-      JSON.stringify({ verdicts: batch.map((m) => ({ id: m.id, verdict: "DELETE", reason: "noise" })) }),
+      JSON.stringify({
+        verdicts: batch.map((m) => ({ id: m.id, verdict: "DELETE", reason: "noise", topic: "engineering" })),
+      }),
     );
     const result = await runCleanup(
       baseOpts({ apply: true, cap: 2000 }),
@@ -878,12 +901,68 @@ describe("discovery", () => {
 
 describe("verdict parsing units", () => {
   it("parseVerdicts accepts valid shapes and rejects garbage", () => {
-    expect(parseVerdicts('{"verdicts":[{"id":"a","verdict":"KEEP","reason":"r"}]}')).toEqual([
-      { id: "a", verdict: "KEEP", reason: "r" },
+    expect(parseVerdicts('{"verdicts":[{"id":"a","verdict":"KEEP","reason":"r","topic":"engineering"}]}')).toEqual([
+      { id: "a", verdict: "KEEP", reason: "r", topic: "engineering" },
     ]);
     expect(() => parseVerdicts("nope")).toThrow();
     expect(() => parseVerdicts('{"verdicts":"x"}')).toThrow();
     expect(() => parseVerdicts('{"verdicts":[{"id":"a","verdict":"EXPLODE"}]}')).toThrow(/verdict/i);
+  });
+
+  it("TC-SLACKAPP-050 every known topic parses and survives onto the verdict", () => {
+    for (const topic of TOPICS) {
+      const [v] = parseVerdicts(
+        JSON.stringify({ verdicts: [{ id: "a", verdict: "KEEP", reason: "r", topic }] }),
+      );
+      expect(v.topic).toBe(topic);
+    }
+    // The set itself is pinned: silently adding a sixth topic would let the
+    // classifier route finance memories somewhere `protectedTopics` never looks.
+    expect([...TOPICS].sort()).toEqual([
+      "content",
+      "engineering",
+      "operations",
+      "other",
+      "personal-finance",
+    ]);
+  });
+
+  it("TC-SLACKAPP-051 a missing topic is malformed, never defaulted to `other`", () => {
+    expect(() =>
+      parseVerdicts('{"verdicts":[{"id":"a","verdict":"DELETE","reason":"r"}]}'),
+    ).toThrow(/topic/iu);
+    // Defaulting is the specific hazard: `other` is unprotected, so a batch
+    // whose model forgot the field would have every personal-finance memory in
+    // it silently eligible for deletion.
+    expect(() =>
+      parseVerdicts('{"verdicts":[{"id":"a","verdict":"KEEP","reason":"r"}]}'),
+    ).toThrow(/topic/iu);
+  });
+
+  it("TC-SLACKAPP-052 an unknown topic is malformed and the message never echoes it", () => {
+    const secretish = "personal-finance-但是我的密码是 hunter2";
+    let caught;
+    try {
+      parseVerdicts(
+        JSON.stringify({ verdicts: [{ id: "a", verdict: "KEEP", reason: "r", topic: secretish }] }),
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught?.name).toBe("MalformedResponse");
+    expect(caught.message).toMatch(/topic/iu);
+    // Fixed strings only — a response can carry memory content, and this error
+    // is logged.
+    expect(caught.message).not.toContain(secretish);
+    expect(caught.message).not.toContain("hunter2");
+  });
+
+  it("TC-SLACKAPP-053 a non-string topic is malformed, not a crash mid-plan", () => {
+    for (const topic of [["personal-finance"], { name: "other" }, 7, null, true]) {
+      expect(() =>
+        parseVerdicts(JSON.stringify({ verdicts: [{ id: "a", verdict: "KEEP", reason: "r", topic }] })),
+      ).toThrow(/topic/iu);
+    }
   });
 
   it("planDecisions never lets `absorbs` override an id's own verdict (TC-MEMCLEAN-014)", () => {
@@ -1169,7 +1248,8 @@ describe("LLM route", () => {
   });
 
   it("TC-MEMCLEAN-072: responses output_text parts reach parseVerdicts verbatim", async () => {
-    const verdicts = '{"verdicts":[{"id":"m1","verdict":"KEEP","reason":"durable"}]}';
+    const verdicts =
+      '{"verdicts":[{"id":"m1","verdict":"KEEP","reason":"durable","topic":"engineering"}]}';
     const { fetchImpl } = recorder([
       responsesReply({
         // Split across parts: the route must concatenate, not take the first.
@@ -1183,7 +1263,9 @@ describe("LLM route", () => {
 
     const raw = await completeChat("sys", [{ id: "m1" }]);
     expect(raw).toBe(verdicts);
-    expect(parseVerdicts(raw)).toEqual([{ id: "m1", verdict: "KEEP", reason: "durable" }]);
+    expect(parseVerdicts(raw)).toEqual([
+      { id: "m1", verdict: "KEEP", reason: "durable", topic: "engineering" },
+    ]);
   });
 
   it("TC-MEMCLEAN-073: a failed responses status throws instead of returning empty", async () => {
@@ -1356,10 +1438,10 @@ describe("LLM route", () => {
         const [s1, a1, a2, ...rest] = batch;
         return JSON.stringify({
           verdicts: [
-            { id: s1.id, verdict: "MERGE", reason: "frags", merge_into: s1.id,
+            { id: s1.id, verdict: "MERGE", reason: "frags", merge_into: s1.id, topic: "engineering",
               absorbs: [a1.id, a2.id], merged_content: "merged fact" },
-            { id: a1.id, verdict: "MERGE", reason: "frags", merge_into: s1.id },
-            { id: a2.id, verdict: "MERGE", reason: "frags", merge_into: s1.id },
+            { id: a1.id, verdict: "MERGE", reason: "frags", merge_into: s1.id, topic: "engineering" },
+            { id: a2.id, verdict: "MERGE", reason: "frags", merge_into: s1.id, topic: "engineering" },
             ...keepAll(rest),
           ],
         });
@@ -1388,6 +1470,57 @@ describe("LLM route", () => {
     );
     const applyLine = applyDeps.log.mock.calls.map((c) => c[0]).find((m) => m.startsWith("apply done:"));
     expect(applyLine).toMatch(/UNCLASSIFIED=20 of 60 memories \(from the replayed decision list\)/);
+  });
+
+  it("TC-SLACKAPP-054 a topic failure retries once then SKIPs the batch, like any malformed response", async () => {
+    // The spec's stated cost, asserted rather than assumed: requiring `topic` on
+    // EVERY verdict means a response that omits it batch-SKIPs the plain #102
+    // path too, including the scheduled weekly run. That is only acceptable if a
+    // topic failure lands in the SAME machinery as any other malformed response
+    // — one retry, then a non-destructive whole-batch SKIP that the
+    // "how much went unaudited" note counts. A topic check bolted on somewhere
+    // that bypasses `classifyBatch`'s retry, or that produces a SKIP the
+    // UNCLASSIFIED note does not recognise, would turn a recoverable hiccup into
+    // a silently unaudited corpus.
+    const memories = Array.from({ length: 40 }, (_, i) => memory(`m-${i}`, `fact ${i}`));
+    const server = fakeServer(memories);
+    let call = 0;
+    const llm = vi.fn(async (_p, batch) => {
+      call += 1;
+      // Batch 0 omits `topic` on BOTH attempts; batch 1 is well-formed.
+      if (call <= CLASSIFY_ATTEMPTS) {
+        return JSON.stringify({
+          verdicts: batch.map((m) => ({ id: m.id, verdict: "DELETE", reason: "stale" })),
+        });
+      }
+      return JSON.stringify({ verdicts: keepAll(batch) });
+    });
+    const deps = baseDeps(server, llm, tempDir());
+    const result = await runCleanup(baseOpts(), deps);
+
+    // Retried exactly once, not indefinitely and not zero times.
+    expect(llm).toHaveBeenCalledTimes(CLASSIFY_ATTEMPTS + 1);
+
+    // The failed batch is SKIP with the SAME reason string the note counts —
+    // not a new "bad topic" reason that the accounting would miss.
+    const skipped = result.decisions.filter((d) => d.verdict === "SKIP");
+    expect(skipped).toHaveLength(20);
+    for (const d of skipped) {
+      expect(d.reason).toBe("classification failed after retry");
+    }
+    // Non-destructive: the batch the classifier wanted to DELETE yields no
+    // DELETE decision at all.
+    expect(result.decisions.some((d) => d.verdict === "DELETE")).toBe(false);
+
+    // Counted by the unaudited note, and the retry log names the topic failure
+    // so an operator can tell a prompt-contract break from a transport outage.
+    const summaryLine = deps.log.mock.calls.map((c) => c[0]).find((m) => m.startsWith("dry-run:"));
+    expect(summaryLine).toMatch(/UNCLASSIFIED=20 of 40 memories \(1\/2 batches failed, 50%\)/);
+    const attempts = deps.log.mock.calls
+      .map((c) => c[0])
+      .filter((m) => /classification batch 0 attempt \d failed/u.test(m));
+    expect(attempts).toHaveLength(CLASSIFY_ATTEMPTS);
+    for (const line of attempts) expect(line).toMatch(/topic/iu);
   });
 
   it("TC-MEMCLEAN-081: a deterministic request-translation defect aborts the run", async () => {
@@ -2966,5 +3099,475 @@ describe("restore CLI validation", () => {
       .filter((line) => !/^\s*(\/\/|\*|\/\*)/u.test(line))
       .join("\n");
     expect(code).not.toMatch(/process\.exit\(/u);
+  });
+});
+
+describe("protected topics (#123)", () => {
+  // The invariant under test is stronger than "never offered for deletion": a
+  // protected memory is never MUTATED by this tool at all — not deleted, not
+  // absorbed into a merge, not rewritten as a merge survivor. One invariant with
+  // one test surface, rather than a per-verdict list that a fourth verdict would
+  // silently escape.
+  const finance = (id, content, version = 1) => ({ ...memory(id, content, version) });
+  const verdict = (id, v, topic, extra = {}) => ({
+    id,
+    verdict: v,
+    reason: "r",
+    topic,
+    ...extra,
+  });
+
+  it("TC-SLACKAPP-060 a protected DELETE is downgraded to RETAIN, never offered", () => {
+    const out = planDecisions(
+      [finance("f-1", "my brokerage rule"), memory("e-1", "a build flag")],
+      [verdict("f-1", "DELETE", "personal-finance"), verdict("e-1", "DELETE", "engineering")],
+      { protectedTopics: ["personal-finance"] },
+    );
+    const byId = Object.fromEntries(out.map((d) => [d.id, d]));
+
+    // Its own verdict, not a KEEP with a note: the summary counts it without
+    // special-casing, and applyDecisions cannot reach a DELETE/MERGE branch.
+    expect(byId["f-1"].verdict).toBe("RETAIN");
+    // The report must show that the classifier judged it deletable and policy
+    // overrode that — not that the classifier decided to keep it.
+    expect(byId["f-1"].originalVerdict).toBe("DELETE");
+    expect(byId["f-1"].retainedReason).toBe("protected topic personal-finance");
+    // Unprotected topics are untouched by the rule.
+    expect(byId["e-1"].verdict).toBe("DELETE");
+  });
+
+  it("TC-SLACKAPP-061 a policy retain is counted separately from SKIP", async () => {
+    // SKIP means "something went wrong or was not audited". A policy retain is
+    // neither, and conflating them would make a classifier outage and a working
+    // protection rule read identically in the summary.
+    const memories = [finance("f-1", "my positions"), memory("e-1", "a flag")];
+    const server = fakeServer(memories);
+    const llm = vi.fn(async (_p, batch) =>
+      JSON.stringify({
+        verdicts: batch.map((m) =>
+          m.id === "f-1"
+            ? verdict(m.id, "DELETE", "personal-finance")
+            : verdict(m.id, "KEEP", "engineering"),
+        ),
+      }),
+    );
+    const deps = baseDeps(server, llm, tempDir());
+    const result = await runCleanup(baseOpts({ protectedTopics: ["personal-finance"] }), deps);
+
+    const summaryLine = deps.log.mock.calls.map((c) => c[0]).find((m) => m.startsWith("dry-run:"));
+    expect(summaryLine).toContain('"RETAIN":1');
+    expect(summaryLine).not.toContain('"SKIP":1');
+    expect(result.decisions.find((d) => d.id === "f-1").verdict).toBe("RETAIN");
+  });
+
+  it("TC-SLACKAPP-066 the summary reports every verdict, zeros included, and invents no bucket", async () => {
+    // Two properties, both about a summary an operator compares across runs.
+    // Zeros must be printed: a run where protection matched nothing must say
+    // `"RETAIN":0` rather than omit the key, because an absent key is
+    // indistinguishable from a build that has no protection rule at all — the
+    // exact silence that would hide the flag being dropped from the invocation.
+    // And the key SET must be closed: `summary[d.verdict] = ... || 0` happily
+    // invents a bucket, so a verdict misspelled at one push site would report
+    // `"RETAINED":1` beside `"RETAIN":0` and look like a data oddity rather than a
+    // routing bug that put a protected memory on an unaudited path.
+    const memories = [memory("e-1", "a flag")];
+    const server = fakeServer(memories);
+    const llm = vi.fn(async (_p, batch) => JSON.stringify({ verdicts: keepAll(batch) }));
+    const deps = baseDeps(server, llm, tempDir());
+    await runCleanup(baseOpts({ protectedTopics: ["personal-finance"] }), deps);
+
+    const summaryLine = deps.log.mock.calls.map((c) => c[0]).find((m) => m.startsWith("dry-run:"));
+    const summary = JSON.parse(summaryLine.match(/\{.*\}/u)[0]);
+    expect(Object.keys(summary).sort()).toEqual(
+      ["DELETE", "KEEP", "MERGE", "RETAIN", "SKIP", "UNSTABLE"],
+    );
+    expect(summary.RETAIN).toBe(0);
+    expect(summary.UNSTABLE).toBe(0);
+    expect(summary.KEEP).toBe(1);
+
+    // Asserted directly, not through a run: `validateDecisions` rejects an unknown
+    // verdict in a replayed file before the summary is built, so no INPUT can reach
+    // this branch — only a planner push site can, and an invariant nothing can
+    // trigger from outside still has to be proven from inside or it is decoration.
+    expect(() => verdictSummary([{ id: "x", verdict: "RETAINED" }])).toThrow(/uncountable/u);
+  });
+
+  it("TC-SLACKAPP-062 a protected memory is withheld from a merge, as survivor and as absorbed", () => {
+    // Absorbing a protected memory into a survivor deletes it just as surely as
+    // DELETE does, so a rule that only checks the top-level verdict is a hole.
+    const asAbsorbed = planDecisions(
+      [memory("s-1", "survivor"), finance("f-1", "my cash plan")],
+      [
+        verdict("s-1", "MERGE", "engineering", {
+          merge_into: "s-1",
+          absorbs: ["f-1"],
+          merged_content: "merged",
+        }),
+        verdict("f-1", "MERGE", "personal-finance", { merge_into: "s-1" }),
+      ],
+      { protectedTopics: ["personal-finance"] },
+    );
+    const absorbedById = Object.fromEntries(asAbsorbed.map((d) => [d.id, d]));
+    expect(absorbedById["f-1"].verdict).toBe("RETAIN");
+    // With its only absorbed id withheld the merge has nothing to absorb, so it
+    // must not rewrite the survivor either.
+    expect(asAbsorbed.some((d) => d.verdict === "MERGE")).toBe(false);
+
+    // As the survivor: a merge REWRITES the survivor's content, which is a
+    // mutation of a protected memory even though nothing is deleted.
+    const asSurvivor = planDecisions(
+      [finance("f-2", "my brokerage"), memory("e-2", "a flag")],
+      [
+        verdict("f-2", "MERGE", "personal-finance", {
+          merge_into: "f-2",
+          absorbs: ["e-2"],
+          merged_content: "merged",
+        }),
+        verdict("e-2", "MERGE", "engineering", { merge_into: "f-2" }),
+      ],
+      { protectedTopics: ["personal-finance"] },
+    );
+    const survivorById = Object.fromEntries(asSurvivor.map((d) => [d.id, d]));
+    expect(survivorById["f-2"].verdict).toBe("RETAIN");
+    expect(asSurvivor.some((d) => d.verdict === "MERGE")).toBe(false);
+    // e-2 is not protected, but its group did not emit — it must still carry a
+    // decision row, because the decision log covers every scanned memory.
+    expect(survivorById["e-2"]).toBeDefined();
+    expect(survivorById["e-2"].verdict).not.toBe("MERGE");
+  });
+
+  it("TC-SLACKAPP-063 protectedTopics defaults to personal-finance; an empty list protects nothing", () => {
+    // Omitted → the default. An operator who wants the default omits the flag.
+    const defaulted = planDecisions(
+      [finance("f-1", "my holdings")],
+      [verdict("f-1", "DELETE", "personal-finance")],
+      {},
+    );
+    expect(defaulted[0].verdict).toBe("RETAIN");
+    expect(parseArgs(["--stage", "test"]).protectedTopics).toEqual(["personal-finance"]);
+
+    // Explicitly empty → protect nothing. A silent fallback to the default would
+    // make a deliberate opt-out impossible to express.
+    const optedOut = planDecisions(
+      [finance("f-1", "my holdings")],
+      [verdict("f-1", "DELETE", "personal-finance")],
+      { protectedTopics: [] },
+    );
+    expect(optedOut[0].verdict).toBe("DELETE");
+    expect(parseArgs(["--stage", "test", "--protected-topics", ""]).protectedTopics).toEqual([]);
+  });
+
+  it("TC-SLACKAPP-065 an --apply run issues no write for a RETAIN row", async () => {
+    // The invariant is "never mutated by this tool at all", so it has to hold on
+    // the run that actually writes — not only in the planner. RETAIN survives
+    // that path because `destructiveCost` returns 0 for it, which is exactly the
+    // kind of implicit protection a fourth verdict would inherit by accident and
+    // a refactor could remove without any test noticing.
+    const memories = [finance("f-1", "my positions"), memory("e-1", "session noise")];
+    const server = fakeServer(memories);
+    const llm = vi.fn(async (_p, batch) =>
+      JSON.stringify({
+        verdicts: batch.map((m) =>
+          m.id === "f-1"
+            ? verdict(m.id, "DELETE", "personal-finance")
+            : verdict(m.id, "DELETE", "engineering"),
+        ),
+      }),
+    );
+    const dryDeps = baseDeps(server, llm, tempDir());
+    const dry = await runCleanup(baseOpts({ protectedTopics: ["personal-finance"] }), dryDeps);
+    expect(dry.writeCalls).toBe(0);
+
+    // Replay the decision file, which is the run that deletes.
+    const applyServer = fakeServer(memories);
+    const applyDeps = baseDeps(applyServer, llm, tempDir());
+    const applied = await runCleanup(
+      baseOpts({ apply: true, decisionsFile: dry.decisionPath, protectedTopics: ["personal-finance"] }),
+      applyDeps,
+    );
+
+    // The unprotected id is deleted, proving the run was capable of deleting.
+    expect(JSON.stringify(applyServer.calls)).toContain("e-1");
+    // Asserted over EVERY call, GETs included, not just the writes. A RETAIN row
+    // that reaches the delete branch is re-read and then skipped as an "LWW
+    // guard" — it has no contentHash to match — so filtering to non-GETs would
+    // pass while protection had become accidental and the run reported the
+    // memory as protected by a concurrent write. The tool must not touch it.
+    expect(JSON.stringify(applyServer.calls)).not.toContain("f-1");
+    const lww = applyDeps.log.mock.calls.map((c) => c[0]).filter((m) => /f-1/u.test(m));
+    expect(lww).toEqual([]);
+    // And no cap was charged for it: a protected row must not shrink the
+    // blast-radius budget for work that never happens.
+    expect(applied.capUsed).toBe(1);
+  });
+
+  it("TC-SLACKAPP-064 an unrecognised protected topic is rejected at argument validation", () => {
+    // A typo that matches no topic silently protects nothing, and the operator
+    // does not find out until finance memories are deleted. Rejected up front.
+    expect(() => parseArgs(["--stage", "test", "--protected-topics", "personal_finance"])).toThrow(
+      /personal_finance/,
+    );
+    expect(() =>
+      parseArgs(["--stage", "test", "--protected-topics", "personal-finance,nope"]),
+    ).toThrow(/nope/);
+    expect(
+      parseArgs(["--stage", "test", "--protected-topics", "personal-finance,operations"])
+        .protectedTopics,
+    ).toEqual(["personal-finance", "operations"]);
+  });
+});
+
+describe("two-pass consensus (#123)", () => {
+  // The 66%-agreement finding that motivated the issue: one classification pass
+  // is not reproducible enough to authorize deletions from. Consensus is the
+  // narrowing operation — an id is offered only if EVERY pass independently said
+  // DELETE, and everything else is reported rather than acted on.
+  const del = (id, extra = {}) => ({
+    id,
+    verdict: "DELETE",
+    reason: "stale",
+    contentHash: contentHash(`c-${id}`),
+    version: 1,
+    ...extra,
+  });
+  const keep = (id) => ({ id, verdict: "KEEP", reason: "durable" });
+
+  // Numbered outside 070-079 because it is a CLI-validation case, a sibling of
+  // TC-SLACKAPP-064, rather than a property of the intersection itself.
+  it("TC-SLACKAPP-069 --consensus-passes must be an integer of at least 2", () => {
+    // 2.5 is the case that matters: `Number.isFinite` and `> 0` both accept it,
+    // the pass loop silently runs twice, and the log says "pass 1 of 2.5" while
+    // the report says 2 — a run whose own summary disagrees with its own
+    // invocation. And `--consensus-passes 1` asks for consensus and gets none,
+    // which is the single-pass behavior the flag exists to replace: refused by
+    // name rather than accepted and quietly downgraded.
+    expect(() => parseArgs(["--stage", "test", "--consensus-passes", "2.5"])).toThrow(/integer/u);
+    expect(() => parseArgs(["--stage", "test", "--consensus-passes", "1"])).toThrow(/at least 2/u);
+    expect(() => parseArgs(["--stage", "test", "--consensus-passes", "0"])).toThrow();
+    expect(parseArgs(["--stage", "test", "--consensus-passes", "3"]).consensusPasses).toBe(3);
+    // Omitted is the single-pass default, not an error: consensus is opt-in.
+    expect(parseArgs(["--stage", "test"]).consensusPasses).toBeUndefined();
+  });
+
+  it("TC-SLACKAPP-070 only ids DELETEd by both passes are offered; the rest are unstable", () => {
+    const { decisions, report } = consensusDecisions([
+      [del("both"), del("one-only"), keep("neither")],
+      [del("both"), keep("one-only"), keep("neither")],
+    ]);
+    const byId = Object.fromEntries(decisions.map((d) => [d.id, d]));
+
+    expect(byId["both"].verdict).toBe("DELETE");
+    // Its own verdict, not a KEEP: a KEEP would claim the classifier judged it
+    // durable, when in fact one pass wanted it gone and the passes disagreed —
+    // which is the number this whole design exists to surface.
+    expect(byId["one-only"].verdict).toBe("UNSTABLE");
+    expect(byId["one-only"].verdicts).toEqual(["DELETE", "KEEP"]);
+    expect(byId["neither"].verdict).toBe("KEEP");
+    expect(report.disagreed).toBe(1);
+  });
+
+  it("TC-SLACKAPP-071 the passes are independent and the INTERSECTION decides", () => {
+    // Neither "first response wins" nor "last response wins" can produce this
+    // answer: pass 1 alone would offer a+b, pass 2 alone would offer b+c.
+    const { decisions } = consensusDecisions([
+      [del("a"), del("b"), keep("c")],
+      [keep("a"), del("b"), del("c")],
+    ]);
+    const offered = decisions.filter((d) => d.verdict === "DELETE").map((d) => d.id);
+    expect(offered).toEqual(["b"]);
+  });
+
+  it("TC-SLACKAPP-072 the summary reports both pass counts, the intersection, and the disagreement rate", async () => {
+    const memories = [memory("a", "x"), memory("b", "y"), memory("c", "z")];
+    const server = fakeServer(memories);
+    let pass = 0;
+    const llm = vi.fn(async (_p, batch) => {
+      pass += 1;
+      // Pass 1 deletes a+b; pass 2 deletes b only. Intersection = {b}.
+      const deleting = pass === 1 ? ["a", "b"] : ["b"];
+      return JSON.stringify({
+        verdicts: batch.map((m) => ({
+          id: m.id,
+          verdict: deleting.includes(m.id) ? "DELETE" : "KEEP",
+          reason: "r",
+          topic: "engineering",
+        })),
+      });
+    });
+    const deps = baseDeps(server, llm, tempDir());
+    await runCleanup(baseOpts({ consensusPasses: 2 }), deps);
+
+    // A drop in reproducibility must be visible: an unreported number is a
+    // number nobody watches.
+    const line = deps.log.mock.calls.map((c) => c[0]).find((m) => /CONSENSUS/u.test(m));
+    expect(line).toMatch(/pass 1 DELETE=2/u);
+    expect(line).toMatch(/pass 2 DELETE=1/u);
+    expect(line).toMatch(/agreed=1/u);
+    expect(line).toMatch(/disagreed=1/u);
+    expect(line).toMatch(/50%/u); // 1 of 2 ids either pass wanted deleted
+  });
+
+  it("TC-SLACKAPP-073 one usable pass is NOT consensus: nothing is offered", () => {
+    // Falling back to "use the other pass" would quietly restore exactly the
+    // non-reproducible single-pass behavior consensus exists to remove.
+    const { decisions, report } = consensusDecisions([[del("a"), del("b")], null]);
+    expect(decisions.some((d) => d.verdict === "DELETE")).toBe(false);
+    expect(report.usablePasses).toBe(1);
+    expect(report.consensusReached).toBe(false);
+  });
+
+  it("TC-SLACKAPP-074 an id a later pass never judged is not treated as agreement", () => {
+    // Absence of a verdict is not a DELETE and is not a KEEP.
+    const { decisions } = consensusDecisions([
+      [del("judged-twice"), del("judged-once")],
+      [del("judged-twice")],
+    ]);
+    const byId = Object.fromEntries(decisions.map((d) => [d.id, d]));
+    expect(byId["judged-twice"].verdict).toBe("DELETE");
+    expect(byId["judged-once"].verdict).toBe("UNSTABLE");
+    expect(byId["judged-once"].verdicts).toEqual(["DELETE", null]);
+  });
+
+  it("TC-SLACKAPP-075 protection wins over the intersection, even when the passes disagree on topic", () => {
+    // Order is asserted because both orders agree today and only one keeps
+    // agreeing when a pass returns a DIFFERENT topic for the same id — the
+    // realistic failure, since topic is a model judgment like any other.
+    const out = planDecisions(
+      [memory("f-1", "my positions")],
+      [{ id: "f-1", verdict: "DELETE", reason: "r", topic: "personal-finance" }],
+      { protectedTopics: ["personal-finance"] },
+    );
+    const alsoOut = planDecisions(
+      [memory("f-1", "my positions")],
+      [{ id: "f-1", verdict: "DELETE", reason: "r", topic: "engineering" }],
+      { protectedTopics: ["personal-finance"] },
+    );
+    // Pass 2 mis-topics it, so an intersection over RAW verdicts would see
+    // DELETE/DELETE and offer it. Protection is applied per pass FIRST, so the
+    // protected pass contributes RETAIN and the id can never be offered.
+    const { decisions } = consensusDecisions([out, alsoOut]);
+    const byId = Object.fromEntries(decisions.map((d) => [d.id, d]));
+    expect(byId["f-1"].verdict).not.toBe("DELETE");
+    expect(["RETAIN", "UNSTABLE"]).toContain(byId["f-1"].verdict);
+  });
+
+  it("TC-SLACKAPP-076 MERGE is withheld from the offered set in v1, and the count is reported", () => {
+    const merge = {
+      id: "s",
+      verdict: "MERGE",
+      reason: "frags",
+      contentHash: contentHash("c-s"),
+      version: 1,
+      mergedContent: "m",
+      mergedContentHash: contentHash("m"),
+      absorbs: [{ id: "a", contentHash: contentHash("c-a"), version: 1 }],
+    };
+    const { decisions, report } = consensusDecisions([
+      [merge, del("d")],
+      [merge, del("d")],
+    ]);
+    const byId = Object.fromEntries(decisions.map((d) => [d.id, d]));
+    // v1 approves deletions only. An unreported withholding would read as "the
+    // classifier found no merges".
+    expect(byId["s"].verdict).not.toBe("MERGE");
+    expect(report.mergesWithheld).toBe(1);
+    expect(byId["d"].verdict).toBe("DELETE");
+  });
+
+  it("TC-SLACKAPP-078 a pass that failed every batch is reported as no consensus, not as disagreement", async () => {
+    // The dangerous shape: `classifyAll` reports a total failure as a full list of
+    // SKIP rows, which look exactly like "this pass judged the memory and declined
+    // to delete it". The intersection is still safe — a SKIP is not a DELETE, so
+    // nothing extra is offered — but the REPORT would claim the two passes
+    // disagreed, when in truth the second pass never ran. An operator reading
+    // "agreement=0%" would go looking for a classifier that changed its mind
+    // instead of a transport that broke.
+    const memories = [memory("a", "x"), memory("b", "y")];
+    const server = fakeServer(memories);
+    let call = 0;
+    const llm = vi.fn(async (_p, batch) => {
+      call += 1;
+      // Attempts 1 (pass 1) succeed; every later attempt (pass 2 and its retry)
+      // throws, so pass 2 loses all of its batches.
+      if (call > 1) throw new Error("transport is down");
+      return JSON.stringify({
+        verdicts: batch.map((m) => ({ id: m.id, verdict: "DELETE", reason: "r", topic: "engineering" })),
+      });
+    });
+    const deps = baseDeps(server, llm, tempDir());
+    const result = await runCleanup(baseOpts({ consensusPasses: 2 }), deps);
+
+    const line = deps.log.mock.calls.map((c) => c[0]).find((m) => /CONSENSUS/u.test(m));
+    expect(line).toMatch(/NO CONSENSUS/u);
+    expect(line).toMatch(/pass 2 DELETE=failed/u);
+    // Nothing offered, and the reason names the failure rather than a
+    // disagreement the model never had.
+    expect(result.decisions.some((d) => d.verdict === "DELETE")).toBe(false);
+    const unstable = result.decisions.filter((d) => d.verdict === "UNSTABLE");
+    expect(unstable.length).toBe(2);
+    for (const d of unstable) expect(d.reason).toMatch(/pass failed/u);
+    // A partial outage across passes is NOT the broken-classifier exit: pass 1
+    // classified the whole corpus, so the path works and 5 would misdiagnose it.
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("TC-SLACKAPP-079 a consensus dry run can be replayed with --apply", async () => {
+    // The same defect class TC-SLACKAPP-065 caught for RETAIN: the planner writes
+    // UNSTABLE rows to the decision file, so a replay validator that does not know
+    // the verdict makes every `--apply` after a consensus run fail at load — the
+    // safety mechanism breaking the tool it exists to make safe.
+    const memories = [memory("agreed", "x"), memory("contested", "y")];
+    const server = fakeServer(memories);
+    let pass = 0;
+    const llm = vi.fn(async (_p, batch) => {
+      pass += 1;
+      const deleting = pass === 1 ? ["agreed", "contested"] : ["agreed"];
+      return JSON.stringify({
+        verdicts: batch.map((m) => ({
+          id: m.id,
+          verdict: deleting.includes(m.id) ? "DELETE" : "KEEP",
+          reason: "r",
+          topic: "engineering",
+        })),
+      });
+    });
+    const dryDeps = baseDeps(server, llm, tempDir());
+    const dry = await runCleanup(baseOpts({ consensusPasses: 2 }), dryDeps);
+    expect(dry.decisions.find((d) => d.id === "contested").verdict).toBe("UNSTABLE");
+
+    const applyServer = fakeServer(memories);
+    const applyDeps = baseDeps(applyServer, llm, tempDir());
+    const applied = await runCleanup(
+      baseOpts({ apply: true, decisionsFile: dry.decisionPath }),
+      applyDeps,
+    );
+
+    expect(applied.exitCode).toBe(0);
+    // The agreed id is deleted; the contested one is not touched at all — asserted
+    // over every call, GETs included, because an UNSTABLE row that reached the
+    // delete branch would be re-read and then skipped as an LWW guard, which
+    // reports as "a concurrent write protected me" rather than as a defect.
+    expect(JSON.stringify(applyServer.calls)).toContain("agreed");
+    expect(JSON.stringify(applyServer.calls)).not.toContain("contested");
+    expect(applied.capUsed).toBe(1);
+  });
+
+  it("TC-SLACKAPP-077 consensus never widens the destructive set", () => {
+    // Asserted as a SET RELATION, not a count, so a future refactor cannot add
+    // an id sourced from anywhere other than the intersection.
+    const passes = [
+      [del("a"), del("b"), keep("c"), del("d")],
+      [del("a"), keep("b"), del("c"), del("d")],
+    ];
+    const { decisions } = consensusDecisions(passes);
+    const deleteIds = (list) =>
+      new Set(list.filter((d) => d.verdict === "DELETE").map((d) => d.id));
+    const intersection = new Set(
+      [...deleteIds(passes[0])].filter((id) => deleteIds(passes[1]).has(id)),
+    );
+    for (const id of deleteIds(decisions)) {
+      expect(intersection.has(id)).toBe(true);
+    }
+    expect(deleteIds(decisions).size).toBeGreaterThan(0); // not vacuously empty
   });
 });

--- a/scripts/memory-cleanup.test.mjs
+++ b/scripts/memory-cleanup.test.mjs
@@ -12,7 +12,9 @@ import {
   buildCompleteChat,
   buildOfferedRecord,
   contentHash,
+  createCleanupDeps,
   inactiveMemoryAdapter,
+  materializeApprovedIds,
   parseArgs,
   consensusDecisions,
   parseVerdicts,
@@ -3647,5 +3649,551 @@ describe("the offered approval record (#123)", () => {
     });
     expect(JSON.stringify(ok).length).toBeLessThanOrEqual(4096);
     expect(ok.ids).toHaveLength(40);
+  });
+});
+
+describe("materializing the approved ids in the apply task (#123)", () => {
+  const OFFERED = "/mem9-on-aws/prod/approvals/offered";
+  const claimName = (hash) => `/mem9-on-aws/prod/approvals/approved-${hash}`;
+
+  /**
+   * Fake SSM whose `send` answers `GetParametersCommand` from a name→value map.
+   *
+   * Keyed on the command's `input.Names` rather than on the class, so a
+   * production switch to `GetParameterCommand` (singular) still reads here —
+   * that distinction is IAM's, and TC-SLACKAPP-047g pins it on the Lambda side.
+   * What this fake exists to model is the shape SSM actually returns: an absent
+   * name is simply MISSING from `Parameters` and echoed in `InvalidParameters`,
+   * never an empty-valued entry.
+   */
+  function fakeSsm(values) {
+    const reads = [];
+    return {
+      reads,
+      send: vi.fn(async (command) => {
+        const names = command?.input?.Names ?? [];
+        reads.push(...names);
+        const found = names.filter((n) => n in values);
+        return {
+          Parameters: found.map((n) => ({ Name: n, Value: values[n] })),
+          InvalidParameters: names.filter((n) => !(n in values)),
+        };
+      }),
+    };
+  }
+
+  const offered = (ids, extra = {}) =>
+    JSON.stringify({
+      stage: "prod",
+      hash: contentHash(ids.join("\n")),
+      ids,
+      generatedAt: "2026-08-05T00:00:00.000Z",
+      ...extra,
+    });
+
+  it("TC-SLACKAPP-091 the ids come from the CLAIM named by the hash, not from the offered record", async () => {
+    // The claim is what the operator's click actually approved. `offered` is
+    // overwritten by every run, so a task that read `offered` would delete the
+    // list the CURRENT run produced rather than the one the operator saw — and
+    // it would do so carrying a valid approval. The claim is immutable once
+    // written (`Overwrite: false`), which is the only reason a click is safe to
+    // honour minutes later.
+    //
+    // Both records are seeded with DIFFERENT ids, so a read from the wrong one
+    // cannot pass: an assertion that only counted ids, or that seeded both with
+    // the same list, would be satisfied by either source.
+    const approvedIds = ["m-approved-1", "m-approved-2"];
+    const hash = contentHash(approvedIds.join("\n"));
+    const ssm = fakeSsm({
+      [OFFERED]: offered(["m-regenerated-since"]),
+      [claimName(hash)]: JSON.stringify({
+        stage: "prod",
+        hash,
+        ids: approvedIds,
+        claimedAt: "2026-08-05T00:05:00.000Z",
+        taskArn: "arn:aws:ecs:ap-northeast-1:123456789012:task/mem9/abc",
+      }),
+    });
+    const dir = tempDir();
+    const idsFile = join(dir, "approved.txt");
+
+    await materializeApprovedIds({
+      ssm,
+      stage: "prod",
+      ssmPrefix: "/mem9-on-aws/prod",
+      hash,
+      idsFile,
+      fs: { writeFileSync },
+    });
+
+    expect(readFileSync(idsFile, "utf8").trim().split("\n")).toEqual(approvedIds);
+    expect(ssm.reads).toContain(claimName(hash));
+    expect(ssm.reads).not.toContain(OFFERED);
+  });
+
+  it("TC-SLACKAPP-092 a claim whose ids do not hash to the requested hash is refused", async () => {
+    // The hash arrives as a container override, which `DescribeTasks` echoes and
+    // any holder of ecs:RunTask on this task definition can choose. Trusting the
+    // record it names without re-deriving the hash over the ids would let a
+    // caller point the apply at a tampered record. Re-deriving makes the ids
+    // themselves the thing the hash vouches for.
+    const hash = contentHash(["m-1"].join("\n"));
+    const ssm = fakeSsm({
+      [claimName(hash)]: JSON.stringify({
+        stage: "prod",
+        hash,
+        // Hash says one id; the record carries another. The record's OWN `hash`
+        // field agrees with the request, so a check that compared those two
+        // strings would pass this.
+        ids: ["m-substituted"],
+        claimedAt: "2026-08-05T00:05:00.000Z",
+      }),
+    });
+    const dir = tempDir();
+    const idsFile = join(dir, "approved.txt");
+
+    await expect(
+      materializeApprovedIds({
+        ssm,
+        stage: "prod",
+        ssmPrefix: "/mem9-on-aws/prod",
+        hash,
+        idsFile,
+        fs: { writeFileSync },
+      }),
+    ).rejects.toThrow(/hash/u);
+    expect(() => readFileSync(idsFile, "utf8")).toThrow();
+  });
+
+  it("TC-SLACKAPP-093 a claim naming another stage is refused", async () => {
+    // Same reasoning as #102's decision-file stage guard: a preview approval must
+    // never apply to prod. The parameter PREFIX is stage-scoped, so this can only
+    // happen through a hand-written record — which is exactly the case a guard is
+    // for, since the alternative is an apply the operator never approved.
+    const ids = ["m-1"];
+    const hash = contentHash(ids.join("\n"));
+    const ssm = fakeSsm({
+      [claimName(hash)]: JSON.stringify({
+        stage: "pr-7",
+        hash,
+        ids,
+        claimedAt: "2026-08-05T00:05:00.000Z",
+      }),
+    });
+    const dir = tempDir();
+    const idsFile = join(dir, "approved.txt");
+
+    await expect(
+      materializeApprovedIds({
+        ssm,
+        stage: "prod",
+        ssmPrefix: "/mem9-on-aws/prod",
+        hash,
+        idsFile,
+        fs: { writeFileSync },
+      }),
+    ).rejects.toThrow(/stage/u);
+    expect(() => readFileSync(idsFile, "utf8")).toThrow();
+  });
+
+  it("TC-SLACKAPP-094 an absent claim is refused, not treated as an empty approval", async () => {
+    // An absent name comes back in `InvalidParameters`, missing from
+    // `Parameters` — so `find(...)?.Value` is `undefined` and a permissive path
+    // would write an EMPTY ids file. `--ids` with an empty file means "approve
+    // nothing", so the run would exit 0 having deleted nothing and the operator
+    // would read a successful apply that never happened.
+    const ssm = fakeSsm({});
+    const dir = tempDir();
+    const idsFile = join(dir, "approved.txt");
+
+    await expect(
+      materializeApprovedIds({
+        ssm,
+        stage: "prod",
+        ssmPrefix: "/mem9-on-aws/prod",
+        hash: contentHash("m-1"),
+        idsFile,
+        fs: { writeFileSync },
+      }),
+    ).rejects.toThrow(/approval record/u);
+    expect(() => readFileSync(idsFile, "utf8")).toThrow();
+  });
+
+  it("TC-SLACKAPP-095 a claim with an empty id list is refused rather than written", async () => {
+    // `[]` hashes consistently, so the hash check cannot catch it, and it is
+    // exactly what a partially-written record looks like. An empty `--ids` file
+    // is indistinguishable from "approve nothing" — a silent no-op reported as a
+    // clean apply.
+    const ids = [];
+    const hash = contentHash(ids.join("\n"));
+    const ssm = fakeSsm({
+      [claimName(hash)]: JSON.stringify({
+        stage: "prod",
+        hash,
+        ids,
+        claimedAt: "2026-08-05T00:05:00.000Z",
+      }),
+    });
+    const dir = tempDir();
+    const idsFile = join(dir, "approved.txt");
+
+    await expect(
+      materializeApprovedIds({
+        ssm,
+        stage: "prod",
+        ssmPrefix: "/mem9-on-aws/prod",
+        hash,
+        idsFile,
+        fs: { writeFileSync },
+      }),
+    ).rejects.toThrow(/no ids/u);
+    expect(() => readFileSync(idsFile, "utf8")).toThrow();
+  });
+
+  it("TC-SLACKAPP-096 a malformed claim is refused by shape", async () => {
+    // A truncated or non-JSON value must not reach `JSON.parse` unguarded: an
+    // uncaught SyntaxError exits 1 with a stack that quotes the parameter value,
+    // and this value is the one place ids legitimately live.
+    const hash = contentHash("m-1");
+    const ssm = fakeSsm({ [claimName(hash)]: '{"stage":"prod","ids":' });
+    const dir = tempDir();
+    const idsFile = join(dir, "approved.txt");
+
+    await expect(
+      materializeApprovedIds({
+        ssm,
+        stage: "prod",
+        ssmPrefix: "/mem9-on-aws/prod",
+        hash,
+        idsFile,
+        fs: { writeFileSync },
+      }),
+    ).rejects.toThrow(/approval record/u);
+    expect(() => readFileSync(idsFile, "utf8")).toThrow();
+  });
+
+  it("TC-SLACKAPP-097 the ids file is newline-delimited exactly as --ids parses it", async () => {
+    // `readApprovedIds` splits on "\n" and trims, so the two formats that would
+    // silently produce ONE id are a JSON array and a comma-joined line. Asserted
+    // by round-tripping through the real parser rather than by matching a
+    // string, so the contract is proven against the consumer.
+    const ids = ["m-1", "m-2", "m-3"];
+    const hash = contentHash(ids.join("\n"));
+    const ssm = fakeSsm({
+      [claimName(hash)]: JSON.stringify({
+        stage: "prod",
+        hash,
+        ids,
+        claimedAt: "2026-08-05T00:05:00.000Z",
+      }),
+    });
+    const dir = tempDir();
+    const idsFile = join(dir, "approved.txt");
+
+    await materializeApprovedIds({
+      ssm,
+      stage: "prod",
+      ssmPrefix: "/mem9-on-aws/prod",
+      hash,
+      idsFile,
+      fs: { writeFileSync },
+    });
+
+    // The consumer's own reading of the file, through runCleanup's --ids path:
+    // three memories offered, all three approved, all three deleted.
+    const server = fakeServer(ids.map((id) => memory(id, `c-${id}`)));
+    const llm = fakeLlm([
+      ids.map((id) => ({ id, verdict: "DELETE", reason: "stale" })),
+    ]);
+    const result = await runCleanup(
+      baseOpts({ apply: true, idsFile }),
+      baseDeps(server, llm, dir),
+    );
+    expect(result.skippedByFilter).toBe(0);
+    for (const id of ids) {
+      expect(server.store.get(id).state).toBe("deleted");
+    }
+  });
+
+  it("TC-SLACKAPP-098 the ids file never contains memory content, and no log line quotes an id", async () => {
+    // The task's log goes to CloudWatch, which is an accepted surface for
+    // snippets — but the ids file lands on the task's ephemeral disk, and the
+    // record it is built from is a plain String parameter readable by anything
+    // with ssm:GetParameters on the stage tree. A record that grew a `snippet`
+    // field must not have it copied into the file.
+    const ids = ["m-1"];
+    const hash = contentHash(ids.join("\n"));
+    const ssm = fakeSsm({
+      [claimName(hash)]: JSON.stringify({
+        stage: "prod",
+        hash,
+        ids,
+        claimedAt: "2026-08-05T00:05:00.000Z",
+        snippet: "SENTINEL-CONTENT",
+      }),
+    });
+    const dir = tempDir();
+    const idsFile = join(dir, "approved.txt");
+    const log = vi.fn();
+
+    await materializeApprovedIds({
+      ssm,
+      stage: "prod",
+      ssmPrefix: "/mem9-on-aws/prod",
+      hash,
+      idsFile,
+      fs: { writeFileSync },
+      log,
+    });
+
+    expect(readFileSync(idsFile, "utf8")).not.toContain("SENTINEL-CONTENT");
+    for (const call of log.mock.calls) {
+      expect(String(call[0])).not.toContain("SENTINEL-CONTENT");
+    }
+    // The COUNT is logged, never the ids: a log line naming them would put
+    // memory identifiers in CloudWatch for an operator who only needs to know
+    // the apply matched the approval.
+    expect(log).toHaveBeenCalled();
+    for (const call of log.mock.calls) {
+      expect(String(call[0])).not.toContain("m-1");
+    }
+  });
+});
+
+describe("the apply task's in-container runtime (#123)", () => {
+  const environmentKeys = [
+    "AWS_REGION",
+    "MEM9_APPROVAL_HASH",
+    "MEM9_BEDROCK_PROJECT",
+    "MEM9_DB_HOST",
+    "MEM9_DB_NAME",
+    "MEM9_DB_PORT",
+    "MEM9_DB_SECRET",
+    "MEM9_LLM_MODEL",
+    "MEM9_SSM_PREFIX",
+    "MEM9_TENANT_ID",
+  ];
+  afterEach(() => {
+    for (const key of environmentKeys) delete process.env[key];
+  });
+
+  /** The env the ECS task definition (infra/slack-approval.ts) actually sets. */
+  function containerEnv(extra = {}) {
+    Object.assign(process.env, {
+      AWS_REGION: "ap-northeast-1",
+      MEM9_DB_HOST: "writer.example.com",
+      MEM9_DB_NAME: "mem9",
+      MEM9_DB_PORT: "5432",
+      // ECS resolves the `ssm:` entry to the secret's JSON before the process
+      // starts, exactly as it does for the consolidation task.
+      MEM9_DB_SECRET: JSON.stringify({
+        username: "mem9",
+        password: "fixture-password",
+      }),
+      MEM9_SSM_PREFIX: "/mem9-on-aws/prod",
+      MEM9_TENANT_ID: TENANT,
+      ...extra,
+    });
+  }
+
+  /** pg double that records every construction and query. */
+  function fakeClientClass(calls) {
+    return class Client {
+      constructor(options) {
+        calls.push(["construct", options]);
+      }
+      async connect() {
+        calls.push(["connect"]);
+      }
+      async query(sql, parameters) {
+        calls.push(["query", sql, parameters]);
+        if (sql.includes("pg_try_advisory_lock")) {
+          return { rows: [{ acquired: true }] };
+        }
+        return { rows: [] };
+      }
+      async end() {
+        calls.push(["end"]);
+      }
+    };
+  }
+
+  function fakeAwsClient(values = {}) {
+    const client = {
+      sent: [],
+      send: vi.fn(async (command) => {
+        client.sent.push(command.input);
+        if (command.input.Names) {
+          const names = command.input.Names;
+          return {
+            Parameters: names
+              .filter((name) => name in values)
+              .map((name) => ({ Name: name, Value: values[name] })),
+            InvalidParameters: names.filter((name) => !(name in values)),
+          };
+        }
+        return { SecretString: values[command.input.SecretId] };
+      }),
+      destroy: () => {},
+    };
+    return client;
+  }
+
+  it("TC-SLACKAPP-100 takes its database configuration from the environment, with no SSM or Secrets Manager read", async () => {
+    // The image ships @aws-sdk/client-ssm now, so this is no longer about a
+    // missing module — it is about grants. The task role holds ssm:GetParameters
+    // ONLY under `approvals/*` (infra/slack-approval.ts), so the operator CLI's
+    // `db/*` discovery is an AccessDenied inside the container, and the DB secret
+    // arrives pre-resolved in `MEM9_DB_SECRET` instead. Mirrors
+    // memory-consolidation.mjs's createProductionDeps.
+    containerEnv();
+    const calls = [];
+    const ssm = fakeAwsClient();
+    const secrets = fakeAwsClient();
+
+    const production = await createCleanupDeps(
+      { stage: "prod", apply: true, cap: 50 },
+      { Client: fakeClientClass(calls), ssm, secrets, getToken: vi.fn(), fromNodeProviderChain: vi.fn() },
+    );
+
+    expect(ssm.send).not.toHaveBeenCalled();
+    expect(secrets.send).not.toHaveBeenCalled();
+    expect(production.tenantId).toBe(TENANT);
+    // Asserted on the connection options, not merely on "it connected": a path
+    // that read the env and then handed pg a partly-undefined config would still
+    // construct and would fail at TLS time with an unrelated message.
+    expect(calls[0]).toEqual([
+      "construct",
+      expect.objectContaining({
+        host: "writer.example.com",
+        port: 5432,
+        database: "mem9",
+        user: "mem9",
+        password: "fixture-password",
+      }),
+    ]);
+    // The shared mutex is what stops a click-triggered apply from racing the
+    // weekly consolidation. Absent, the two would interleave writes.
+    const mutex = await production.deps.acquireMutex("prod");
+    expect(mutex).not.toBeNull();
+    await mutex.release();
+    await production.close();
+    expect(calls.at(-1)).toEqual(["end"]);
+  });
+
+  it("TC-SLACKAPP-101 still resolves the database through SSM and Secrets Manager for the operator CLI", async () => {
+    // The operator path has no MEM9_DB_SECRET and its human IAM identity CAN read
+    // `db/*`. Both paths must keep working from one function: a container-only
+    // rewrite would break the #102 runbook the README documents.
+    process.env.AWS_REGION = "ap-northeast-1";
+    process.env.MEM9_TENANT_ID = TENANT;
+    const calls = [];
+    const secretArn =
+      "arn:aws:secretsmanager:ap-northeast-1:123456789012:secret:mem9-db-x";
+    const ssm = fakeAwsClient({
+      "/mem9-on-aws/prod/db/host": "writer.example.com",
+      "/mem9-on-aws/prod/db/port": "5432",
+      "/mem9-on-aws/prod/db/name": "mem9",
+      "/mem9-on-aws/prod/db/secret-arn": secretArn,
+    });
+    const secrets = fakeAwsClient({
+      [secretArn]: JSON.stringify({ username: "mem9", password: "from-secret" }),
+    });
+
+    const production = await createCleanupDeps(
+      { stage: "prod", apply: true, cap: 50 },
+      { Client: fakeClientClass(calls), ssm, secrets, getToken: vi.fn(), fromNodeProviderChain: vi.fn() },
+    );
+
+    expect(ssm.sent[0].Names).toEqual([
+      "/mem9-on-aws/prod/db/host",
+      "/mem9-on-aws/prod/db/port",
+      "/mem9-on-aws/prod/db/name",
+      "/mem9-on-aws/prod/db/secret-arn",
+    ]);
+    expect(secrets.sent[0].SecretId).toBe(secretArn);
+    expect(calls[0][1]).toMatchObject({ password: "from-secret" });
+    await production.close();
+  });
+
+  it("TC-SLACKAPP-102 materializes the approved ids at the --ids path the task definition passes", async () => {
+    const ids = ["m-1", "m-2"];
+    const hash = contentHash(ids.join("\n"));
+    const dir = tempDir();
+    const idsFile = join(dir, "approved.txt");
+    containerEnv({ MEM9_APPROVAL_HASH: hash });
+    const ssm = fakeAwsClient({
+      [`/mem9-on-aws/prod/approvals/approved-${hash}`]: JSON.stringify({
+        stage: "prod",
+        hash,
+        ids,
+        claimedAt: "2026-08-05T00:05:00.000Z",
+      }),
+    });
+
+    const production = await createCleanupDeps(
+      { stage: "prod", apply: true, cap: 50, idsFile },
+      {
+        Client: fakeClientClass([]),
+        ssm,
+        secrets: fakeAwsClient(),
+        getToken: vi.fn(),
+        fromNodeProviderChain: vi.fn(),
+      },
+    );
+
+    // The path is the CONTRACT with the task definition's `--ids` argument. A file
+    // written anywhere else leaves `readApprovedIds` reading a missing file, so the
+    // run dies loud — or worse, reads a stale one.
+    expect(readFileSync(idsFile, "utf8")).toBe("m-1\nm-2\n");
+    await production.close();
+  });
+
+  it("TC-SLACKAPP-103 refuses an approval hash with no ids file rather than applying unfiltered", async () => {
+    // This is the whole loop's failure mode. `readApprovedIds` returns null for a
+    // missing `--ids`, and null means "no filter" — so a hash-driven run that
+    // materialized nowhere would delete EVERY DELETE verdict in the run, not the
+    // ones the operator approved, and exit 0 reporting success.
+    const hash = contentHash(["m-1"].join("\n"));
+    containerEnv({ MEM9_APPROVAL_HASH: hash });
+
+    await expect(
+      createCleanupDeps(
+        { stage: "prod", apply: true, cap: 50 },
+        { Client: fakeClientClass([]), ssm: fakeAwsClient(), secrets: fakeAwsClient() },
+      ),
+    ).rejects.toThrow(/--ids/u);
+  });
+
+  it("TC-SLACKAPP-104 aborts before opening the database when the claim does not match the hash", async () => {
+    // Ordering, not just the error: materialization is the cheapest guard and the
+    // only one that can prove the ids are the approved ids, so it runs before the
+    // connection and before the advisory lock. Reversed, a tampered claim would
+    // hold the shared mutex for the length of its own failure and could block the
+    // weekly consolidation.
+    const ids = ["m-1"];
+    const hash = contentHash(ids.join("\n"));
+    const dir = tempDir();
+    const idsFile = join(dir, "approved.txt");
+    containerEnv({ MEM9_APPROVAL_HASH: hash });
+    const calls = [];
+    const ssm = fakeAwsClient({
+      [`/mem9-on-aws/prod/approvals/approved-${hash}`]: JSON.stringify({
+        stage: "prod",
+        // Agrees with the request, so a string comparison of the two would pass.
+        hash,
+        ids: ["m-substituted"],
+        claimedAt: "2026-08-05T00:05:00.000Z",
+      }),
+    });
+
+    await expect(
+      createCleanupDeps(
+        { stage: "prod", apply: true, cap: 50, idsFile },
+        { Client: fakeClientClass(calls), ssm, secrets: fakeAwsClient() },
+      ),
+    ).rejects.toThrow(/hash/u);
+    expect(calls).toEqual([]);
+    expect(existsSync(idsFile)).toBe(false);
   });
 });

--- a/scripts/memory-cleanup.test.mjs
+++ b/scripts/memory-cleanup.test.mjs
@@ -1,6 +1,7 @@
 // Unit tests for scripts/memory-cleanup.mjs (issue #102).
 // Test IDs map to docs/test-cases/memory-cleanup.md. All I/O is faked through
 // the injected deps object — no network, no real filesystem outside tmpdirs.
+import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
@@ -52,6 +53,10 @@ const TENANT = "tenant-key-0123456789abcdef";
 // computes, derived the same way rather than hardcoded, and shared by both tests
 // of the guard so they cannot disagree about where the tree ends.
 const SCRIPT_TREE = dirname(dirname(fileURLToPath(import.meta.url)));
+
+// The CLI under test, for the two cases that need a real process (TC-MEMRESTORE-061
+// and -071). Everything else in this file injects deps instead.
+const CLI = new URL("./memory-cleanup.mjs", import.meta.url).pathname;
 
 function memory(id, content, version = 1) {
   return { id, content, version, state: "active", memory_type: "insight" };
@@ -3240,23 +3245,62 @@ describe("restore CLI validation", () => {
     // truncated — so a partial listing reads as complete, nondeterministically.
     // The listing itself needs a database, so this drives the same exit path
     // through --help, which writes a comparable volume and needs nothing.
-    const { execFileSync } = await import("node:child_process");
-    const script = new URL("./memory-cleanup.mjs", import.meta.url).pathname;
+    //
     // Every run, not one: the defect is a race, and a single green run is what
     // makes it look fixed. `sh -c` with a pipe is what puts stdout on a pipe
     // rather than on the test's own fd.
     for (let i = 0; i < 5; i += 1) {
-      const piped = execFileSync("sh", ["-c", `node ${script} --help | cat`], { encoding: "utf8" });
+      const piped = execFileSync("sh", ["-c", `node ${CLI} --help | cat`], { encoding: "utf8" });
       expect(piped, `run ${i} was truncated`).toContain(USAGE.trimEnd());
     }
     // ...and the source has no `process.exit(` left to reintroduce it. Behaviour
     // above is the real assertion; this pins the mechanism so the next exit site
     // added to the CLI has to make the same decision deliberately.
-    const code = readFileSync(script, "utf8")
+    const code = readFileSync(CLI, "utf8")
       .split("\n")
       .filter((line) => !/^\s*(\/\/|\*|\/\*)/u.test(line))
       .join("\n");
     expect(code).not.toMatch(/process\.exit\(/u);
+  });
+
+  it("TC-MEMRESTORE-071 the recovery modes reach the database layer, not a TypeError", async () => {
+    // The CLI wiring is the one layer the injected-deps tests cannot reach:
+    // `recoveryDeps` is module-private and every unit test hands fakes straight to
+    // `runListInactive`/`runRestore`, so an error in how the CLI BUILDS those deps
+    // is invisible to all of them — which is how the rebase bug this pins reached a
+    // green suite. Rationale in docs/test-cases/memory-restore.md.
+    //
+    // A nonexistent stage is the point: it fails at the SSM read either way, so
+    // the assertion is WHICH failure. An SSM/credentials diagnostic is something an
+    // operator can act on; a TypeError means the wiring is broken.
+    for (const mode of [["--list-inactive"], ["--restore", "--ids", "/dev/null"]]) {
+      let output = "";
+      try {
+        output = execFileSync(
+          "node",
+          [CLI, "--stage", "mem9-nonexistent-probe-stage", ...mode],
+          {
+            encoding: "utf8",
+            stdio: ["ignore", "pipe", "pipe"],
+            // Unset so `resolveDatabaseConfig` takes the SSM branch, which is the
+            // one that reaches `runtime`. A CI runner with these set would
+            // otherwise skip the very code path under test.
+            env: {
+              ...process.env,
+              MEM9_DB_SECRET: "",
+              MEM9_DB_HOST: "",
+              MEM9_DB_NAME: "",
+            },
+          },
+        );
+      } catch (err) {
+        output = `${err.stdout ?? ""}${err.stderr ?? ""}`;
+      }
+      expect(output, `${mode[0]} reached the deps builder`).not.toMatch(/TypeError/u);
+      expect(output, `${mode[0]} is not a wiring error`).not.toMatch(
+        /Cannot read properties of undefined/u,
+      );
+    }
   });
 });
 

--- a/scripts/memory-cleanup.test.mjs
+++ b/scripts/memory-cleanup.test.mjs
@@ -10,6 +10,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   buildCompleteChat,
+  buildOfferedRecord,
   contentHash,
   inactiveMemoryAdapter,
   parseArgs,
@@ -3569,5 +3570,82 @@ describe("two-pass consensus (#123)", () => {
       expect(intersection.has(id)).toBe(true);
     }
     expect(deleteIds(decisions).size).toBeGreaterThan(0); // not vacuously empty
+  });
+});
+
+describe("the offered approval record (#123)", () => {
+  const del = (id) => ({
+    id,
+    verdict: "DELETE",
+    reason: "stale",
+    contentHash: contentHash(`c-${id}`),
+    version: 1,
+  });
+
+  it("TC-SLACKAPP-023b the offered record carries ids, a hash, a stage, and a timestamp — no memory content", () => {
+    // This parameter is a plain `String` (the boundary admits neither
+    // `kms:Encrypt` nor `kms:GenerateDataKey`, so a SecureString write is denied
+    // at runtime), readable by anything holding `ssm:GetParameters` on the stage
+    // tree. Asserted structurally over the SERIALIZED value rather than by
+    // eyeballing fields: a nested `snippet` added later would satisfy a
+    // field-by-field check and still publish memory content.
+    const record = buildOfferedRecord({
+      stage: "prod",
+      decisions: [
+        del("m-1"),
+        { ...del("m-2"), snippet: "SENTINEL-CONTENT" },
+        // Only DELETE is offered. Every other verdict in the list is a memory
+        // the run decided NOT to destroy, and a RETAIN is one policy actively
+        // protected — so a record built over every row would hand the apply task
+        // exactly the ids the protected-topic rule exists to withhold, with the
+        // operator's approval attached.
+        { id: "m-keep", verdict: "KEEP", reason: "durable" },
+        { id: "m-protected", verdict: "RETAIN", reason: "protected topic personal-finance" },
+        { id: "m-unstable", verdict: "UNSTABLE", reason: "passes disagreed on deletion" },
+      ],
+      generatedAt: "2026-08-05T00:00:00.000Z",
+    });
+    expect(Object.keys(record).sort()).toEqual(["generatedAt", "hash", "ids", "stage"]);
+    expect(record.ids).toEqual(["m-1", "m-2"]);
+    expect(record.stage).toBe("prod");
+    expect(JSON.stringify(record)).not.toMatch(/SENTINEL-CONTENT/u);
+    // The hash is over the ids, so the callback's comparison detects a
+    // regenerated list (TC-SLACKAPP-020) — and it is over a JOIN with a
+    // separator no id can contain, so two different lists whose ids concatenate
+    // identically get different hashes. Without the separator `["ab","c"]` and
+    // `["a","bc"]` are one hash, and a click approving one list would be accepted
+    // against the other.
+    expect(record.hash).toMatch(/^sha256:[0-9a-f]{64}$/u);
+    const stamp = { stage: "prod", generatedAt: "2026-08-05T00:00:00.000Z" };
+    expect(buildOfferedRecord({ ...stamp, decisions: [del("ab"), del("c")] }).hash).not.toBe(
+      buildOfferedRecord({ ...stamp, decisions: [del("a"), del("bc")] }).hash,
+    );
+  });
+
+  it("TC-SLACKAPP-024 an offered list over the 4096-byte parameter limit throws rather than truncating", () => {
+    // Truncating would ask the operator to approve a list that is not the list
+    // they were shown, and the ids are what the apply task deletes — so a
+    // silently shortened record is the one failure mode that produces a WRONG
+    // apply rather than a failed one. It must be loud.
+    //
+    // 4096 is the STANDARD tier's content limit; the advanced tier's 8 KB is not
+    // an option here, since an advanced parameter incurs a charge and cannot be
+    // reverted. `--cap 50` keeps a real record at ~2 KB, so hitting this needs a
+    // cap far above the default — which is exactly the operator mistake worth
+    // failing on.
+    const many = Array.from({ length: 200 }, (_, i) => del(`memory-with-a-realistic-id-${i}`));
+    expect(() =>
+      buildOfferedRecord({ stage: "prod", decisions: many, generatedAt: "2026-08-05T00:00:00.000Z" }),
+    ).toThrow(/4096|parameter limit/u);
+    // Asserted on the SERIALIZED length, not the id count: a limit expressed as
+    // "N ids" drifts from the real constraint the moment ids get longer, and the
+    // thing SSM rejects is bytes.
+    const ok = buildOfferedRecord({
+      stage: "prod",
+      decisions: many.slice(0, 40),
+      generatedAt: "2026-08-05T00:00:00.000Z",
+    });
+    expect(JSON.stringify(ok).length).toBeLessThanOrEqual(4096);
+    expect(ok.ids).toHaveLength(40);
   });
 });

--- a/scripts/run-slack-approval-e2e.sh
+++ b/scripts/run-slack-approval-e2e.sh
@@ -40,11 +40,43 @@ if ! [[ "$STAGE" =~ ^pr-[0-9]+$ ]]; then
   exit 1
 fi
 
-# `|| true` on every probe: an absent parameter is `ParameterNotFound`, which is
-# a SKIP condition here, not a failure (see the gate below).
+# An absent parameter is a SKIP condition here; anything else is a FAILURE.
+# `2>/dev/null || true` would collapse the two, and that is not a cosmetic
+# difference: `AccessDenied` (say a boundary change that leaves the CI role only
+# the plural `ssm:GetParameters`), a KMS denial on `--with-decryption`, throttling,
+# expired credentials, or the wrong region would all read as "not deployed" and
+# exit 0. The gate would then report green forever while sending no request at
+# all — the exact failure the `pr-N` refusal above exists to prevent, so it gets
+# the same treatment: only the one benign cause skips.
+#
+# The two streams are captured SEPARATELY rather than merged with `2>&1`. On the
+# success path a merge would prepend whatever the CLI wrote to stderr — a botocore
+# deprecation notice, a credential-source line — onto the returned VALUE, and one
+# of the values returned here is the signing secret that gets HMAC'd. A polluted
+# secret produces a signature the facade rejects, which would read as the facade
+# being broken. The unit-test fakes cannot catch this: they only write to stderr
+# on the paths where they also exit non-zero.
 ssm_value() {
-  aws ssm get-parameter --name "$1" --region "$REGION" \
-    --with-decryption --query Parameter.Value --output text 2>/dev/null || true
+  local out err rc=0
+  err=$(mktemp)
+  # `|| rc=$?` rather than a bare `rc=$?` on the next line: a plain assignment is
+  # subject to errexit, and while a call in a command substitution survives it
+  # (the subshell carries the failure to the caller's assignment), a direct call
+  # would abort the script before reaching the classifier below.
+  out=$(aws ssm get-parameter --name "$1" --region "$REGION" \
+    --with-decryption --query Parameter.Value --output text 2>"$err") || rc=$?
+  local stderr_text
+  stderr_text=$(<"$err")
+  rm -f "$err"
+  if ((rc == 0)); then
+    printf '%s' "$out"
+    return 0
+  fi
+  if [[ "$stderr_text" == *ParameterNotFound* ]]; then
+    return 0
+  fi
+  echo "::error::reading $1 failed (exit ${rc}): ${stderr_text}" >&2
+  exit 1
 }
 
 FACADE=$(ssm_value "${PREFIX}/facade/url")
@@ -71,7 +103,12 @@ APPROVED_ID="mem9-e2e-nonexistent-${STAGE}"
 # refuses on a mismatch — so this is what lets the run reach the apply at all.
 IDS_HASH="sha256:$(printf '%s' "$APPROVED_ID" | shasum -a 256 | cut -d' ' -f1)"
 OFFERED_NAME="${PREFIX}/approvals/offered"
-CLAIM_NAME="${PREFIX}/approvals/approved-${IDS_HASH}"
+# The colon of `sha256:` is replaced, matching `claimParameterName` in
+# scripts/memory-cleanup.mjs and infra/src/oauth-facade/slack-interactions.ts. An
+# SSM parameter name may contain only letters, numbers and `.-_` per sub-path, so
+# the colon form is rejected by PutParameter — and on a READ it is parsed as a
+# version selector instead, which is why the mismatch does not simply 404.
+CLAIM_NAME="${PREFIX}/approvals/approved-${IDS_HASH//:/-}"
 
 cleanup() {
   # Both records, always, including on failure: `offered` is overwritten by the
@@ -177,13 +214,45 @@ echo "run-slack-approval-e2e: apply task ${TASK_ARN##*/} started"
 
 # 4. The apply task's own exit code. Without this the check passes on a click
 #    that started a task which then crashed.
-CLUSTER="${TASK_ARN##*:task/}"
-CLUSTER="${CLUSTER%%/*}"
+#
+# The cluster comes from SSM, NOT from slicing the task ARN. `${TASK_ARN##*:task/}`
+# assumes the long ARN format (`.../task/<cluster>/<id>`); on an account without
+# the long-ARN opt-in the ARN is `.../task/<id>`, so the slice yields the task id
+# and every describe-tasks below would be called with a nonexistent cluster.
+CLUSTER=$(ssm_value "${PREFIX}/cleanup/cluster-name")
+if [[ -z "$CLUSTER" || "$CLUSTER" == "None" ]]; then
+  echo "::error::no cleanup/cluster-name on ${STAGE}, so the apply task cannot be polled" >&2
+  exit 1
+fi
+
+# A failed describe is NOT an unknown status. Swallowing it would spin the full
+# 15 minutes and then report `lastStatus=UNKNOWN`, which reads as "the task hung"
+# and sends the next engineer to debug the apply task when the real cause is an
+# IAM denial or a bad cluster.
+#
+# Streams kept separate for the same reason as `ssm_value`: the value returned here
+# is compared against `STOPPED` and against exit codes, and a warning line merged
+# onto it would make the comparison silently never match — the 15-minute spin the
+# error message above is meant to rule out.
+describe_task() {
+  local out err rc=0
+  err=$(mktemp)
+  out=$(aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$TASK_ARN" \
+    --region "$REGION" --query "$1" --output text 2>"$err") || rc=$?
+  local stderr_text
+  stderr_text=$(<"$err")
+  rm -f "$err"
+  if ((rc != 0)); then
+    echo "::error::describe-tasks ($1) failed (exit ${rc}): ${stderr_text}" >&2
+    exit 1
+  fi
+  printf '%s' "$out"
+}
+
 DEADLINE=$((SECONDS + 900))
 LAST_STATUS=""
 while [[ $SECONDS -lt $DEADLINE ]]; do
-  LAST_STATUS=$(aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$TASK_ARN" \
-    --region "$REGION" --query 'tasks[0].lastStatus' --output text 2>/dev/null || echo "UNKNOWN")
+  LAST_STATUS=$(describe_task 'tasks[0].lastStatus')
   [[ "$LAST_STATUS" == "STOPPED" ]] && break
   sleep 10
 done
@@ -192,13 +261,28 @@ if [[ "$LAST_STATUS" != "STOPPED" ]]; then
   exit 1
 fi
 
-EXIT_CODE=$(aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$TASK_ARN" \
-  --region "$REGION" --query 'tasks[0].containers[0].exitCode' --output text)
-STOP_REASON=$(aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$TASK_ARN" \
-  --region "$REGION" --query 'tasks[0].stoppedReason' --output text)
+EXIT_CODE=$(describe_task 'tasks[0].containers[0].exitCode')
+STOP_REASON=$(describe_task 'tasks[0].stoppedReason')
 echo "run-slack-approval-e2e: apply task stopped (exitCode=${EXIT_CODE}, reason='${STOP_REASON}')"
+# `None` means the container never produced an exit code — the task died before
+# or outside the entrypoint (a pull failure, or the secret-fetch phase, which is
+# the predicted first-deploy outcome while the execution role is not admitted to
+# the boundary's secret-decrypt exception list). Named separately because
+# "exited None" invites the reader to look for a bug in the app instead.
+if [[ "$EXIT_CODE" == "None" ]]; then
+  echo "::error::the apply task never ran its container (reason='${STOP_REASON}'); this is a startup failure, not an application exit" >&2
+  exit 1
+fi
 if [[ "$EXIT_CODE" != "0" ]]; then
   echo "::error::the apply task exited ${EXIT_CODE}" >&2
+  exit 1
+fi
+# `stoppedReason` is asserted, not merely printed: a task killed by OOM or a
+# failed secret/image pull can stop with a reason set, and the essential-container
+# message is the only benign value here.
+if [[ -n "$STOP_REASON" && "$STOP_REASON" != "None" ]] \
+  && [[ "$STOP_REASON" != *"Essential container in task exited"* ]]; then
+  echo "::error::the apply task stopped for an unexpected reason: ${STOP_REASON}" >&2
   exit 1
 fi
 

--- a/scripts/run-slack-approval-e2e.sh
+++ b/scripts/run-slack-approval-e2e.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# run-slack-approval-e2e.sh — end-to-end check of the Slack approval loop
+# (issue #123, TC-SLACKAPP-090) against a deployed stage.
+#
+# A real Slack workspace round trip is not reproducible in CI, and it is not what
+# needs proving: the handler distinguishes Slack from anyone else ONLY by the
+# request signature, so a correctly signed synthetic interaction exercises the
+# identical path. What this adds over the unit tests is everything they inject —
+# API Gateway's routing and base64 handling, the Lambda's own SSM and ECS grants,
+# the task definition, and the container's entrypoint.
+#
+# The invalid-signature POST runs FIRST and its 401 is a hard requirement: a
+# facade that accepted an unsigned interaction would pass every other check here.
+# It has to precede the valid click so "no record was written" is assertable at
+# all — after a successful click there is a record, and nothing can then tell the
+# two writers apart.
+#
+# The approved id is a synthetic sentinel that names no real memory. This
+# approves a DELETION against a live stage, so an id that resolved to preview
+# data would delete it; the apply's "already gone" branch is what makes the run
+# exit 0.
+
+set -euo pipefail
+
+STAGE="${STAGE:?STAGE is required (for example, prod or pr-123)}"
+REGION="${AWS_REGION:-ap-northeast-1}"
+PREFIX="/mem9-on-aws/${STAGE}"
+
+# Disposable stages only, refused BEFORE the first write, and one pattern rather
+# than a general stage check plus a prod denylist: `pr-N` is the only shape that is
+# safe, so an allowlist cannot be outrun by a stage name nobody thought to deny.
+# Seeding `offered` OVERWRITES it, so on a shared stage this destroys a pending
+# human approval — the operator's next click is then answered against CI's record —
+# and the id it approves is a DELETION against that stage's database. A REFUSAL
+# rather than a skip: an exit 0 here would let a workflow edit silently stop
+# testing anything while still reporting green. The pattern doubles as the
+# injection guard on every `${PREFIX}/...` parameter name built below.
+if ! [[ "$STAGE" =~ ^pr-[0-9]+$ ]]; then
+  echo "::error::refusing to run against ${STAGE}: this seeds and deletes approval records, so it is limited to disposable pr-N stages" >&2
+  exit 1
+fi
+
+# `|| true` on every probe: an absent parameter is `ParameterNotFound`, which is
+# a SKIP condition here, not a failure (see the gate below).
+ssm_value() {
+  aws ssm get-parameter --name "$1" --region "$REGION" \
+    --with-decryption --query Parameter.Value --output text 2>/dev/null || true
+}
+
+FACADE=$(ssm_value "${PREFIX}/facade/url")
+if [[ -z "$FACADE" || "$FACADE" == "None" ]]; then
+  echo "::warning::no facade/url on ${STAGE} — OAuth façade not deployed (skipping)"
+  exit 0
+fi
+
+# Slack approval is gated on MEM9_SLACK_APPROVAL_ENABLED at SYNTH time, so a
+# stage that never seeded the secrets has no endpoint to exercise. Failing hard
+# there would block every PR on a feature the stage does not deploy.
+SIGNING_SECRET=$(ssm_value "${PREFIX}/slack/signing-secret")
+if [[ -z "$SIGNING_SECRET" || "$SIGNING_SECRET" == "None" ]]; then
+  echo "::warning::no slack/signing-secret on ${STAGE} — Slack approval not enabled (skipping)"
+  exit 0
+fi
+
+# An id no memory can have. `mem9-e2e-` is not the store's id format, so the
+# apply's `client.get` resolves nothing and its "already gone" branch runs. The
+# stage is in the id so two concurrent preview runs cannot claim the same hash.
+APPROVED_ID="mem9-e2e-nonexistent-${STAGE}"
+# The same derivation `buildOfferedRecord` and `materializeApprovedIds` use:
+# sha256 over the ids joined by newline. Recomputed by the apply task, which
+# refuses on a mismatch — so this is what lets the run reach the apply at all.
+IDS_HASH="sha256:$(printf '%s' "$APPROVED_ID" | shasum -a 256 | cut -d' ' -f1)"
+OFFERED_NAME="${PREFIX}/approvals/offered"
+CLAIM_NAME="${PREFIX}/approvals/approved-${IDS_HASH}"
+
+cleanup() {
+  # Both records, always, including on failure: `offered` is overwritten by the
+  # next real run, but the claim is written with `Overwrite: false`, so a
+  # leftover would make the NEXT run's click a losing claim that starts nothing.
+  aws ssm delete-parameter --name "$OFFERED_NAME" --region "$REGION" >/dev/null 2>&1 || true
+  aws ssm delete-parameter --name "$CLAIM_NAME" --region "$REGION" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+OFFERED=$(jq -cn --arg stage "$STAGE" --arg hash "$IDS_HASH" --arg id "$APPROVED_ID" \
+  '{stage: $stage, hash: $hash, ids: [$id], generatedAt: (now | todate)}')
+echo "run-slack-approval-e2e: seeding ${OFFERED_NAME} with one synthetic id"
+aws ssm put-parameter --name "$OFFERED_NAME" --type String --value "$OFFERED" \
+  --overwrite --region "$REGION" >/dev/null
+
+# Slack's own encoding: form-urlencoded with the JSON in a `payload` field. A
+# JSON body would 400 here and pass nothing but a smoke test.
+PAYLOAD=$(jq -cn --arg hash "$IDS_HASH" \
+  '{type: "block_actions",
+    user: {id: "U0E2E", username: "ci"},
+    actions: [{action_id: "cleanup_approve", type: "button", value: $hash}]}')
+BODY="payload=$(jq -rn --arg p "$PAYLOAD" '$p | @uri')"
+TIMESTAMP=$(date +%s)
+
+# The HMAC is computed in a node child that reads the secret from its
+# ENVIRONMENT. `openssl dgst -hmac "$SECRET"` would put it in an argv, which is
+# world-readable on the runner (TC-SLACKAPP-090).
+#
+# The single quotes are load-bearing, so SC2016 is disabled rather than "fixed":
+# the `${...}` below are JS template-literal substitutions that NODE must
+# evaluate, and the values arrive through the child's environment. Switching to
+# double quotes would interpolate them in the SHELL — which both breaks the
+# script (the shell has no such variables) and would defeat the argv-avoidance
+# this block exists for.
+# shellcheck disable=SC2016
+SIGNATURE=$(
+  SLACK_SIGNING_SECRET="$SIGNING_SECRET" SIG_TS="$TIMESTAMP" SIG_BODY="$BODY" node -e '
+    const { createHmac } = require("node:crypto");
+    const mac = createHmac("sha256", process.env.SLACK_SIGNING_SECRET)
+      .update(`v0:${process.env.SIG_TS}:${process.env.SIG_BODY}`)
+      .digest("hex");
+    process.stdout.write(`v0=${mac}`);
+  '
+)
+
+post() {
+  local signature="$1" out="$2"
+  curl -sS -o "$out" -w '%{http_code}' \
+    -X POST \
+    -H 'content-type: application/x-www-form-urlencoded' \
+    -H "x-slack-request-timestamp: ${TIMESTAMP}" \
+    -H "x-slack-signature: ${signature}" \
+    --data-binary "$BODY" \
+    "${FACADE}/slack/interactions"
+}
+
+RESPONSE_BODY=$(mktemp)
+trap 'rm -f "$RESPONSE_BODY"; cleanup' EXIT
+
+# 1. Invalid signature FIRST. The same body, so the rejection is provably the
+#    signature's doing and not the payload's.
+echo "run-slack-approval-e2e: POSTing with an invalid signature (expecting 401)"
+BAD_STATUS=$(post "v0=deadbeef" "$RESPONSE_BODY")
+if [[ "$BAD_STATUS" != "401" ]]; then
+  echo "::error::an invalid signature was answered HTTP ${BAD_STATUS}, not 401" >&2
+  exit 1
+fi
+if aws ssm get-parameter --name "$CLAIM_NAME" --region "$REGION" >/dev/null 2>&1; then
+  echo "::error::a rejected interaction still wrote an approval record" >&2
+  exit 1
+fi
+
+# 2. The correctly signed click.
+echo "run-slack-approval-e2e: POSTing a correctly signed interaction (expecting 200)"
+GOOD_STATUS=$(post "$SIGNATURE" "$RESPONSE_BODY")
+if [[ "$GOOD_STATUS" != "200" ]]; then
+  echo "::error::the signed interaction was answered HTTP ${GOOD_STATUS}, not 200" >&2
+  exit 1
+fi
+
+# 3. The RECORD, read back by name. A 200 alone proves nothing: the handler also
+#    answers 200 for a stale hash, an unknown action, and "already applied".
+echo "run-slack-approval-e2e: reading the approval record back by name"
+CLAIM=""
+for attempt in 1 2 3 4 5 6; do
+  CLAIM=$(ssm_value "$CLAIM_NAME")
+  [[ -n "$CLAIM" && "$CLAIM" != "None" ]] && break
+  echo "run-slack-approval-e2e: record not visible yet (attempt ${attempt}/6)"
+  sleep 5
+done
+if [[ -z "$CLAIM" || "$CLAIM" == "None" ]]; then
+  echo "::error::no approval record at ${CLAIM_NAME} after a 200" >&2
+  exit 1
+fi
+
+TASK_ARN=$(jq -r '.taskArn // empty' <<<"$CLAIM")
+if [[ -z "$TASK_ARN" ]]; then
+  echo "::error::the approval record has no taskArn — the claim was recorded but no apply started" >&2
+  exit 1
+fi
+echo "run-slack-approval-e2e: apply task ${TASK_ARN##*/} started"
+
+# 4. The apply task's own exit code. Without this the check passes on a click
+#    that started a task which then crashed.
+CLUSTER="${TASK_ARN##*:task/}"
+CLUSTER="${CLUSTER%%/*}"
+DEADLINE=$((SECONDS + 900))
+LAST_STATUS=""
+while [[ $SECONDS -lt $DEADLINE ]]; do
+  LAST_STATUS=$(aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$TASK_ARN" \
+    --region "$REGION" --query 'tasks[0].lastStatus' --output text 2>/dev/null || echo "UNKNOWN")
+  [[ "$LAST_STATUS" == "STOPPED" ]] && break
+  sleep 10
+done
+if [[ "$LAST_STATUS" != "STOPPED" ]]; then
+  echo "::error::the apply task did not stop within 15 minutes (lastStatus=${LAST_STATUS})" >&2
+  exit 1
+fi
+
+EXIT_CODE=$(aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$TASK_ARN" \
+  --region "$REGION" --query 'tasks[0].containers[0].exitCode' --output text)
+STOP_REASON=$(aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$TASK_ARN" \
+  --region "$REGION" --query 'tasks[0].stoppedReason' --output text)
+echo "run-slack-approval-e2e: apply task stopped (exitCode=${EXIT_CODE}, reason='${STOP_REASON}')"
+if [[ "$EXIT_CODE" != "0" ]]; then
+  echo "::error::the apply task exited ${EXIT_CODE}" >&2
+  exit 1
+fi
+
+echo "run-slack-approval-e2e: OK — signed click accepted, record written, apply exited 0 on ${STAGE}"

--- a/scripts/run-slack-approval-e2e.test.mjs
+++ b/scripts/run-slack-approval-e2e.test.mjs
@@ -48,6 +48,10 @@ function runFixture({
   stage = "pr-123",
   taskExitCode = "0",
   taskStatus = "STOPPED",
+  cluster = "mem9-cleanup-cluster",
+  stoppedReason = "Essential container in task exited",
+  facadeError = "",
+  noisyStderr = "",
 } = {}) {
   const directory = mkdtempSync(join(tmpdir(), "mem9-slack-e2e-"));
   temporaryPaths.push(directory);
@@ -72,20 +76,52 @@ const option = (name) => {
   return index === -1 ? undefined : args[index + 1];
 };
 const command = args.slice(0, 2).join(" ");
+// The real CLI writes to stderr on SUCCESSFUL calls too — a botocore deprecation
+// notice, a credential-source line. Every other knob in this fake writes stderr
+// only when it also exits non-zero, which is exactly why merging the streams with
+// \`2>&1\` looked harmless: no case could produce the polluted-value shape.
+if (process.env.MOCK_NOISY_STDERR) console.error(process.env.MOCK_NOISY_STDERR);
+// The real CLI writes this to STDERR and exits 255 for an absent parameter. The
+// script distinguishes it from every other failure by that text, so a fake that
+// merely exited 255 would let an AccessDenied-style regression pass as a skip —
+// the fake has to be wrong in the same shape as reality to test anything.
+const notFound = (name) => {
+  console.error(
+    "An error occurred (ParameterNotFound) when calling the GetParameter " +
+      \`operation: Parameter \${name} not found.\`,
+  );
+  process.exit(255);
+};
+// Every OTHER way a read can fail: no ParameterNotFound text, so the script has
+// no license to treat it as "not deployed". The real CLI's exit code for these is
+// 255 as well, which is precisely why the code cannot be the discriminator.
+const readError = (name, code) => {
+  console.error(
+    \`An error occurred (\${code}) when calling the GetParameter operation: \` +
+      \`explicit deny in a service control policy or resource policy for \${name}\`,
+  );
+  process.exit(255);
+};
 if (command === "ssm get-parameter") {
   const name = option("--name") ?? "";
   if (name.endsWith("/facade/url")) {
-    if (!process.env.MOCK_FACADE) process.exit(255);
+    if (process.env.MOCK_FACADE_ERROR) {
+      readError(name, process.env.MOCK_FACADE_ERROR);
+    }
+    if (!process.env.MOCK_FACADE) notFound(name);
     console.log(process.env.MOCK_FACADE);
   } else if (name.endsWith("/slack/signing-secret")) {
-    if (!process.env.MOCK_SECRET) process.exit(255);
+    if (!process.env.MOCK_SECRET) notFound(name);
     console.log(process.env.MOCK_SECRET);
+  } else if (name.endsWith("/cleanup/cluster-name")) {
+    if (!process.env.MOCK_CLUSTER) notFound(name);
+    console.log(process.env.MOCK_CLUSTER);
   } else if (name.includes("/approvals/approved-")) {
     // Stateful, like a real stage: no claim exists until the signed click
     // creates one. A fake that served it unconditionally would make the
     // pre-click "no record was written" assertion fail against a correct script.
     if (!existsSync(process.env.MOCK_CLICKED) || !process.env.MOCK_CLAIM) {
-      process.exit(255);
+      notFound(name);
     }
     console.log(process.env.MOCK_CLAIM);
   } else {
@@ -96,9 +132,20 @@ if (command === "ssm get-parameter") {
   process.exit(0);
 } else if (command === "ecs describe-tasks") {
   const query = option("--query") ?? "";
+  // The cluster is asserted, not ignored: the script must pass the name it read
+  // from SSM. Slicing it out of the task ARN (the previous implementation) yields
+  // the task id on an account without the long-ARN opt-in, and a fake that
+  // accepted any --cluster could not tell the two apart.
+  if (option("--cluster") !== process.env.MOCK_CLUSTER) {
+    console.error(
+      "An error occurred (ClusterNotFoundException) when calling the " +
+        \`DescribeTasks operation: cluster not found: \${option("--cluster")}\`,
+    );
+    process.exit(254);
+  }
   if (query.includes("lastStatus")) console.log(process.env.MOCK_TASK_STATUS);
   else if (query.includes("exitCode")) console.log(process.env.MOCK_TASK_EXIT);
-  else console.log("Essential container in task exited");
+  else console.log(process.env.MOCK_STOP_REASON);
 } else {
   console.error("unexpected aws command:", command);
   process.exit(2);
@@ -155,6 +202,10 @@ process.stdout.write(status);
       MOCK_CLAIM: claim === null ? "" : claim,
       MOCK_TASK_EXIT: taskExitCode,
       MOCK_TASK_STATUS: taskStatus,
+      MOCK_CLUSTER: cluster,
+      MOCK_STOP_REASON: stoppedReason,
+      MOCK_FACADE_ERROR: facadeError,
+      MOCK_NOISY_STDERR: noisyStderr,
       PATH: `${bin}${delimiter}${process.env.PATH}`,
       STAGE: stage,
       AWS_REGION: "ap-northeast-1",
@@ -338,6 +389,98 @@ describe("Slack approval E2E harness (TC-SLACKAPP-090)", () => {
       ),
     ).toHaveLength(0);
     expect(callRecords.filter(([tool]) => tool === "curl")).toHaveLength(0);
+  });
+
+  it("TC-SLACKAPP-090b a parameter read that fails for any reason OTHER than absence is a hard failure", () => {
+    // The distinction the gate depends on. `2>/dev/null || true` collapsed every
+    // error into "" and every "" into a skip, so an AccessDenied — say a boundary
+    // change leaving the CI role only the plural `ssm:GetParameters` — would have
+    // reported green forever while sending no request at all. That is the same
+    // vacuous-gate failure the pr-N refusal exists to prevent.
+    const { callRecords, result, output } = runFixture({ facadeError: "AccessDeniedException" });
+    expect(result.status, output).not.toBe(0);
+    expect(output).toMatch(/AccessDeniedException/u);
+    // And it must not be mistaken for the benign skip.
+    expect(output).not.toMatch(/skipping/iu);
+    expect(callRecords.filter(([tool]) => tool === "curl")).toHaveLength(0);
+  });
+
+  it("TC-SLACKAPP-090b the cluster comes from SSM, not from slicing the task ARN", () => {
+    // `${TASK_ARN##*:task/}` assumes the long ARN format. On an account without
+    // the long-ARN opt-in the ARN carries no cluster segment, so the slice yields
+    // the task id and every describe-tasks runs against a cluster that does not
+    // exist. The fake rejects a mismatched --cluster, so this fails if the script
+    // ever goes back to deriving it.
+    const { callRecords, result, output } = runFixture({
+      claim: claimWith(),
+      cluster: "mem9-real-cluster",
+    });
+    expect(result.status, output).toBe(0);
+    const describes = callRecords.filter(
+      ([tool, service, operation]) =>
+        tool === "aws" && service === "ecs" && operation === "describe-tasks",
+    );
+    expect(describes.length).toBeGreaterThanOrEqual(1);
+    for (const call of describes) {
+      expect(call).toContain("mem9-real-cluster");
+    }
+  });
+
+  it("TC-SLACKAPP-090b a task that never ran its container is named as a startup failure", () => {
+    // ECS reports a NULL exitCode as the literal "None" when the task died before
+    // the entrypoint — the predicted first-deploy outcome while the execution role
+    // is outside the boundary's secret-decrypt exception list. "exited None" would
+    // send the next engineer looking for an application bug.
+    const { result, output } = runFixture({
+      claim: claimWith(),
+      taskExitCode: "None",
+      stoppedReason: "ResourceInitializationError: unable to pull secrets",
+    });
+    expect(result.status, output).not.toBe(0);
+    expect(output).toMatch(/never ran its container/iu);
+    expect(output).toMatch(/ResourceInitializationError/u);
+  });
+
+  it("TC-SLACKAPP-090b an unexpected stoppedReason fails the run even when the exit code is 0", () => {
+    // stoppedReason used to be fetched, printed, and never asserted. A task killed
+    // by OOM can stop with a reason set, and only the essential-container message
+    // is benign here.
+    const { result, output } = runFixture({
+      claim: claimWith(),
+      taskExitCode: "0",
+      stoppedReason: "OutOfMemoryError: container killed due to memory usage",
+    });
+    expect(result.status, output).not.toBe(0);
+    expect(output).toMatch(/unexpected reason/iu);
+    expect(output).toMatch(/OutOfMemoryError/u);
+  });
+
+  it("TC-SLACKAPP-090b a warning the CLI prints on a SUCCESSFUL call never lands in the value", () => {
+    // `out=$(aws ... 2>&1)` reads as a harmless way to capture the error text for
+    // the classifier, but on the success path it prepends stderr onto the VALUE.
+    // Two of the values read here make that a real failure rather than cosmetic:
+    // the cluster name, which then matches no cluster, and the signing secret,
+    // which is HMAC'd — producing a signature the facade correctly rejects, so the
+    // harness would blame the facade for its own contamination.
+    const { callRecords, result, output } = runFixture({
+      claim: claimWith(),
+      cluster: "mem9-real-cluster",
+      noisyStderr: "urllib3 v2 only supports OpenSSL 1.1.1+",
+    });
+    expect(result.status, output).toBe(0);
+    // The signature is the load-bearing one: a polluted secret still produces a
+    // well-formed hex digest, so only the fake's own signature check can tell.
+    // The fake `curl` treats any non-matching signature as invalid, and the valid
+    // click must still have been accepted for the run to reach exit 0 at all.
+    const describes = callRecords.filter(
+      ([tool, service, operation]) =>
+        tool === "aws" && service === "ecs" && operation === "describe-tasks",
+    );
+    expect(describes.length).toBeGreaterThanOrEqual(1);
+    for (const call of describes) {
+      // The value, not the value with a warning glued to its front.
+      expect(call).toContain("mem9-real-cluster");
+    }
   });
 
   it("TC-SLACKAPP-090 a failure still removes the records it seeded", () => {

--- a/scripts/run-slack-approval-e2e.test.mjs
+++ b/scripts/run-slack-approval-e2e.test.mjs
@@ -1,0 +1,401 @@
+/**
+ * Unit tests for the Slack approval E2E harness (issue #123, TC-SLACKAPP-090).
+ * Test ids map to docs/test-cases/slack-approval-loop.md.
+ *
+ * The harness itself talks to a deployed stage, so every case here runs it
+ * against a fake `aws` and a fake `curl` on PATH. That is the only way to assert
+ * the properties that actually matter — that a 200 on the INVALID signature
+ * fails the run, that "a record exists" is read back by name, that the signing
+ * secret never reaches stdout — without a deployed stage and a Slack workspace.
+ */
+
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { afterEach, describe, expect, it } from "vitest";
+
+const script = resolve("scripts/run-slack-approval-e2e.sh");
+const SECRET = "fixture-signing-secret";
+const temporaryPaths = [];
+
+afterEach(() => {
+  for (const path of temporaryPaths.splice(0)) {
+    rmSync(path, { force: true, recursive: true });
+  }
+});
+
+/**
+ * Run the harness with a fake `aws` and `curl`.
+ *
+ * Every knob is a MOCK_* env var read inside the fakes rather than a fixture
+ * file, so a case reads as the one deviation it is testing.
+ */
+function runFixture({
+  secret = SECRET,
+  facade = "https://facade.example.com",
+  badSignatureStatus = "401",
+  approveStatus = "200",
+  claim = null,
+  stage = "pr-123",
+  taskExitCode = "0",
+  taskStatus = "STOPPED",
+} = {}) {
+  const directory = mkdtempSync(join(tmpdir(), "mem9-slack-e2e-"));
+  temporaryPaths.push(directory);
+  const bin = join(directory, "bin");
+  const calls = join(directory, "calls.jsonl");
+  mkdirSync(bin);
+
+  const aws = join(bin, "aws");
+  writeFileSync(
+    aws,
+    // The shebang is the ABSOLUTE interpreter, never `env node`: this fixture
+    // prepends `bin` to PATH (below), so `env node` would resolve to any file
+    // named `node` in `bin` — and a stub that re-invokes `node` then forks
+    // forever. That is not hypothetical; it once spawned ~70k processes and
+    // exhausted the systemd user slice's TasksMax.
+    `#!${process.execPath}
+import { appendFileSync, existsSync } from "node:fs";
+const args = process.argv.slice(2);
+appendFileSync(process.env.MOCK_CALLS, JSON.stringify(["aws", ...args]) + "\\n");
+const option = (name) => {
+  const index = args.indexOf(name);
+  return index === -1 ? undefined : args[index + 1];
+};
+const command = args.slice(0, 2).join(" ");
+if (command === "ssm get-parameter") {
+  const name = option("--name") ?? "";
+  if (name.endsWith("/facade/url")) {
+    if (!process.env.MOCK_FACADE) process.exit(255);
+    console.log(process.env.MOCK_FACADE);
+  } else if (name.endsWith("/slack/signing-secret")) {
+    if (!process.env.MOCK_SECRET) process.exit(255);
+    console.log(process.env.MOCK_SECRET);
+  } else if (name.includes("/approvals/approved-")) {
+    // Stateful, like a real stage: no claim exists until the signed click
+    // creates one. A fake that served it unconditionally would make the
+    // pre-click "no record was written" assertion fail against a correct script.
+    if (!existsSync(process.env.MOCK_CLICKED) || !process.env.MOCK_CLAIM) {
+      process.exit(255);
+    }
+    console.log(process.env.MOCK_CLAIM);
+  } else {
+    console.error("unexpected parameter:", name);
+    process.exit(2);
+  }
+} else if (command === "ssm put-parameter" || command === "ssm delete-parameter") {
+  process.exit(0);
+} else if (command === "ecs describe-tasks") {
+  const query = option("--query") ?? "";
+  if (query.includes("lastStatus")) console.log(process.env.MOCK_TASK_STATUS);
+  else if (query.includes("exitCode")) console.log(process.env.MOCK_TASK_EXIT);
+  else console.log("Essential container in task exited");
+} else {
+  console.error("unexpected aws command:", command);
+  process.exit(2);
+}
+`,
+    { mode: 0o755 },
+  );
+  chmodSync(aws, 0o755);
+
+  // The fake `curl` decides which POST it is by the SIGNATURE header, exactly as
+  // the real endpoint does: that is the one thing this E2E exists to exercise.
+  const curl = join(bin, "curl");
+  writeFileSync(
+    curl,
+    `#!${process.execPath}
+import { appendFileSync, writeFileSync } from "node:fs";
+const args = process.argv.slice(2);
+appendFileSync(process.env.MOCK_CALLS, JSON.stringify(["curl", ...args]) + "\\n");
+const option = (name) => {
+  const index = args.indexOf(name);
+  return index === -1 ? undefined : args[index + 1];
+};
+const headers = args.filter((a, i) => args[i - 1] === "-H");
+const signature = headers.find((h) => /^x-slack-signature:/i.test(h)) ?? "";
+const invalid = /deadbeef|invalid/i.test(signature);
+const status = invalid ? process.env.MOCK_BAD_STATUS : process.env.MOCK_APPROVE_STATUS;
+const body = invalid
+  ? "unauthorized"
+  : JSON.stringify({ response_type: "ephemeral", text: "Apply started for 1 memories." });
+const out = option("-o");
+if (out) writeFileSync(out, body);
+// A 200 on the VALID signature is what creates the claim on a real stage.
+if (!invalid && status === "200") writeFileSync(process.env.MOCK_CLICKED, "1");
+process.stdout.write(status);
+`,
+    { mode: 0o755 },
+  );
+  chmodSync(curl, 0o755);
+
+  const sleep = join(bin, "sleep");
+  writeFileSync(sleep, "#!/usr/bin/env bash\nexit 0\n", { mode: 0o755 });
+  chmodSync(sleep, 0o755);
+
+  const result = spawnSync("bash", [script], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      MOCK_CALLS: calls,
+      MOCK_CLICKED: join(directory, "clicked"),
+      MOCK_FACADE: facade,
+      MOCK_SECRET: secret,
+      MOCK_BAD_STATUS: badSignatureStatus,
+      MOCK_APPROVE_STATUS: approveStatus,
+      MOCK_CLAIM: claim === null ? "" : claim,
+      MOCK_TASK_EXIT: taskExitCode,
+      MOCK_TASK_STATUS: taskStatus,
+      PATH: `${bin}${delimiter}${process.env.PATH}`,
+      STAGE: stage,
+      AWS_REGION: "ap-northeast-1",
+    },
+  });
+  // The log file only exists once a fake has been invoked, and the whole point of
+  // the protected-stage case is that NOTHING is invoked — so an absent file is a
+  // valid result (no calls), not a fixture error.
+  const callRecords = (existsSync(calls) ? readFileSync(calls, "utf8") : "")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+  return { callRecords, result, output: `${result.stdout}${result.stderr}` };
+}
+
+/** The claim the callback writes when it wins and RunTask succeeds. */
+function claimWith(overrides = {}) {
+  return JSON.stringify({
+    stage: "pr-123",
+    hash: "sha256:unused-by-the-harness",
+    ids: ["mem9-e2e-nonexistent"],
+    claimedAt: "2026-08-05T12:00:00.000Z",
+    taskArn: "arn:aws:ecs:ap-northeast-1:123456789012:task/mem9-pr-123/task-abc",
+    ...overrides,
+  });
+}
+
+describe("Slack approval E2E harness (TC-SLACKAPP-090)", () => {
+  it("TC-SLACKAPP-090 signs a synthetic interaction, proves the record exists, and waits for the apply", () => {
+    const { callRecords, result, output } = runFixture({ claim: claimWith() });
+    expect(result.status, output).toBe(0);
+
+    const curls = callRecords.filter(([tool]) => tool === "curl");
+    expect(curls).toHaveLength(2);
+
+    // The INVALID signature goes first, so "no record" is asserted before the
+    // valid click creates one. Reversed, the 401 case would have to assert the
+    // absence of a record that already exists, which nothing can do.
+    const [bad, good] = curls;
+    expect(bad.join(" ")).toMatch(/x-slack-signature:\s*v0=deadbeef/iu);
+    expect(good.join(" ")).toMatch(/x-slack-signature:\s*v0=[0-9a-f]{64}/u);
+
+    // Same body both times. A different body would make the 401 provable by the
+    // body rather than by the signature, which is not the property under test.
+    const bodyOf = (call) => call[call.indexOf("--data-binary") + 1];
+    expect(bodyOf(bad)).toBe(bodyOf(good));
+    expect(bodyOf(good)).toMatch(/^payload=/u);
+    expect(decodeURIComponent(bodyOf(good).slice("payload=".length))).toContain(
+      "cleanup_approve",
+    );
+
+    // The record is read back BY NAME, so "a record was written" is a positive
+    // assertion rather than the absence of an error.
+    const claimReads = callRecords.filter(
+      ([tool, service, operation, , name]) =>
+        tool === "aws" &&
+        service === "ssm" &&
+        operation === "get-parameter" &&
+        String(name).includes("/approvals/approved-"),
+    );
+    expect(claimReads.length).toBeGreaterThanOrEqual(2);
+
+    // And the apply task's own exit code is checked. Without this the harness
+    // would pass on a click that started a task which then crashed.
+    const describes = callRecords.filter(
+      ([tool, service, operation]) =>
+        tool === "aws" && service === "ecs" && operation === "describe-tasks",
+    );
+    expect(describes.length).toBeGreaterThanOrEqual(1);
+    expect(describes.some((c) => c.join(" ").includes("task-abc"))).toBe(true);
+
+    // Both parameters are removed, so a rerun is not blocked by its own leftovers
+    // (the offered record is overwritten, but the claim is written with
+    // Overwrite:false and would make the second run's click a losing claim).
+    const deletes = callRecords.filter(
+      ([tool, service, operation]) =>
+        tool === "aws" && service === "ssm" && operation === "delete-parameter",
+    );
+    expect(deletes).toHaveLength(2);
+  });
+
+  it("TC-SLACKAPP-090 the secret never reaches the output, and never an argv", () => {
+    const { callRecords, output } = runFixture({ claim: claimWith() });
+    // stdout/stderr is CI output, which is retained per-run and readable by
+    // anyone with Actions access.
+    expect(output).not.toContain(SECRET);
+    expect(JSON.stringify(callRecords)).not.toContain(SECRET);
+
+    // The argv half is asserted against the SOURCE, not the run. An argv is
+    // visible to every process on the box, but the fakes above only see the
+    // commands they replace — so a signer written as
+    // `openssl dgst -hmac "$SIGNING_SECRET"` would put the secret in a
+    // world-readable argv and satisfy every runtime assertion here. That is the
+    // obvious way to write this in bash, which is exactly why it is pinned:
+    // the secret must reach its consumer through the ENVIRONMENT.
+    //
+    // Scanned over EXECUTABLE lines only. The comment above the signer names
+    // `openssl dgst -hmac "$SECRET"` as the anti-pattern it exists to warn about,
+    // and a scan of the raw file flags that prose as the very thing it forbids.
+    // Full-line comments only — `#` also appears mid-code in `${VAR##*/}`, so
+    // truncating every line at its first `#` would mangle the code being scanned,
+    // and a trailing comment cannot hide a command from this either way.
+    const code = readFileSync(script, "utf8")
+      .split("\n")
+      .filter((line) => !/^\s*#/u.test(line))
+      .join("\n");
+    const secretRefs = code.match(/[^\n]*\$\{?SIGNING_SECRET\}?[^\n]*/gu) ?? [];
+    expect(secretRefs.length).toBeGreaterThan(0);
+    for (const line of secretRefs) {
+      // Allowed: the SSM read that produces it, the emptiness check that gates
+      // the skip, and an `NAME="$SIGNING_SECRET"` environment assignment.
+      const isEnvAssignment = /\b[A-Z_]+="\$SIGNING_SECRET"/u.test(line);
+      const isGuard = /^\s*(SIGNING_SECRET=|if \[\[|.*-z "\$SIGNING_SECRET")/u.test(line);
+      expect(
+        isEnvAssignment || isGuard,
+        `the secret is interpolated into a command line: ${line.trim()}`,
+      ).toBe(true);
+    }
+    expect(code).not.toMatch(/-hmac\s+"?\$/u);
+  });
+
+  it("TC-SLACKAPP-090 a 200 on the INVALID signature fails the run", () => {
+    // The case the whole harness exists for. A facade that accepted an unsigned
+    // interaction would otherwise pass every other assertion here.
+    const { result, output } = runFixture({
+      badSignatureStatus: "200",
+      claim: claimWith(),
+    });
+    expect(result.status).not.toBe(0);
+    expect(output).toMatch(/invalid signature/iu);
+  });
+
+  it("TC-SLACKAPP-090 a non-200 on the VALID signature fails the run", () => {
+    const { result, output } = runFixture({ approveStatus: "500", claim: claimWith() });
+    expect(result.status).not.toBe(0);
+    expect(output).toMatch(/signed interaction/iu);
+  });
+
+  it("TC-SLACKAPP-090 an absent approval record fails the run", () => {
+    // A 200 is not proof: the handler answers 200 for "already applied", for an
+    // unknown action, and for a stale hash. Only the record proves the claim.
+    const { result, output } = runFixture({ claim: null });
+    expect(result.status).not.toBe(0);
+    // Pinned to the phrase only THIS branch emits. `/approval record/` also
+    // matches the taskArn branch's message, so a script that dropped the record
+    // check entirely still satisfied it — the failure arrived one step later, from
+    // `jq` finding no taskArn in an empty string, and looked identical.
+    expect(output).toMatch(/no approval record at/iu);
+  });
+
+  it("TC-SLACKAPP-090 a claim with no taskArn fails the run", () => {
+    // The claim exists but nothing was started — the exact state a RunTask
+    // failure leaves behind, and the one an operator most needs surfaced.
+    const raw = JSON.parse(claimWith());
+    delete raw.taskArn;
+    const { result, output } = runFixture({ claim: JSON.stringify(raw) });
+    expect(result.status).not.toBe(0);
+    expect(output).toMatch(/has no taskArn/iu);
+  });
+
+  it("TC-SLACKAPP-090 an apply task that exits non-zero fails the run", () => {
+    const { result, output } = runFixture({ claim: claimWith(), taskExitCode: "6" });
+    expect(result.status).not.toBe(0);
+    expect(output).toMatch(/exited 6/iu);
+  });
+
+  it("TC-SLACKAPP-090 a stage with no Slack secret skips instead of failing", () => {
+    // Slack approval is gated on MEM9_SLACK_APPROVAL_ENABLED at SYNTH time, so a
+    // stage that did not seed the secrets has no endpoint to test. A hard failure
+    // there would block every PR on a feature the stage does not deploy — the
+    // same shape as run-oauth-facade-smoke.sh's absent-facade skip.
+    const { callRecords, result, output } = runFixture({ secret: "" });
+    expect(result.status, output).toBe(0);
+    expect(output).toMatch(/skipping/iu);
+    // And it must not have half-run: no seeded record, no POST.
+    expect(
+      callRecords.filter(
+        ([tool, service, operation]) =>
+          tool === "aws" && service === "ssm" && operation === "put-parameter",
+      ),
+    ).toHaveLength(0);
+    expect(callRecords.filter(([tool]) => tool === "curl")).toHaveLength(0);
+  });
+
+  it("TC-SLACKAPP-090 a failure still removes the records it seeded", () => {
+    // Otherwise the first failure leaves an `approvals/offered` record behind on
+    // the stage, and the NEXT run's click is answered against it.
+    const { callRecords, result } = runFixture({ approveStatus: "500", claim: claimWith() });
+    expect(result.status).not.toBe(0);
+    const deletes = callRecords.filter(
+      ([tool, service, operation]) =>
+        tool === "aws" && service === "ssm" && operation === "delete-parameter",
+    );
+    expect(deletes.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("TC-SLACKAPP-090 a protected stage is refused before anything is written", () => {
+    // The harness OVERWRITES `approvals/offered` to seed its synthetic id. On prod
+    // that destroys a pending human approval — the operator's next click is then
+    // answered against CI's record — and the id it approves is a DELETION against
+    // the live database. The CI step is preview-only, but a workflow edit or a
+    // manual run is one env var away from prod, so the refusal lives in the script
+    // where neither can bypass it.
+    for (const stage of ["prod", "PROD", "production", "staging"]) {
+      const { callRecords, result, output } = runFixture({ stage, claim: claimWith() });
+      expect(result.status, `${stage}: ${output}`).not.toBe(0);
+      expect(output).toMatch(/refusing to run against/iu);
+      // Refused BEFORE the seed, not after: a run that wrote first and failed
+      // second has already clobbered the record it was protecting.
+      expect(
+        callRecords.filter(
+          ([tool, service, operation]) =>
+            tool === "aws" && service === "ssm" && operation === "put-parameter",
+        ),
+        `${stage} seeded a record before refusing`,
+      ).toHaveLength(0);
+      expect(callRecords.filter(([tool]) => tool === "curl")).toHaveLength(0);
+    }
+
+    // And it is a REFUSAL, not a skip: an exit 0 here would let a workflow edit
+    // silently stop testing anything while reporting green.
+    const { result } = runFixture({ stage: "prod", claim: claimWith() });
+    expect(result.status).toBe(1);
+  });
+
+  it("TC-SLACKAPP-090 the approved id cannot name a real memory", () => {
+    // The harness approves a DELETION. An id that resolved to real preview data
+    // would delete it — so the id is a synthetic sentinel, and the apply's
+    // "already gone" branch is what makes the run exit 0.
+    const { callRecords } = runFixture({ claim: claimWith() });
+    const put = callRecords.find(
+      ([tool, service, operation]) =>
+        tool === "aws" && service === "ssm" && operation === "put-parameter",
+    );
+    const value = JSON.parse(put[put.indexOf("--value") + 1]);
+    expect(value.ids).toHaveLength(1);
+    expect(value.ids[0]).toMatch(/e2e/iu);
+    // Hash over the ids, the same derivation the apply task re-computes. A
+    // mismatch there refuses the apply, so this is what makes the run reach it.
+    expect(value.hash).toMatch(/^sha256:[0-9a-f]{64}$/u);
+    expect(value.stage).toBe("pr-123");
+  });
+});

--- a/scripts/workload-permissions-boundary-contract.json
+++ b/scripts/workload-permissions-boundary-contract.json
@@ -13,7 +13,7 @@
     {
       "id": "infra-ci.yml",
       "path": ".github/workflows/infra-ci.yml",
-      "reviewedBlob": "0d17288f7b8b72a9174351bf70461ca3391dd5f6"
+      "reviewedBlob": "8ceb3f723818c6a11033a4a6b2c626340e9a8cfa"
     },
     {
       "id": "reconcile-previews.yml",

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -158,6 +158,14 @@ export default $config({
     const { gateway } = await import("./infra/gateway");
     gateway(cognitoOut, ecsOut, identityOut, facadeOut.readerClientId);
 
+    // Slack approval loop (#123): the on-demand cleanup-apply Task plus the SSM
+    // inputs and grants the façade Lambda needs to start it. Built AFTER
+    // oauthFacade() because the grants attach to that Lambda's EXISTING role
+    // rather than creating a second role needing its own boundary exception.
+    // Entirely absent unless MEM9_SLACK_APPROVAL_ENABLED=1.
+    const { slackApproval } = await import("./infra/slack-approval");
+    slackApproval(ecsOut, dbOut, identityOut, facadeOut);
+
     return {};
   },
 });


### PR DESCRIPTION
Closes #123.

Adds an opt-in human approval loop so the cleanup task cannot delete memories
without a signed click. The façade distinguishes Slack from anyone else **only**
by the request signature, so verification happens before any state change, and
the approved ids are pinned into an immutable `approvals/approved-{hash}` record
that the apply task re-reads — a click cannot approve a set the operator never
saw.

## What's here

- `infra/slack-approval.ts` — the approval stack, synthesised only when
  `MEM9_SLACK_APPROVAL_ENABLED` is set. It **fails synthesis** when the flag is
  on but a secret is unseeded, rather than deploying a loop that silently cannot
  notify.
- `oauth-facade/slack-interactions` — signature verification (timing-safe, with
  a two-sided replay window), the offered→approved record transition, and a
  deliberately inert default: only `cleanup_approve` approves, so a new button
  or a template typo cannot become a deletion trigger.
- `scripts/run-slack-approval-e2e.sh` — a signed synthetic interaction against a
  deployed preview stage (TC-SLACKAPP-090). The HMAC is computed in a child's
  environment so the signing secret never reaches `argv`.
- `infra-ci.yml` — preview-only E2E, **deliberately not mirrored to prod**: the
  harness overwrites `approvals/offered` to seed its synthetic id, so on prod it
  would destroy a pending human approval and approve a deletion against the live
  database. The flag comes from `vars.` rather than a literal `1` because GitHub
  exposes an unset secret as an empty string, which would fail synthesis on every
  PR of a repo that has not seeded a Slack app.
- `workload-permissions-boundary-contract.json` — re-pins `infra-ci.yml`'s
  reviewed blob. The rollout interlock requires the workflow to be byte-exact on
  the default branch, so editing the workflow obliges updating the pin in the
  same reviewed change.

## Verification

- **1,116 tests** pass (807 root + 309 infra); both typechecks and shellcheck clean.
- **Mutation-proved**, not just asserted: deleting the approval-record guard, the
  `taskArn` guard, or rewriting the signer as `openssl dgst -hmac "$SECRET"` each
  fail exactly one test. Reading `approvals/offered` instead of the claim fails 9.
- Review of this branch added three cases that closed gaps a surviving mutation
  exposed: a **base64-encoded body** is decoded before verification (API Gateway
  base64-encodes unrecognised content types, and nothing else in the suite set
  `isBase64Encoded` — a production-only 401-everything failure), a tampered
  base64 body is still rejected, and the `response_url` **SSRF abstinence** is now
  enforced against an attacker-chosen host instead of resting on a comment.

## Sequencing — please read before deploying

Merging is safe; **deploying is not, yet**. Two operator-owned steps remain:

1. `scripts/rollout-workload-permissions-boundary.sh` must run from `main`.
   Until it does, the approval-record SSM write is denied at runtime. `main` is
   currently self-consistent, so the interlock passes either before or after this
   merge.
2. **Unresolved:** whether an explicit identity DENY on `kms:Decrypt` is evaluated
   for `GetSecretValue` under the default `aws/secretsmanager` key.
   `Mem9CleanupExecutionRole-` is absent from the boundary's exception list, while
   `Mem9ConsolidationExecutionRole-` had to be added for a task that reads the
   same two secrets. If the deny bites, this task dies at startup *after* the
   click is spent. `infra/slack-approval.ts` carries the full evidence chain in a
   BOUNDARY NOTE. Settle it before the first deploy.

`Deploy PR Preview` is expected to fail until step 1 completes.