### PR TITLE
feat(cleanup): recover soft-deleted memories with --list-inactive and --restore (#124)

### DIFF
--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -170,6 +170,9 @@ jobs:
       - name: Consolidation coverage (root)
         run: npm run test:consolidation:coverage
 
+      - name: Cleanup and recovery coverage (root)
+        run: npm run test:cleanup:coverage
+
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"

--- a/.gitignore
+++ b/.gitignore
@@ -57,5 +57,19 @@ scripts/upload-screenshot.sh
 scripts/write-verdict-artifact.sh
 scripts/write-verdict-body.sh
 
+# memory-cleanup.mjs decision and restore logs. These hold memory snippets
+# (instance-private data) and belong outside any checkout — `snippetLogDir`
+# refuses an `--out` that resolves in here. These patterns are the second line of
+# that defence, for a file copied in by hand or written by an older revision.
+#
+# Anchored deliberately, and so covering only the root: unanchored, they would
+# match at every depth and silently swallow an unrelated `docs/decisions-*.json`
+# or `infra/restore-*.json` — and a file that is invisibly untracked is the
+# failure mode an ignore rule is worst at revealing. A stray log in a
+# SUBdirectory is therefore NOT ignored and will show up in `git status`, which
+# for a file this size is the outcome to want.
+/decisions-*.json
+/restore-*.json
+
 # OS
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -949,21 +949,86 @@ host. Production execution is a deliberate manual flow:
    result as "these 740 are fine" — re-run before treating the audit as
    complete.
 
-Requires VPC-internal network access to `mnemo.mem9-<stage>.local:8080` (the
-script discovers the task IP via Cloud Map `DiscoverInstances`; pass
-`--base-url` explicitly when tunneling) plus IAM for `ssm:GetParameter` on
-`/mem9-on-aws/<stage>/tenant/secret-arn`, `secretsmanager:GetSecretValue` on
-the tenant secret, `servicediscovery:DiscoverInstances`, and
-`bedrock-mantle:CreateInference`/`CallWithBearerToken`. A reasoning-model run
-needs those Bedrock grants in the **responses region** as well (default
-`us-west-2`), since the bearer is minted per region; cost attribution uses
-`MEM9_BEDROCK_PROJECT_OPENAI` there and `MEM9_BEDROCK_PROJECT` in the
-application region (Mantle projects are regional and never cross-applied).
+   **The audit and clean mode** requires VPC-internal network access to
+   `mnemo.mem9-<stage>.local:8080` (the script discovers the task IP via Cloud
+   Map `DiscoverInstances`; pass `--base-url` explicitly when tunneling) plus IAM
+   for `ssm:GetParameter` on `/mem9-on-aws/<stage>/tenant/secret-arn`,
+   `secretsmanager:GetSecretValue` on the tenant secret,
+   `servicediscovery:DiscoverInstances`, and
+   `bedrock-mantle:CreateInference`/`CallWithBearerToken`. A reasoning-model run
+   needs those Bedrock grants in the **responses region** as well (default
+   `us-west-2`), since the bearer is minted per region; cost attribution uses
+   `MEM9_BEDROCK_PROJECT_OPENAI` there and `MEM9_BEDROCK_PROJECT` in the
+   application region (Mantle projects are regional and never cross-applied).
+   `--apply` additionally needs the Aurora writer endpoint and the
+   `/mem9-on-aws/<stage>/db/*` grants below, because it takes the shared advisory
+   mutex on the database. The recovery modes below need none of the REST, tenant,
+   or Bedrock access — see their own requirements.
 
-The consolidation task additionally needs the Aurora writer endpoint plus IAM for
-`/mem9-on-aws/<stage>/db/*` parameters and the DB secret. The host must trust the
-current Amazon RDS CA; set `NODE_EXTRA_CA_CERTS` to the regional RDS bundle
+### Recovering a soft-deleted or archived memory
+
+Soft deletion is reversible by design, but nothing surfaced the reversal until
+issue #124. Two read-only-by-default modes on the same script do it. Both read
+and write the database directly, because the mem9 REST API filters every read to
+`state = 'active'` — GetByID 404s on an inactive row and the list endpoint never
+returns one, so the REST surface cannot see the rows being recovered. That makes
+their requirements narrower than the audit mode's, not wider — see
+**Requirements** below.
+
+```bash
+# What is recoverable? Read-only, takes no lock, safe to run against prod
+# at any time — including while a weekly consolidation apply is running.
+node scripts/memory-cleanup.mjs --stage prod --list-inactive \
+  [--state deleted|archived] [--since 2026-07-01T00:00:00Z] [--limit 100]
+
+# Restore. Dry-run is the default; --apply writes.
+node scripts/memory-cleanup.mjs --stage prod --restore --ids recover.local.txt
+node scripts/memory-cleanup.mjs --stage prod --restore --ids recover.local.txt \
+  --apply [--cap 50] [--force]
+```
+
+`deleted` and `archived` are **not** interchangeable. `deleted` came from a #102
+cleanup judgment. `archived` came from #103 contradiction resolution and carries
+`superseded_by`: restoring it returns the *loser* of a contradiction while the
+winner is still active, so search can then return two directly contradictory
+memories — the defect #103 exists to remove. Restoring an `archived` row
+therefore requires `--force`, and both the refusal and the forced restore name
+the winning id. `superseded_by` is preserved either way, keeping the audit link
+and #103's handle on the pair.
+
+`--since` filters `updated_at`, the only timestamp that *moves on deletion* —
+there is no `memories.deleted_at`, and `created_at` records insertion. For a
+soft-deleted row `updated_at` equals the deletion time only if nothing has
+touched the row since. Restore itself moves `updated_at` to
+`NOW()` (the `BEFORE UPDATE` trigger is unconditional), so the pre-restore value
+is recorded in `~/.mem9-cleanup/<stage>/restore-*.json` (mode 0600, outside any
+checkout — it contains memory snippets and must never be committed or attached to
+issues/PRs). `version` and the `vector(1024)` embedding are untouched: the row was
+never removed, so there is nothing to re-embed.
+
+Exit codes match cleanup, plus `6`: the run finished but not everything the ids
+file asked for happened — an unknown id, a refused `archived` id, a row this tool
+does not know how to restore, or a row whose state or version moved between the
+read and the write. An already-`active` id is a reported no-op and exits 0, so
+finishing a partially-applied restore is safe. Exit `1` also covers the case
+where every write landed but the restore log could not be written: the rows moved
+and the record of which ones did not survive, so the ids on stderr are the only
+copy.
+
+**Requirements for the recovery modes:** network reachability of the **Aurora
+writer endpoint** (they never call the REST service, so no Cloud Map discovery
+and no `mnemo` reachability) plus IAM for `ssm:GetParameters` on
+`/mem9-on-aws/<stage>/db/{host,port,name,secret-arn}` and
+`secretsmanager:GetSecretValue` on the DB secret those parameters name. No tenant
+secret, no `servicediscovery:DiscoverInstances`, no Bedrock. The host must trust
+the current Amazon RDS CA; set `NODE_EXTRA_CA_CERTS` to the regional RDS bundle
 before starting Node when that CA is not already in the host trust store.
+
+Flags are validated against the mode: `--state`/`--since`/`--limit` are rejected
+on a restore, and `--apply` is rejected on a listing, rather than silently
+ignored. An operator who believes a flag narrowed the run would otherwise act on
+that belief — and `--list-inactive --apply` would make a read-only listing take
+the shared advisory mutex and contend with the weekly consolidation.
 
 ## Weekly memory consolidation
 

--- a/docs/test-cases/memory-cleanup.md
+++ b/docs/test-cases/memory-cleanup.md
@@ -166,6 +166,15 @@ version before it reaches the wire.
 - **TC-MEMCLEAN-050** — the tenant id/API key never appears in the decision
   log, stdout, or stderr (assertion greps all three against the configured
   key).
+- **TC-MEMCLEAN-082** — `--out` pointing inside the checkout is refused, and
+  refused *before* the scan and the classification pass. The decision list
+  carries `snippet` fields sliced from memory content, so writing it into a repo
+  planned to be open-sourced is the leak the default `~/.mem9-cleanup/<stage>/`
+  exists to prevent; `--out` overrode that with no constraint. Validating it at
+  the write site inside `loadDecisions` was not enough: `--out ./tmp` on a prod
+  dry run burned a reasoning-model run at `--effort high`, then threw and
+  discarded every decision. See *Where the record may be written* in
+  [memory-restore.md](memory-restore.md) for the shared guard.
 
 ## Discovery
 

--- a/docs/test-cases/memory-restore.md
+++ b/docs/test-cases/memory-restore.md
@@ -1,0 +1,304 @@
+# Test Cases: inactive-memory listing and restore (issue #124)
+
+Unit tests live in `scripts/memory-cleanup.test.mjs` (an injected `pg`-client
+fake), alongside the #102 cleanup cases in
+[memory-cleanup.md](memory-cleanup.md). As with #102 there is no CI E2E: the
+database is VPC-internal and the CI runner pool is outside that VPC, so live
+verification is an operator round trip from a VPC-internal host
+(TC-MEMRESTORE-070).
+
+## Why these modes use SQL rather than the REST API
+
+Not a stylistic choice. The mem9 REST surface filters to `state = 'active'`:
+GetByID 404s on a soft-deleted or archived row and the list endpoint never
+returns one, so the REST API cannot see the rows this feature exists to recover.
+#103 already goes direct to Aurora for the same reason — its `archiveMemory`
+writes `state='archived'`, a transition the REST surface cannot express (it never
+*reads* an archived row; its predicate is `AND loser.state = 'active'`). And
+`memory-cleanup.mjs` already holds a `pg` client and the shared advisory-lock
+mutex, so these modes extend existing plumbing rather than forking mem9.
+
+A consequence for the tests: the fake `db` cannot catch a malformed statement,
+a wrong column name, or a bind-arity mismatch, all of which are runtime errors
+against a real server. Two mitigations, both in place — `fakeDb` asserts every
+statement's `$n` placeholders match the values supplied (real Postgres rejects a
+surplus bind outright), and every schema-dependent claim was confirmed against a
+real database (see below).
+
+## Why the two inactive states are not interchangeable
+
+`deleted` and `archived` are different states with different meanings, and the
+whole risk in this feature is a shared code path that silently conflates them:
+
+| | written by | carries `superseded_by` | meaning |
+|---|---|---|---|
+| `deleted` | #102 retroactive cleanup | no | judged not worth keeping |
+| `archived` | #103 contradiction resolution | **yes** | superseded by a winner that is still active |
+
+Restoring a `deleted` row returns it to the corpus. Restoring an `archived` row
+without further thought resurrects the **loser** of a contradiction while the
+winner is still active, so search can return two rows that directly contradict
+each other — reintroducing exactly the defect #103 exists to remove.
+
+**Decision (tested by TC-MEMRESTORE-040/041):** restoring an `archived` row
+requires `--force` and prints a warning naming the `superseded_by` winner.
+`superseded_by` is **preserved**, not cleared. Preserving it keeps the audit
+trail of what superseded what, and it is what this tool's own gate reads
+(TC-MEMRESTORE-059); clearing it would silently destroy that link and make the
+resurrected contradiction look like an ordinary independent memory. It does
+**not** feed #103: consolidation only ever writes the column, and
+`listActiveMemories` does not project it, so a restored loser is rediscovered by
+embedding similarity rather than by the link. `--force` is required per run, not
+per id — which is why every superseded id it will resurrect is named during
+planning, on the dry run (TC-MEMRESTORE-060).
+
+## Schema facts these cases depend on
+
+Verified twice: read from `docker/bootstrap/schema.sql`, then confirmed by
+loading that schema plus `docker/bootstrap/migrations/` into a throwaway
+`pgvector/pgvector:pg17` container and running the adapter's real SQL through a
+real `pg` client. The unit tests use a fake `db`, which by construction cannot
+catch a malformed statement, a wrong column name, or a bind-arity error — so
+each claim below was also observed end to end:
+
+| Claim | Live observation |
+|---|---|
+| restore preserves `version` | `version=7` before and after |
+| restore preserves `superseded_by` | `superseded_by=live-win` survives `--force` |
+| restore does not re-embed | `vector_dims=1024` and `md5(embedding::text)` byte-identical across restore |
+| the fence rejects a stale version | `restoreMemory(version: 999)` returned false, row stayed `deleted` |
+| `updated_at` is overwritten by the trigger | `updated_at` moved on every restored row |
+| the log preserves the real age | `updatedAtBefore=2025-11-02T03:04:05.000Z` for a row whose `updated_at` had already been overwritten |
+| `--limit` bounds rows, the count does not | 4 rows returned, `total=25` |
+| `findByIds` is not scoped to inactive rows | an `active` id came back, reported as a no-op rather than not-found |
+
+Underlying facts:
+
+- **There is no `memories.deleted_at`** — only `tenants` has one (line 40).
+  `created_at` exists but records insertion, so `updated_at` is the only
+  timestamp that moves on deletion: `--since` filters on it, and for a
+  soft-deleted row that is the deletion time only if nothing touched the row
+  afterwards (TC-MEMRESTORE-021).
+- **`trg_memories_updated` is `BEFORE UPDATE`** and its function
+  unconditionally assigns `NEW.updated_at = NOW()` (lines 105-111). A restore
+  therefore **cannot** preserve the prior timestamp, which is why the
+  pre-restore value is recorded in the decision log (TC-MEMRESTORE-042/043).
+  Note the limit of that: nothing reads the log, and #103's timeline gate
+  compares `updated_at` on the rows themselves, so a restored row still presents
+  as the fresher side of a contradiction. Recorded, not corrected.
+- **`embedding vector(1024)` is nullable and survives soft delete** (line 76) —
+  the row was never removed, so restore must not re-embed
+  (TC-MEMRESTORE-044).
+- **`updated_at` and `version` are both nullable in `schema.sql`** (lines 86 and
+  82): `TIMESTAMPTZ DEFAULT NOW()` and `INT DEFAULT 1`, neither `NOT NULL`. The
+  `NOT NULL` + `CHECK (version > 0)` arrive only via
+  `migrations/001_ingest_jobs.sql`, and that block is guarded by
+  `IF to_regclass('memories') IS NOT NULL` — so a store bootstrapped from
+  `schema.sql` alone can hold NULLs in both. A NULL `updated_at` must be recorded
+  as absent rather than as 1970 (TC-MEMRESTORE-053), and a NULL `version` makes
+  the fence permanently unsatisfiable (`version = NULL` is never true), so the
+  row is refused as unfenceable rather than attempted and blamed on a concurrent
+  write (TC-MEMRESTORE-055).
+
+## `--list-inactive` (read-only)
+
+- **TC-MEMRESTORE-001** — lists inactive memories with id, state, `updated_at`,
+  `superseded_by`, and a bounded content snippet; issues **only** `SELECT`s
+  (asserted over every recorded statement) and reports `writes: 0`. A second case
+  covers the pre-built-adapter shape, which is the only one production takes.
+- **TC-MEMRESTORE-002** — *withdrawn.* The spec assumed the #102 REST paging
+  loop. `--limit` is a single bounded window plus an unbounded `COUNT`, so there
+  is no page cursor to terminate and no possibility of a row appearing twice. What
+  the case was protecting against — a silent cap reading as completeness — is
+  covered by TC-MEMRESTORE-022 instead, and confirmed live (4 rows, `total=25`).
+- **TC-MEMRESTORE-003** — an empty result set prints an explicit "no inactive
+  memories" line and exits 0, never a bare empty listing that reads like a
+  failure.
+- **TC-MEMRESTORE-004** — the snippet is bounded to a fixed maximum and a
+  truncated snippet is marked as truncated; a memory whose content contains
+  newlines stays on one record so the output remains machine-readable.
+- **TC-MEMRESTORE-005** — `--list-inactive` never requires `--apply` and never
+  takes the lockfile: it is read-only, so two concurrent listings must both
+  succeed (contrast TC-MEMRESTORE-033).
+
+### Filters
+
+- **TC-MEMRESTORE-020** — `--state deleted` and `--state archived` each return
+  only that state; an unrecognised `--state` value is rejected by argument
+  validation rather than silently returning everything (the dangerous default).
+  Omitting `--state` returns both, and the output distinguishes them.
+- **TC-MEMRESTORE-021** — `--since <iso>` filters on `updated_at`, and the
+  command documents that limitation in its own output because there is no
+  `deleted_at`: a row soft-deleted long ago but touched since will still match a
+  recent `--since`. A non-ISO `--since` is rejected.
+- **TC-MEMRESTORE-022** — `--limit N` bounds the rows shown and reports that
+  the listing was truncated together with the total matched, so a silent cap can
+  never read as "this is all there is". Non-positive/non-numeric `--limit` is
+  rejected.
+
+## `--restore` — dry-run is the default
+
+- **TC-MEMRESTORE-030** — `--restore --ids <file>` **without** `--apply`
+  performs zero writes and prints what would change, consistent with #102's
+  dry-run-by-default contract. A second case covers a dry run that cannot fully
+  honour the file: it exits 6, not 0, because the dry run is where the operator
+  decides whether to pass `--apply` and a refusal discovered afterwards is a
+  refusal discovered too late.
+- **TC-MEMRESTORE-031** — with `--apply`, listed ids are flipped to
+  `state='active'`; the `UPDATE`'s SET clause is enumerated (not spot-checked) to
+  assert `state` is the only column assigned, so content, embedding, `version`,
+  and `superseded_by` are all untouched. Each write carries the state and version
+  observed for *that* row, not a shared anchor.
+- **TC-MEMRESTORE-032** — cap: one mutation per id, reserved before the write
+  (the #102 reservation pattern). With `cap=2` and three ids the run aborts
+  before the third mutation and reports the abort; exact-hit (used == cap) is
+  allowed; and a non-positive or non-finite `--cap` is refused before any read,
+  since on a write path an unparseable bound must stop the run rather than
+  default to something.
+- **TC-MEMRESTORE-033** — the same stage-scoped lockfile as #102: a second
+  concurrent restore for the same stage refuses to start, and a stale lock older
+  than `--lock-ttl` is reclaimed rather than deadlocking the operator forever.
+  The same shared advisory-lock mutex as cleanup and consolidation is taken for
+  `--apply` only, and both the lock and the mutex are released even when a write
+  throws mid-run — a crashed apply that keeps them locks the operator out of
+  recovery and blocks the next weekly consolidation. A separate case pins the
+  mutex key itself: all three writers derive `mem9-cleanup:<stage>` from one
+  exported helper, and nothing else would fail if a caller drifted to its own
+  literal — the locks would simply stop colliding, silently.
+- **TC-MEMRESTORE-034** — restoring an id that is **already `active`** is
+  reported as a no-op, exits 0, consumes no cap, and issues no write. It is not
+  an error: an operator re-running a partially-applied restore must be able to
+  finish it, and idempotence is what makes that safe.
+- **TC-MEMRESTORE-035** — an id in the file that does not exist at all is
+  reported as not-found and does **not** abort the remaining ids; the exit code
+  distinguishes "some ids could not be restored" from total success, so a typo
+  cannot look like a clean run.
+- **TC-MEMRESTORE-036** — the decision log is written to
+  `~/.mem9-cleanup/<stage>/` with mode `0600`, outside any checkout, matching
+  TC-MEMCLEAN-021's placement rule; it records, per id, the prior state and the
+  pre-restore `updated_at`.
+- **TC-MEMRESTORE-037** — an ids file for another stage is refused on replay
+  (the TC-MEMCLEAN-016 stage-mismatch guard), so a prod ids file cannot be
+  replayed against a preview stage. Also covered: the plain one-id-per-line form,
+  the stage-matched JSON form with duplicate ids de-duplicated (charging the cap
+  twice for one memory would abort a run that fits), an empty file, and a
+  stage-matched JSON file with no `ids` array — the last two throw rather than
+  reporting a clean "restored 0 of 0" from a file the operator believed held ids.
+- **TC-MEMRESTORE-039** — a lost fence (`rowCount 0`, meaning the row's state or
+  version moved between the read and the write) is reported as skipped and
+  changes the exit code. It is never counted as restored: telling an operator a
+  memory is back when it is not is the one report they cannot recover from.
+
+## Archived-vs-deleted separation
+
+- **TC-MEMRESTORE-040** — restoring an `archived` id **without** `--force` is
+  refused, exits non-zero, performs no write, and the message names the
+  `superseded_by` winner so the operator can decide with the relevant fact in
+  hand. An archived row whose `superseded_by` is NULL — representable, and the
+  case where the operator has the least information — still refuses, and the
+  message says the winner was not recorded rather than printing "superseded by
+  null", which reads as a bug and conveys nothing.
+- **TC-MEMRESTORE-041** — with `--force`, the archived id is restored,
+  `superseded_by` is **preserved**, and the warning naming the winner is still
+  emitted. A test asserts `superseded_by` is unchanged after restore, which is
+  what fails if someone later "simplifies" the two states onto one path.
+- **TC-MEMRESTORE-042** — a mixed ids file (some `deleted`, some `archived`)
+  without `--force` restores the `deleted` ids and refuses only the `archived`
+  ones, reporting both groups separately. `--force` is not retroactively implied
+  by the presence of any archived id.
+- **TC-MEMRESTORE-043** — the log records the pre-restore `updated_at`, because
+  the `BEFORE UPDATE` trigger overwrites it with `NOW()`. Asserted as an
+  explicit field so #103's timeline gate has a source for the real age and
+  cannot mistake a restore for recency evidence. The prior state is snapshotted
+  *before* the write for the same reason: reading `row.state` back afterwards
+  reports `active` as the prior state, which makes the log worthless for the one
+  thing it exists to record. (This was a real defect, caught by this case.)
+- **TC-MEMRESTORE-044** — restore issues **no** embedding request: the injected
+  `fetchImpl` throws if called, so an untouched spy is the evidence rather than an
+  absent assertion. Confirmed at the database level too — a real `vector(1024)`
+  is byte-identical (`md5(embedding::text)`, `vector_dims=1024`) across a restore.
+  Re-embedding would burn inference cost and could shift the vector under a
+  different model version than the rest of the corpus.
+- **TC-MEMRESTORE-045** — `version` is **preserved**, not bumped: restore
+  returns a row to visibility without changing its content, and `version` is the
+  concurrency token #128's If-Match fence compares against. Bumping it on a
+  no-content-change would invalidate a concurrent writer's fence for no reason.
+  Asserted explicitly, because either choice is defensible and silence is not.
+
+## CLI validation
+
+- **TC-MEMRESTORE-050** — `--list-inactive` and `--restore` together are
+  rejected (one mode per run); `--restore` without `--ids` is rejected;
+  `--state`/`--since`/`--limit` passed with `--restore` are rejected rather than
+  silently ignored, since an operator who expects them to filter a restore would
+  otherwise restore more than they intended.
+- **TC-MEMRESTORE-051** — the new flags appear in `--help` with dry-run
+  documented as the default for `--restore` and `--force` documented as
+  archived-only. The check iterates `ARG_SPECS`, so a flag added later without a
+  `--help` entry fails this case rather than shipping undocumented. `--help`
+  itself does not require `--stage`: an operator reaching for it does not yet know
+  the invocation.
+
+## Exit codes
+
+Restore reuses #102's vocabulary and adds one:
+
+| code | meaning |
+|---|---|
+| 0 | everything the ids file asked for happened |
+| 1 | error — including a run whose writes all succeeded but whose decision log could not be written (TC-MEMRESTORE-048) |
+| 3 | a lock or the shared mutex is held |
+| 4 | `--cap` exceeded; the run aborted before overflowing |
+| 6 | the run completed but not everything asked for was done — a not-found id, a refused `archived`/unknown-state/unfenceable id, a lost fence, or a dry-run plan larger than `--cap` |
+
+6 exists because the alternative is worse in both directions: exiting 0 lets a
+typo'd or partially-refused run read as clean, and exiting 1 makes a successful
+restore of 9 out of 10 ids indistinguishable from a crash.
+
+A lost decision log is exit 1 rather than 6 for the opposite reason: the rows did
+move, and the durable record of *which* ones did not survive. That is not a
+partial success an operator can act on later — it is the one outcome that needs
+attention now, while the ids are still on stderr.
+
+## Durability of the record
+
+The decision log is written from the apply loop's `finally`, not after it, and
+the summary line is emitted before the file write. Three failure modes drove
+that, each of which left memories restored in production with no record at all:
+
+- a write that **throws** mid-loop (a dropped connection) skipped the log
+  entirely, so an exit-1 stack read as "nothing happened" when rows were already
+  active (TC-MEMRESTORE-047);
+- a log that **cannot be written** (a typo'd `--out`, a full disk) threw before
+  the summary, losing both records at once — now the restored ids fall back to
+  stderr, ids only, because the entries carry memory snippets and stderr on a
+  scheduled task lands in CloudWatch (TC-MEMRESTORE-048);
+- a `finally` step that **throws** replaced the in-flight exception, reporting
+  `Connection terminated` for a run that died of something else — and a lock file
+  that could not be removed skipped the mutex release, leaking an advisory lock
+  that blocks the next weekly consolidation (TC-MEMRESTORE-049).
+
+## Flag/mode validation
+
+Every flag in `ARG_SPECS` declares the `mode`s it belongs to, and anything
+outside them is **rejected**, not ignored (TC-MEMRESTORE-054). The parser already
+made this argument for `--state` on a restore — an operator who believes a flag
+narrowed the run acts on that belief — and the reasoning does not stop at the
+flags that happened to be thought of first. `--list-inactive --apply` is the one
+that bites hardest: `recoveryDeps` keys the shared mutex on `opts.apply`, so it
+would make a read-only listing take the advisory lock and contend with the weekly
+consolidation, exactly what "a listing takes no lock" promises cannot happen.
+Declaring `mode` per flag rather than as a one-off check means a flag added later
+must answer the question — the test fails on a missing `mode`.
+
+## Operator round trip (no CI E2E)
+
+- **TC-MEMRESTORE-070** — from a VPC-internal host on the PR preview stage:
+  soft-delete a seeded memory via #102 `--apply`, confirm `--list-inactive`
+  shows it as `deleted`, `--restore` it (dry-run first, then `--apply`), and
+  confirm it is `active` and returned by search again. Then repeat against an
+  `archived` row to confirm the `--force` refusal and the winner-naming warning.
+  Record **exit codes and counts only** in the PR. The listing prints one JSON
+  record per memory including a content snippet, and the restore log holds the
+  same — neither may be pasted into an issue, a PR, or any other repository
+  surface, here or anywhere else.

--- a/docs/test-cases/memory-restore.md
+++ b/docs/test-cases/memory-restore.md
@@ -246,7 +246,7 @@ Restore reuses #102's vocabulary and adds one:
 | code | meaning |
 |---|---|
 | 0 | everything the ids file asked for happened |
-| 1 | error — including a run whose writes all succeeded but whose decision log could not be written (TC-MEMRESTORE-048) |
+| 1 | error — including a run whose writes all succeeded but whose teardown (log write, lock removal, or mutex release) failed (TC-MEMRESTORE-048) |
 | 3 | a lock or the shared mutex is held |
 | 4 | `--cap` exceeded; the run aborted before overflowing |
 | 6 | the run completed but not everything asked for was done — a not-found id, a refused `archived`/unknown-state/unfenceable id, a lost fence, or a dry-run plan larger than `--cap` |
@@ -259,6 +259,15 @@ A lost decision log is exit 1 rather than 6 for the opposite reason: the rows di
 move, and the durable record of *which* ones did not survive. That is not a
 partial success an operator can act on later — it is the one outcome that needs
 attention now, while the ids are still on stderr.
+
+**4 and 6 outrank 1**, and the order is load-bearing (TC-MEMRESTORE-062). All
+three teardown steps share one flag, and testing it first meant an EROFS lock
+file reported exit 1 for a run that had *also* hit the cap and left the ids file
+half-applied — indistinguishable from an outright crash, which is exit 1 too. A
+teardown failure is about the run's bookkeeping; 4 and 6 are about what the run
+did to the store, which is the fact the operator's next command depends on. Every
+teardown failure still names itself in a log line regardless of which code wins,
+and a lost log is still identifiable by an absent `logPath`.
 
 ## Durability of the record
 
@@ -277,6 +286,37 @@ that, each of which left memories restored in production with no record at all:
   `Connection terminated` for a run that died of something else — and a lock file
   that could not be removed skipped the mutex release, leaking an advisory lock
   that blocks the next weekly consolidation (TC-MEMRESTORE-049).
+
+### Where the record may be written
+
+Both snippet-bearing artifacts — the cleanup decision list and the restore log —
+go through `snippetLogDir`, which **refuses an `--out` that resolves inside the
+tree containing the script** (TC-MEMRESTORE-063). The default
+`~/.mem9-cleanup/<stage>/` was always outside a checkout, but `--out` overrode it
+with no constraint, and `--out ./tmp` is the natural thing for an operator
+reviewing a plan to type. The result was instance-private memory text in a repo
+planned to be open-sourced, in files no `.gitignore` pattern matched. CI's
+`scripts/scan-public-artifacts.mjs` would not catch them either: its detectors
+look for private keys, bearer tokens, access-key ids, and ARNs — none of which
+memory prose resembles — and it runs on a pushed range, after the commit already
+exists.
+
+The check runs at the **top** of a restore, not inside `persist()`. Rejecting it
+from the teardown `finally` would restore the rows first and then report the
+operator's typo as "failed to write the restore log", costing them the only
+record of a run that did happen. The same rule governs the cleanup path
+(TC-MEMCLEAN-082): the guard sits next to the cap validation at the top of
+`runCleanup`, not at the write inside `loadDecisions`, which runs *after* the full
+scan and the whole classification pass — there, `--out ./tmp` on a prod dry run
+burned a reasoning-model run at `--effort high` and then threw, discarding every
+decision, which is the entire artifact of a dry run.
+
+The bound is the script's own tree rather than a `git rev-parse` probe, so it
+behaves identically inside the container image, where there is no git and `--out`
+is never passed. It is computed with `path.relative`, not `startsWith`
+(TC-MEMRESTORE-064): a sibling worktree whose name merely *extends* this one's
+(`…/124-memory-restore-other`) shares the prefix but is a different checkout, and
+refusing it would lock an operator out of the adjacent tree for no reason.
 
 ## Flag/mode validation
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests",
-    "test:consolidation:coverage": "vitest run scripts/memory-consolidation.test.mjs --coverage.enabled=true --coverage.include=scripts/memory-consolidation.mjs --coverage.reporter=text --coverage.thresholds.lines=80 --coverage.thresholds.functions=80 --coverage.thresholds.statements=80 --coverage.thresholds.branches=80"
+    "test:consolidation:coverage": "vitest run scripts/memory-consolidation.test.mjs --coverage.enabled=true --coverage.include=scripts/memory-consolidation.mjs --coverage.reporter=text --coverage.thresholds.lines=80 --coverage.thresholds.functions=80 --coverage.thresholds.statements=80 --coverage.thresholds.branches=80",
+    "test:cleanup:coverage": "vitest run scripts/memory-cleanup.test.mjs --coverage.enabled=true --coverage.include=scripts/memory-cleanup.mjs --coverage.reporter=text --coverage.thresholds.lines=80 --coverage.thresholds.functions=80 --coverage.thresholds.statements=80 --coverage.thresholds.branches=80"
   },
   "devDependencies": {
     "@aws-sdk/client-secrets-manager": "^3.1100.0",

--- a/scripts/memory-cleanup.mjs
+++ b/scripts/memory-cleanup.mjs
@@ -68,6 +68,10 @@ const UNCLASSIFIED_REASON = "classification failed after retry";
 const HOUR_MS = 3600 * 1000;
 const DEFAULT_LOCK_TTL_MS = 2 * HOUR_MS;
 const SNIPPET_LEN = 120;
+// The two inactive states, and the only values --state accepts. They are NOT
+// interchangeable: see `inactiveMemoryAdapter` and issue #124.
+const INACTIVE_STATES = ["deleted", "archived"];
+const DEFAULT_LIST_LIMIT = 100;
 
 export function sharedCleanupMutexKey(stage) {
   return `mem9-cleanup:${stage}`;
@@ -1017,33 +1021,646 @@ export function buildCompleteChat(opts, deps) {
 }
 
 // ---------------------------------------------------------------------------
+// Inactive listing & restore (issue #124)
+
+/**
+ * SQL access to memories the REST API cannot see.
+ *
+ * Not a stylistic choice: upstream's GetByID and list handler both select
+ * `WHERE state = 'active'`, so a soft-deleted or archived row 404s on the REST
+ * surface and never appears in a listing. There is no REST route that reaches
+ * them, and forking mem9 to add one would be a far larger change than reusing
+ * the `pg` client this file already opens for the shared apply mutex. #103 goes
+ * direct to Aurora for the same reason — its `archiveMemory` WRITES
+ * `state='archived'`, a transition the REST surface cannot express. It never
+ * reads an archived row: its predicate is `AND loser.state = 'active'`.
+ *
+ * `deleted` and `archived` are DIFFERENT states with different meanings:
+ *   deleted  — #102 judged the memory not worth keeping. No `superseded_by`.
+ *   archived — #103 resolved a contradiction against it. `superseded_by` names
+ *              the winner, which is still active.
+ * Restoring an archived row therefore puts a known contradiction back into
+ * search alongside its winner, which is the defect #103 exists to remove. The
+ * two states share one `UPDATE` but never one DECISION: `runRestore` branches
+ * before planning, and the gate is `superseded_by` as much as the state
+ * (TC-MEMRESTORE-042, TC-MEMRESTORE-059).
+ */
+export function inactiveMemoryAdapter(db) {
+  // Every column is load-bearing downstream: `version` is the fence value,
+  // `superseded_by` drives the archived refusal, `updated_at` is the only
+  // pre-restore age the decision log can record, and `content` is the snippet an
+  // operator reviews.
+  const READ_COLUMNS =
+    "id, content, state, version, updated_at, superseded_by";
+  return {
+    listInactive: async ({ state, since, limit } = {}) => {
+      const where = [];
+      // Built once and then COPIED per statement. Sharing one mutable array
+      // across the count and the page would make each query's parameter list
+      // depend on when the other happened to read it. `pg` uses the extended
+      // protocol, which rejects a surplus bind outright ("bind message supplies
+      // 2 parameters, but prepared statement \"\" requires 1"), so the aliasing
+      // would surface as a runtime error rather than as a wrong number.
+      const filters = [];
+      if (state) {
+        where.push(`state = $${filters.push(state)}`);
+      } else {
+        // Never a bare `SELECT ... FROM memories`: with no --state this must
+        // still exclude active rows, or "list what was deleted" would dump the
+        // entire corpus.
+        where.push("state <> 'active'");
+      }
+      // `updated_at` is the only timestamp that MOVES on deletion — there is no
+      // `memories.deleted_at` (only `tenants` has one). (`created_at` exists but
+      // records insertion.) So this filters when the row was last touched, which
+      // for a soft-deleted row is the deletion time only if nothing has touched
+      // it since. Surfaced in the output and in --help rather than left for the
+      // operator to infer.
+      if (since) where.push(`updated_at >= $${filters.push(since)}`);
+      const clause = `WHERE ${where.join(" AND ")}`;
+
+      // Counted unbounded and separately from the page: reporting "10 of 10"
+      // for a capped listing would make a silent truncation read as complete.
+      const counted = await db.query(
+        `SELECT count(*)::bigint AS total FROM memories ${clause}`,
+        [...filters],
+      );
+      const page = await db.query(
+        `SELECT ${READ_COLUMNS}
+           FROM memories ${clause}
+          ORDER BY updated_at DESC, id
+          LIMIT $${filters.length + 1}`,
+        [...filters, limit ?? DEFAULT_LIST_LIMIT],
+      );
+      // No `?? 0`. This number is the entire truncation signal — "listed 100 of
+      // 2811" is how an operator learns the page is partial — so a count query
+      // that answered nothing must fail loudly rather than default to a
+      // denominator that makes any page look complete.
+      const total = Number(counted.rows[0]?.total);
+      if (!Number.isFinite(total)) {
+        throw new Error(
+          `inactive count query returned no usable total: ${JSON.stringify(counted.rows[0] ?? null)}`,
+        );
+      }
+      return { rows: page.rows, total };
+    },
+
+    // Deliberately NOT scoped to inactive rows: an already-active id must come
+    // back so restore can report it as an idempotent no-op rather than as
+    // "not found", which is what lets an operator finish a half-applied run.
+    findByIds: async (ids) => {
+      const result = await db.query(
+        `SELECT ${READ_COLUMNS} FROM memories WHERE id = ANY($1)`,
+        [ids],
+      );
+      return result.rows;
+    },
+
+    /**
+     * Flip one row back to active, fenced on the state AND version that were
+     * read. Returns false when the fence loses, so the caller reports a skip
+     * instead of claiming a restore that did not happen.
+     *
+     * Sets exactly one column, and each omission is load-bearing:
+     *  - `version` is preserved. It is the concurrency token #128's `If-Match`
+     *    compares against; restore changes no content, so bumping it would
+     *    invalidate a concurrent writer's fence for nothing.
+     *  - `superseded_by` is preserved. It is the audit link to the winner, and
+     *    this tool's own gate reads it (TC-MEMRESTORE-059); clearing it would
+     *    make a resurrected contradiction look like an ordinary independent
+     *    memory. #103 only ever writes the column — `listActiveMemories` does not
+     *    project it — so a restored loser re-enters clustering by embedding
+     *    similarity, not by this link.
+     *  - `embedding` is untouched. The row was never removed, so `vector(1024)`
+     *    still holds the original embedding — rewriting it would burn inference
+     *    cost and could shift the vector under a different model version.
+     *  - `updated_at` cannot be preserved: `trg_memories_updated` is BEFORE
+     *    UPDATE and unconditionally assigns NOW(). The pre-restore value goes in
+     *    the decision log so the real age survives somewhere an operator can
+     *    find it. Note what that does NOT fix: #103's timeline gate compares
+     *    `updated_at` on the rows themselves and nothing reads this log, so a
+     *    restored row still presents as the fresher side of a contradiction.
+     *    That is a known limitation, recorded rather than corrected.
+     */
+    restoreMemory: async ({ id, priorState, version }) => {
+      const result = await db.query(
+        `UPDATE memories
+            SET state = 'active'
+          WHERE id = $1
+            AND state = $2
+            AND version = $3`,
+        [id, priorState, version],
+      );
+      return result.rowCount === 1;
+    },
+  };
+}
+
+/**
+ * `updated_at` as an ISO string, or null when the column holds nothing usable.
+ *
+ * It is nullable in `schema.sql` (TIMESTAMPTZ DEFAULT NOW(), no NOT NULL), and
+ * `new Date(null)` is epoch 0 rather than an error — so the unguarded form
+ * records a fabricated 1970 as fact. This is the one field the decision log
+ * exists to preserve, and it is read by an operator judging whether a memory is
+ * worth bringing back: an absent timestamp means "age unknown", while 1970 reads
+ * as a definite answer that happens to be maximally stale. An unparseable value
+ * throws `RangeError: Invalid time value` naming no row at all, which would take
+ * down a whole listing over one bad row.
+ */
+function isoOrNull(value) {
+  if (value === null || value === undefined) return null;
+  const ms = new Date(value).getTime();
+  return Number.isFinite(ms) ? new Date(ms).toISOString() : null;
+}
+
+/** One display record per inactive row: bounded, single-line, truncation marked. */
+function inactiveRecord(row) {
+  const content = row.content ?? "";
+  const truncated = content.length > SNIPPET_LEN;
+  return {
+    id: row.id,
+    state: row.state,
+    // Serialised here rather than at the print site so the returned record is
+    // directly comparable and loggable.
+    updated_at: isoOrNull(row.updated_at),
+    superseded_by: row.superseded_by ?? null,
+    // Newlines collapse: one record per line keeps the listing greppable, and
+    // an embedded newline would split one memory across what look like three
+    // records.
+    snippet: content.slice(0, SNIPPET_LEN).replace(/\s*\n\s*/gu, " ").trim(),
+    truncated,
+  };
+}
+
+/**
+ * `--list-inactive`: read-only. Takes NO lock — neither the stage lockfile nor
+ * the shared database mutex — so an operator can always look at what was
+ * deleted, even while a weekly consolidation apply is running.
+ */
+export async function runListInactive(opts, deps) {
+  const log = deps.log || console.error;
+  const adapter = deps.listInactive ? deps : inactiveMemoryAdapter(deps.db);
+  const { rows, total } = await adapter.listInactive({
+    state: opts.state,
+    since: opts.since,
+    limit: opts.limit,
+  });
+  const records = rows.map(inactiveRecord);
+  // Named per row rather than left implicit: a null here means the row's age is
+  // unknown, and the operator is choosing what to restore from these timestamps.
+  for (const record of records) {
+    if (record.updated_at === null) {
+      log(`${record.id}: updated_at is missing or unreadable — its age is unknown from this listing`);
+    }
+  }
+
+  if (records.length === 0) {
+    // An empty listing on its own is indistinguishable from a broken query or a
+    // connection to the wrong stage — the moment an operator most needs to know
+    // which of the three happened.
+    log(`no inactive memories matched${opts.state ? ` state=${opts.state}` : ""}${opts.since ? ` since=${opts.since}` : ""}`);
+    return { exitCode: 0, rows: [], total, writes: 0 };
+  }
+  for (const record of records) log(JSON.stringify(record));
+  log(
+    `listed ${records.length} of ${total} inactive memories` +
+      (opts.since ? "; --since filters updated_at (there is no deleted_at column)" : ""),
+  );
+  return { exitCode: 0, rows: records, total, writes: 0 };
+}
+
+/**
+ * Read the ids to restore. Accepts the plain one-id-per-line form and the
+ * stage-bound JSON form; a JSON file for another stage is refused before any
+ * database read, because ids collide across stages and a prod file replayed
+ * against preview would resurrect whatever happens to share those ids.
+ */
+function readRestoreIds(fs, opts) {
+  const raw = fs.readFileSync(opts.idsFile, "utf8");
+  let ids;
+  if (raw.trimStart().startsWith("[")) {
+    // Line-splitting a JSON array yields ids of `[`, `"d-1",`, `]`, which present
+    // as "3 id(s) not found" — a format error disguised as a bad id list, and the
+    // operator's next guess is that the ids are wrong.
+    throw new Error(
+      `${opts.idsFile} is a JSON array; use one id per line, or the stage-bound ` +
+        `{"stage":"...","ids":[...]} form`,
+    );
+  }
+  if (raw.trimStart().startsWith("{")) {
+    const doc = JSON.parse(raw);
+    if (doc.stage !== opts.stage) {
+      throw new Error(
+        `ids file is for stage ${JSON.stringify(doc.stage)}, not ${JSON.stringify(opts.stage)}`,
+      );
+    }
+    ids = Array.isArray(doc.ids) ? doc.ids : [];
+  } else {
+    ids = raw.split("\n");
+  }
+  const cleaned = [...new Set(ids.map((line) => String(line).trim()).filter(Boolean))];
+  // "restored 0 of 0" from a file the operator believed held ids is the report
+  // that ends in a second, hand-written attempt against the database.
+  if (cleaned.length === 0) throw new Error(`no ids in ${opts.idsFile}`);
+  return cleaned;
+}
+
+/**
+ * `--restore`: dry-run by default; `--apply` writes. Mirrors #102's contract —
+ * the destructive verb is a flag, the blast radius is bounded by `--cap`, the
+ * run is serialised by the same stage lockfile and the same shared database
+ * mutex, and every decision is logged outside the repository.
+ *
+ * @returns {exitCode, planned, restored, alreadyActive, notFound,
+ *           refusedArchived, refusedUnknownState, fencedOut, capUsed, logPath?}
+ */
+export async function runRestore(opts, deps) {
+  const log = deps.log || console.error;
+  const fs = deps.fs || (await import("node:fs"));
+  const clock = deps.clock || Date.now;
+  const adapter = deps.findByIds ? deps : inactiveMemoryAdapter(deps.db);
+  const cap = opts.cap ?? DEFAULT_CAP;
+  if (!Number.isFinite(cap) || cap <= 0) {
+    throw new Error(`cap must be a positive finite number, got ${cap}`);
+  }
+
+  // Both throw, and both before any read: a stage-mismatched or empty ids file
+  // is an operator error to correct, not a run to report on.
+  const ids = readRestoreIds(fs, opts);
+  const rows = await adapter.findByIds(ids);
+  const byId = new Map(rows.map((row) => [row.id, row]));
+
+  const notFound = ids.filter((id) => !byId.has(id));
+  const alreadyActive = [];
+  const refusedArchived = [];
+  const refusedUnknownState = [];
+  const unfenceable = [];
+  const forced = [];
+  const planned = [];
+  for (const id of ids) {
+    const row = byId.get(id);
+    if (!row) continue;
+    if (row.state === "active") {
+      // Idempotent, not an error: re-running a partially-applied restore has to
+      // be safe, or an operator reaches for hand-written SQL instead.
+      alreadyActive.push(id);
+      log(`${id}: already active — nothing to do`);
+      continue;
+    }
+    if (!INACTIVE_STATES.includes(row.state)) {
+      // Closed set, checked before the per-state rules rather than left as the
+      // fall-through. Every inactive state needs its own judgment about what
+      // reactivating it means — `deleted` is a straight undo, `archived` puts a
+      // contradiction loser back — so a state this tool has never been taught
+      // to reason about has no safe default, and the permissive one is the
+      // worst available guess. --force does not override this: it is consent to
+      // resurrect a known loser, not consent to guess.
+      refusedUnknownState.push(id);
+      log(
+        `${id}: state "${row.state}" is not a state this tool knows how to restore ` +
+          `(expected one of ${INACTIVE_STATES.join(", ")}) — skipped`,
+      );
+      continue;
+    }
+    if (row.version === null || row.version === undefined) {
+      // `version` is nullable in schema.sql, and the NOT NULL only arrives via a
+      // migration guarded by `IF to_regclass('memories') IS NOT NULL`. In SQL
+      // `version = NULL` is never true, so the fence can never be satisfied and
+      // the row is unrestorable until the schema is fixed. Attempting the write
+      // would report it as "state or version changed since it was read", sending
+      // the operator into an unbounded retry against a row that cannot move.
+      unfenceable.push(id);
+      log(
+        `${id}: version is NULL, so the If-Match fence can never match — not attempted; ` +
+          `this needs a schema fix (memories.version SET NOT NULL), not a retry`,
+      );
+      continue;
+    }
+    // Keyed on `superseded_by` as well as the state, because `superseded_by` is
+    // the hazard: "restoring this returns a memory that lost a contradiction
+    // while the winner is still active" is a statement about the link, not about
+    // the state. The two diverge, reachably, with only today's two states — #103
+    // archives a loser, an operator --force-restores it (this tool PRESERVES
+    // `superseded_by` deliberately), then a later #102 cleanup soft-deletes it
+    // without clearing the column. That row is `deleted` and still names a live
+    // winner, so a state-only gate waves it through.
+    const superseded = row.state === "archived" || row.superseded_by != null;
+    if (superseded) {
+      const winner = row.superseded_by ?? "an unrecorded winner";
+      if (!opts.force) {
+        // The winner's id is the fact the decision turns on, so the refusal
+        // carries it: "pass --force" alone tells the operator nothing.
+        refusedArchived.push(id);
+        log(
+          `${id}: ${row.state}, superseded by ${winner} — ` +
+            `restoring it returns a memory that lost a contradiction while the winner is still ` +
+            `active; pass --force to restore it anyway`,
+        );
+        continue;
+      }
+      // Named HERE, during planning, so the dry run carries it. --force is
+      // per-run and never per id, so an operator who passes it for one known
+      // loser has silently consented for every other superseded id in the same
+      // file — and the dry run is where they decide whether to pass --apply.
+      forced.push(id);
+      log(
+        `${id}: ${row.state} — will be restored under --force; it was superseded by ` +
+          `${winner}, which is still active, so search can then return both`,
+      );
+    }
+    planned.push(id);
+  }
+
+  const result = (fields) => ({
+    planned,
+    restored: [],
+    alreadyActive,
+    notFound,
+    refusedArchived,
+    refusedUnknownState,
+    unfenceable,
+    fencedOut: [],
+    capUsed: 0,
+    ...fields,
+  });
+  // Anything the operator's file asked for that did not happen changes the exit
+  // code, so a typo or a refusal can never look like a clean run. `planned`
+  // exceeding the cap counts too: the dry run is where the operator decides, and
+  // "would restore 120" at exit 0 followed by an exit-4 apply that restored 50
+  // is a plan reading as executable when it is not.
+  const incomplete = () =>
+    notFound.length > 0 ||
+    refusedArchived.length > 0 ||
+    refusedUnknownState.length > 0 ||
+    unfenceable.length > 0 ||
+    planned.length > cap;
+
+  if (notFound.length > 0) log(`${notFound.length} id(s) not found: ${notFound.join(", ")}`);
+
+  if (!opts.apply) {
+    log(
+      `dry-run: would restore ${planned.length} memory(ies)` +
+        `${planned.length ? ` (${planned.join(", ")})` : ""}; ` +
+        `alreadyActive=${alreadyActive.length}; archivedRefused=${refusedArchived.length}; ` +
+        `archivedForced=${forced.length}; unknownStateRefused=${refusedUnknownState.length}; ` +
+        `unfenceable=${unfenceable.length}; ` +
+        `notFound=${notFound.length}; re-run with --apply to write`,
+    );
+    if (planned.length > cap) {
+      // Said on the dry run, not discovered at exit 4 after a partial apply.
+      log(
+        `plan of ${planned.length} exceeds cap ${cap} — an --apply would restore ${cap} and abort; ` +
+          `raise --cap or split the ids file`,
+      );
+    }
+    return result({ exitCode: incomplete() ? 6 : 0 });
+  }
+
+  const lockFile =
+    deps.lockFile ||
+    join(process.env.XDG_RUNTIME_DIR || join(homedir(), ".cache"), "mem9-cleanup", `${opts.stage}.lock`);
+  const ttlMs = deps.lockTtlMs ?? (opts.lockTtlHours ? opts.lockTtlHours * HOUR_MS : DEFAULT_LOCK_TTL_MS);
+  // The same shared mutex cleanup and consolidation take. A restore racing
+  // consolidation could re-activate the loser of a contradiction while #103 is
+  // mid-resolution on that very pair.
+  const sharedMutex = deps.acquireMutex ? await deps.acquireMutex(opts.stage) : undefined;
+  if (deps.acquireMutex && !sharedMutex) {
+    log("another cleanup, consolidation, or restore apply holds the shared database mutex");
+    return result({ exitCode: 3 });
+  }
+  if (!acquireLock(fs, lockFile, clock, log, ttlMs, deps.pidAlive || defaultPidAlive)) {
+    await sharedMutex?.release();
+    // "another restore" would send an operator looking for a restore that does
+    // not exist: the lockfile path is shared with `runCleanup` by default.
+    log(`another cleanup or restore run holds ${lockFile} — aborting`);
+    return result({ exitCode: 3 });
+  }
+
+  const restored = [];
+  const fencedOut = [];
+  const entries = [];
+  let capUsed = 0;
+  let capAborted = false;
+  let logPath;
+  let persistFailed = false;
+  try {
+    for (const id of planned) {
+      const row = byId.get(id);
+      // Snapshot BEFORE the write. Everything below — the fence values, the log
+      // entry, and the archived warning — describes the row as it was read, and
+      // reading `row.state` back after a successful restore would report
+      // "active" as the prior state, making the decision log worthless for the
+      // one thing it exists to record.
+      const priorState = row.state;
+      const priorVersion = row.version;
+      const supersededBy = row.superseded_by ?? null;
+      // Reservation-style cap, one mutation per id (the #102 pattern): the
+      // charge is taken BEFORE the write, and overflow aborts the run rather
+      // than silently restoring a prefix.
+      if (capUsed + 1 > cap) {
+        log(`cap exceeded: used ${capUsed} + 1 > cap ${cap} — aborting run`);
+        capAborted = true;
+        break;
+      }
+      const ok = await adapter.restoreMemory({ id, priorState, version: priorVersion });
+      // Charged only on a write that landed, matching #102's decision for a
+      // fenced merge (TC-MEMCLEAN-043): charging a lost fence shrinks the
+      // blast-radius budget for work that never happened, and a mostly-fenced
+      // run could trip the exit-4 abort having restored almost nothing. The
+      // check above still runs before the write, so the cap cannot be overrun.
+      if (ok) capUsed += 1;
+      entries.push({
+        id,
+        priorState,
+        // The only surviving record of the row's real age: by the time this file
+        // is read back, trg_memories_updated has overwritten `updated_at` with
+        // NOW() (BEFORE UPDATE, unconditional). Null when the column held
+        // nothing usable: "age unknown" is a different fact from a definite 1970.
+        updatedAtBefore: isoOrNull(row.updated_at),
+        version: priorVersion,
+        supersededBy,
+        forced: priorState === "archived" || supersededBy !== null,
+        snippet: (row.content ?? "").slice(0, SNIPPET_LEN),
+        outcome: ok ? "restored" : "fenced-out",
+      });
+      if (ok) {
+        restored.push(id);
+      } else {
+        // rowCount 0 means the row moved between the read and the write.
+        // Counting it as restored would tell the operator a memory is back
+        // when it is not.
+        fencedOut.push(id);
+        log(`${id}: state or version changed since it was read — skipped, not restored`);
+      }
+    }
+  } finally {
+    // Every step runs even if an earlier one throws, and none of them may
+    // replace the in-flight exception. A throw from a `finally` REPLACES the
+    // original: `pg_advisory_unlock` runs on the same client the loop just died
+    // on, so a dropped connection kills the release for the same reason it
+    // killed the loop — and the operator would be told "Connection terminated"
+    // for a run that died of something else. A lock file that cannot be removed
+    // must likewise not skip the mutex release: a leaked advisory lock blocks
+    // the next weekly consolidation outright.
+    for (const [what, step] of [
+      ["remove the lock file", () => fs.rmSync(lockFile, { force: true })],
+      ["release the shared database mutex", () => sharedMutex?.release()],
+      // The record goes here too: the loop can throw after rows are already
+      // active, and losing it leaves the operator reconstructing a half-applied
+      // run from nothing. The summary is emitted BEFORE the file write, so a
+      // failed write cannot cost both.
+      ["write the restore log", () => { logPath = persist(); }],
+    ]) {
+      try {
+        await step();
+      } catch (err) {
+        log(`failed to ${what}: ${err.message}`);
+        persistFailed = true;
+      }
+    }
+  }
+
+  return result({
+    // A failed log write is exit 1, not 0: rows moved and the durable record of
+    // which ones did not survive, so the run needs an operator's attention even
+    // though every write succeeded.
+    exitCode: persistFailed ? 1 : capAborted ? 4 : incomplete() || fencedOut.length > 0 ? 6 : 0,
+    restored,
+    fencedOut,
+    capUsed,
+    ...(logPath ? { logPath } : {}),
+  });
+
+  /**
+   * Emit the summary, then persist the entries. The log holds memory snippets,
+   * so it lands outside any checkout at 0600 (the repo is planned to be
+   * open-sourced) — and when it cannot be written, the fallback on stderr
+   * carries the restored IDS ONLY. Stderr on a scheduled task lands in
+   * CloudWatch, which is exactly where the snippets must not go.
+   */
+  function persist() {
+    log(
+      `apply done: restored=${restored.length}/${planned.length}; capUsed=${capUsed}/${cap}; ` +
+        `alreadyActive=${alreadyActive.length}; archivedRefused=${refusedArchived.length}; ` +
+        `archivedForced=${forced.length}; unknownStateRefused=${refusedUnknownState.length}; ` +
+        `unfenceable=${unfenceable.length}; ` +
+        `notFound=${notFound.length}; fencedOut=${fencedOut.length}`,
+    );
+    const generatedAt = new Date(clock()).toISOString();
+    const outDir = deps.outDir || join(homedir(), ".mem9-cleanup", opts.stage);
+    const target = join(outDir, `restore-${generatedAt.replace(/[:.]/g, "-")}.json`);
+    try {
+      fs.mkdirSync(outDir, { recursive: true, mode: 0o700 });
+      fs.writeFileSync(
+        target,
+        JSON.stringify({ stage: opts.stage, generatedAt, forced: Boolean(opts.force), entries }, null, 2),
+        { mode: 0o600 },
+      );
+    } catch (err) {
+      log(
+        `restore log could not be written to ${target}: ${err.message} — ` +
+          `restored ids: ${restored.join(", ") || "(none)"}; ` +
+          `fenced-out ids: ${fencedOut.join(", ") || "(none)"}`,
+      );
+      throw err;
+    }
+    log(`restore log written to ${target}`);
+    return target;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // CLI wiring (not exercised by unit tests — production deps only).
 
+/** The three things this script can be asked to do; `mode` below names them. */
+const MODES = ["cleanup", "list", "restore"];
+
 // --flag -> the opts key it sets. `flag: true` takes no value; `number: true`
-// values must parse to a positive number (a NaN cap would disable the cap).
-// `choices` restricts the accepted values.
-const ARG_SPECS = {
-  "--stage": { key: "stage" },
-  "--base-url": { key: "baseUrl" },
-  "--tenant-secret-arn": { key: "tenantSecretArn" },
-  "--decisions": { key: "decisionsFile" },
-  "--ids": { key: "idsFile" },
-  "--out": { key: "outDir" },
-  "--lock-file": { key: "lockFile" },
-  "--cap": { key: "cap", number: true },
-  "--lock-ttl": { key: "lockTtlHours", number: true },
-  "--apply": { key: "apply", flag: true },
-  "--model": { key: "model" },
-  "--effort": { key: "effort", choices: REASONING_EFFORTS },
-  "--llm-region": { key: "llmRegion" },
+// values must parse to a positive number (a NaN cap would disable the cap);
+// `integer: true` additionally requires a whole number. `choices` restricts the
+// accepted values; `iso` requires a parseable ISO timestamp.
+//
+// `mode` lists the run modes the flag belongs to, and anything outside them is
+// REJECTED rather than ignored: an operator who believes --state narrowed a
+// restore would restore more than they intended, and that reasoning does not
+// stop applying at the flags that happened to be thought of first. Declaring it
+// per flag rather than as a one-off check means a flag added later has to answer
+// the question — TC-MEMRESTORE-054 fails on a missing `mode`.
+export const ARG_SPECS = {
+  "--stage": { key: "stage", mode: MODES },
+  "--base-url": { key: "baseUrl", mode: ["cleanup"] },
+  "--tenant-secret-arn": { key: "tenantSecretArn", mode: ["cleanup"] },
+  "--decisions": { key: "decisionsFile", mode: ["cleanup"] },
+  "--ids": { key: "idsFile", mode: ["cleanup", "restore"] },
+  "--out": { key: "outDir", mode: ["cleanup", "restore"] },
+  "--lock-file": { key: "lockFile", mode: ["cleanup", "restore"] },
+  "--cap": { key: "cap", integer: true, mode: ["cleanup", "restore"] },
+  "--lock-ttl": { key: "lockTtlHours", number: true, mode: ["cleanup", "restore"] },
+  "--apply": { key: "apply", flag: true, mode: ["cleanup", "restore"] },
+  "--model": { key: "model", mode: ["cleanup"] },
+  "--effort": { key: "effort", choices: REASONING_EFFORTS, mode: ["cleanup"] },
+  "--llm-region": { key: "llmRegion", mode: ["cleanup"] },
+  // Recovery modes (issue #124).
+  "--list-inactive": { key: "listInactive", flag: true, mode: ["list"] },
+  "--restore": { key: "restore", flag: true, mode: ["restore"] },
+  "--force": { key: "force", flag: true, mode: ["restore"] },
+  "--state": { key: "state", choices: INACTIVE_STATES, mode: ["list"] },
+  "--since": { key: "since", iso: true, mode: ["list"] },
+  "--limit": { key: "limit", integer: true, mode: ["list"] },
+  "--help": { key: "help", flag: true, mode: MODES },
 };
+
+export const USAGE = `memory-cleanup.mjs — audit, clean, and recover the mem9 memory store
+
+Audit and clean (issue #102) — dry-run by default, --apply writes:
+  --stage <name>              required for every mode
+  --base-url <url>            skip service discovery
+  --tenant-secret-arn <arn>   tenant key source (else MEM9_TENANT_ID)
+  --apply                     execute the plan; without it nothing is written
+  --decisions <file.json>      replay a prior dry-run's decision list
+  --ids <file>                restrict --apply to the reviewed ids in <file>
+  --cap <n>                   max mutations per run (default ${DEFAULT_CAP})
+  --out <dir>                 decision/restore log directory
+  --lock-file <path>          stage lockfile path
+  --lock-ttl <hours>          age after which a lock may be reclaimed
+  --model <id>                classifier model
+  --effort <${REASONING_EFFORTS.join("|")}>
+  --llm-region <region>       region for the reasoning-model route
+
+Recover soft-deleted and archived memories (issue #124):
+  --list-inactive             read-only listing; takes no lock
+  --state <${INACTIVE_STATES.join("|")}>   restrict the listing to one state
+                              (omit for both; the output distinguishes them)
+  --since <iso>               filter on updated_at — there is NO deleted_at
+                              column, so a row deleted long ago but touched
+                              since will still match a recent --since
+  --limit <n>                 bound the rows shown (default ${DEFAULT_LIST_LIMIT});
+                              the total matched is reported alongside
+  --restore --ids <file>      restore the listed ids. DRY-RUN IS THE DEFAULT:
+                              --apply is required to write. Bounded by --cap
+                              (one mutation per id) and serialised by the same
+                              stage lockfile and shared database mutex.
+                              Restoring an already-active id is a reported
+                              no-op, not an error.
+  --force                     required to restore an ARCHIVED memory. Archived
+                              rows lost a contradiction (#103) and their winner
+                              is still active, so restoring one puts both back
+                              into search. superseded_by is preserved either
+                              way. --force applies per run, never per id.
+  --help                      print this and exit
+
+Exit codes: 0 ok; 1 error; 2 discovery failed; 3 lock held; 4 cap exceeded;
+5 classifier broken; 6 the run completed but not everything asked for was done.`;
 
 export function parseArgs(argv) {
   const opts = { apply: false, cap: DEFAULT_CAP };
+  const seen = new Set();
   for (let i = 0; i < argv.length; i += 1) {
     const name = argv[i];
     const spec = ARG_SPECS[name];
     if (!spec) throw new Error(`unknown argument ${name}`);
+    seen.add(name);
     if (spec.flag) {
       opts[spec.key] = true;
       continue;
@@ -1054,7 +1671,17 @@ export function parseArgs(argv) {
     if (spec.choices && !spec.choices.includes(raw)) {
       throw new Error(`${name} must be one of ${spec.choices.join("|")}`);
     }
-    if (!spec.number) {
+    if (spec.iso) {
+      // A rejected value, never a silently-NaN one: `updated_at >= 'yesterday'`
+      // would be an error from the database mid-run, and a value that parsed to
+      // an unintended instant would quietly change what the operator reviews.
+      if (Number.isNaN(Date.parse(raw))) {
+        throw new Error(`${name} must be an ISO timestamp, got ${JSON.stringify(raw)}`);
+      }
+      opts[spec.key] = raw;
+      continue;
+    }
+    if (!spec.number && !spec.integer) {
       opts[spec.key] = raw;
       continue;
     }
@@ -1062,9 +1689,43 @@ export function parseArgs(argv) {
     if (!Number.isFinite(value) || value <= 0) {
       throw new Error(`${name} must be a positive number`);
     }
+    // A row count is a whole number, and `LIMIT $n` binds a bigint: `--limit 5.5`
+    // would fail at the server, after the SSM reads, the secret fetch, and the
+    // connection. `--lock-ttl` is deliberately not integer-checked — half an hour
+    // is a meaningful TTL.
+    if (spec.integer && !Number.isSafeInteger(value)) {
+      throw new Error(`${name} must be a whole number, got ${raw}`);
+    }
     opts[spec.key] = value;
   }
+  // --help must not require --stage: an operator reaching for it does not yet
+  // know the invocation.
+  if (opts.help) return opts;
   if (!opts.stage) throw new Error("--stage is required");
+  // One mode per run: with both flags set it is not knowable whether --apply
+  // was meant to write.
+  if (opts.listInactive && opts.restore) {
+    throw new Error("pass exactly one of --list-inactive or --restore");
+  }
+  if (opts.restore && !opts.idsFile) {
+    throw new Error("--restore requires --ids <file>");
+  }
+  if (!opts.restore && opts.force) {
+    throw new Error("--force applies only to --restore");
+  }
+  // Rejected, not ignored, for EVERY flag: an operator who believes a flag
+  // narrowed the run acts on that belief. `--apply` on a listing is the one that
+  // bites hardest — `recoveryDeps` keys the shared mutex on `opts.apply`, so a
+  // read-only listing would take the advisory lock and contend with the weekly
+  // consolidation, exactly what "a listing takes no lock" promises it cannot.
+  const mode = opts.listInactive ? "list" : opts.restore ? "restore" : "cleanup";
+  for (const [name, spec] of Object.entries(ARG_SPECS)) {
+    if (!seen.has(name)) continue;
+    if (spec.mode.includes(mode)) continue;
+    throw new Error(
+      `${name} applies only to ${spec.mode.map((m) => `--${m === "cleanup" ? "apply/--decisions (audit)" : m === "list" ? "list-inactive" : "restore"}`).join(" or ")}`,
+    );
+  }
   return opts;
 }
 
@@ -1142,6 +1803,10 @@ async function productionDatabaseMutex(stage, region) {
   await db.connect();
 
   return {
+    // Exposed for the recovery modes (issue #124), which read and write rows the
+    // REST API cannot see at all — its GetByID and list both filter to
+    // `state = 'active'`.
+    db,
     acquireMutex: async (lockStage) => {
       const result = await db.query(
         "SELECT pg_try_advisory_lock(hashtextextended($1, 0)) AS acquired",
@@ -1158,6 +1823,32 @@ async function productionDatabaseMutex(stage, region) {
       };
     },
     close: () => db.end(),
+  };
+}
+
+/**
+ * Deps for `--list-inactive` / `--restore`. Deliberately NOT `productionDeps`:
+ * recovery needs no tenant key, no service discovery, and no LLM, so requiring
+ * them would make a read-only listing fail on unrelated configuration. The
+ * shared mutex is passed only for an actual `--apply`, matching cleanup.
+ */
+async function recoveryDeps(opts) {
+  const region = process.env.AWS_REGION || "ap-northeast-1";
+  const database = await productionDatabaseMutex(opts.stage, region);
+  const adapter = inactiveMemoryAdapter(database.db);
+  return {
+    deps: {
+      ...adapter,
+      // A listing takes no lock, so an operator can look at what was deleted
+      // even while a weekly consolidation apply is running. Keyed on `restore`
+      // too, not `apply` alone: `--list-inactive --apply` is rejected by
+      // `parseArgs`, and this is the second line of that same defence.
+      acquireMutex: opts.apply && opts.restore ? database.acquireMutex : undefined,
+      outDir: opts.outDir,
+      lockFile: opts.lockFile,
+      log: (msg) => console.error(`[memory-cleanup ${new Date().toISOString()}] ${msg}`),
+    },
+    close: () => database.close(),
   };
 }
 
@@ -1231,17 +1922,36 @@ if (isMain) {
   let production;
   try {
     const opts = parseArgs(process.argv.slice(2));
-    production = await productionDeps(opts);
-    const result = await runCleanup(
-      { ...opts, tenantId: production.tenantId },
-      production.deps,
-    );
-    process.exit(result.exitCode);
+    if (opts.help) {
+      // stdout, not stderr: --help is the requested output, not a diagnostic.
+      console.log(USAGE);
+      // `process.exitCode`, never `process.exit()`. Every record this script
+      // produces — the whole `--list-inactive` listing and the restore summary —
+      // goes to stderr, and `process.exit()` discards writes still queued in a
+      // pipe. A truncated listing then loses both its tail rows AND the
+      // "listed N of TOTAL" trailer that is the only signal it was truncated,
+      // so a partial listing reads as complete, nondeterministically. Setting
+      // the code and letting the event loop drain is the only form that cannot.
+      process.exitCode = 0;
+    } else if (opts.listInactive || opts.restore) {
+      production = await recoveryDeps(opts);
+      const result = opts.restore
+        ? await runRestore(opts, production.deps)
+        : await runListInactive(opts, production.deps);
+      process.exitCode = result.exitCode;
+    } else {
+      production = await productionDeps(opts);
+      const result = await runCleanup(
+        { ...opts, tenantId: production.tenantId },
+        production.deps,
+      );
+      process.exitCode = result.exitCode;
+    }
   } catch (err) {
     // Full stack on a destructive tool: an operator reconstructing a
     // half-applied run needs more than one context-free message line.
     console.error(`memory-cleanup: ${err.stack || err.message}`);
-    process.exit(1);
+    process.exitCode = 1;
   } finally {
     await production?.close();
   }

--- a/scripts/memory-cleanup.mjs
+++ b/scripts/memory-cleanup.mjs
@@ -20,13 +20,16 @@
 //        [--cap 50] [--out dir] [--lock-file path] [--lock-ttl hours]
 //        [--model openai.gpt-5.6-terra] [--effort high] [--llm-region us-west-2]
 //
-// The decision log contains memory snippets — instance-private data. It is
-// written OUTSIDE the repository (default ~/.mem9-cleanup/<stage>/) and must
-// never be committed (the repo is planned to be open-sourced).
+// The decision log and the restore log contain memory snippets — instance-private
+// data. Both are written OUTSIDE the repository (default ~/.mem9-cleanup/<stage>/)
+// and must never be committed (the repo is planned to be open-sourced).
+// `snippetLogDir` enforces the part of that a check can reach: an `--out` inside
+// THIS script's tree is refused. Another checkout of the same repo is still the
+// operator's to avoid.
 
 import { createHash } from "node:crypto";
 import { homedir, hostname } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join, relative, resolve, sep } from "node:path";
 import process from "node:process";
 import { setTimeout as delay } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
@@ -655,10 +658,51 @@ function classificationFailureNote({ batches, failedBatches, decisions, scanned 
 }
 
 /**
+ * Where a snippet-bearing log may be written, and the check that keeps it out of
+ * a checkout.
+ *
+ * Both artifacts this script persists — the cleanup decision list and the restore
+ * log — carry `snippet` fields sliced from memory content. The header comment says
+ * they are written outside the repository, and the default
+ * `~/.mem9-cleanup/<stage>/` honours that, but `--out` overrode it with NO
+ * constraint. `--out ./tmp` in a checkout is the natural thing for an operator
+ * reviewing a plan to type, and the result is instance-private memory text in a
+ * repo that is planned to be open-sourced, in files no `.gitignore` pattern
+ * matched. A comment cannot enforce this; a thrown error can.
+ *
+ * The bound is the tree containing this script, which is the checkout when run
+ * from one. Deliberately not a `git rev-parse` probe: this must fail the same way
+ * inside the container image, where there is no git and no repository, and where
+ * `--out` is never passed anyway.
+ */
+export function snippetLogDir(outDir, stage) {
+  if (!outDir) return join(homedir(), ".mem9-cleanup", stage);
+  const target = resolve(outDir);
+  const scriptTree = dirname(dirname(fileURLToPath(import.meta.url)));
+  // `relative` answers with a `..`-prefixed path exactly when the target is
+  // OUTSIDE the tree — and with "" when it IS the tree root, which these two
+  // predicates already reject (`"".startsWith("../")` is false).
+  //
+  // Both halves are exact for a reason. The `${sep}` keeps `<tree>/..cache` — a
+  // directory INSIDE the tree whose NAME starts with `..` — from reading as
+  // outside, and the `!== ".."` catches the parent, whose relative path has no
+  // separator to match.
+  const inside = relative(scriptTree, target);
+  if (!inside.startsWith(`..${sep}`) && inside !== "..") {
+    throw new Error(
+      `--out ${outDir} resolves inside ${scriptTree}; the log holds memory ` +
+        `snippets and must not be written into a checkout — omit --out to use ` +
+        `${join(homedir(), ".mem9-cleanup", stage)}`,
+    );
+  }
+  return target;
+}
+
+/**
  * Obtain the decision list: replay a prior dry-run file, or scan + classify and
  * persist a new one outside the repo (0700/0600 — it holds memory snippets).
  */
-async function loadDecisions(opts, deps, { client, fs, clock, log }) {
+async function loadDecisions(opts, deps, { client, fs, clock, log, outDir }) {
   if (opts.decisionsFile) {
     const loaded = JSON.parse(fs.readFileSync(opts.decisionsFile, "utf8"));
     // A decision file is stage-bound: ids/hashes from one store must never be
@@ -690,7 +734,6 @@ async function loadDecisions(opts, deps, { client, fs, clock, log }) {
   const classifierBroken = batches > 0 && failedBatches === batches;
 
   const generatedAt = new Date(clock()).toISOString();
-  const outDir = deps.outDir || join(homedir(), ".mem9-cleanup", opts.stage);
   fs.mkdirSync(outDir, { recursive: true, mode: 0o700 });
   const decisionPath = join(outDir, `decisions-${generatedAt.replace(/[:.]/g, "-")}.json`);
   fs.writeFileSync(
@@ -827,6 +870,13 @@ export async function runCleanup(opts, deps) {
   if (!Number.isFinite(cap) || cap <= 0) {
     throw new Error(`cap must be a positive finite number, got ${cap}`);
   }
+  // Validated HERE, next to the cap, and not at the write site inside
+  // `loadDecisions`: there it runs AFTER the full scan and the whole
+  // classification pass, so `--out ./tmp` on a prod dry run burned a
+  // reasoning-model run at `--effort high` and then threw, discarding every
+  // decision — the entire artifact of a dry run. Same rule the restore path
+  // follows: an operator's path error fails before the expensive work, not after.
+  const outDir = snippetLogDir(deps.outDir, opts.stage);
   // Shared tail of every return: the counters object is read at return time.
   const result = (fields) => ({
     decisions: [],
@@ -851,6 +901,7 @@ export async function runCleanup(opts, deps) {
     fs,
     clock,
     log,
+    outDir,
   });
   const summary = verdictSummary(decisions);
   const failureNote = classificationFailureNote({ batches, failedBatches, decisions, scanned });
@@ -1285,8 +1336,16 @@ export async function runRestore(opts, deps) {
     throw new Error(`cap must be a positive finite number, got ${cap}`);
   }
 
-  // Both throw, and both before any read: a stage-mismatched or empty ids file
-  // is an operator error to correct, not a run to report on.
+  // Resolved HERE rather than in `persist()`, which runs in the teardown
+  // `finally`: a rejected `--out` there would be caught as "failed to write the
+  // restore log" AFTER rows had already been restored, costing the operator the
+  // record of a run that did happen. An operator error must fail before the
+  // first write, not be reported as a lost log.
+  const outDir = snippetLogDir(deps.outDir, opts.stage);
+
+  // Like the cap and the `--out` above, this throws — and all three do so before
+  // any read: a bad cap, an `--out` in a checkout, and a stage-mismatched or
+  // empty ids file are operator errors to correct, not runs to report on.
   const ids = readRestoreIds(fs, opts);
   const rows = await adapter.findByIds(ids);
   const byId = new Map(rows.map((row) => [row.id, row]));
@@ -1443,7 +1502,11 @@ export async function runRestore(opts, deps) {
   let capUsed = 0;
   let capAborted = false;
   let logPath;
-  let persistFailed = false;
+  // Any of the three teardown steps below failing. One flag for all three is
+  // deliberate: they map to the same exit code, they each name themselves in a
+  // log line, and `logPath` is left undefined when it was specifically the write
+  // — so nothing an operator needs is lost by pooling them.
+  let teardownFailed = false;
   try {
     for (const id of planned) {
       const row = byId.get(id);
@@ -1516,16 +1579,31 @@ export async function runRestore(opts, deps) {
         await step();
       } catch (err) {
         log(`failed to ${what}: ${err.message}`);
-        persistFailed = true;
+        teardownFailed = true;
       }
     }
   }
 
   return result({
-    // A failed log write is exit 1, not 0: rows moved and the durable record of
-    // which ones did not survive, so the run needs an operator's attention even
-    // though every write succeeded.
-    exitCode: persistFailed ? 1 : capAborted ? 4 : incomplete() || fencedOut.length > 0 ? 6 : 0,
+    // A failed teardown step is exit 1, not 0: rows moved and either the durable
+    // record of which ones, or the release of a lock the next run needs, did not
+    // survive — so the run needs attention even though every write succeeded.
+    //
+    // But it is tested LAST, not first. A teardown failure is about the run's
+    // bookkeeping; exits 4 and 6 are about what the run DID to the store, which
+    // is the more urgent fact and the one an operator's next command depends on.
+    // Ordering this first meant an EROFS lock file could report a clean-looking
+    // exit 1 for a run that had actually hit the cap and left the ids file
+    // half-applied — and exit 1 is also what an outright crash gives, so the
+    // partial apply was indistinguishable from a run that did nothing. Every
+    // teardown failure still names itself in a log line either way.
+    exitCode: capAborted
+      ? 4
+      : incomplete() || fencedOut.length > 0
+        ? 6
+        : teardownFailed
+          ? 1
+          : 0,
     restored,
     fencedOut,
     capUsed,
@@ -1548,7 +1626,6 @@ export async function runRestore(opts, deps) {
         `notFound=${notFound.length}; fencedOut=${fencedOut.length}`,
     );
     const generatedAt = new Date(clock()).toISOString();
-    const outDir = deps.outDir || join(homedir(), ".mem9-cleanup", opts.stage);
     const target = join(outDir, `restore-${generatedAt.replace(/[:.]/g, "-")}.json`);
     try {
       fs.mkdirSync(outDir, { recursive: true, mode: 0o700 });
@@ -1621,7 +1698,9 @@ Audit and clean (issue #102) — dry-run by default, --apply writes:
   --decisions <file.json>      replay a prior dry-run's decision list
   --ids <file>                restrict --apply to the reviewed ids in <file>
   --cap <n>                   max mutations per run (default ${DEFAULT_CAP})
-  --out <dir>                 decision/restore log directory
+  --out <dir>                 decision/restore log directory (default
+                              ~/.mem9-cleanup/<stage>/; must be outside the
+                              checkout — the log holds memory snippets)
   --lock-file <path>          stage lockfile path
   --lock-ttl <hours>          age after which a lock may be reclaimed
   --model <id>                classifier model

--- a/scripts/memory-cleanup.test.mjs
+++ b/scripts/memory-cleanup.test.mjs
@@ -2,7 +2,7 @@
 // Test IDs map to docs/test-cases/memory-cleanup.md. All I/O is faked through
 // the injected deps object — no network, no real filesystem outside tmpdirs.
 import { createHash } from "node:crypto";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -10,11 +10,16 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildCompleteChat,
   contentHash,
+  inactiveMemoryAdapter,
   parseArgs,
   parseVerdicts,
   planDecisions,
   runCleanup,
+  runListInactive,
+  runRestore,
+  ARG_SPECS,
   DURABLE_ONLY_RULES,
+  USAGE,
 } from "./memory-cleanup.mjs";
 
 const tempDirs = [];
@@ -1374,5 +1379,1447 @@ describe("LLM route", () => {
     } finally {
       vi.unstubAllEnvs();
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Inactive listing & restore (TC-MEMRESTORE-001..070) — issue #124.
+// Test IDs map to docs/test-cases/memory-restore.md.
+//
+// The REST surface cannot reach these rows at all: upstream's GetByID and list
+// both select `WHERE state = 'active'` (the fakeServer above 404s a deleted id
+// for exactly that reason), so recovery has to go through SQL. #103 already
+// does, and this file's `productionDatabaseMutex` already holds a `pg` client,
+// so the tests below fake the client rather than the HTTP layer.
+
+/** Row as `memories` stores it — snake_case, because the adapter reads raw rows. */
+function inactiveRow(id, state, overrides = {}) {
+  return {
+    id,
+    content: `fact about ${id}`,
+    state,
+    version: 3,
+    updated_at: new Date("2026-06-01T09:00:00Z"),
+    // #103 sets this when it archives the loser of a contradiction; #102's
+    // soft delete never does. The asymmetry is the whole point of TC-040..042.
+    superseded_by: state === "archived" ? `winner-of-${id}` : null,
+    ...overrides,
+  };
+}
+
+/**
+ * Minimal `pg` client fake: records every statement, and answers the ones the
+ * test names. Statements are matched on a substring so the assertions stay on
+ * the SQL the adapter actually built (values included) rather than on a mock's
+ * return shape.
+ *
+ * Handlers are tried in declaration order and a COUNT also reads `FROM
+ * memories`, so declare the narrower `"count("` key first wherever both are
+ * needed — otherwise the count silently answers with the listing's rows.
+ *
+ * Every statement is checked for placeholder/values arity, because that is the
+ * one class of bug a permissive fake hides completely: real Postgres rejects a
+ * surplus bind outright ("Expected 1 parameters but got 2"), so a statement that
+ * this fake answers happily can still be a hard runtime error. Sharing one
+ * mutable values array across two statements is how that happens.
+ */
+function fakeDb(handlers = {}) {
+  const queries = [];
+  const query = vi.fn(async (text, values = []) => {
+    assertBindArity(text, values);
+    queries.push({ text, values });
+    for (const [needle, handler] of Object.entries(handlers)) {
+      if (text.includes(needle)) return handler(values);
+    }
+    return { rows: [], rowCount: 0 };
+  });
+  return { queries, query };
+}
+
+/**
+ * Reject what the server would reject: the highest `$n` referenced must equal
+ * the number of values supplied, and every index below it must be referenced.
+ */
+function assertBindArity(text, values) {
+  const referenced = new Set(
+    [...text.matchAll(/\$(\d+)/gu)].map((m) => Number(m[1])),
+  );
+  const highest = referenced.size ? Math.max(...referenced) : 0;
+  const missing = Array.from({ length: highest }, (_, i) => i + 1).filter(
+    (n) => !referenced.has(n),
+  );
+  const detail = `${JSON.stringify(text)} values=${JSON.stringify(values)}`;
+  expect(missing, `unreferenced placeholder(s) in ${detail}`).toEqual([]);
+  expect(
+    values.length,
+    `bind arity mismatch: statement uses $1..$${highest} in ${detail}`,
+  ).toBe(highest);
+}
+
+const restoreOpts = (overrides = {}) => ({
+  stage: "test",
+  apply: false,
+  cap: 50,
+  force: false,
+  ...overrides,
+});
+
+function restoreDeps(overrides = {}) {
+  return {
+    log: vi.fn(),
+    outDir: overrides.outDir,
+    clock: () => new Date("2026-08-05T00:00:00Z").getTime(),
+    // Restore must never re-embed: `vector(1024)` survived the soft delete
+    // (schema.sql line 76). Any HTTP call would go through here, so an
+    // untouched spy is the evidence (TC-MEMRESTORE-044).
+    fetchImpl: vi.fn(async () => {
+      throw new Error("restore must not make HTTP calls");
+    }),
+    ...overrides,
+  };
+}
+
+describe("inactive-memory SQL adapter", () => {
+  it("TC-MEMRESTORE-020 filters by state and never returns active rows", async () => {
+    // The count handler is declared first and is no longer optional: the total
+    // is the truncation signal, so the adapter refuses a count that answered
+    // nothing rather than defaulting the denominator (TC-MEMRESTORE-024).
+    const db = fakeDb({
+      "count(": () => ({ rows: [{ total: "1" }] }),
+      "FROM memories": () => ({ rows: [inactiveRow("d-1", "deleted")] }),
+    });
+    const adapter = inactiveMemoryAdapter(db);
+
+    await adapter.listInactive({ state: "deleted" });
+    const scoped = db.queries.at(-1);
+    // `state = $n` alone is not enough: an unparameterised or absent state
+    // predicate would still return rows and read as a successful filter.
+    expect(scoped.values).toContain("deleted");
+    expect(scoped.text).toMatch(/state\s*=\s*\$\d/u);
+
+    await adapter.listInactive({});
+    const both = db.queries.at(-1);
+    // With no --state the query must still exclude active rows. A bare
+    // `SELECT ... FROM memories` would list the entire corpus, which for a
+    // 2811-memory store is not a listing an operator can review.
+    expect(both.text).toMatch(/state\s*(<>|!=)\s*'active'|state\s+IN\s*\(\s*'archived'\s*,\s*'deleted'\s*\)|state\s+IN\s*\(\s*'deleted'\s*,\s*'archived'\s*\)/u);
+    expect(both.values).not.toContain("active");
+  });
+
+  it("TC-MEMRESTORE-021 --since filters updated_at, the only timestamp that exists", async () => {
+    const db = fakeDb({ "count(": () => ({ rows: [{ total: "0" }] }), "FROM memories": () => ({ rows: [] }) });
+    const adapter = inactiveMemoryAdapter(db);
+    await adapter.listInactive({ since: "2026-07-01T00:00:00Z" });
+    const { text, values } = db.queries.at(-1);
+    // There is no `memories.deleted_at` — only `tenants` has one (schema.sql
+    // line 40). A query that referenced one would fail at runtime against the
+    // real database, so pin the column here where it is cheap to catch.
+    expect(text).not.toMatch(/deleted_at/u);
+    expect(text).toMatch(/updated_at\s*>=?\s*\$\d/u);
+    expect(values).toContain("2026-07-01T00:00:00Z");
+  });
+
+  it("TC-MEMRESTORE-022 --limit bounds the rows but the total is counted unbounded", async () => {
+    const db = fakeDb({
+      "count(": () => ({ rows: [{ total: "42" }] }),
+      "FROM memories": (values) =>
+        // Mirror LIMIT: the fake returns as many rows as asked for, so a
+        // missing LIMIT shows up as an unbounded listing rather than passing.
+        ({ rows: Array.from({ length: Math.min(5, values.at(-1) ?? 5) }, (_, i) => inactiveRow(`d-${i}`, "deleted")) }),
+    });
+    const adapter = inactiveMemoryAdapter(db);
+    const page = await adapter.listInactive({ limit: 2 });
+    expect(page.rows).toHaveLength(2);
+    // A silent cap is the failure mode: 2 of 42 must never read as "42 is all
+    // there is", so the total comes from a separate unbounded COUNT.
+    expect(page.total).toBe(42);
+    const counted = db.queries.find((q) => /count\(/iu.test(q.text));
+    expect(counted).toBeDefined();
+    expect(counted.text).not.toMatch(/LIMIT/iu);
+
+    // The count and the page must not share one values array. `fakeDb` records
+    // the array by reference, so if the page appended its LIMIT parameter to the
+    // count's array, the count would be recorded here carrying a parameter its
+    // SQL never references. That reads as a surplus bind — which real Postgres
+    // rejects outright — even when the live call happened to be well-formed.
+    expect(counted.values).toHaveLength(0);
+    expect(counted.values).not.toBe(db.queries.at(-1).values);
+  });
+
+  it("TC-MEMRESTORE-041 the restore UPDATE is fenced, preserves version, and touches nothing else", async () => {
+    const db = fakeDb({ "UPDATE memories": () => ({ rowCount: 1 }) });
+    const adapter = inactiveMemoryAdapter(db);
+    const ok = await adapter.restoreMemory({ id: "a-1", priorState: "archived", version: 7 });
+    expect(ok).toBe(true);
+    const { text, values } = db.queries.at(-1);
+
+    // Fenced on BOTH the observed state and version. Without the state
+    // predicate a row someone else already restored (and then edited) would be
+    // re-"restored" over their change; without the version predicate the write
+    // is unprotected in exactly the way #128 fixed for the merge path.
+    expect(text).toMatch(/state\s*=\s*\$\d/u);
+    expect(text).toMatch(/version\s*=\s*\$\d/u);
+    expect(values).toEqual(expect.arrayContaining(["a-1", "archived", 7]));
+
+    // `version` is the concurrency token #128's If-Match compares against.
+    // Restore changes no content, so bumping it would invalidate a concurrent
+    // writer's fence for nothing. Preserved, and asserted because either
+    // choice is defensible and silence is not (TC-MEMRESTORE-045).
+    expect(text).not.toMatch(/version\s*=\s*version\s*\+/u);
+
+    // `superseded_by` is PRESERVED for an archived row: it is the audit link to
+    // the winner and #103's handle on the pair. Clearing it would make a
+    // resurrected contradiction look like an ordinary independent memory.
+    expect(text).not.toMatch(/superseded_by\s*=/u);
+
+    // The embedding survived the soft delete, so restore must not clear or
+    // rewrite it — that would silently drop the row out of vector search while
+    // reporting a successful restore.
+    expect(text).not.toMatch(/embedding/iu);
+
+    // A lost fence is reported, not swallowed.
+    const stale = fakeDb({ "UPDATE memories": () => ({ rowCount: 0 }) });
+    expect(
+      await inactiveMemoryAdapter(stale).restoreMemory({ id: "a-1", priorState: "deleted", version: 1 }),
+    ).toBe(false);
+  });
+
+  it("TC-MEMRESTORE-045 the restore UPDATE sets exactly one column", async () => {
+    const db = fakeDb({ "UPDATE memories": () => ({ rowCount: 1 }) });
+    await inactiveMemoryAdapter(db).restoreMemory({ id: "a", priorState: "deleted", version: 1 });
+    const setClause = db.queries.at(-1).text.match(/SET([\s\S]*?)WHERE/iu)[1];
+    // Enumerated rather than spot-checked: a future edit that adds a column to
+    // the SET clause has to come through this assertion and say why.
+    expect(setClause.match(/\w+\s*=/gu).map((s) => s.replace(/\s*=$/u, ""))).toEqual(["state"]);
+    expect(setClause).toMatch(/'active'/u);
+  });
+
+  it("findByIds reads the pre-restore state, version, and updated_at for the log", async () => {
+    const db = fakeDb({ "FROM memories": () => ({ rows: [inactiveRow("d-1", "deleted")] }) });
+    await inactiveMemoryAdapter(db).findByIds(["d-1", "d-2"]);
+    const { text, values } = db.queries.at(-1);
+    // Parameterised as an array, never interpolated: ids come from an operator
+    // file, and this is a destructive tool holding a live database connection.
+    expect(text).toMatch(/id\s*=\s*ANY\s*\(\s*\$1\s*\)/u);
+    expect(values[0]).toEqual(["d-1", "d-2"]);
+    // The pre-restore `updated_at` cannot be recovered afterwards:
+    // trg_memories_updated is BEFORE UPDATE and unconditionally assigns NOW()
+    // (schema.sql 105-111), so it has to be read here.
+    for (const column of ["state", "version", "updated_at", "superseded_by"]) {
+      expect(text).toContain(column);
+    }
+    // Deliberately NOT scoped to inactive rows: an already-active id must come
+    // back so restore can report it as a no-op instead of "not found"
+    // (TC-MEMRESTORE-034 vs 035).
+    expect(text).not.toMatch(/state\s*(<>|!=)\s*'active'/u);
+  });
+});
+
+describe("--list-inactive", () => {
+  it("TC-MEMRESTORE-001 reports id, state, updated_at, superseded_by and a snippet, with zero writes", async () => {
+    const rows = [inactiveRow("d-1", "deleted"), inactiveRow("a-1", "archived")];
+    const db = fakeDb({
+      "count(": () => ({ rows: [{ total: "2" }] }),
+      "FROM memories": () => ({ rows }),
+    });
+    const deps = restoreDeps({ db });
+    const result = await runListInactive(restoreOpts(), deps);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.rows).toHaveLength(2);
+    expect(result.rows[0]).toMatchObject({
+      id: "d-1",
+      state: "deleted",
+      superseded_by: null,
+      snippet: "fact about d-1",
+    });
+    expect(result.rows[0].updated_at).toBe("2026-06-01T09:00:00.000Z");
+    // The archived row carries its winner, which is what makes the --force
+    // refusal message in TC-040 actionable.
+    expect(result.rows[1]).toMatchObject({ state: "archived", superseded_by: "winner-of-a-1" });
+
+    // Read-only means read-only: a listing that mutated anything would be a
+    // recovery tool an operator cannot safely run against prod to look around.
+    expect(db.queries.every((q) => /^\s*SELECT/iu.test(q.text))).toBe(true);
+    expect(result.writes).toBe(0);
+    expect(deps.fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("TC-MEMRESTORE-003 an empty result says so instead of printing nothing", async () => {
+    const db = fakeDb({ "count(": () => ({ rows: [{ total: "0" }] }), "FROM memories": () => ({ rows: [] }) });
+    const deps = restoreDeps({ db });
+    const result = await runListInactive(restoreOpts(), deps);
+    expect(result.exitCode).toBe(0);
+    expect(result.rows).toHaveLength(0);
+    // A bare empty listing is indistinguishable from a broken query or a
+    // wrong-stage connection, which is the moment an operator most needs to
+    // know which one happened.
+    expect(deps.log).toHaveBeenCalledWith(expect.stringMatching(/no inactive memories/iu));
+  });
+
+  it("TC-MEMRESTORE-004 snippets are bounded, marked when truncated, and single-line", async () => {
+    const long = "x".repeat(400);
+    const db = fakeDb({
+      "count(": () => ({ rows: [{ total: "2" }] }),
+      "FROM memories": () => ({
+        rows: [
+          inactiveRow("long", "deleted", { content: long }),
+          inactiveRow("multi", "deleted", { content: "line one\nline two\nline three" }),
+        ],
+      }),
+    });
+    const result = await runListInactive(restoreOpts(), restoreDeps({ db }));
+    const [longRow, multiRow] = result.rows;
+    expect(longRow.snippet.length).toBeLessThanOrEqual(120);
+    expect(longRow.truncated).toBe(true);
+    // Unmarked truncation invites an operator to restore or discard a memory
+    // based on a sentence that was never the whole sentence.
+    expect(multiRow.truncated).toBe(false);
+    // One record per line keeps the output greppable; an embedded newline would
+    // split one memory across what looks like three records.
+    expect(multiRow.snippet).not.toContain("\n");
+    expect(multiRow.snippet).toContain("line one");
+  });
+
+  it("TC-MEMRESTORE-005 listing takes no lock, so two concurrent listings both succeed", async () => {
+    const db = fakeDb({ "count(": () => ({ rows: [{ total: "0" }] }), "FROM memories": () => ({ rows: [] }) });
+    const acquireMutex = vi.fn(async () => null);
+    const deps = restoreDeps({ db, acquireMutex });
+    const [a, b] = await Promise.all([
+      runListInactive(restoreOpts(), deps),
+      runListInactive(restoreOpts(), deps),
+    ]);
+    expect(a.exitCode).toBe(0);
+    expect(b.exitCode).toBe(0);
+    // Taking the shared apply mutex here would let a long weekly consolidation
+    // block an operator from even looking at what was deleted.
+    expect(acquireMutex).not.toHaveBeenCalled();
+  });
+
+  it("TC-MEMRESTORE-022 a truncated listing reports the total it was truncated from", async () => {
+    const db = fakeDb({
+      "count(": () => ({ rows: [{ total: "42" }] }),
+      "FROM memories": () => ({ rows: [inactiveRow("d-1", "deleted")] }),
+    });
+    const deps = restoreDeps({ db });
+    const result = await runListInactive(restoreOpts({ limit: 1 }), deps);
+    expect(result.total).toBe(42);
+    expect(deps.log).toHaveBeenCalledWith(expect.stringMatching(/1 of 42/u));
+  });
+
+  it("TC-MEMRESTORE-021 the output names updated_at as the column --since filtered", async () => {
+    const db = fakeDb({
+      "count(": () => ({ rows: [{ total: "1" }] }),
+      "FROM memories": () => ({ rows: [inactiveRow("d-1", "deleted")] }),
+    });
+    const deps = restoreDeps({ db });
+    await runListInactive(restoreOpts({ since: "2026-07-01T00:00:00Z" }), deps);
+    // Documenting the limitation in --help is not enough: the operator reading
+    // this listing is deciding what to restore from it, and a row deleted long
+    // ago but touched since is in the result set. `deleted_at` does not exist.
+    expect(deps.log).toHaveBeenCalledWith(
+      expect.stringMatching(/updated_at[\s\S]*deleted_at/u),
+    );
+  });
+
+  it("TC-MEMRESTORE-020/021 an empty listing echoes back the filters it applied", async () => {
+    const db = fakeDb({ "count(": () => ({ rows: [{ total: "0" }] }), "FROM memories": () => ({ rows: [] }) });
+    const deps = restoreDeps({ db });
+    await runListInactive(
+      restoreOpts({ state: "archived", since: "2026-07-01T00:00:00Z" }),
+      deps,
+    );
+    // "No results" plus the filters is diagnosable; "no results" alone leaves an
+    // operator unable to tell a too-narrow filter from an empty corpus.
+    const [message] = deps.log.mock.calls.at(-1);
+    expect(message).toMatch(/state=archived/u);
+    expect(message).toMatch(/since=2026-07-01T00:00:00Z/u);
+  });
+
+  it("TC-MEMRESTORE-023 one unreadable updated_at marks that row, and never kills the listing", async () => {
+    const db = fakeDb({
+      "count(": () => ({ rows: [{ total: "3" }] }),
+      "FROM memories": () => ({
+        rows: [
+          inactiveRow("d-1", "deleted"),
+          inactiveRow("d-bad", "deleted", { updated_at: "not a timestamp" }),
+          inactiveRow("d-3", "deleted"),
+        ],
+      }),
+    });
+    const deps = restoreDeps({ db });
+    // `new Date("not a timestamp").toISOString()` throws RangeError: Invalid
+    // time value — with no id, no column, and no row in the message. One
+    // unexpected value must not take down the operator's only view into
+    // inactive data, and the row it came from has to be identifiable.
+    const result = await runListInactive(restoreOpts(), deps);
+    expect(result.exitCode).toBe(0);
+    expect(result.rows.map((r) => r.id)).toEqual(["d-1", "d-bad", "d-3"]);
+    const bad = result.rows.find((r) => r.id === "d-bad");
+    expect(bad.updated_at).toBeNull();
+    expect(deps.log).toHaveBeenCalledWith(expect.stringMatching(/d-bad[\s\S]*updated_at/u));
+  });
+
+  it("TC-MEMRESTORE-024 a COUNT that answers nothing throws instead of printing 'of 0'", async () => {
+    // The denominator is the whole truncation signal: "listed 100 of 2811" is
+    // how an operator learns the page is partial. `?? 0` on a missing count row
+    // prints "listed 1 of 0" and exits 0 — a default masking a failed query,
+    // not an absent value.
+    const missing = fakeDb({ "count(": () => ({ rows: [] }), "FROM memories": () => ({ rows: [inactiveRow("d-1", "deleted")] }) });
+    await expect(runListInactive(restoreOpts(), restoreDeps({ db: missing }))).rejects.toThrow(/count/iu);
+
+    const renamed = fakeDb({ "count(": () => ({ rows: [{ tally: "7" }] }), "FROM memories": () => ({ rows: [inactiveRow("d-1", "deleted")] }) });
+    await expect(runListInactive(restoreOpts(), restoreDeps({ db: renamed }))).rejects.toThrow(/count/iu);
+  });
+
+  it("TC-MEMRESTORE-001 accepts a pre-built adapter, which is how the CLI supplies it", async () => {
+    // `recoveryDeps` spreads `inactiveMemoryAdapter(db)` into deps, so in
+    // production this branch is the ONLY one taken — untested, it would be the
+    // one seam that unit tests never reach.
+    const listInactive = vi.fn(async () => ({ rows: [inactiveRow("d-1", "deleted")], total: 1 }));
+    const result = await runListInactive(restoreOpts(), restoreDeps({ listInactive, db: undefined }));
+    expect(listInactive).toHaveBeenCalledOnce();
+    expect(result.rows[0].id).toBe("d-1");
+  });
+});
+
+describe("--restore", () => {
+  function idsFile(dir, ids) {
+    const path = join(dir, "ids.txt");
+    writeFileSync(path, `${ids.join("\n")}\n`);
+    return path;
+  }
+
+  function applyDeps(dir, rows, overrides = {}) {
+    const store = new Map(rows.map((r) => [r.id, { ...r }]));
+    const restoreMemory = vi.fn(async ({ id, priorState, version }) => {
+      const row = store.get(id);
+      if (!row || row.state !== priorState || row.version !== version) return false;
+      row.state = "active";
+      return true;
+    });
+    return {
+      store,
+      restoreMemory,
+      deps: restoreDeps({
+        outDir: dir,
+        lockFile: join(dir, "restore.lock"),
+        findByIds: vi.fn(async (ids) => ids.map((id) => store.get(id)).filter(Boolean)),
+        restoreMemory,
+        ...overrides,
+      }),
+    };
+  }
+
+  it("TC-MEMRESTORE-030 dry-run is the default: zero writes, full plan printed", async () => {
+    const dir = tempDir();
+    const { deps, store, restoreMemory } = applyDeps(dir, [inactiveRow("d-1", "deleted")]);
+    const result = await runRestore(
+      restoreOpts({ idsFile: idsFile(dir, ["d-1"]) }),
+      deps,
+    );
+    // Consistent with #102: the destructive verb is --apply, never the absence
+    // of a guard flag. An operator's first run must not change anything.
+    expect(restoreMemory).not.toHaveBeenCalled();
+    expect(store.get("d-1").state).toBe("deleted");
+    expect(result.exitCode).toBe(0);
+    expect(result.planned).toEqual(["d-1"]);
+    expect(deps.log).toHaveBeenCalledWith(expect.stringMatching(/dry-run/iu));
+  });
+
+  it("TC-MEMRESTORE-031 --apply flips listed ids to active, fenced on what was read", async () => {
+    const dir = tempDir();
+    const { deps, store, restoreMemory } = applyDeps(dir, [
+      inactiveRow("d-1", "deleted", { version: 4 }),
+      inactiveRow("d-2", "deleted", { version: 9 }),
+    ]);
+    const result = await runRestore(
+      restoreOpts({ apply: true, idsFile: idsFile(dir, ["d-1", "d-2"]) }),
+      deps,
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.restored).toEqual(["d-1", "d-2"]);
+    expect(store.get("d-1").state).toBe("active");
+    expect(store.get("d-2").state).toBe("active");
+    // Each write carries the version and state that were actually observed for
+    // THAT row — not a shared or defaulted anchor.
+    expect(restoreMemory).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "d-1", priorState: "deleted", version: 4 }),
+    );
+    expect(restoreMemory).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "d-2", priorState: "deleted", version: 9 }),
+    );
+  });
+
+  it("TC-MEMRESTORE-032 cap reserves one mutation per id and aborts before overflowing", async () => {
+    const dir = tempDir();
+    const rows = ["d-1", "d-2", "d-3"].map((id) => inactiveRow(id, "deleted"));
+    const { deps, store, restoreMemory } = applyDeps(dir, rows);
+    const result = await runRestore(
+      restoreOpts({ apply: true, cap: 2, idsFile: idsFile(dir, ["d-1", "d-2", "d-3"]) }),
+      deps,
+    );
+    expect(result.exitCode).toBe(4);
+    expect(restoreMemory).toHaveBeenCalledTimes(2);
+    expect(store.get("d-3").state).toBe("deleted");
+    expect(result.capUsed).toBe(2);
+    // Silent truncation at the cap would read as "all three restored".
+    expect(deps.log).toHaveBeenCalledWith(expect.stringMatching(/cap/iu));
+    // The log is written even though the run aborted — this is the ONE run
+    // guaranteed to be partial, so it is the run whose record matters most. An
+    // early return on abort would lose the record of the ids that DID change.
+    const aborted = JSON.parse(readFileSync(result.logPath, "utf8"));
+    expect(aborted.entries.map((e) => e.id)).toEqual(["d-1", "d-2"]);
+    expect(aborted.entries.every((e) => e.outcome === "restored")).toBe(true);
+
+    // Exact hit (used == cap) is allowed, not off-by-one refused.
+    const dir2 = tempDir();
+    const exact = applyDeps(dir2, rows.map((r) => ({ ...r })));
+    const ok = await runRestore(
+      restoreOpts({ apply: true, cap: 3, idsFile: idsFile(dir2, ["d-1", "d-2", "d-3"]) }),
+      exact.deps,
+    );
+    expect(ok.exitCode).toBe(0);
+    expect(ok.capUsed).toBe(3);
+  });
+
+  it("TC-MEMRESTORE-033 a second concurrent restore refuses; a stale lock with a dead holder is reclaimed", async () => {
+    const dir = tempDir();
+    const lockFile = join(dir, "stage.lock");
+    const host = (await import("node:os")).hostname();
+    const rows = [inactiveRow("d-1", "deleted")];
+
+    writeFileSync(lockFile, JSON.stringify({ pid: 99999, host, at: Date.now() }));
+    const held = applyDeps(dir, rows, { lockFile, clock: () => Date.now() });
+    const blocked = await runRestore(
+      restoreOpts({ apply: true, idsFile: idsFile(dir, ["d-1"]) }),
+      held.deps,
+    );
+    expect(blocked.exitCode).toBe(3);
+    expect(held.store.get("d-1").state).toBe("deleted");
+
+    writeFileSync(lockFile, JSON.stringify({ pid: 999999999, host, at: Date.now() - 3 * 3600 * 1000 }));
+    const stale = applyDeps(dir, rows, { lockFile, clock: () => Date.now() });
+    const reclaimed = await runRestore(
+      restoreOpts({ apply: true, idsFile: idsFile(dir, ["d-1"]) }),
+      stale.deps,
+    );
+    // Without reclaim, one crashed run locks the operator out of recovery
+    // permanently — the worst possible time for that.
+    expect(reclaimed.exitCode).toBe(0);
+    expect(stale.store.get("d-1").state).toBe("active");
+  });
+
+  it("TC-MEMRESTORE-033 restore shares the database apply mutex with cleanup and consolidation", async () => {
+    const dir = tempDir();
+    const acquireMutex = vi.fn(async () => null);
+    const held = applyDeps(dir, [inactiveRow("d-1", "deleted")], { acquireMutex });
+    const blocked = await runRestore(
+      restoreOpts({ apply: true, idsFile: idsFile(dir, ["d-1"]) }),
+      held.deps,
+    );
+    // A restore racing consolidation could re-activate the loser of a
+    // contradiction while #103 is mid-resolution on the same pair.
+    expect(acquireMutex).toHaveBeenCalledWith("test");
+    expect(blocked.exitCode).toBe(3);
+    expect(held.store.get("d-1").state).toBe("deleted");
+
+    const release = vi.fn(async () => {});
+    const ok = applyDeps(dir, [inactiveRow("d-1", "deleted")], {
+      acquireMutex: vi.fn(async () => ({ release })),
+    });
+    await runRestore(restoreOpts({ apply: true, idsFile: idsFile(dir, ["d-1"]) }), ok.deps);
+    // Released even on the happy path, or the next weekly run finds it held.
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("TC-MEMRESTORE-033 the mutex is taken before the lockfile and released if the lockfile is held", async () => {
+    const dir = tempDir();
+    const lockFile = join(dir, "ordering.lock");
+    const host = (await import("node:os")).hostname();
+    // A live holder, so acquireLock fails and the run bails out AFTER the mutex
+    // was already taken.
+    writeFileSync(lockFile, JSON.stringify({ pid: process.pid, host, at: Date.now() }));
+
+    const order = [];
+    const release = vi.fn(async () => {
+      order.push("release");
+    });
+    const acquireMutex = vi.fn(async () => {
+      order.push("mutex");
+      return { release };
+    });
+    const ctx = applyDeps(dir, [inactiveRow("d-1", "deleted")], {
+      lockFile,
+      acquireMutex,
+      clock: () => Date.now(),
+    });
+    const result = await runRestore(
+      restoreOpts({ apply: true, idsFile: idsFile(dir, ["d-1"]) }),
+      ctx.deps,
+    );
+    expect(result.exitCode).toBe(3);
+    // Bailing out on the lockfile while still holding the shared mutex blocks
+    // the next weekly consolidation until something else releases it — and
+    // nothing else will.
+    expect(release).toHaveBeenCalledOnce();
+    // Ordering, not just release: the mutex is acquired first, so a run that
+    // loses the lockfile race has already taken and given back the mutex.
+    expect(order).toEqual(["mutex", "release"]);
+
+    // And the same order in `runCleanup`, observed the same way. Two writers
+    // that acquire the same two locks in opposite orders deadlock; that failure
+    // appears only under real concurrency, never in CI, so both orders are
+    // pinned rather than left to match by luck.
+    const cleanupOrder = [];
+    const cleanupLock = join(dir, "cleanup-ordering.lock");
+    writeFileSync(cleanupLock, JSON.stringify({ pid: process.pid, host, at: Date.now() }));
+    const cleanupResult = await runCleanup(baseOpts({ apply: true }), {
+      ...baseDeps(fakeServer([memory("m-1", "x")]), fakeLlm([[]]), dir),
+      lockFile: cleanupLock,
+      clock: () => Date.now(),
+      acquireMutex: vi.fn(async () => {
+        cleanupOrder.push("mutex");
+        return { release: vi.fn(async () => cleanupOrder.push("release")) };
+      }),
+    });
+    expect(cleanupResult.exitCode).toBe(3);
+    expect(cleanupOrder).toEqual(["mutex", "release"]);
+  });
+
+  it("TC-MEMRESTORE-034 an already-active id is a reported no-op: exit 0, no write, no cap", async () => {
+    const dir = tempDir();
+    const { deps, restoreMemory } = applyDeps(dir, [inactiveRow("act-1", "active", { superseded_by: null })]);
+    const result = await runRestore(
+      restoreOpts({ apply: true, idsFile: idsFile(dir, ["act-1"]) }),
+      deps,
+    );
+    // Idempotence is what makes finishing a partially-applied restore safe.
+    // Treating this as an error would push an operator toward hand-written SQL.
+    expect(result.exitCode).toBe(0);
+    expect(result.alreadyActive).toEqual(["act-1"]);
+    expect(restoreMemory).not.toHaveBeenCalled();
+    expect(result.capUsed).toBe(0);
+    expect(deps.log).toHaveBeenCalledWith(expect.stringMatching(/act-1.*already active/iu));
+  });
+
+  it("TC-MEMRESTORE-035 an unknown id is reported, does not abort the rest, and changes the exit code", async () => {
+    const dir = tempDir();
+    const { deps, store } = applyDeps(dir, [inactiveRow("d-1", "deleted")]);
+    const result = await runRestore(
+      restoreOpts({ apply: true, idsFile: idsFile(dir, ["d-1", "typo-1"]) }),
+      deps,
+    );
+    expect(store.get("d-1").state).toBe("active");
+    expect(result.notFound).toEqual(["typo-1"]);
+    // A typo must not be able to look like a clean run: the good ids still
+    // apply, but the exit code says the file was not fully honoured.
+    expect(result.exitCode).toBe(6);
+    expect(deps.log).toHaveBeenCalledWith(expect.stringMatching(/typo-1/u));
+  });
+
+  it("TC-MEMRESTORE-036 the decision log lands outside any checkout at 0600", async () => {
+    const dir = tempDir();
+    const { deps } = applyDeps(dir, [inactiveRow("d-1", "deleted")]);
+    const result = await runRestore(
+      restoreOpts({ apply: true, idsFile: idsFile(dir, ["d-1"]) }),
+      deps,
+    );
+    const { statSync } = await import("node:fs");
+    expect(result.logPath.startsWith(dir)).toBe(true);
+    // The log holds memory snippets — instance-private data in a repo that is
+    // planned to be open-sourced.
+    expect(statSync(result.logPath).mode & 0o777).toBe(0o600);
+    expect(deps.log).toHaveBeenCalledWith(expect.stringContaining(result.logPath));
+  });
+
+  it("TC-MEMRESTORE-037 an ids file bound to another stage is refused before any read", async () => {
+    const dir = tempDir();
+    const path = join(dir, "prod-ids.json");
+    writeFileSync(path, JSON.stringify({ stage: "prod", ids: ["d-1"] }));
+    const { deps, restoreMemory } = applyDeps(dir, [inactiveRow("d-1", "deleted")]);
+    // Ids collide across stages, so a prod file replayed against preview would
+    // silently resurrect whatever happens to share those ids.
+    await expect(
+      runRestore(restoreOpts({ apply: true, idsFile: path }), deps),
+    ).rejects.toThrow(/stage/u);
+    expect(restoreMemory).not.toHaveBeenCalled();
+    expect(deps.findByIds).not.toHaveBeenCalled();
+  });
+
+  it("TC-MEMRESTORE-037 an empty ids file is an error, not a silent no-op run", async () => {
+    const dir = tempDir();
+    const path = join(dir, "empty.txt");
+    writeFileSync(path, "\n  \n");
+    const { deps } = applyDeps(dir, [inactiveRow("d-1", "deleted")]);
+    // "Restored 0 of 0" from a file the operator believed held ids is the
+    // report that ends with a second, hand-written attempt.
+    await expect(
+      runRestore(restoreOpts({ apply: true, idsFile: path }), deps),
+    ).rejects.toThrow(/no ids/iu);
+  });
+
+  it("TC-MEMRESTORE-039 a lost fence is reported as skipped, not counted as restored", async () => {
+    const dir = tempDir();
+    const { deps } = applyDeps(dir, [inactiveRow("d-1", "deleted")], {
+      restoreMemory: vi.fn(async () => false),
+    });
+    const result = await runRestore(
+      restoreOpts({ apply: true, idsFile: idsFile(dir, ["d-1"]) }),
+      deps,
+    );
+    // rowCount 0 means the row moved between the read and the write. Counting
+    // it as restored would tell the operator a memory is back when it is not.
+    expect(result.restored).toEqual([]);
+    expect(result.fencedOut).toEqual(["d-1"]);
+    expect(result.exitCode).toBe(6);
+    // A fenced-out id is IN the log with its outcome, not omitted from it. A log
+    // that only records successes cannot answer "what did this run attempt",
+    // which is the question it exists for — and a run where every id fenced out
+    // still has to leave a record behind.
+    const logged = JSON.parse(readFileSync(result.logPath, "utf8"));
+    expect(logged.entries).toHaveLength(1);
+    expect(logged.entries[0]).toMatchObject({ id: "d-1", outcome: "fenced-out" });
+  });
+
+  it("TC-MEMRESTORE-047 a write that throws mid-run still leaves the log and the summary behind", async () => {
+    const dir = tempDir();
+    const outDir = join(dir, "logs");
+    const rows = ["d-1", "d-2", "d-3", "d-4"].map((id) => inactiveRow(id, "deleted"));
+    const store = new Map(rows.map((r) => [r.id, { ...r }]));
+    let calls = 0;
+    const ctx = applyDeps(dir, rows, {
+      outDir,
+      restoreMemory: vi.fn(async ({ id }) => {
+        calls += 1;
+        if (calls === 3) throw new Error("connection reset by peer");
+        store.get(id).state = "active";
+        return true;
+      }),
+    });
+    // The throw propagates — the run really did fail, and a destructive tool
+    // must not swallow that. What must NOT happen is that it takes the record
+    // of the two rows already flipped to active down with it: the operator's
+    // next move is reconstructing a half-applied run, and exit 1 with a bare
+    // stack tells them nothing was done.
+    await expect(
+      runRestore(restoreOpts({ apply: true, idsFile: idsFile(dir, ["d-1", "d-2", "d-3", "d-4"]) }), ctx.deps),
+    ).rejects.toThrow(/connection reset/u);
+
+    const written = readdirSync(outDir).filter((f) => f.startsWith("restore-"));
+    expect(written).toHaveLength(1);
+    const logged = JSON.parse(readFileSync(join(outDir, written[0]), "utf8"));
+    expect(logged.entries.map((e) => e.id)).toEqual(["d-1", "d-2"]);
+    expect(ctx.deps.log).toHaveBeenCalledWith(expect.stringMatching(/apply done: restored=2/u));
+  });
+
+  it("TC-MEMRESTORE-048 a log that cannot be written degrades to the ids on stderr, never to silence", async () => {
+    const dir = tempDir();
+    // A file where a directory is expected: the ENOTDIR a typo'd --out gives,
+    // and the same shape a full disk gives at writeFileSync.
+    const blocker = join(dir, "not-a-dir");
+    writeFileSync(blocker, "x");
+    const ctx = applyDeps(dir, [inactiveRow("d-1", "deleted"), inactiveRow("d-2", "deleted")], {
+      outDir: join(blocker, "logs"),
+    });
+    const result = await runRestore(
+      restoreOpts({ apply: true, idsFile: idsFile(dir, ["d-1", "d-2"]) }),
+      ctx.deps,
+    );
+    // Two rows ARE active. Losing the log AND the summary would leave the
+    // operator with an exception and no way to learn which ids moved, so the
+    // ids fall back to stderr and the exit code says the run needs attention.
+    expect(ctx.store.get("d-1").state).toBe("active");
+    expect(result.restored).toEqual(["d-1", "d-2"]);
+    expect(result.exitCode).toBe(1);
+    expect(result.logPath).toBeUndefined();
+    const failure = ctx.deps.log.mock.calls.flat().find((m) => /could not be written/iu.test(m));
+    expect(failure).toMatch(/d-1/u);
+    expect(failure).toMatch(/d-2/u);
+    // The fallback carries ids only. The entries hold memory snippets, and
+    // stderr on a scheduled task lands in CloudWatch — outside the 0600 file
+    // the snippets are supposed to stay in.
+    expect(failure).not.toMatch(/fact about/u);
+    expect(ctx.deps.log).toHaveBeenCalledWith(expect.stringMatching(/apply done: restored=2/u));
+  });
+
+  it("TC-MEMRESTORE-049 a failing lock or mutex release is logged and never replaces the real error", async () => {
+    const dir = tempDir();
+    const realFs = await import("node:fs");
+    const release = vi.fn(async () => {
+      throw new Error("Connection terminated unexpectedly");
+    });
+    const ctx = applyDeps(dir, [inactiveRow("d-1", "deleted")], {
+      fs: { ...realFs, rmSync: vi.fn(() => { throw new Error("EROFS: read-only file system"); }) },
+      acquireMutex: vi.fn(async () => ({ release })),
+      restoreMemory: vi.fn(async () => { throw new Error("connection reset by peer"); }),
+    });
+    // The mutex release runs `pg_advisory_unlock` on the SAME client the loop
+    // just died on, so it throws for the same reason — and an exception from a
+    // `finally` REPLACES the in-flight one. The operator would be told
+    // "Connection terminated unexpectedly" for a run that died of something
+    // else, with the real cause gone.
+    await expect(
+      runRestore(restoreOpts({ apply: true, idsFile: idsFile(dir, ["d-1"]) }), ctx.deps),
+    ).rejects.toThrow(/connection reset by peer/u);
+    // ...and a lock that could not be removed must not skip the mutex release:
+    // a leaked advisory lock blocks the next weekly consolidation outright.
+    expect(release).toHaveBeenCalledOnce();
+    expect(ctx.deps.log).toHaveBeenCalledWith(expect.stringMatching(/EROFS/u));
+    expect(ctx.deps.log).toHaveBeenCalledWith(expect.stringMatching(/Connection terminated/u));
+  });
+
+  it("TC-MEMRESTORE-052 a dry-run whose plan exceeds --cap says so instead of exiting 0", async () => {
+    const dir = tempDir();
+    const ids = Array.from({ length: 5 }, (_, i) => `d-${i}`);
+    const ctx = applyDeps(dir, ids.map((id) => inactiveRow(id, "deleted")), {});
+    const result = await runRestore(
+      restoreOpts({ cap: 2, idsFile: idsFile(dir, ids) }),
+      ctx.deps,
+    );
+    // The dry run is where the operator decides. "would restore 5", exit 0,
+    // then --apply restores 2 and exits 4 is the plan reading as executable
+    // when it is not — the same class of defect as a silent truncation.
+    expect(result.exitCode).toBe(6);
+    expect(ctx.deps.log).toHaveBeenCalledWith(expect.stringMatching(/5[\s\S]*cap 2|cap 2[\s\S]*5/u));
+  });
+
+  it("TC-MEMRESTORE-053 a NULL updated_at is recorded as null, not as 1970", async () => {
+    const dir = tempDir();
+    const ctx = applyDeps(dir, [inactiveRow("d-1", "deleted", { updated_at: null })], {});
+    const result = await runRestore(
+      restoreOpts({ apply: true, idsFile: idsFile(dir, ["d-1"]) }),
+      ctx.deps,
+    );
+    // `memories.updated_at` is nullable (schema.sql: TIMESTAMPTZ DEFAULT NOW(),
+    // no NOT NULL) and `new Date(null)` is epoch 0, not an error. This is the
+    // one field the log exists to preserve — #103's timeline gate reads it so a
+    // restore cannot be read as recency evidence, and a fabricated 1970 reads
+    // as maximally stale. An absent timestamp must look absent.
+    expect(result.restored).toEqual(["d-1"]);
+    const logged = JSON.parse(readFileSync(result.logPath, "utf8"));
+    expect(logged.entries[0].updatedAtBefore).toBeNull();
+  });
+
+  it("TC-MEMRESTORE-055 a NULL version is refused as unfenceable, not attempted and blamed on a race", async () => {
+    const dir = tempDir();
+    const ctx = applyDeps(dir, [
+      inactiveRow("d-1", "deleted", { version: null }),
+      inactiveRow("d-2", "deleted"),
+    ], {});
+    const result = await runRestore(
+      restoreOpts({ apply: true, idsFile: idsFile(dir, ["d-1", "d-2"]) }),
+      ctx.deps,
+    );
+    // `version` is nullable in schema.sql too, and the NOT NULL only arrives via
+    // a migration guarded by `IF to_regclass('memories') IS NOT NULL`. In SQL
+    // `version = NULL` is never true, so the fence can never be satisfied: the
+    // row is unrestorable until the schema is fixed. Reporting that as "state or
+    // version changed since it was read" sends the operator into an unbounded
+    // retry loop against a row that cannot move.
+    expect(ctx.restoreMemory).not.toHaveBeenCalledWith(expect.objectContaining({ id: "d-1" }));
+    expect(result.restored).toEqual(["d-2"]);
+    expect(result.exitCode).toBe(6);
+    const message = ctx.deps.log.mock.calls.flat().find((m) => /d-1/u.test(m));
+    expect(message).toMatch(/version/u);
+    expect(message).not.toMatch(/changed since/u);
+  });
+
+  it("TC-MEMRESTORE-057 a JSON array ids file is rejected, not line-split into garbage", async () => {
+    const dir = tempDir();
+    const path = join(dir, "ids.json");
+    writeFileSync(path, '[\n  "m-1",\n  "m-2"\n]\n');
+    const ctx = applyDeps(dir, [inactiveRow("m-1", "deleted")], {});
+    // Line-splitting this yields ids of `[`, `"m-1",`, `"m-2"`, `]`, which
+    // present as "4 ids not found" — a format error disguised as a bad id list,
+    // and the operator's next guess is that the ids are wrong.
+    await expect(
+      runRestore(restoreOpts({ apply: true, idsFile: path }), ctx.deps),
+    ).rejects.toThrow(/array|one id per line|\{"stage"/u);
+    expect(ctx.restoreMemory).not.toHaveBeenCalled();
+  });
+
+  it("TC-MEMRESTORE-058 a fenced-out id does not consume cap", async () => {
+    const dir = tempDir();
+    const ctx = applyDeps(dir, [
+      inactiveRow("d-1", "deleted"),
+      inactiveRow("d-2", "deleted"),
+      inactiveRow("d-3", "deleted"),
+    ], {
+      restoreMemory: vi.fn(async ({ id }) => id !== "d-1"),
+    });
+    const result = await runRestore(
+      restoreOpts({ apply: true, cap: 2, idsFile: idsFile(dir, ["d-1", "d-2", "d-3"]) }),
+      ctx.deps,
+    );
+    // Same decision #102 already made for a fenced merge (TC-MEMCLEAN-043):
+    // charging a lost fence against the cap shrinks the blast-radius budget for
+    // work that never happened, and a mostly-fenced run could trip the exit-4
+    // abort having restored almost nothing. The cap is still checked BEFORE the
+    // write, so it cannot be overrun.
+    expect(result.capUsed).toBe(2);
+    expect(result.restored).toEqual(["d-2", "d-3"]);
+    expect(result.fencedOut).toEqual(["d-1"]);
+    expect(result.exitCode).toBe(6);
+  });
+
+  it("TC-MEMRESTORE-030 a dry-run that cannot fully honour the file still says so", async () => {
+    const dir = tempDir();
+    const { deps, restoreMemory } = applyDeps(dir, [inactiveRow("a-1", "archived")]);
+    const result = await runRestore(
+      restoreOpts({ idsFile: idsFile(dir, ["a-1", "typo-1"]) }),
+      deps,
+    );
+    // The dry run is where the operator decides whether to pass --apply. Exiting
+    // 0 here and 6 on apply would hide the refusal until after the decision.
+    expect(result.exitCode).toBe(6);
+    expect(result.refusedArchived).toEqual(["a-1"]);
+    expect(result.notFound).toEqual(["typo-1"]);
+    expect(restoreMemory).not.toHaveBeenCalled();
+    expect(deps.log).toHaveBeenCalledWith(
+      expect.stringMatching(/dry-run: would restore 0[\s\S]*archivedRefused=1/u),
+    );
+  });
+
+  it("TC-MEMRESTORE-037 a stage-matched JSON ids file is accepted and de-duplicated", async () => {
+    const dir = tempDir();
+    const path = join(dir, "ids.json");
+    // The form #102's own decision log emits, including a repeated id: charging
+    // the cap twice for one memory would abort a run that fits.
+    writeFileSync(path, JSON.stringify({ stage: "test", ids: ["d-1", "d-1", "d-2"] }));
+    const { deps, restoreMemory } = applyDeps(dir, [
+      inactiveRow("d-1", "deleted"),
+      inactiveRow("d-2", "deleted"),
+    ]);
+    const result = await runRestore(restoreOpts({ apply: true, idsFile: path }), deps);
+    expect(result.exitCode).toBe(0);
+    expect(result.restored).toEqual(["d-1", "d-2"]);
+    expect(restoreMemory).toHaveBeenCalledTimes(2);
+    expect(result.capUsed).toBe(2);
+  });
+
+  it("TC-MEMRESTORE-037 a JSON ids file for the right stage but with no ids array is an error", async () => {
+    const dir = tempDir();
+    const path = join(dir, "ids.json");
+    // A hand-edited or half-written log: the stage matches, so the guard passes,
+    // and the run would otherwise report a clean "restored 0 of 0".
+    writeFileSync(path, JSON.stringify({ stage: "test", decisions: [{ id: "d-1" }] }));
+    const { deps } = applyDeps(dir, [inactiveRow("d-1", "deleted")]);
+    await expect(
+      runRestore(restoreOpts({ apply: true, idsFile: path }), deps),
+    ).rejects.toThrow(/no ids/iu);
+    expect(deps.findByIds).not.toHaveBeenCalled();
+  });
+
+  it("TC-MEMRESTORE-032 a non-positive or non-finite --cap is refused before any read", async () => {
+    const dir = tempDir();
+    const { deps } = applyDeps(dir, [inactiveRow("d-1", "deleted")]);
+    // cap=0 must not read as "unbounded". A restore is a write path, so an
+    // unparseable bound has to stop the run, not default to one.
+    for (const cap of [0, -1, Number.NaN]) {
+      await expect(
+        runRestore(restoreOpts({ apply: true, cap, idsFile: idsFile(dir, ["d-1"]) }), deps),
+      ).rejects.toThrow(/cap/iu);
+    }
+    expect(deps.findByIds).not.toHaveBeenCalled();
+  });
+
+  it("TC-MEMRESTORE-031 accepts a pre-built adapter, which is how the CLI supplies it", async () => {
+    const dir = tempDir();
+    const store = new Map([["d-1", { ...inactiveRow("d-1", "deleted") }]]);
+    // Mirrors `recoveryDeps`: the adapter methods arrive spread onto deps with
+    // no `db`, so this is the shape production actually runs.
+    const deps = restoreDeps({
+      outDir: dir,
+      lockFile: join(dir, "restore.lock"),
+      findByIds: async (ids) => ids.map((id) => store.get(id)).filter(Boolean),
+      restoreMemory: async ({ id }) => {
+        store.get(id).state = "active";
+        return true;
+      },
+    });
+    const result = await runRestore(
+      restoreOpts({ apply: true, idsFile: idsFile(dir, ["d-1"]) }),
+      deps,
+    );
+    expect(result.restored).toEqual(["d-1"]);
+    expect(store.get("d-1").state).toBe("active");
+  });
+
+  it("TC-MEMRESTORE-033 the lock and the shared mutex are released even when a write throws", async () => {
+    const dir = tempDir();
+    const lockFile = join(dir, "restore.lock");
+    const release = vi.fn(async () => {});
+    const { deps } = applyDeps(dir, [inactiveRow("d-1", "deleted")], {
+      lockFile,
+      acquireMutex: vi.fn(async () => ({ release })),
+      restoreMemory: vi.fn(async () => {
+        throw new Error("connection reset");
+      }),
+    });
+    await expect(
+      runRestore(restoreOpts({ apply: true, idsFile: idsFile(dir, ["d-1"]) }), deps),
+    ).rejects.toThrow(/connection reset/u);
+    // A crashed apply that keeps the lock and the mutex locks the operator out
+    // of recovery and blocks the next weekly consolidation — at the worst time.
+    expect(existsSync(lockFile)).toBe(false);
+    expect(release).toHaveBeenCalledOnce();
+  });
+});
+
+describe("archived-vs-deleted separation", () => {
+  function idsFile(dir, ids) {
+    const path = join(dir, "ids.txt");
+    writeFileSync(path, `${ids.join("\n")}\n`);
+    return path;
+  }
+  function deps(dir, rows, overrides = {}) {
+    const store = new Map(rows.map((r) => [r.id, { ...r }]));
+    const restoreMemory = vi.fn(async ({ id, priorState, version }) => {
+      const row = store.get(id);
+      if (!row || row.state !== priorState || row.version !== version) return false;
+      row.state = "active";
+      return true;
+    });
+    return {
+      store,
+      restoreMemory,
+      deps: restoreDeps({
+        outDir: dir,
+        lockFile: join(dir, "restore.lock"),
+        findByIds: vi.fn(async (ids) => ids.map((id) => store.get(id)).filter(Boolean)),
+        restoreMemory,
+        ...overrides,
+      }),
+    };
+  }
+
+  it("TC-MEMRESTORE-059 a deleted row that still names a live winner is refused like an archived one", async () => {
+    const dir = tempDir();
+    // Reachable today, with only the two states: #103 archives a loser
+    // (superseded_by=winner-1) → an operator --force-restores it, and
+    // `superseded_by` is PRESERVED by design → a later #102 cleanup judges it
+    // DELETE, and the soft delete sets state='deleted' without touching
+    // superseded_by. The row is now `deleted` while still naming a live winner.
+    const ctx = deps(dir, [
+      inactiveRow("d-1", "deleted", { superseded_by: "winner-1" }),
+    ]);
+    const result = await runRestore(
+      restoreOpts({ apply: true, idsFile: idsFile(dir, ["d-1"]) }),
+      ctx.deps,
+    );
+    // The hazard the gate exists to stop is "restoring this returns a memory
+    // that lost a contradiction while the winner is still active" — which is a
+    // statement about `superseded_by`, not about `state`. Keying on the state
+    // alone lets the row through at exit 0 with no warning, while the run's own
+    // log entry records the disqualifying fact.
+    expect(ctx.restoreMemory).not.toHaveBeenCalled();
+    expect(result.refusedArchived).toEqual(["d-1"]);
+    expect(result.exitCode).toBe(6);
+    expect(ctx.deps.log).toHaveBeenCalledWith(expect.stringContaining("winner-1"));
+  });
+
+  it("TC-MEMRESTORE-060 --force names every superseded id it is about to resurrect, on the dry run", async () => {
+    const dir = tempDir();
+    const ctx = deps(dir, [
+      inactiveRow("a-1", "archived"),
+      inactiveRow("a-2", "archived"),
+      inactiveRow("d-1", "deleted"),
+    ]);
+    const result = await runRestore(
+      restoreOpts({ force: true, idsFile: idsFile(dir, ["a-1", "a-2", "d-1"]) }),
+      ctx.deps,
+    );
+    // --force is per-run, never per id (by design), so an operator who adds it
+    // for ONE known-archived id silently consents for every other archived id in
+    // the same file. The dry run is where that decision is made, so it is where
+    // the names have to appear — after the write is too late.
+    expect(result.exitCode).toBe(0);
+    expect(result.planned).toEqual(["a-1", "a-2", "d-1"]);
+    for (const id of ["a-1", "a-2"]) {
+      expect(ctx.deps.log).toHaveBeenCalledWith(
+        expect.stringMatching(new RegExp(`${id}[\\s\\S]*winner-of-${id}`, "u")),
+      );
+    }
+    expect(ctx.deps.log).toHaveBeenCalledWith(expect.stringMatching(/archivedForced=2/u));
+    expect(ctx.restoreMemory).not.toHaveBeenCalled();
+  });
+
+  it("TC-MEMRESTORE-040 an archived id without --force is refused, names the winner, writes nothing", async () => {
+    const dir = tempDir();
+    const ctx = deps(dir, [inactiveRow("a-1", "archived")]);
+    const result = await runRestore(
+      restoreOpts({ apply: true, idsFile: idsFile(dir, ["a-1"]) }),
+      ctx.deps,
+    );
+    // Restoring the loser of a contradiction while the winner is still active
+    // puts two directly contradictory memories back in search — the exact
+    // defect #103 exists to remove. It must not happen by default.
+    expect(ctx.restoreMemory).not.toHaveBeenCalled();
+    expect(ctx.store.get("a-1").state).toBe("archived");
+    expect(result.refusedArchived).toEqual(["a-1"]);
+    expect(result.exitCode).toBe(6);
+    // The winner's id is the fact the decision turns on, so the refusal has to
+    // carry it: "use --force" alone tells the operator nothing.
+    expect(ctx.deps.log).toHaveBeenCalledWith(expect.stringContaining("winner-of-a-1"));
+    expect(ctx.deps.log).toHaveBeenCalledWith(expect.stringMatching(/--force/u));
+  });
+
+  it("TC-MEMRESTORE-041 --force restores the archived row, preserves superseded_by, still warns", async () => {
+    const dir = tempDir();
+    const ctx = deps(dir, [inactiveRow("a-1", "archived", { version: 5 })]);
+    const result = await runRestore(
+      restoreOpts({ apply: true, force: true, idsFile: idsFile(dir, ["a-1"]) }),
+      ctx.deps,
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.restored).toEqual(["a-1"]);
+    expect(ctx.store.get("a-1").state).toBe("active");
+    // Preserved: it is the audit link, and #103's re-resolution needs the pair.
+    expect(ctx.store.get("a-1").superseded_by).toBe("winner-of-a-1");
+    expect(ctx.restoreMemory).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "a-1", priorState: "archived", version: 5 }),
+    );
+    // --force suppresses the refusal, not the warning: the operator has just
+    // put a known contradiction back and the log has to say so.
+    expect(ctx.deps.log).toHaveBeenCalledWith(expect.stringContaining("winner-of-a-1"));
+  });
+
+  it("TC-MEMRESTORE-042 a mixed file restores the deleted ids and refuses EVERY archived one", async () => {
+    const dir = tempDir();
+    // TWO archived ids, deliberately. With only one, a refusal that applies to
+    // the first archived id and then silently lets the rest through is
+    // invisible — the per-id gate and a first-one-only gate agree on a
+    // single-archived file. That is the whole "--force never leaks" claim, so
+    // the case has to be able to see the difference.
+    const ctx = deps(dir, [
+      inactiveRow("d-1", "deleted"),
+      inactiveRow("a-1", "archived"),
+      inactiveRow("d-2", "deleted"),
+      inactiveRow("a-2", "archived"),
+    ]);
+    const result = await runRestore(
+      restoreOpts({ apply: true, idsFile: idsFile(dir, ["d-1", "a-1", "d-2", "a-2"]) }),
+      ctx.deps,
+    );
+    expect(result.restored).toEqual(["d-1", "d-2"]);
+    expect(result.refusedArchived).toEqual(["a-1", "a-2"]);
+    expect(ctx.store.get("a-1").state).toBe("archived");
+    expect(ctx.store.get("a-2").state).toBe("archived");
+    // --force is per run and never inferred: if one archived id in a file could
+    // imply consent for the batch, the flag would protect nothing.
+    expect(result.exitCode).toBe(6);
+    // Both groups reported, so the operator does not have to diff the file
+    // against the store to learn what happened.
+    expect(result.restored).not.toContain("a-1");
+    expect(result.restored).not.toContain("a-2");
+    expect(ctx.restoreMemory).toHaveBeenCalledTimes(2);
+    // Each refusal names its own winner: one message covering "some archived
+    // ids" would leave the operator to work out which.
+    for (const id of ["a-1", "a-2"]) {
+      expect(ctx.deps.log).toHaveBeenCalledWith(expect.stringContaining(`winner-of-${id}`));
+    }
+  });
+
+  it("TC-MEMRESTORE-046 an unrecognised state is refused, not silently restored", async () => {
+    const dir = tempDir();
+    // Only `deleted` and `archived` exist today, so this is latent — but the
+    // whole premise of this feature is that the inactive states are NOT
+    // interchangeable, and a gate that names one state and lets everything else
+    // through treats the next one as the permissive case. A future `purged` or
+    // `quarantined` must arrive as a refusal that an operator reads, not as a
+    // restore nobody asked for.
+    const ctx = deps(dir, [
+      inactiveRow("d-1", "deleted"),
+      inactiveRow("p-1", "purged"),
+    ]);
+    const result = await runRestore(
+      restoreOpts({ apply: true, force: true, idsFile: idsFile(dir, ["d-1", "p-1"]) }),
+      ctx.deps,
+    );
+    expect(result.restored).toEqual(["d-1"]);
+    expect(ctx.store.get("p-1").state).toBe("purged");
+    // --force is consent to resurrect a contradiction loser, not blanket
+    // consent for a state this tool has never been taught to reason about.
+    expect(result.refusedUnknownState).toEqual(["p-1"]);
+    expect(result.exitCode).toBe(6);
+    expect(ctx.deps.log).toHaveBeenCalledWith(
+      expect.stringMatching(/p-1[\s\S]*purged[\s\S]*not a state this tool/u),
+    );
+  });
+
+  it("TC-MEMRESTORE-043 the log records the prior state and the pre-restore updated_at", async () => {
+    const dir = tempDir();
+    const ctx = deps(dir, [
+      inactiveRow("d-1", "deleted", { updated_at: new Date("2025-11-02T03:04:05Z") }),
+      inactiveRow("a-1", "archived"),
+    ]);
+    const result = await runRestore(
+      restoreOpts({ apply: true, force: true, idsFile: idsFile(dir, ["d-1", "a-1"]) }),
+      ctx.deps,
+    );
+    const logged = JSON.parse(readFileSync(result.logPath, "utf8"));
+    expect(logged.stage).toBe("test");
+    const byId = Object.fromEntries(logged.entries.map((e) => [e.id, e]));
+    // trg_memories_updated has already overwritten the row's updated_at with
+    // NOW() by the time this file is read back, so this is the only surviving
+    // record of how old the memory really is — and #103's timeline gate must
+    // read the real age, not mistake a restore for recency evidence.
+    expect(byId["d-1"]).toMatchObject({
+      priorState: "deleted",
+      updatedAtBefore: "2025-11-02T03:04:05.000Z",
+      outcome: "restored",
+    });
+    expect(byId["a-1"]).toMatchObject({
+      priorState: "archived",
+      supersededBy: "winner-of-a-1",
+      forced: true,
+    });
+  });
+
+  it("TC-MEMRESTORE-040/041 an archived row with no recorded winner still refuses, and still warns", async () => {
+    const dir = tempDir();
+    // Archived with a null `superseded_by`: the column is nullable, so this is
+    // representable, and it is the case where the operator has the LEAST
+    // information. Falling through to a silent restore would be backwards.
+    const rows = () => [inactiveRow("a-1", "archived", { superseded_by: null })];
+    const refused = deps(dir, rows());
+    const blocked = await runRestore(
+      restoreOpts({ apply: true, idsFile: idsFile(dir, ["a-1"]) }),
+      refused.deps,
+    );
+    expect(blocked.refusedArchived).toEqual(["a-1"]);
+    expect(refused.restoreMemory).not.toHaveBeenCalled();
+    // "superseded by null" or "superseded by undefined" reads as a bug and tells
+    // the operator nothing; it has to say the winner was not recorded.
+    expect(refused.deps.log).toHaveBeenCalledWith(
+      expect.stringMatching(/a-1: archived[\s\S]*unrecorded winner/u),
+    );
+
+    const dir2 = tempDir();
+    const forced = deps(dir2, rows());
+    const result = await runRestore(
+      restoreOpts({ apply: true, force: true, idsFile: idsFile(dir2, ["a-1"]) }),
+      forced.deps,
+    );
+    expect(result.restored).toEqual(["a-1"]);
+    // Emitted during planning (so the dry run carries it too, TC-060), which is
+    // why this reads "will be restored" rather than "restored".
+    expect(forced.deps.log).toHaveBeenCalledWith(
+      expect.stringMatching(/restored under --force[\s\S]*unrecorded winner/u),
+    );
+    const logged = JSON.parse(readFileSync(result.logPath, "utf8"));
+    expect(logged.entries[0]).toMatchObject({ supersededBy: null, forced: true });
+  });
+
+  it("TC-MEMRESTORE-036/043 a row with no content logs an empty snippet rather than crashing", async () => {
+    const dir = tempDir();
+    // `content` is not part of the fence and a row could be read with it absent;
+    // a TypeError here would abort the whole run after some ids were written.
+    const ctx = deps(dir, [inactiveRow("d-1", "deleted", { content: undefined })]);
+    const result = await runRestore(
+      restoreOpts({ apply: true, idsFile: idsFile(dir, ["d-1"]) }),
+      ctx.deps,
+    );
+    expect(result.restored).toEqual(["d-1"]);
+    expect(JSON.parse(readFileSync(result.logPath, "utf8")).entries[0].snippet).toBe("");
+  });
+
+  it("TC-MEMRESTORE-044 restore issues no embedding request over any route", async () => {
+    const dir = tempDir();
+    // Driven through the REAL adapter over a fake `db`, not through injected
+    // method spies: that is what makes the SQL inspectable below.
+    const db = fakeDb({
+      "UPDATE memories": () => ({ rowCount: 1 }),
+      "FROM memories": () => ({ rows: [inactiveRow("d-1", "deleted")] }),
+    });
+    // `runRestore` never receives `fetchImpl`, so asserting that an injected spy
+    // went uncalled is true by construction and proves nothing. Close the routes
+    // a re-embed could actually take instead: the global fetch (what a bare
+    // `fetch(...)` resolves to), and the SQL itself.
+    const globalFetch = vi.fn(async () => {
+      throw new Error("restore must not make network calls");
+    });
+    vi.stubGlobal("fetch", globalFetch);
+    let result;
+    try {
+      result = await runRestore(
+        restoreOpts({ apply: true, idsFile: idsFile(dir, ["d-1"]) }),
+        restoreDeps({ outDir: dir, lockFile: join(dir, "restore.lock"), db }),
+      );
+    } finally {
+      vi.unstubAllGlobals();
+    }
+    expect(result.restored).toEqual(["d-1"]);
+    // The row was never removed and `vector(1024)` is still populated, so a
+    // re-embed would burn inference cost and could shift the vector under a
+    // different model version than the rest of the corpus.
+    expect(globalFetch).not.toHaveBeenCalled();
+    // Nor via SQL: no statement this run issued so much as mentions the column,
+    // and the run did issue statements (otherwise this loop is vacuous). The
+    // live round trip confirmed the vector is byte-identical across a restore;
+    // this is the assertion that keeps it that way in CI.
+    expect(db.queries.length).toBeGreaterThan(0);
+    for (const q of db.queries) {
+      expect(q.text).not.toMatch(/embedding/iu);
+    }
+  });
+});
+
+describe("shared apply mutex key", () => {
+  it("TC-MEMRESTORE-033 restore, cleanup, and consolidation derive one key per stage", async () => {
+    // The mutex is an advisory lock over `hashtextextended(key)`, so it only
+    // serialises the three writers if all three derive the SAME string. This is
+    // imported by memory-consolidation.mjs and used by restore's --apply, and
+    // nothing else would fail if a caller drifted to its own literal — the locks
+    // would simply stop colliding, silently.
+    const { sharedCleanupMutexKey } = await import("./memory-cleanup.mjs");
+    expect(sharedCleanupMutexKey("prod")).toBe("mem9-cleanup:prod");
+    // Stage-scoped: a preview apply must never block a prod apply.
+    expect(sharedCleanupMutexKey("preview")).not.toBe(sharedCleanupMutexKey("prod"));
+
+    const consolidation = readFileSync("scripts/memory-consolidation.mjs", "utf8");
+    expect(consolidation).toMatch(/sharedCleanupMutexKey/u);
+    expect(consolidation).not.toMatch(/["'`]mem9-cleanup:/u);
+  });
+});
+
+describe("restore CLI validation", () => {
+  it("TC-MEMRESTORE-050 rejects mode conflicts, a missing --ids, and misapplied filters", () => {
+    expect(parseArgs(["--stage", "test", "--list-inactive"])).toMatchObject({ listInactive: true });
+    expect(
+      parseArgs(["--stage", "test", "--restore", "--ids", "a.txt", "--force"]),
+    ).toMatchObject({ restore: true, idsFile: "a.txt", force: true });
+
+    // One mode per run: with both flags it is not knowable whether --apply was
+    // meant to write.
+    expect(() => parseArgs(["--stage", "test", "--list-inactive", "--restore", "--ids", "a.txt"])).toThrow(
+      /one of --list-inactive or --restore/u,
+    );
+    expect(() => parseArgs(["--stage", "test", "--restore"])).toThrow(/--restore requires --ids/u);
+    // Silently ignoring a filter on --restore is the dangerous reading: an
+    // operator who believes --state narrowed the run would restore more than
+    // they intended.
+    for (const filter of [["--state", "deleted"], ["--since", "2026-01-01T00:00:00Z"], ["--limit", "5"]]) {
+      expect(() =>
+        parseArgs(["--stage", "test", "--restore", "--ids", "a.txt", ...filter]),
+      ).toThrow(new RegExp(`${filter[0]}.*--list-inactive|--restore.*${filter[0]}`, "u"));
+    }
+    // --force only means anything for --restore.
+    expect(() => parseArgs(["--stage", "test", "--list-inactive", "--force"])).toThrow(/--force/u);
+  });
+
+  it("TC-MEMRESTORE-020/021/022 validates --state, --since, and --limit values", () => {
+    expect(parseArgs(["--stage", "test", "--list-inactive", "--state", "archived"])).toMatchObject({
+      state: "archived",
+    });
+    // An unrecognised --state must not fall through to "return everything":
+    // a typo'd filter that silently widens the listing is how an operator ends
+    // up reviewing the active corpus and restoring something never deleted.
+    expect(() => parseArgs(["--stage", "test", "--list-inactive", "--state", "purged"])).toThrow(
+      /deleted\|archived|archived\|deleted/u,
+    );
+    expect(() => parseArgs(["--stage", "test", "--list-inactive", "--state", "active"])).toThrow();
+    expect(() => parseArgs(["--stage", "test", "--list-inactive", "--since", "yesterday"])).toThrow(
+      /ISO/iu,
+    );
+    expect(
+      parseArgs(["--stage", "test", "--list-inactive", "--since", "2026-07-01T00:00:00Z"]),
+    ).toMatchObject({ since: "2026-07-01T00:00:00Z" });
+    expect(() => parseArgs(["--stage", "test", "--list-inactive", "--limit", "0"])).toThrow(/positive/u);
+    expect(() => parseArgs(["--stage", "test", "--list-inactive", "--limit", "abc"])).toThrow(/positive/u);
+  });
+
+  it("TC-MEMRESTORE-054 every flag is rejected outside the mode it belongs to", () => {
+    // Table-driven off the same `mode` field the parser reads, so a flag added to
+    // ARG_SPECS without a mode fails here rather than being silently accepted in
+    // all three modes. The rationale the parser already states for --state — an
+    // operator who believes a flag narrowed the run acts on that belief — does
+    // not stop applying at the flags that happen to have been thought of.
+    const base = { cleanup: ["--stage", "test"], list: ["--stage", "test", "--list-inactive"], restore: ["--stage", "test", "--restore", "--ids", "a.txt"] };
+    const sample = { number: "5", iso: "2026-01-01T00:00:00Z" };
+    for (const [flag, spec] of Object.entries(ARG_SPECS)) {
+      if (flag === "--help") continue;
+      const value = spec.flag ? [] : [spec.choices ? spec.choices[0] : spec.number ? sample.number : spec.iso ? sample.iso : "x"];
+      const modes = spec.mode ?? ["cleanup", "list", "restore"];
+      expect(Array.isArray(modes), `${flag} has no mode declared in ARG_SPECS`).toBe(true);
+      for (const [mode, argv] of Object.entries(base)) {
+        // A flag that IS its own mode selector is excluded: passing --restore in
+        // "restore" mode is the mode, not a misapplied flag.
+        if (["--list-inactive", "--restore"].includes(flag)) continue;
+        if (modes.includes(mode)) continue;
+        expect(
+          () => parseArgs([...argv, flag, ...value]),
+          `${flag} should be rejected in ${mode} mode`,
+        ).toThrow(flag);
+      }
+    }
+    // The specific combinations both reviewers reached for by hand.
+    expect(() => parseArgs(["--stage", "test", "--list-inactive", "--apply"])).toThrow(/--apply/u);
+    expect(() => parseArgs(["--stage", "test", "--restore", "--ids", "a.txt", "--decisions", "d.json"])).toThrow(
+      /--decisions/u,
+    );
+    // ...and the modes each flag DOES belong to still parse.
+    expect(parseArgs([...base.list, "--limit", "5"])).toMatchObject({ limit: 5 });
+    expect(parseArgs([...base.restore, "--apply", "--force"])).toMatchObject({ apply: true, force: true });
+    expect(parseArgs([...base.cleanup, "--decisions", "d.json"])).toMatchObject({ decisionsFile: "d.json" });
+  });
+
+  it("TC-MEMRESTORE-056 --limit and --cap reject non-integers Postgres would refuse", () => {
+    // `LIMIT $n` takes a bigint bind, so a fractional value fails at the server
+    // after the connection, the SSM reads, and the secret fetch have all
+    // happened. A count of memories is a count; reject it at the boundary.
+    for (const bad of ["5.5", "1e30", "Infinity"]) {
+      expect(() => parseArgs(["--stage", "test", "--list-inactive", "--limit", bad])).toThrow(/--limit/u);
+      expect(() => parseArgs(["--stage", "test", "--cap", bad])).toThrow(/--cap/u);
+    }
+    expect(parseArgs(["--stage", "test", "--list-inactive", "--limit", "250"])).toMatchObject({ limit: 250 });
+    // --lock-ttl is genuinely fractional (a 0.5-hour TTL is meaningful), so it
+    // must NOT be swept into the same rule.
+    expect(parseArgs(["--stage", "test", "--lock-ttl", "0.5"])).toMatchObject({ lockTtlHours: 0.5 });
+  });
+
+  it("TC-MEMRESTORE-051 --help documents dry-run as the default and --force as archived-only", () => {
+    expect(parseArgs(["--help"])).toMatchObject({ help: true });
+    // --help must not require --stage: an operator reaching for it does not
+    // yet know the invocation.
+    for (const flag of Object.keys(ARG_SPECS)) {
+      expect(USAGE, `${flag} is undocumented`).toContain(flag);
+    }
+    expect(USAGE).toMatch(/--restore[\s\S]*dry-run|dry-run[\s\S]*--restore/u);
+    // Case-insensitive: the assertion is that the --force entry names the state
+    // it gates, not how the prose capitalises it.
+    expect(USAGE).toMatch(/--force[\s\S]{0,200}archived/iu);
+    // There is no memories.deleted_at, so --since cannot mean "deleted since".
+    // Documenting that is the difference between a filter an operator trusts
+    // and one they misread.
+    expect(USAGE).toMatch(/--since[\s\S]{0,200}updated_at/u);
+  });
+
+  it("TC-MEMRESTORE-061 the CLI never truncates its own output through a pipe", async () => {
+    // The only case in this file that needs a real process: `process.exit()`
+    // discards writes still queued in a pipe, and no in-process test can observe
+    // that. A `--list-inactive` of 1000 rows through `| cat` loses its tail rows
+    // AND the "listed N of TOTAL" trailer — the sole signal that the page was
+    // truncated — so a partial listing reads as complete, nondeterministically.
+    // The listing itself needs a database, so this drives the same exit path
+    // through --help, which writes a comparable volume and needs nothing.
+    const { execFileSync } = await import("node:child_process");
+    const script = new URL("./memory-cleanup.mjs", import.meta.url).pathname;
+    // Every run, not one: the defect is a race, and a single green run is what
+    // makes it look fixed. `sh -c` with a pipe is what puts stdout on a pipe
+    // rather than on the test's own fd.
+    for (let i = 0; i < 5; i += 1) {
+      const piped = execFileSync("sh", ["-c", `node ${script} --help | cat`], { encoding: "utf8" });
+      expect(piped, `run ${i} was truncated`).toContain(USAGE.trimEnd());
+    }
+    // ...and the source has no `process.exit(` left to reintroduce it. Behaviour
+    // above is the real assertion; this pins the mechanism so the next exit site
+    // added to the CLI has to make the same decision deliberately.
+    const code = readFileSync(script, "utf8")
+      .split("\n")
+      .filter((line) => !/^\s*(\/\/|\*|\/\*)/u.test(line))
+      .join("\n");
+    expect(code).not.toMatch(/process\.exit\(/u);
   });
 });

--- a/scripts/memory-cleanup.test.mjs
+++ b/scripts/memory-cleanup.test.mjs
@@ -3,8 +3,9 @@
 // the injected deps object — no network, no real filesystem outside tmpdirs.
 import { createHash } from "node:crypto";
 import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { homedir, tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -17,6 +18,7 @@ import {
   runCleanup,
   runListInactive,
   runRestore,
+  snippetLogDir,
   ARG_SPECS,
   DURABLE_ONLY_RULES,
   USAGE,
@@ -33,6 +35,11 @@ afterEach(() => {
 });
 
 const TENANT = "tenant-key-0123456789abcdef";
+
+// dirname(dirname(scripts/memory-cleanup.mjs)) — the same bound `snippetLogDir`
+// computes, derived the same way rather than hardcoded, and shared by both tests
+// of the guard so they cannot disagree about where the tree ends.
+const SCRIPT_TREE = dirname(dirname(fileURLToPath(import.meta.url)));
 
 function memory(id, content, version = 1) {
   return { id, content, version, state: "active", memory_type: "insight" };
@@ -782,6 +789,62 @@ describe("secrets", () => {
     for (const call of deps.log.mock.calls) {
       expect(String(call[0])).not.toContain(TENANT);
     }
+  });
+});
+
+describe("snippet log location", () => {
+  it("TC-MEMRESTORE-064 the --out bound is the script's tree, and a sibling is not inside it", () => {
+    // No --out: the documented default, outside any checkout.
+    expect(snippetLogDir(undefined, "prod")).toBe(join(homedir(), ".mem9-cleanup", "prod"));
+    expect(snippetLogDir("", "prod")).toBe(join(homedir(), ".mem9-cleanup", "prod"));
+
+    // Inside, and the tree root itself — `relative` answers "" for the root, which
+    // is why the guard tests the two `..` forms rather than truthiness of `inside`.
+    // `..cache` is the case the `${sep}` in that check carries: a directory INSIDE
+    // the tree whose NAME begins with `..`, which a bare `startsWith("..")` would
+    // wave through as outside.
+    for (const bad of [
+      join(SCRIPT_TREE, "tmp"),
+      join(SCRIPT_TREE, "docs", "x"),
+      SCRIPT_TREE,
+      join(SCRIPT_TREE, "..cache"),
+      // The form an operator actually types. Bare and relative, resolved against
+      // cwd — which for any invocation from a checkout is the checkout.
+      "tmp-decisions",
+    ]) {
+      expect(() => snippetLogDir(bad, "prod")).toThrow(/must not be written into a checkout/u);
+    }
+
+    // A relative --out is resolved, not passed through: an accepted path comes
+    // back absolute, so the caller cannot end up writing relative to a cwd that
+    // has since changed.
+    const relOut = join("..", "mem9-logs");
+    expect(snippetLogDir(relOut, "prod")).toBe(resolve(relOut));
+
+    // Outside: the parent, and — the case a `startsWith(scriptTree)` check gets
+    // wrong — a sibling worktree whose name merely EXTENDS this one's. Refusing
+    // it would lock an operator out of the adjacent checkout for no reason.
+    const sibling = `${SCRIPT_TREE}-other`;
+    expect(snippetLogDir(sibling, "prod")).toBe(sibling);
+    expect(snippetLogDir(dirname(SCRIPT_TREE), "prod")).toBe(dirname(SCRIPT_TREE));
+    expect(snippetLogDir("/tmp/mem9-logs", "prod")).toBe(resolve("/tmp/mem9-logs"));
+  });
+
+  it("TC-MEMCLEAN-082 a cleanup --out inside the checkout is refused before the scan", async () => {
+    // The guard's other call site. It first sat at the write inside
+    // `loadDecisions`, which runs AFTER the scan and the whole classification
+    // pass: `--out ./tmp` on a prod dry run burned a reasoning-model run at
+    // `--effort high`, then threw and discarded every decision — the entire
+    // artifact of a dry run. Untested, that regression is invisible.
+    const inCheckout = join(SCRIPT_TREE, "tmp-decision-logs");
+    const server = fakeServer([memory("m-1", "x")]);
+    const llm = fakeLlm([[{ id: "m-1", verdict: "DELETE", reason: "stale" }]]);
+    await expect(runCleanup(baseOpts(), baseDeps(server, llm, inCheckout))).rejects.toThrow(
+      /must not be written into a checkout/u,
+    );
+    expect(llm).not.toHaveBeenCalled();
+    expect(server.fetchImpl).not.toHaveBeenCalled();
+    expect(existsSync(inCheckout)).toBe(false);
   });
 });
 
@@ -2261,6 +2324,88 @@ describe("--restore", () => {
     expect(result.restored).toEqual(["d-2", "d-3"]);
     expect(result.fencedOut).toEqual(["d-1"]);
     expect(result.exitCode).toBe(6);
+  });
+
+  it("TC-MEMRESTORE-062 a failed teardown does not mask the cap abort or a lost fence", async () => {
+    const realFs = await import("node:fs");
+    // Both outcome codes, against the same teardown failure. Asserted as a table
+    // because the defect was the ORDER of one ternary: with `teardownFailed`
+    // tested first, both of these reported 1, and 1 is also what an outright
+    // crash gives — so a run that had hit the cap and left the ids file
+    // half-applied was indistinguishable from one that did nothing at all.
+    const cases = [
+      {
+        what: "the cap abort",
+        ids: ["d-1", "d-2", "d-3"],
+        cap: 2,
+        overrides: {},
+        exitCode: 4,
+        restored: ["d-1", "d-2"],
+      },
+      {
+        what: "a lost fence",
+        ids: ["d-1"],
+        cap: 50,
+        overrides: { restoreMemory: vi.fn(async () => false) },
+        exitCode: 6,
+        restored: [],
+      },
+    ];
+    for (const { what, ids, cap, overrides, exitCode, restored } of cases) {
+      const dir = tempDir();
+      const ctx = applyDeps(
+        dir,
+        ["d-1", "d-2", "d-3"].map((id) => inactiveRow(id, "deleted")),
+        {
+          // An EROFS lock file: the teardown step furthest from the store, so the
+          // only thing it can legitimately change is the bookkeeping code.
+          fs: {
+            ...realFs,
+            rmSync: vi.fn(() => {
+              throw new Error("EROFS: read-only file system");
+            }),
+          },
+          ...overrides,
+        },
+      );
+      const result = await runRestore(
+        restoreOpts({ apply: true, cap, idsFile: idsFile(dir, ids) }),
+        ctx.deps,
+      );
+      expect(result.exitCode, `${what} must survive a failed teardown`).toBe(exitCode);
+      expect(result.restored).toEqual(restored);
+      // The teardown failure is never silent — it just does not win the code.
+      expect(ctx.deps.log).toHaveBeenCalledWith(expect.stringMatching(/EROFS/u));
+    }
+  });
+
+  it("TC-MEMRESTORE-063 --out inside the checkout is refused before any row moves", async () => {
+    const dir = tempDir();
+    // The repo root as an operator reviewing a plan would reach for it: the log
+    // holds memory snippets, and CI's scan-public-artifacts.mjs looks for keys,
+    // tokens, and ARNs — nothing that memory prose resembles — on a range that
+    // only exists once the commit does. The header comment said "outside the
+    // repository" and `--out` had no constraint.
+    const inCheckout = join(SCRIPT_TREE, "tmp-restore-logs");
+    const ctx = applyDeps(dir, [inactiveRow("d-1", "deleted")], { outDir: inCheckout });
+    await expect(
+      runRestore(restoreOpts({ apply: true, idsFile: idsFile(dir, ["d-1"]) }), ctx.deps),
+    ).rejects.toThrow(/must not be written into a checkout/u);
+    // Refused at the top of the run, NOT in the teardown `finally`: rejecting it
+    // there would restore the row first and then report the operator's typo as a
+    // lost log — the one record of a run that did happen.
+    expect(ctx.store.get("d-1").state).toBe("deleted");
+    expect(ctx.deps.restoreMemory).not.toHaveBeenCalled();
+    expect(existsSync(inCheckout)).toBe(false);
+
+    // ...and the default still works, so the guard rejects the path rather than
+    // the feature.
+    const ok = applyDeps(dir, [inactiveRow("d-2", "deleted")], {});
+    const result = await runRestore(
+      restoreOpts({ apply: true, idsFile: idsFile(dir, ["d-2"]) }),
+      ok.deps,
+    );
+    expect(result.restored).toEqual(["d-2"]);
   });
 
   it("TC-MEMRESTORE-030 a dry-run that cannot fully honour the file still says so", async () => {

--- a/scripts/workload-permissions-boundary-contract.json
+++ b/scripts/workload-permissions-boundary-contract.json
@@ -13,7 +13,7 @@
     {
       "id": "infra-ci.yml",
       "path": ".github/workflows/infra-ci.yml",
-      "reviewedBlob": "bc66da331c7457e8427ca12ae773894eca84e552"
+      "reviewedBlob": "0d17288f7b8b72a9174351bf70461ca3391dd5f6"
     },
     {
       "id": "reconcile-previews.yml",


### PR DESCRIPTION
Closes #124.

Adds an operator path to recover memories the weekly cleanup soft-deleted, and
hardens the two defects a review of it turned up.

## What this adds

`--list-inactive` reports soft-deleted and archived rows; `--restore` returns a
listed set to `active`. Both go through the same advisory mutex and cap as the
cleanup path, so a restore cannot race the weekly consolidation or exceed the
blast-radius limit.

The recovery path is deliberately narrow:

- **`deleted` restores, `archived` refuses.** An archived row was archived by a
  decision, not an accident; conflating them would let a restore quietly reverse
  a deliberate action. A dry run reports the refusal, so the operator learns it
  before deciding whether to pass `--apply`.
- **An ids file is stage-bound.** Replaying a preview file against prod would
  restore whatever ids happen to collide.
- **Every flag declares the modes it belongs to** and is rejected outside them.
  `--list-inactive --apply` is the one that bites: the shared mutex is keyed on
  `opts.apply`, so it would make a read-only listing take the lock and contend
  with consolidation.

## What the review found

**Snippet logs could be written into the checkout.** Both artifacts this script
persists carry `snippet` fields sliced from memory content. The default
`~/.mem9-cleanup/<stage>/` is outside any checkout, but `--out` overrode it with
no constraint — and `--out ./tmp` is the natural thing to type when reviewing a
plan, putting instance-private memory text in a repo planned to be
open-sourced, in files no `.gitignore` pattern matched. CI's
`scan-public-artifacts.mjs` would not have caught it either: its detectors look
for keys, tokens, and ARNs, none of which memory prose resembles, and it runs on
a pushed range — after the commit exists.

`snippetLogDir` now refuses an `--out` resolving inside the script's own tree.
Both call sites validate at the **top** of the run, which is the part that took
two passes to get right:

- In `runRestore`, rejecting from the teardown `finally` would restore the rows
  first and then report the operator's typo as "failed to write the restore
  log" — costing them the only record of a run that did happen.
- In `runCleanup`, validating at the write inside `loadDecisions` ran *after*
  the full scan and classification pass, so `--out ./tmp` on a prod dry run
  burned a reasoning-model run at `--effort high` and then threw, discarding
  every decision. That is the entire artifact of a dry run.

**Restore exit codes were ordered by the wrong thing.** The teardown flag was
tested first, so an EROFS lock file reported a clean-looking exit 1 for a run
that had *also* hit the cap and left the ids file half-applied. Exit 1 is what an
outright crash gives too, making a partial apply indistinguishable from a run
that did nothing. Teardown is bookkeeping; 4 and 6 describe what the run did to
the store, which is what the operator's next command depends on — so they now
outrank it. Every teardown failure still names itself in a log line.

## Verification

791 tests pass; `tsc --noEmit` clean. New cases: TC-MEMRESTORE-062 (exit-code
precedence, table-driven over both outcome codes), -063 and TC-MEMCLEAN-082 (the
two guard call sites), -064 (boundary math).

Each was proven by mutation rather than by a passing suite — including the two
assertions added in the last pass, which exist because the first versions left
`resolve()` and the `${sep}` in the `..` check unpinned. The `startsWith` mutant
is the interesting one: it fails only on a sibling worktree whose name *extends*
this one's (`…/124-memory-restore-other`), which shares the prefix but is a
different checkout — refusing it would lock an operator out of the adjacent tree
for no reason.

Not covered by CI: TC-MEMRESTORE-070 needs a VPC-internal host, per the runbook.