### PR TITLE
fix(iam): admit the cleanup execution role to the boundary's secret-decrypt deny

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -558,8 +558,8 @@ Resource and condition denies constrain project resources, KMS use, short-term
 Mantle bearer use, and Lambda VPC ENI access. KMS decrypt is limited to either
 the project SSM parameter context, Lambda cold-start environment decryption
 with a project function ARN context, or one of the project DB/tenant
-`SecretARN` families through Secrets Manager from a server/bootstrap ECS
-execution role. AWS documents that Secrets Manager supplies `SecretARN` and
+`SecretARN` families through Secrets Manager from one of the four allowlisted
+ECS execution roles (server, bootstrap, consolidation, cleanup). AWS documents that Secrets Manager supplies `SecretARN` and
 `SecretVersionId` as its KMS encryption context:
 [Secrets Manager encryption](https://docs.aws.amazon.com/secretsmanager/latest/userguide/security-encryption.html).
 A decrypt without one of the three project contexts remains denied. The
@@ -568,7 +568,7 @@ because that path does not expose it consistently during permissions-boundary
 evaluation. Non-Lambda-context decrypts must come through SSM or Secrets
 Manager in the application region. Separate denies restrict Lambda contexts to
 the three required Lambda execution-role types plus the optional facade
-authorizer role, and secret contexts to the two ECS execution-role types. AWS
+authorizer role, and secret contexts to the four ECS execution-role types. AWS
 defines `aws:PrincipalArn` for an IAM role as the IAM role ARN, not its
 assumed-role session ARN:
 [global condition keys](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-keys.html).
@@ -580,8 +580,8 @@ exception requires both a generated proxy-role name and
 explicitly denies the same actions to function code. The name match is
 therefore not the sole authorization check. The deploy role likewise denies
 passing any of the four allowlisted Lambda role-name patterns to a non-Lambda
-service, and denies passing either allowlisted ECS execution-role pattern to a
-non-ECS service. These `PassRole` denies do not constrain a role trust policy
+service, and denies passing any of the four allowlisted ECS execution-role
+patterns to a non-ECS service. These `PassRole` denies do not constrain a role trust policy
 supplied to `CreateRole`; the accepted trusted-writer model therefore remains
 load-bearing for direct assumption, as described below.
 

--- a/docs/designs/workload-permissions-boundary.md
+++ b/docs/designs/workload-permissions-boundary.md
@@ -60,8 +60,8 @@ current runtime roles:
 
 - ECS image pull, log delivery, and Secrets Manager startup injection.
 - ECS startup decrypt for only the DB and tenant secret families, mediated by
-  Secrets Manager in the application region and limited to the server/bootstrap
-  execution-role types.
+  Secrets Manager in the application region and limited to the four
+  execution-role types (server, bootstrap, consolidation, cleanup).
 - ECS Exec control/data channels for the server and bootstrap task roles.
 - Lambda log delivery and VPC network-interface lifecycle.
 - The OAuth facade's SSM reads and KMS decrypt, constrained to Parameter Store
@@ -86,7 +86,7 @@ resources, the project Parameter Store, Lambda function, or Secrets Manager
 `SecretARN` KMS contexts, and short-term Mantle bearers. The boundary does not
 require `kms:ViaService` for Lambda's default environment-key grant. Every other
 decrypt must be mediated by application-region SSM or Secrets Manager. A
-`SecretARN` path is further restricted to the two ECS execution-role types and
+`SecretARN` path is further restricted to the four ECS execution-role types and
 the known DB/tenant secret families; a Lambda source remains denied on this path.
 AWS returns the IAM role ARN, not an STS session ARN, for
 [`aws:PrincipalArn`](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-keys.html).

--- a/infra/cloudformation/github-actions-role.yaml
+++ b/infra/cloudformation/github-actions-role.yaml
@@ -236,6 +236,7 @@ Resources:
               - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/mem9-on-a*-*Mem9ServerExecutionRole-*
               - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/mem9-on-a*-*Mem9BootstrapExecutionRole-*
               - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/mem9-on-a*-*Mem9ConsolidationExecutionRole-*
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/mem9-on-a*-*Mem9CleanupExecutionRole-*
             Condition:
               StringNotEquals:
                 iam:PassedToService: ecs-tasks.amazonaws.com

--- a/infra/cloudformation/workload-permissions-boundary.yaml
+++ b/infra/cloudformation/workload-permissions-boundary.yaml
@@ -147,7 +147,7 @@ Resources:
           # Lambda cold starts, SSM SecureStrings, and the two ECS task-definition
           # secret families use different KMS encryption contexts. Missing and
           # foreign contexts remain denied.
-          - Sid: DenyKmsDecryptOutsideProjectParameterFunctionOrSecretContexts
+          - Sid: DenyKmsDecryptOutsideReviewedContexts
             Effect: Deny
             Action:
               - kms:Decrypt
@@ -160,7 +160,7 @@ Resources:
                   - !Sub arn:${AWS::Partition}:secretsmanager:${ApplicationRegion}:${AWS::AccountId}:secret:mem9-on-aws-*-Mem9DbProxySecret-*
                   - !Sub arn:${AWS::Partition}:secretsmanager:${ApplicationRegion}:${AWS::AccountId}:secret:mem9-on-aws-*-Mem9DbSecret-*
                   - !Sub arn:${AWS::Partition}:secretsmanager:${ApplicationRegion}:${AWS::AccountId}:secret:mem9-on-aws-*-tenant-api-key-*
-          - Sid: DenyKmsDecryptOutsideSsmSecretsManagerOrProjectLambdaPath
+          - Sid: DenyKmsDecryptOutsideReviewedViaServices
             Effect: Deny
             Action:
               - kms:Decrypt
@@ -207,6 +207,7 @@ Resources:
                   - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/mem9-on-a*-*Mem9ServerExecutionRole-*
                   - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/mem9-on-a*-*Mem9BootstrapExecutionRole-*
                   - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/mem9-on-a*-*Mem9ConsolidationExecutionRole-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/mem9-on-a*-*Mem9CleanupExecutionRole-*
           # Only the reviewed Lambda execution-role types may present the Lambda
           # cold-start context. Other workload roles cannot forge it.
           - Sid: DenyLambdaContextDecryptFromNonLambdaRoles

--- a/infra/slack-approval.ts
+++ b/infra/slack-approval.ts
@@ -21,30 +21,38 @@
  * boundary is operator-owned (rolled out separately from application deploys).
  *
  * BOUNDARY NOTE — the SSM half is admissible under the DEPLOYED boundary; the
- * Secrets Manager half is NOT yet established and is a deploy-time risk:
+ * Secrets Manager half REQUIRES A BOUNDARY ROLLOUT FIRST:
  *   - The SecureString reads are gated by `DenyParameterContextDecryptOutsideSsm`
  *     on `kms:ViaService`, NOT on the `ECS_EXECUTION_ROLE_TOKENS` list, so an
  *     unlisted execution role may still decrypt a `/mem9-on-aws/*` parameter.
- *   - UNRESOLVED: the Secrets Manager reads (`MEM9_DB_SECRET`, `MEM9_TENANT_ID`)
- *     resolve under the DEFAULT `aws/secretsmanager` key (neither secret sets
- *     `kmsKeyId` — see infra/db.ts and infra/tenant-identity.ts). AWS needs no
- *     identity `kms:Decrypt` ALLOW on that key, but an explicit DENY is a
- *     different question, and three things in this repo say the deny does bite on
- *     the service-mediated path: the boundary's own comment above
- *     `DenySecretContextDecryptFromNonEcsExecutionRoles` says it "constrains which
- *     project role types may use that service-mediated path"; the SecretARN
- *     encryption-context allowlist enumerates `Mem9DbSecret-*` and
- *     `tenant-api-key-*`, which would be pointless if the decrypt were never
- *     attributed to the workload principal; and #122 had to admit
- *     `Mem9ConsolidationExecutionRole-` to that same list for a task that reads
- *     THESE SAME TWO default-key secrets (pinned by TC-CONSOL-032).
- *     `Mem9CleanupExecutionRole-` is NOT in the list. If the deny is evaluated,
- *     this execution role cannot fetch either secret and the task dies at startup
- *     — AFTER the click has been spent — on every bounded stage. Adding the role
- *     to the exception list is safe either way (it only narrows a deny, and is a
- *     no-op if the deny never fires), but it changes the OPERATOR-OWNED template
- *     and so needs its own guarded rollout ahead of this stack's first deploy.
- *     Settle it before deploying, not by re-reading this comment.
+ *   - SETTLED, and the answer is that the deny DOES bite. The Secrets Manager
+ *     reads (`MEM9_DB_SECRET`, `MEM9_TENANT_ID`) resolve under the DEFAULT
+ *     `aws/secretsmanager` key (neither secret sets `kmsKeyId` — see infra/db.ts
+ *     and infra/tenant-identity.ts), and AWS needs no identity `kms:Decrypt`
+ *     ALLOW there — but an explicit DENY is a separate question, so it was
+ *     measured rather than reasoned about. Against the LIVE v10 boundary,
+ *     `iam:simulate-custom-policy` for `kms:Decrypt` on the regional
+ *     `alias/aws/secretsmanager` key, with `kms:ViaService=secretsmanager.<region>
+ *     .amazonaws.com` and a `SecretARN` encryption context matching the
+ *     allowlisted `mem9-on-aws-*-Mem9DbSecret-*` / `*-tenant-api-key-*` shapes:
+ *       Mem9ServerExecutionRole-        → allowed        (on the list)
+ *       Mem9ConsolidationExecutionRole- → allowed        (on the list, from #122)
+ *       Mem9CleanupExecutionRole-       → explicitDeny   (NOT on the list)
+ *       Mem9ConsolidationTaskRole-      → explicitDeny   (NOT on the list)
+ *     Isolating each deny statement in turn attributes it to exactly
+ *     `DenySecretContextDecryptFromNonEcsExecutionRoles`, for BOTH secrets.
+ *     CloudTrail corroborates the premise the simulation rests on: real
+ *     `SecretARN`-context Decrypt events are attributed to the calling workload
+ *     principal, not to Secrets Manager as a service, so that statement's
+ *     `aws:PrincipalArn` condition has something to match.
+ *     (Simulating this yourself requires passing `aws:PrincipalArn` as an explicit
+ *     `--context-entries` value. Inferred from `--caller-arn` alone, every role
+ *     reads as denied and the differential vanishes.)
+ *   - CONSEQUENCE: `Mem9CleanupExecutionRole-` must be admitted to
+ *     `ECS_EXECUTION_ROLE_TOKENS` in the OPERATOR-OWNED boundary template, and
+ *     that rollout must land BEFORE this stack first deploys to a bounded stage.
+ *     Without it the task dies at startup fetching its own credentials — AFTER the
+ *     click has been spent, which is the one failure mode this loop must not have.
  *
  * Gated on `MEM9_SLACK_APPROVAL_ENABLED=1`. Disabled means ABSENT, not
  * present-and-idle: a task definition that exists is a task definition `RunTask`

--- a/infra/workload-permissions-boundary.test-fixtures.ts
+++ b/infra/workload-permissions-boundary.test-fixtures.ts
@@ -20,12 +20,18 @@ export const CONSOLIDATION_SCHEDULER_ROLE_NAME =
  * role, so both must be admitted or the exact-set assertion in
  * `workload-permissions-boundary.roles.test.ts` fails.
  *
- * Neither name appears in the operator-owned boundary's
- * `ECS_EXECUTION_ROLE_TOKENS`, and it does not need to: the task's SecureString
- * reads are gated on `kms:ViaService`, and its Secrets Manager reads resolve
- * under the default `aws/secretsmanager` key, which needs no identity
- * `kms:Decrypt`. Moving either secret to a customer managed key would require
- * adding `Mem9CleanupExecutionRole-` to that deny's exception list.
+ * `Mem9CleanupExecutionRole-` IS on the operator-owned boundary's
+ * `ECS_EXECUTION_ROLE_TOKENS` list, and has to be. The reasoning that once said
+ * otherwise — the Secrets Manager reads resolve under the default
+ * `aws/secretsmanager` key, which needs no identity `kms:Decrypt` ALLOW — is
+ * true but irrelevant: `DenySecretContextDecryptFromNonEcsExecutionRoles` is an
+ * `ArnNotLike` DENY, so an unlisted role is explicitly denied rather than merely
+ * ungranted. Simulating each role against the live boundary shows listed ones
+ * allowed and unlisted ones explicitDeny. See the BOUNDARY NOTE in
+ * `infra/slack-approval.ts` for the measurement.
+ *
+ * `Mem9CleanupTaskRole` is correctly absent: only the EXECUTION role fetches
+ * `valueFrom` secrets during task startup.
  */
 export const SLACK_APPROVAL_ROLE_NAMES = [
   "Mem9CleanupExecutionRole",

--- a/scripts/lib/workload-permissions-boundary.mjs
+++ b/scripts/lib/workload-permissions-boundary.mjs
@@ -87,10 +87,20 @@ function matchesProjectLambdaRoleName(roleName, type) {
     : roleName.includes(type.roleToken);
 }
 
+// Every ECS execution role that fetches a Secrets Manager secret for `valueFrom`
+// injection has to be listed here, because
+// DenySecretContextDecryptFromNonEcsExecutionRoles is an ArnNotLike deny: an
+// omitted role is denied, not merely ungranted. Measured against the live policy
+// rather than reasoned about — the default `aws/secretsmanager` key needs no
+// identity ALLOW, which makes it tempting to conclude the deny never fires, but a
+// simulation of each role shows listed ones allowed and unlisted ones
+// explicitDeny. A missing token costs a task death in the ECS agent's
+// secret-fetch phase, before the entrypoint runs.
 const ECS_EXECUTION_ROLE_TOKENS = [
   "Mem9ServerExecutionRole-",
   "Mem9BootstrapExecutionRole-",
   "Mem9ConsolidationExecutionRole-",
+  "Mem9CleanupExecutionRole-",
 ];
 const ALLOWED_PASS_SERVICES = new Set([
   "bedrock-agentcore.amazonaws.com",
@@ -404,7 +414,7 @@ export function expectedBoundaryPolicyDocument(contract) {
         NotResource: [ssmApprovalParameterArn],
       },
       {
-        Sid: "DenyKmsDecryptOutsideProjectParameterFunctionOrSecretContexts",
+        Sid: "DenyKmsDecryptOutsideReviewedContexts",
         Effect: "Deny",
         Action: [...CONDITIONED_RUNTIME_ACTIONS],
         Resource: "*",
@@ -418,7 +428,7 @@ export function expectedBoundaryPolicyDocument(contract) {
         },
       },
       {
-        Sid: "DenyKmsDecryptOutsideSsmSecretsManagerOrProjectLambdaPath",
+        Sid: "DenyKmsDecryptOutsideReviewedViaServices",
         Effect: "Deny",
         Action: [...CONDITIONED_RUNTIME_ACTIONS],
         Resource: "*",

--- a/scripts/workload-permissions-boundary.test.mjs
+++ b/scripts/workload-permissions-boundary.test.mjs
@@ -7453,10 +7453,10 @@ describe("boundary and deploy-role templates", () => {
     ]);
     expect(
       bySid(
-        "DenyKmsDecryptOutsideProjectParameterFunctionOrSecretContexts",
+        "DenyKmsDecryptOutsideReviewedContexts",
       ),
     ).toEqual({
-      Sid: "DenyKmsDecryptOutsideProjectParameterFunctionOrSecretContexts",
+      Sid: "DenyKmsDecryptOutsideReviewedContexts",
       Effect: "Deny",
       Action: ["kms:Decrypt"],
       Resource: "*",
@@ -7481,9 +7481,9 @@ describe("boundary and deploy-role templates", () => {
     });
     expect(bySid("DenyKmsDecryptOutsideSsm")).toBeUndefined();
     expect(
-      bySid("DenyKmsDecryptOutsideSsmSecretsManagerOrProjectLambdaPath"),
+      bySid("DenyKmsDecryptOutsideReviewedViaServices"),
     ).toEqual({
-      Sid: "DenyKmsDecryptOutsideSsmSecretsManagerOrProjectLambdaPath",
+      Sid: "DenyKmsDecryptOutsideReviewedViaServices",
       Effect: "Deny",
       Action: ["kms:Decrypt"],
       Resource: "*",
@@ -7520,6 +7520,8 @@ describe("boundary and deploy-role templates", () => {
               "mem9-on-a*-*Mem9BootstrapExecutionRole-*",
             "arn:aws:iam::123456789012:role/" +
               "mem9-on-a*-*Mem9ConsolidationExecutionRole-*",
+            "arn:aws:iam::123456789012:role/" +
+              "mem9-on-a*-*Mem9CleanupExecutionRole-*",
           ],
         },
       },
@@ -7753,12 +7755,30 @@ describe("boundary and deploy-role templates", () => {
   // against the fixture shape only.
   //
   // 64 is close to the largest reserve this document can currently hold: the
-  // configured shape is 6023 bytes, so 121 is the ceiling and anything above that
-  // fails on commit. That is the finding, not a comfort — the statement this
-  // change added cost 189 bytes, so the next comparable statement breaches the
-  // gate and the quota at nearly the same moment. Splitting the boundary across a
-  // second managed policy is the real fix when that happens; until then this at
-  // least fails in CI rather than at rollout.
+  // configured shape is 6054 bytes, so 90 is the ceiling and anything above that
+  // fails on commit. That is the finding, not a comfort.
+  //
+  // This gate has now fired once, and the escape hatch the earlier note proposed
+  // — "split the boundary across a second managed policy" — does not exist. A
+  // role has exactly ONE permissions boundary (get-role returns a singular
+  // PermissionsBoundaryArn), and the 6144 managed-policy limit is Adjustable:
+  // False, so there is no quota increase to request either. Re-homing deny
+  // statements into an attached identity policy is not equivalent: a boundary
+  // cannot be shed by the principal, whereas anything holding
+  // iam:DetachRolePolicy can drop an identity policy. Merging denies is worse
+  // still — separate statements are a logical OR, while conditions inside one
+  // statement are ANDed, so a merge weakens enforcement.
+  //
+  // What is left is byte reduction that preserves semantics. Sid is an optional
+  // identifier and carries no authorization meaning, so shortening the longest
+  // ones is free; that is what bought the room for the fourth ECS execution-role
+  // ARN here (6095 -> 6054). Two further semantics-preserving reserves exist
+  // before scope has to give: dropping Sids entirely frees 626 bytes, and
+  // collapsing the singleton arrays to scalars another 20. Dropping the Sids
+  // costs this suite every bySid() lookup, so it is a refactor rather than a
+  // deletion; both are deliberately unspent. They mean a failure here is a
+  // prompt to choose, not yet a forced loss of enforcement. Only once they are
+  // spent does the choice narrow to a coarser scope.
   const OPENAI_PROJECT_ARN =
     "arn:aws:bedrock-mantle:us-west-2:123456789012:project/proj_openai";
   const BOUNDARY_SIZE_RESERVE = 64;
@@ -7984,6 +8004,8 @@ describe("boundary and deploy-role templates", () => {
           "mem9-on-a*-*Mem9BootstrapExecutionRole-*",
         "arn:aws:iam::123456789012:role/" +
           "mem9-on-a*-*Mem9ConsolidationExecutionRole-*",
+        "arn:aws:iam::123456789012:role/" +
+          "mem9-on-a*-*Mem9CleanupExecutionRole-*",
       ],
       Condition: {
         StringNotEquals: {


### PR DESCRIPTION
## What

Admits `Mem9CleanupExecutionRole-` to the workload boundary's
`DenySecretContextDecryptFromNonEcsExecutionRoles` exception list, and to the
deploy role's `DenyEcsExecutionRolePassToOtherServices`, which derives its
`Resource` list from the same `ECS_EXECUTION_ROLE_TOKENS` constant.

## Why this is a blocker for #123, not a cleanup

That statement is an `ArnNotLike` **deny**. An execution role missing from the
list is *explicitly denied* `kms:Decrypt` on a `SecretARN` context — not merely
ungranted. #123's cleanup task was never added, so setting
`MEM9_SLACK_APPROVAL_ENABLED=1` on a bounded stage would kill the task in the
ECS agent's secret-fetch phase — **after the approval click has been spent**,
which is the one failure mode an approval loop must not have.

#123 merged safely because its Slack stack is flag-gated and was never
synthesized on the preview stage (`no slack/signing-secret on pr-134 …
skipping`). The deny only bites when someone first sets the flag.

### Measured, not reasoned about

`iam:simulate-custom-policy` for `kms:Decrypt` against the **live** boundary,
with `kms:ViaService=secretsmanager.<region>.amazonaws.com` and an allowlisted
`SecretARN` context:

| Principal | Result |
| --- | --- |
| `Mem9ServerExecutionRole-` | allowed (listed) |
| `Mem9ConsolidationExecutionRole-` | allowed (listed, from #122) |
| `Mem9CleanupExecutionRole-` | **explicitDeny** (not listed) |
| `Mem9ConsolidationTaskRole-` | **explicitDeny** (not listed) |

Isolating each deny in turn attributes it to this statement alone, for both
secrets. The tempting counter-argument — the secrets resolve under the default
`aws/secretsmanager` key, which needs no identity `kms:Decrypt` ALLOW — is true
and irrelevant to an *explicit deny*.

> Reproducing this requires passing `aws:PrincipalArn` as an explicit
> `--context-entries` value. Inferred from `--caller-arn` alone, every role
> reads as denied and the differential vanishes.

## The size gate fired

Adding a fourth ARN took the OpenAI-configured document from 6023 to **6095**
bytes, over the suite's 6080 gate (6144 quota minus a 64-byte reserve). The
escape hatch the old comment proposed — "split the boundary across a second
managed policy" — **does not exist**:

- A role has exactly **one** permissions boundary (`get-role` returns a
  singular `PermissionsBoundaryArn`).
- `Managed policy length` = 6144, **`Adjustable: False`** — no quota increase
  to request.
- Re-homing denies into an attached identity policy is not equivalent: a
  boundary cannot be shed by the principal, while anything holding
  `iam:DetachRolePolicy` can drop an identity policy.
- Merging denies is worse: separate statements are a logical OR, whereas
  conditions inside one statement are ANDed.

So: **semantics-preserving byte reduction**. `Sid` is an optional identifier
with no authorization meaning, so two verbose KMS `Sid`s are renamed,
recovering 41 bytes → **6054** (90 to the hard quota). The comment now records
the two remaining reserves (dropping Sids = 626 bytes, scalarizing singleton
arrays = 20) so the next person meets a choice rather than a wall.

## Also

- Corrects the fixture comment that asserted the *opposite* of this finding
  ("does not need to" appear in the list).
- Fixes `two`/`either` execution-role counts in `docs/ARCHITECTURE.md` and the
  design doc — stale since #122 made it three.

## Verification

- `scripts/workload-permissions-boundary.test.mjs`: **345/345**.
- `npm run typecheck`: clean.
- `infra` suite: 6 failures, **identical with this diff stashed** — pre-existing
  on `497bf6c`, unrelated.
- `deploy-workload-permissions-boundary.sh --verify-only`: **drift detected**,
  as expected — this change is inert until the rollout runs.
- Reviewed by Codex over two passes; the first caught the missing
  `DenyEcsExecutionRolePassToOtherServices` entry. No P1/P2 outstanding.

## Rollout required

Merging does not apply this. The operator-owned boundary needs
`scripts/rollout-workload-permissions-boundary.sh` from `main`. Only after that
should `MEM9_SLACK_APPROVAL_ENABLED=1` be set and the Slack secrets seeded.
