### PR TITLE
fix(e2e): make the MCP probe's recall and log-scan guards actually run

### DIFF
--- a/docs/test-cases/recall-min-confidence.md
+++ b/docs/test-cases/recall-min-confidence.md
@@ -27,7 +27,7 @@ Design: [`docs/designs/recall-min-confidence.md`](../designs/recall-min-confiden
 | ID | Scenario | Expected |
 |---|---|---|
 | TC-RECALL-030 | Existing keyword probe (marker string) | Unchanged; still passes |
-| TC-RECALL-031 | **Natural-language probe:** after the keyword search finds the marker, search with a ≥25-char natural-language query describing the marker fact (not containing the raw marker token verbatim-only) | ≥1 result containing the marker within the retry window |
+| TC-RECALL-031 | **Natural-language probe:** after the keyword search finds the marker, search with a ≥25-char natural-language query describing the marker fact. The query MUST NOT interpolate the run id or the marker token — a run-scoped literal makes retrieval return zero candidates, so the cutoff never runs and the probe fails for a reason unrelated to #23 (issue #137) | `total ≥ 1` within the retry window. The marker's own rank is NOT asserted: on a long-lived tenant hundreds of real memories compete for the top-N. A zero result is reported as "check `cutoff_reason` in the server log", never attributed to #23 client-side — the MCP payload carries only `{limit,memories,offset,total}` and cannot distinguish `min_confidence` from `no_candidates` |
 
 ## Build-time guards
 

--- a/scripts/run-mcp-e2e.sh
+++ b/scripts/run-mcp-e2e.sh
@@ -252,7 +252,22 @@ echo "run-mcp-e2e: OK — write→search round-trip verified (marker found) for 
 # "this run's marker in the top 10" is a flakiness generator, not a
 # regression guard (bit run 30085629030). Finding the marker is logged as a
 # bonus signal when it happens.
-NL_QUERY="what secret marker did the e2e probe store for run ${GITHUB_RUN_ID:-local}"
+#
+# The query MUST NOT interpolate the run id or the marker (issue #137). A
+# run-scoped high-cardinality literal makes retrieval return ZERO candidates, so
+# the cutoff never runs at all and the server logs cutoff_reason=no_candidates —
+# not the min_confidence signature this probe exists to catch. The previous query
+# here interpolated the run id and was therefore deterministically zero: the probe
+# failed every prod deploy on a condition unrelated to #23. A leading "what " also
+# classifies the query as shape=exact upstream, which reorders candidate buckets,
+# but shape alone is not the cause — a shape=general query carrying the marker also
+# returns zero. Queries built from the memory's ordinary words retrieve reliably.
+#
+# So: keep the query free of the run id and the marker. Reintroducing either turns
+# a #23 cutoff guard back into a retrieval check that always fails. To re-measure,
+# compare a query's `total` here against the server's `confidence recall search`
+# log line for the same window, which reports shape and candidate count.
+NL_QUERY="recall what the mem9 end-to-end probe recorded about its secret marker"
 echo "run-mcp-e2e: natural-language recall probe (query: ${NL_QUERY})"
 NL_NONEMPTY=0
 for attempt in 1 2 3; do
@@ -269,7 +284,14 @@ for attempt in 1 2 3; do
 done
 
 if [[ "$NL_NONEMPTY" != "1" ]]; then
-  MSG="natural-language recall probe failed: a long NL query returned ZERO results (min_confidence cutoff regression — see issue #23). Last response: $(printf '%s' "${MCP_RESP:-}" | head -c 400)"
+  # Do NOT name a root cause here. The MCP response carries only
+  # {limit,memories,offset,total} — `cutoff_reason` is a server-side slog field,
+  # not part of the payload — so a client-side zero-result is consistent with a
+  # min_confidence cutoff regression (#23) AND with retrieval simply returning no
+  # candidates. The previous wording asserted #23 unconditionally and sent the
+  # last three prod investigations down the wrong path. Point at the log line
+  # that actually discriminates instead.
+  MSG="natural-language recall probe returned ZERO results for query: ${NL_QUERY} — check the mnemo-server 'confidence recall search' log line for this window: cutoff_reason=min_confidence with non-zero candidates is the issue #23 cutoff regression; cutoff_reason=no_candidates means retrieval/embedding returned nothing and #23 is NOT implicated. Last response: $(printf '%s' "${MCP_RESP:-}" | head -c 400)"
   if [[ "$SOFT" == "1" ]]; then
     echo "::warning::${MSG}"
     exit 0
@@ -284,26 +306,87 @@ echo "run-mcp-e2e: OK — natural-language recall verified (non-empty, ${NL_TOTA
 # A 401 means the llm-proxy bearer is dead — smart-ingest data is being lost
 # silently (the 2026-07-22 incident). HARD fail on any 401 regardless of
 # E2E_SOFT — an auth failure is never a timing flake.
-LOG_GROUP="/sst/cluster/mem9-on-aws-${STAGE}/mnemo-server"
+#
+# The group name comes from the ACTIVE task definition's mnemo-server
+# awslogs-group — the only reliable source. SST auto-names container log groups
+# with random hash segments and sets ignoreChanges:["name"], so the hand-computed
+# "/sst/cluster/mem9-on-aws-<stage>/mnemo-server" this used to assume matches no
+# real group on any stage: prod's is
+# /sst/cluster/<cluster>-<hash>/<service>-<hash>/mnemo-server. start-query
+# answered ResourceNotFoundException every time and the old `2>/dev/null || true`
+# turned that into an empty QUERY_ID, i.e. the "log group may not exist yet"
+# skip. This guard had therefore never run once, on any stage (issue #137).
+# infra/ecs.ts derives the alarm's group the same way for the same reason.
+LOG_GROUP=$(aws ecs describe-task-definition \
+  --task-definition "$ACTIVE_TASK_DEFINITION" \
+  --region "$REGION" \
+  --output json | jq -r \
+  '.taskDefinition.containerDefinitions[]
+   | select(.name == "mnemo-server")
+   | .logConfiguration.options["awslogs-group"] // empty')
+if [[ -z "$LOG_GROUP" ]]; then
+  echo "::error::could not read the mnemo-server awslogs-group from task definition ${ACTIVE_TASK_DEFINITION} — the issue #26 log-scan guard cannot run"
+  exit 1
+fi
+
 echo "run-mcp-e2e: log-scan for auth failures in ${LOG_GROUP} (last 10 min)"
 SCAN_START=$(( $(date +%s) - 600 ))000
 SCAN_END=$(date +%s)000
-QUERY_ID=$(aws logs start-query --region "$REGION" \
-  --log-group-name "$LOG_GROUP" \
-  --start-time "$SCAN_START" --end-time "$SCAN_END" \
-  --query-string 'filter msg = "extraction LLM call failed" and err like /401/' \
-  --output text 2>/dev/null || true)
 
-if [[ -n "$QUERY_ID" ]]; then
-  sleep 5
-  AUTH_FAILURES=$(aws logs get-query-results --region "$REGION" \
-    --query-id "$QUERY_ID" \
-    --query 'results | length(@)' --output text 2>/dev/null || echo "0")
-  if [[ "$AUTH_FAILURES" != "0" && "$AUTH_FAILURES" != "None" ]]; then
-    echo "::error::log-scan found ${AUTH_FAILURES} LLM auth failure(s) (401) in ${LOG_GROUP} during the E2E window — llm-proxy bearer may be dead (issue #24 regression). Investigate immediately."
-    exit 1
+# stderr goes to a FILE, never merged into a captured value with `2>&1`: the real
+# CLI writes to stderr on SUCCESSFUL calls too (a botocore deprecation notice, a
+# credential-source line), and merging that into the JSON below would break `jq`
+# on a call that actually worked.
+ERR_FILE=$(mktemp)
+trap 'rm -f "$ERR_FILE"' EXIT
+
+scan_for_auth_failures() {
+  local query_id out status auth_failures
+  query_id=$(aws logs start-query --region "$REGION" \
+    --log-group-name "$LOG_GROUP" \
+    --start-time "$SCAN_START" --end-time "$SCAN_END" \
+    --query-string 'filter msg = "extraction LLM call failed" and err like /401/' \
+    --output text 2>"$ERR_FILE") || query_id=""
+
+  if [[ -z "$query_id" ]]; then
+    # An absent log group is the ONE legitimate skip: a brand-new stage whose
+    # service has not written a log event yet. Every other start-query failure
+    # (throttling, an IAM regression, a malformed query string) means this guard
+    # did not run — and scoring that as "clean" is exactly how a dead llm-proxy
+    # bearer stayed invisible for weeks.
+    if grep -q 'ResourceNotFoundException' "$ERR_FILE"; then
+      echo "run-mcp-e2e: log-scan skipped — ${LOG_GROUP} does not exist yet (fresh stage, no service logs)"
+      return 0
+    fi
+    echo "::error::log-scan could not start a Logs Insights query on ${LOG_GROUP}: $(head -c 400 "$ERR_FILE")"
+    return 1
   fi
-  echo "run-mcp-e2e: log-scan clean — no auth failures in the last 10 min"
-else
-  echo "run-mcp-e2e: log-scan skipped (could not start Logs Insights query — log group may not exist yet on fresh stages)"
-fi
+
+  # Wait for the query to actually finish. A Running query returns an EMPTY
+  # results array, which the previous single `sleep 5` + one read scored as
+  # "clean" whenever Insights took longer than five seconds.
+  status="Unknown"
+  for _ in {1..20}; do
+    out=$(aws logs get-query-results --region "$REGION" \
+      --query-id "$query_id" --output json 2>"$ERR_FILE") || {
+      echo "::error::log-scan get-query-results failed on ${LOG_GROUP}: $(head -c 400 "$ERR_FILE")"
+      return 1
+    }
+    status=$(printf '%s' "$out" | jq -r '.status // "Unknown"')
+    [[ "$status" == "Running" || "$status" == "Scheduled" ]] || break
+    sleep 3
+  done
+  if [[ "$status" != "Complete" ]]; then
+    echo "::error::log-scan query on ${LOG_GROUP} ended in status ${status} (not Complete) — the issue #26 auth-failure guard did not run"
+    return 1
+  fi
+
+  auth_failures=$(printf '%s' "$out" | jq -r '.results | length')
+  if [[ "$auth_failures" != "0" ]]; then
+    echo "::error::log-scan found ${auth_failures} LLM auth failure(s) (401) in ${LOG_GROUP} during the E2E window — llm-proxy bearer may be dead (issue #24 regression). Investigate immediately."
+    return 1
+  fi
+  echo "run-mcp-e2e: log-scan clean — no auth failures in ${LOG_GROUP} in the last 10 min"
+}
+
+scan_for_auth_failures || exit 1

--- a/scripts/run-mcp-e2e.test.mjs
+++ b/scripts/run-mcp-e2e.test.mjs
@@ -1,0 +1,370 @@
+/**
+ * Unit tests for the MCP write→search E2E harness (issue #137).
+ * The recall cases map to docs/test-cases/recall-min-confidence.md (TC-RECALL-03x).
+ * The log-scan cases cover step 6 of the script, added for issue #26; it detects
+ * the issue #24 failure mode (a dead llm-proxy bearer) but is not the #24 fix,
+ * which lives in docker/llm-proxy and is covered by TC-PROXY401-00x.
+ *
+ * The harness talks to a deployed stage, so every case runs it against a fake
+ * `aws` and `curl` on PATH. That is the only way to assert the properties that
+ * actually broke: that the log-scan resolves the hash-suffixed log group and hard
+ * fails when it cannot run, that a still-Running Insights query is never scored
+ * as clean, and that a zero-result recall probe does not blame issue #23.
+ *
+ * All three defects were invisible for weeks precisely because the failures were
+ * swallowed into success paths. Asserting the swallow is gone is the whole point.
+ */
+
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { afterEach, describe, expect, it } from "vitest";
+
+const script = resolve("scripts/run-mcp-e2e.sh");
+const STAGE = "pr-137";
+const RUN_ID = "4242424242";
+const RUN_ATTEMPT = "1";
+const MARKER = `mcp-e2e-${STAGE}-${RUN_ID}-${RUN_ATTEMPT}`;
+const HASHED_LOG_GROUP =
+  "/sst/cluster/mem9-on-aws-pr-137-Mem9ClusterCluster-aaaabbbb/mem9-on-aws-pr-137-Mem9Server-ccccdddd/mnemo-server";
+const temporaryPaths = [];
+
+afterEach(() => {
+  for (const path of temporaryPaths.splice(0)) {
+    rmSync(path, { force: true, recursive: true });
+  }
+});
+
+/** Run the harness with a fake `aws`, `curl`, and `sleep`. */
+function runFixture({
+  logGroup = HASHED_LOG_GROUP,
+  nlTotal = "1",
+  startQueryError = "",
+  queryStatus = "Complete",
+  authFailures = "0",
+  soft = "0",
+} = {}) {
+  const directory = mkdtempSync(join(tmpdir(), "mem9-mcp-e2e-"));
+  temporaryPaths.push(directory);
+  const bin = join(directory, "bin");
+  const calls = join(directory, "calls.jsonl");
+  mkdirSync(bin);
+
+  // The shebang is the ABSOLUTE interpreter, never `env node`: this fixture
+  // prepends `bin` to PATH, so `env node` would resolve to any file named `node`
+  // in `bin` — a stub that re-invokes `node` then forks forever.
+  const aws = join(bin, "aws");
+  writeFileSync(
+    aws,
+    `#!${process.execPath}
+import { appendFileSync } from "node:fs";
+const args = process.argv.slice(2);
+appendFileSync(process.env.MOCK_CALLS, JSON.stringify(["aws", ...args]) + "\\n");
+const option = (name) => {
+  const index = args.indexOf(name);
+  return index === -1 ? undefined : args[index + 1];
+};
+const command = args.slice(0, 2).join(" ");
+const TASK_DEF =
+  "arn:aws:ecs:ap-northeast-1:123456789012:task-definition/mem9-Mem9Server:69";
+
+if (command === "ssm get-parameter") {
+  const name = option("--name") ?? "";
+  const values = {
+    "/ecs/cluster-name": "mem9-cluster",
+    "/ecs/service-name": "mem9-service",
+    "/cognito/token-endpoint": "https://token.example.com/oauth2/token",
+    "/cognito/client-id": "fixture-client-id",
+    "/cognito/client-secret": "fixture-client-secret",
+    "/cognito/scope": "mem9/read mem9/write",
+    "/gateway/url": "https://gateway.example.com/mcp",
+  };
+  const suffix = Object.keys(values).find((key) => name.endsWith(key));
+  if (!suffix) {
+    console.error("unexpected ssm parameter: " + name);
+    process.exit(255);
+  }
+  console.log(values[suffix]);
+} else if (command === "ecs wait") {
+  // services-stable: converged.
+} else if (command === "ecs describe-services") {
+  console.log(JSON.stringify({ services: [{ taskDefinition: TASK_DEF }] }));
+} else if (command === "ecs list-tasks") {
+  console.log(JSON.stringify(["arn:aws:ecs:ap-northeast-1:123456789012:task/mem9-cluster/task-1"]));
+} else if (command === "ecs describe-tasks") {
+  console.log(JSON.stringify({ tasks: [{ taskDefinitionArn: TASK_DEF }] }));
+} else if (command === "ecs describe-task-definition") {
+  // Each container gets its OWN hash-suffixed group. A fake that returned one
+  // flat group could not catch a lookup that grabs the wrong container.
+  const group = process.env.MOCK_LOG_GROUP;
+  console.log(JSON.stringify({
+    taskDefinition: {
+      containerDefinitions: [
+        {
+          name: "qwen3-embed",
+          logConfiguration: { options: { "awslogs-group": "/sst/cluster/c-hash/s-eeeeffff/qwen3-embed" } },
+        },
+        {
+          name: "mnemo-server",
+          logConfiguration: { options: group ? { "awslogs-group": group } : {} },
+        },
+        {
+          name: "llm-proxy",
+          logConfiguration: { options: { "awslogs-group": "/sst/cluster/c-hash/s-gggghhhh/llm-proxy" } },
+        },
+      ],
+    },
+  }));
+} else if (command === "logs start-query") {
+  const failure = process.env.MOCK_START_QUERY_ERROR;
+  if (failure) {
+    // The real CLI writes the error to STDERR and exits non-zero. The script
+    // discriminates the ONE legitimate skip by this text, so the fake has to be
+    // wrong in the same shape as reality to test anything.
+    console.error(
+      "An error occurred (" + failure + ") when calling the StartQuery operation: " +
+        "log group does not exist or is not permitted",
+    );
+    process.exit(254);
+  }
+  console.log("fixture-query-id");
+} else if (command === "logs get-query-results") {
+  const rows = Number(process.env.MOCK_AUTH_FAILURES ?? "0");
+  console.log(JSON.stringify({
+    status: process.env.MOCK_QUERY_STATUS ?? "Complete",
+    // A Running query returns an EMPTY results array — the shape that used to
+    // read as "clean".
+    results: Array.from({ length: rows }, () => [
+      { field: "@message", value: "extraction LLM call failed err=401" },
+    ]),
+    statistics: { recordsScanned: 10 },
+  }));
+} else {
+  console.error("unexpected aws command: " + command);
+  process.exit(2);
+}
+`,
+    { mode: 0o755 },
+  );
+  chmodSync(aws, 0o755);
+
+  const curl = join(bin, "curl");
+  writeFileSync(
+    curl,
+    `#!${process.execPath}
+import { appendFileSync, writeFileSync } from "node:fs";
+const args = process.argv.slice(2);
+appendFileSync(process.env.MOCK_CALLS, JSON.stringify(["curl", ...args]) + "\\n");
+const option = (name) => {
+  const index = args.indexOf(name);
+  return index === -1 ? undefined : args[index + 1];
+};
+const url = args.find((arg) => arg.startsWith("https://")) ?? "";
+const body = option("-d") ?? "";
+
+if (url.includes("token.example.com")) {
+  console.log(JSON.stringify({ access_token: "fixture-jwt", expires_in: 3600 }));
+  process.exit(0);
+}
+
+const headerFile = option("-D");
+if (headerFile) writeFileSync(headerFile, "HTTP/1.1 200 OK\\r\\nContent-Type: application/json\\r\\n\\r\\n");
+
+const request = JSON.parse(body || "{}");
+const reply = (result) => console.log(JSON.stringify({ jsonrpc: "2.0", id: 1, result }));
+const payload = (value) => ({ isError: false, content: [{ type: "text", text: JSON.stringify(value) }] });
+
+if (request.method === "initialize") {
+  reply({ protocolVersion: "2025-03-26", capabilities: {}, serverInfo: { name: "fixture", version: "1" } });
+} else if (request.method === "tools/list") {
+  // Namespaced exactly as AgentCore Gateway exposes OpenAPI targets.
+  reply({ tools: [
+    { name: "fixture-mem9-rest___add_memory" },
+    { name: "fixture-mem9-rest___search_memories" },
+  ] });
+} else if (request.method === "tools/call") {
+  const { name, arguments: callArgs } = request.params;
+  if (name.endsWith("add_memory")) {
+    reply(payload({ status: "accepted" }));
+  } else if (callArgs.q === process.env.MOCK_MARKER) {
+    // Keyword probe: the exact marker always resolves.
+    reply(payload({
+      limit: 5,
+      offset: 0,
+      total: 1,
+      memories: [{ content: "mem9 MCP e2e probe: the secret marker is " + process.env.MOCK_MARKER + "." }],
+    }));
+  } else {
+    // NL probe. The response shape is the REAL one: no cutoff_reason field
+    // exists in the MCP payload, which is why the script cannot attribute a
+    // zero result to issue #23.
+    reply(payload({ limit: 10, offset: 0, total: Number(process.env.MOCK_NL_TOTAL ?? "1"), memories: [] }));
+  }
+} else {
+  console.error("unexpected MCP method: " + request.method);
+  process.exit(2);
+}
+`,
+    { mode: 0o755 },
+  );
+  chmodSync(curl, 0o755);
+
+  const sleep = join(bin, "sleep");
+  writeFileSync(sleep, "#!/usr/bin/env bash\nexit 0\n", { mode: 0o755 });
+  chmodSync(sleep, 0o755);
+
+  const result = spawnSync("bash", [script], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      AWS_REGION: "ap-northeast-1",
+      E2E_SOFT: soft,
+      GITHUB_RUN_ATTEMPT: RUN_ATTEMPT,
+      GITHUB_RUN_ID: RUN_ID,
+      MOCK_AUTH_FAILURES: authFailures,
+      MOCK_CALLS: calls,
+      MOCK_LOG_GROUP: logGroup,
+      MOCK_MARKER: MARKER,
+      MOCK_NL_TOTAL: nlTotal,
+      MOCK_QUERY_STATUS: queryStatus,
+      MOCK_START_QUERY_ERROR: startQueryError,
+      PATH: `${bin}${delimiter}${process.env.PATH}`,
+      STAGE,
+    },
+  });
+  const callRecords = readFileSync(calls, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+  return { callRecords, result };
+}
+
+/** The MCP `tools/call` bodies the harness sent, in order. */
+function toolCalls(callRecords) {
+  return callRecords
+    .filter(([tool]) => tool === "curl")
+    .map((args) => {
+      const index = args.indexOf("-d");
+      if (index === -1) return null;
+      try {
+        return JSON.parse(args[index + 1]);
+      } catch {
+        return null;
+      }
+    })
+    .filter((request) => request?.method === "tools/call");
+}
+
+describe("natural-language recall probe (TC-RECALL-031)", () => {
+  it("queries with no run-scoped literal, so the probe tests the cutoff and not retrieval", () => {
+    const { callRecords, result } = runFixture();
+    expect(result.status, result.stderr).toBe(0);
+
+    const searches = toolCalls(callRecords).filter(({ params }) =>
+      params.name.endsWith("search_memories"),
+    );
+    const nl = searches.at(-1).params.arguments.q;
+
+    // The whole of issue #137: a query carrying the run id or the marker makes
+    // retrieval return ZERO candidates, so the min_confidence cutoff this probe
+    // exists to guard never runs and the step fails for an unrelated reason.
+    expect(nl).not.toContain(RUN_ID);
+    expect(nl).not.toContain(MARKER);
+    // Still a genuine natural-language query (the ≥25-char premise of #23).
+    expect(nl.length).toBeGreaterThanOrEqual(25);
+    // A leading "what " classifies the query as shape=exact upstream, which
+    // reorders candidate buckets away from this memory.
+    expect(nl.toLowerCase().startsWith("what ")).toBe(false);
+  });
+
+  it("does not blame issue #23 for a zero result it cannot attribute", () => {
+    const { result } = runFixture({ nlTotal: "0" });
+    expect(result.status).toBe(1);
+    const output = result.stdout + result.stderr;
+
+    // The MCP payload is only {limit,memories,offset,total} — `cutoff_reason` is
+    // a server-side log field. A zero result is equally consistent with the #23
+    // cutoff and with retrieval returning nothing, so the message must send the
+    // reader to the log line that discriminates rather than asserting a cause.
+    expect(output).toContain("cutoff_reason=min_confidence");
+    expect(output).toContain("cutoff_reason=no_candidates");
+    expect(output).toContain("confidence recall search");
+    expect(output).not.toContain("(min_confidence cutoff regression — see issue #23)");
+  });
+
+  it("downgrades a zero result to a warning under E2E_SOFT", () => {
+    const { result } = runFixture({ nlTotal: "0", soft: "1" });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("::warning::");
+  });
+});
+
+describe("log-scan hardening (issue #26 guard, detects the #24 failure mode)", () => {
+  it("scans the hashed log group named by the active task definition", () => {
+    const { callRecords, result } = runFixture();
+    expect(result.status, result.stderr).toBe(0);
+
+    const startQuery = callRecords.find(
+      ([tool, service, operation]) =>
+        tool === "aws" && service === "logs" && operation === "start-query",
+    );
+    // SST auto-names container log groups with random hash segments and sets
+    // ignoreChanges:["name"], so the hand-computed name this used to assume
+    // matched no real group on ANY stage — start-query answered
+    // ResourceNotFoundException every time and the guard never ran.
+    expect(startQuery[startQuery.indexOf("--log-group-name") + 1]).toBe(HASHED_LOG_GROUP);
+    expect(startQuery.join(" ")).not.toContain(`/sst/cluster/mem9-on-aws-${STAGE}/mnemo-server`);
+    expect(result.stdout).toContain("log-scan clean");
+  });
+
+  it("hard fails on a 401 even under E2E_SOFT — an auth failure is never a timing flake", () => {
+    const { result } = runFixture({ authFailures: "2", soft: "1" });
+    expect(result.status).toBe(1);
+    expect(result.stdout + result.stderr).toContain("2 LLM auth failure(s)");
+  });
+
+  it("skips only for an absent log group", () => {
+    const { result } = runFixture({ startQueryError: "ResourceNotFoundException" });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("log-scan skipped");
+  });
+
+  it.each(["AccessDeniedException", "ThrottlingException", "MalformedQueryException"])(
+    "hard fails when start-query fails with %s instead of scoring it clean",
+    (failure) => {
+      const { result } = runFixture({ startQueryError: failure, soft: "1" });
+      // The old `2>/dev/null || true` turned EVERY start-query failure into an
+      // empty query id and routed it to the "log group may not exist yet" skip.
+      // An IAM regression or a throttle would silently disable the guard.
+      expect(result.status).toBe(1);
+      expect(result.stdout + result.stderr).toContain("could not start a Logs Insights query");
+    },
+  );
+
+  it.each(["Running", "Failed", "Timeout"])(
+    "does not score a %s query as clean",
+    (status) => {
+      const { result } = runFixture({ queryStatus: status, soft: "1" });
+      // A Running query returns an empty results array. The previous single
+      // `sleep 5` + one read called that "no auth failures".
+      expect(result.status).toBe(1);
+      expect(result.stdout + result.stderr).toContain(`status ${status}`);
+      expect(result.stdout).not.toContain("log-scan clean");
+    },
+  );
+
+  it("hard fails when the task definition names no mnemo-server log group", () => {
+    const { result } = runFixture({ logGroup: "", soft: "1" });
+    expect(result.status).toBe(1);
+    expect(result.stdout + result.stderr).toContain("could not read the mnemo-server awslogs-group");
+  });
+});


### PR DESCRIPTION
Fixes #137. Also removes the cause of #136 (same defect, separate auto-filed issue).

The MCP E2E probe had three defects. Two of them meant a guard reported success without ever running, and the third made every prod deploy fail for a reason unrelated to what it was testing.

## 1. The recall probe interpolated the CI run id — it could never pass

```
query: what secret marker did the e2e probe store for run 31257468709
[error] natural-language recall probe failed: a long NL query returned ZERO results
```

A run-scoped high-cardinality literal drives retrieval to **zero candidates**, so the min_confidence cutoff this probe exists to guard never executes and the server logs `cutoff_reason=no_candidates` — not the `min_confidence` signature of #23. Measured against prod, 3 attempts per query: the old form returned 0 every time, queries built from the memory's ordinary words returned results reliably. A leading `what ` also classifies the query as `shape=exact` upstream, but shape alone is not the cause — a `shape=general` query carrying the marker returns zero too.

This is why the last three prod deploys "failed": #136, #137, and #139 all carry this identical annotation. The deploys themselves succeeded.

## 2. The zero-result message asserted a cause it cannot determine

It hard-coded `(min_confidence cutoff regression — see issue #23)`. The MCP payload carries only `{limit,memories,offset,total}`; `cutoff_reason` is a server-side slog field, so no client can distinguish the #23 cutoff from retrieval returning nothing. The message now points at the `confidence recall search` log line and states which value implicates #23 and which rules it out.

## 3. The log-scan guard for #26 had never run once, on any stage

It used a hand-computed `/sst/cluster/mem9-on-aws-<stage>/mnemo-server`. SST auto-names container log groups with random hash segments and sets `ignoreChanges:["name"]`, so `start-query` answered `ResourceNotFoundException` every time — and `2>/dev/null || true` turned that into an empty query id, routing straight into the "log group may not exist yet" skip that returns success. The group is now read from the active task definition's `awslogs-group`, exactly as `infra/ecs.ts:562-577` already does for the alarm.

Two adjacent false-cleans in the same guard:

- **Only an absent group skips now.** Throttling, an IAM regression, or a malformed query hard-fail instead of being scored clean.
- **The query is polled to `Complete`.** A still-`Running` Insights query returns an empty `results` array, which the previous single `sleep 5` + one read called "no auth failures".

`stderr` goes to a file rather than being merged with `2>&1`, because the real AWS CLI writes to stderr on successful calls too and merging it breaks the `jq` parse.

## Verification

- **13 new fixture tests** (`scripts/run-mcp-e2e.test.mjs`) run the real script against fake `aws`/`curl`/`sleep` on PATH. **11 of the 13 fail against `main`** — the other 2 cover behavior that was already correct. Follows the `run-slack-approval-e2e.test.mjs` precedent, including the absolute-interpreter shebang.
- Full suite **893/893**; `shellcheck` clean apart from a pre-existing SC2046 at line 72.
- **Verified live against prod**: exits 0, the NL probe returns results, and the log-scan executes against the real hashed group for the first time.
- Also confirmed the four branches of the new scan directly: real group → Complete/clean; old hand-computed name → skip; malformed query → hard fail; and a `filter msg = "confidence recall search"` probe over 24h returned rows, proving the filter form genuinely matches.

## Notes

- No IAM change needed — the role already has `logs:StartQuery`/`GetQueryResults` on `/sst/*` and `ecs:DescribeTaskDefinition`.
- The dangling `TC-OBS-010` id predates this change (real ids are TC-OBS-001…003 in `infra/ecs.test.ts`); I corrected the test file to cite the guard's actual origin (#26) rather than the failure mode it detects (#24), and left the pre-existing id alone.

