### PR TITLE
test(approval): close the two mutation-surviving gaps in the approval loop (#141)

### DIFF
--- a/docs/test-cases/slack-approval-loop.md
+++ b/docs/test-cases/slack-approval-loop.md
@@ -837,6 +837,15 @@ made safe or quietly defeated.
   request reaching the server, since a rejected batch-delete would leave the store
   looking untouched.
 
+  An **unreadable** `--ids` file must likewise abort rather than fall back to no
+  filter. Pinning only the empty-file meaning left the same hazard reachable by a
+  more plausible edit than the one it guards: `try { … } catch { return null; }` (or
+  an `existsSync` guard) reads as ordinary defensive tidying, and turns a typo in the
+  `--ids` path into a run that deletes every `DELETE` verdict it classified and exits
+  0. A caller that cannot read the approved list knows nothing about what was
+  approved, and "nothing was approved" and "everything is approved" are the two
+  things it must never confuse.
+
 ## Closing the loop on the message
 
 The offer posts and the apply deletes; without these the message keeps showing a
@@ -1004,6 +1013,24 @@ fail the run.
     trailing comment is not a child process. The leak assertion is checked **before**
     the counters, since an argv rewrite trips both and "expected 0 to be greater than
     0" would point at a deleted signer rather than at the argv just introduced.
+
+    The expansion pattern matches `${NAME}` with **any** parameter-expansion operator
+    (`${NAME:-}`, `${NAME#}`, `${NAME@Q}`, `${NAME//a/b}`, …), not the bare braced form
+    alone. Matching only `${NAME}` made the entire audit defeasible by one character —
+    `"${SIGNING_SECRET#}"` is the secret verbatim, produces a byte-identical HMAC, and
+    was invisible to the violation scan and to `uses` alike. An operator does not have
+    to be meaningful to carry the value; it only has to be syntax nobody enumerated,
+    which is the same failure as the `-hmac` allowlist one layer up. `${#NAME}` is
+    excluded deliberately: that is the length, not the value.
+
+    A here-string (`cmd <<<"$SECRET"`) is exempt, because a redirection is not an argv
+    and a file descriptor is *more* private than the environment this pins — reporting
+    it as "argv is world-readable" told a maintainer hardening the signer to do the
+    opposite. Two safe shapes stay rejected on purpose: piping from a builtin
+    (`printf '%s' "$SECRET" | cmd`) is safe only because `printf` forks nothing, and
+    position cannot distinguish it from `openssl dgst -hmac "$SECRET" | tee`, which is
+    a real leak; and a call to a shell function defined in the same file would only
+    move the question inside the function, which this does not analyze.
   - **`pr-N` stages only, refused before the first write.** The harness
     *overwrites* `approvals/offered`, so on a shared stage it destroys a pending
     human approval — the operator's next click would be answered against CI's

--- a/docs/test-cases/slack-approval-loop.md
+++ b/docs/test-cases/slack-approval-loop.md
@@ -811,6 +811,14 @@ made safe or quietly defeated.
   outright, counted in `skippedByFilter`, and logged. Asserted on no non-GET request
   reaching the server at all, because a PUT writing identical content would leave
   the store looking untouched.
+- **TC-SLACKAPP-132** — the converse, in the same pair: an approved id whose fresh
+  verdict is now `KEEP` fell out at `destructiveCost === 0` and incremented nothing,
+  so the outcome said "1 of 2 approved deletion(s)" with no note and a changed
+  verdict read as a partial failure. It is now counted as `reclassified` and gets
+  its own note, distinct from "not in the approved list": that one counts things the
+  operator did **not** approve, this counts things they did. Suppressed on a cap
+  abort, where the tail of the decision list was never examined and #121's note
+  already explains the shortfall.
 - **TC-SLACKAPP-133** — an **empty** `--ids` file approves nothing; it does not
   disable the filter (issue #141).
 
@@ -820,22 +828,14 @@ made safe or quietly defeated.
   run classified, and exit 0 reporting success". The apply path already names that
   as this loop's worst failure mode, but every other `--ids` case writes a
   **non-empty** file, so inverting the branch to
-  `return set.size > 0 ? set : null` passed the entire suite. Three shapes are
-  covered — empty, a lone newline, whitespace-only — plus the converse (no `--ids`
-  at all still means no filter), so a fix cannot be written as "treat empty and
-  absent alike": the operator CLI runs without `--ids` and must keep deleting what
-  it classified. Asserted through real `runCleanup` rather than on the reader
-  directly, because the hazard is what the **call site** does with null; and on no
-  non-GET request reaching the server, since a rejected batch-delete would leave the
-  store looking untouched.
-- **TC-SLACKAPP-132** — the converse, in the same pair: an approved id whose fresh
-  verdict is now `KEEP` fell out at `destructiveCost === 0` and incremented nothing,
-  so the outcome said "1 of 2 approved deletion(s)" with no note and a changed
-  verdict read as a partial failure. It is now counted as `reclassified` and gets
-  its own note, distinct from "not in the approved list": that one counts things the
-  operator did **not** approve, this counts things they did. Suppressed on a cap
-  abort, where the tail of the decision list was never examined and #121's note
-  already explains the shortfall.
+  `return set.size > 0 ? set : null` passed the entire suite. Covered for an empty
+  file, a lone newline and whitespace-only, plus the converse (no `--ids` at all
+  still means no filter), so a fix cannot be written as "treat empty and absent
+  alike": the operator CLI runs without `--ids` and must keep deleting what it
+  classified. Asserted through real `runCleanup` rather than on the reader directly,
+  because the hazard is what the **call site** does with null; and on no non-GET
+  request reaching the server, since a rejected batch-delete would leave the store
+  looking untouched.
 
 ## Closing the loop on the message
 
@@ -989,12 +989,21 @@ fail the run.
     it holds** — an assignment (the environment, `/proc/PID/environ`, owner-only)
     or a command word (`/proc/PID/cmdline`, world-readable). It names no tool and no
     flag, so a signer rewritten around a different tool is judged by the same rule.
-    Two counters keep it non-vacuous: `uses > 0` (a file-wide rename of the secret
-    cannot make it an audit of nothing) and `envUses > 0` (the secret must still
-    reach a child, through the environment — so "never use it" does not pass).
-    The leak assertion is checked **before** the counters, since an argv rewrite
-    trips both and "expected 0 to be greater than 0" would point at a deleted
-    signer rather than at the argv just introduced.
+
+    The exempt position is specifically the one a **command** could occupy, which is
+    a stricter test than "an identifier and an `=` precede the value" and has to be:
+    `awk -v key="$SECRET"` and `docker run -e K="$SECRET"` are indistinguishable from
+    a prefix assignment by the two characters before the expansion, yet both put the
+    secret on a world-readable argv. Requiring the command position rejects them, and
+    `--key=` with them. Two counters keep the audit non-vacuous: `uses > 0` (a
+    file-wide rename of the secret cannot make it an audit of nothing) and
+    `envUses > 0` (the secret must still reach a child, through the environment — so
+    "never use it" does not pass). `envUses` requires a command **after** the prefix
+    assignment rather than merely "something follows", so deleting the signer and
+    leaving `SIG_KEY="$SIGNING_SECRET"  # unused` behind fails instead of passing: a
+    trailing comment is not a child process. The leak assertion is checked **before**
+    the counters, since an argv rewrite trips both and "expected 0 to be greater than
+    0" would point at a deleted signer rather than at the argv just introduced.
   - **`pr-N` stages only, refused before the first write.** The harness
     *overwrites* `approvals/offered`, so on a shared stage it destroys a pending
     human approval — the operator's next click would be answered against CI's

--- a/docs/test-cases/slack-approval-loop.md
+++ b/docs/test-cases/slack-approval-loop.md
@@ -811,6 +811,23 @@ made safe or quietly defeated.
   outright, counted in `skippedByFilter`, and logged. Asserted on no non-GET request
   reaching the server at all, because a PUT writing identical content would leave
   the store looking untouched.
+- **TC-SLACKAPP-133** — an **empty** `--ids` file approves nothing; it does not
+  disable the filter (issue #141).
+
+  `readApprovedIds` returns `null` for an **absent** `--ids`, and null means "no
+  filter" at the call site — so the empty-`Set`-vs-`null` distinction is what stands
+  between "the operator approved nothing" and "delete every `DELETE` verdict this
+  run classified, and exit 0 reporting success". The apply path already names that
+  as this loop's worst failure mode, but every other `--ids` case writes a
+  **non-empty** file, so inverting the branch to
+  `return set.size > 0 ? set : null` passed the entire suite. Three shapes are
+  covered — empty, a lone newline, whitespace-only — plus the converse (no `--ids`
+  at all still means no filter), so a fix cannot be written as "treat empty and
+  absent alike": the operator CLI runs without `--ids` and must keep deleting what
+  it classified. Asserted through real `runCleanup` rather than on the reader
+  directly, because the hazard is what the **call site** does with null; and on no
+  non-GET request reaching the server, since a rejected batch-delete would leave the
+  store looking untouched.
 - **TC-SLACKAPP-132** — the converse, in the same pair: an approved id whose fresh
   verdict is now `KEEP` fell out at `destructiveCost === 0` and incremented nothing,
   so the outcome said "1 of 2 approved deletion(s)" with no note and a changed
@@ -960,6 +977,24 @@ fail the run.
     would put the secret in a world-readable command line. Pinned by a static
     assertion over the script source, because the fakes only see the commands they
     replace and would happily let the argv version pass.
+
+    Asserted as a **taint property**, not a per-line allowlist (issue #141). The
+    first version inspected only lines mentioning `SIGNING_SECRET` and separately
+    forbade the token `-hmac`, which one alias defeated: after
+    `SIG_KEY="$SIGNING_SECRET"` the signing line no longer mentions the secret and
+    was never inspected, the alias line read as a legal env assignment, and any
+    tool whose flag is not spelled `-hmac` put the key on an argv with the suite
+    still green. `auditSecretTaint` instead takes the transitive closure of every
+    name assigned from `SIGNING_SECRET` and judges each expansion by the **position
+    it holds** — an assignment (the environment, `/proc/PID/environ`, owner-only)
+    or a command word (`/proc/PID/cmdline`, world-readable). It names no tool and no
+    flag, so a signer rewritten around a different tool is judged by the same rule.
+    Two counters keep it non-vacuous: `uses > 0` (a file-wide rename of the secret
+    cannot make it an audit of nothing) and `envUses > 0` (the secret must still
+    reach a child, through the environment — so "never use it" does not pass).
+    The leak assertion is checked **before** the counters, since an argv rewrite
+    trips both and "expected 0 to be greater than 0" would point at a deleted
+    signer rather than at the argv just introduced.
   - **`pr-N` stages only, refused before the first write.** The harness
     *overwrites* `approvals/offered`, so on a shared stage it destroys a pending
     human approval — the operator's next click would be answered against CI's

--- a/scripts/memory-cleanup.test.mjs
+++ b/scripts/memory-cleanup.test.mjs
@@ -525,6 +525,42 @@ describe("apply, cap, --ids", () => {
     expect(server.store.get("d2").state).toBe("deleted");
   });
 
+  it("TC-SLACKAPP-133 an UNREADABLE --ids file aborts; it does not fall back to no filter", async () => {
+    // The third way into the same hazard, and the most plausible one: the two cases
+    // above pin what an empty file MEANS, but not what an absent-or-unreadable one
+    // does. Wrapping the read in `try { ... } catch { return null; }`, or guarding it
+    // with `existsSync`, reads as ordinary defensive tidying — "a missing file is
+    // just no filter" — and a reviewer would wave it through. Measured, it turns a
+    // typo in the `--ids` path into a run that deletes every DELETE verdict it
+    // classified and exits 0 reporting success: exactly the outcome the empty-file
+    // cases exist to prevent, reached without touching the branch they pin.
+    //
+    // So the abort is asserted as the CONTRACT, not left implicit in `readFileSync`'s
+    // behavior. A caller that cannot read the approved list knows nothing about what
+    // was approved, and "nothing was approved" and "everything is approved" are the
+    // two things it must never confuse — the Slack path supplies this file, and a
+    // path that does not resolve means the claim was never materialized.
+    const dir = tempDir();
+    const server = fakeServer([memory("d1", "x"), memory("d2", "y")]);
+    const llm = fakeLlm([
+      [
+        { id: "d1", verdict: "DELETE", reason: "noise", topic: "engineering" },
+        { id: "d2", verdict: "DELETE", reason: "noise", topic: "engineering" },
+      ],
+    ]);
+    const idsFile = join(dir, "does-not-exist", "approved.txt");
+
+    await expect(
+      runCleanup(baseOpts({ apply: true, idsFile }), baseDeps(server, llm, dir)),
+    ).rejects.toThrow(/ENOENT|no such file/iu);
+
+    // Nothing was deleted, and no write reached the server — the abort has to happen
+    // instead of the deletions, not alongside them.
+    expect(server.store.get("d1").state).toBe("active");
+    expect(server.store.get("d2").state).toBe("active");
+    expect(server.calls.filter((c) => c.method !== "GET")).toEqual([]);
+  });
+
   it("TC-SLACKAPP-132 --ids refuses a MERGE outright, absorbed ids included", async () => {
     // The privilege-escalation hole this closes. `buildOfferedRecord` offers
     // DELETE verdicts only, so no MERGE can ever be in an approved list — but the

--- a/scripts/memory-cleanup.test.mjs
+++ b/scripts/memory-cleanup.test.mjs
@@ -460,10 +460,10 @@ describe("apply, cap, --ids", () => {
   });
 
   it.each([
-    ["empty", ""],
-    ["a single newline", "\n"],
-    ["whitespace only", "  \n\t\n   \n"],
-  ])("TC-SLACKAPP-133 an %s --ids file approves NOTHING, it does not disable the filter", async (_label, contents) => {
+    ["an empty", ""],
+    ["a single-newline", "\n"],
+    ["a whitespace-only", "  \n\t\n   \n"],
+  ])("TC-SLACKAPP-133 %s --ids file approves NOTHING, it does not disable the filter", async (_label, contents) => {
     // The distinction `readApprovedIds` carries is load-bearing and was asserted
     // only indirectly: it returns `null` for an ABSENT `--ids`, and null means "no
     // filter" at the call site. So an empty file must yield an empty Set — a Set
@@ -475,7 +475,12 @@ describe("apply, cap, --ids", () => {
     // Every other `--ids` case writes a NON-empty file, so before this the
     // inversion passed the whole suite (issue #141). Asserted through real
     // `runCleanup` rather than on `readApprovedIds` directly, because the hazard
-    // is what the CALL SITE does with null, not what the reader returns.
+    // is what the CALL SITE does with null, not what the reader returns — and so
+    // the same hazard is caught wherever it is reintroduced. Verified against
+    // three separate sites: the reader's return, the call site's binding, and an
+    // `approved.size > 0` short-circuit added inside `applyDecisions`. Each fails
+    // all three cases below, which is the point of asserting on outcomes (nothing
+    // deleted, everything counted as filtered) rather than on one line's shape.
     const dir = tempDir();
     const server = fakeServer([memory("d1", "x"), memory("d2", "y")]);
     const llm = fakeLlm([

--- a/scripts/memory-cleanup.test.mjs
+++ b/scripts/memory-cleanup.test.mjs
@@ -459,6 +459,67 @@ describe("apply, cap, --ids", () => {
     expect(result.skippedByFilter).toBe(1);
   });
 
+  it.each([
+    ["empty", ""],
+    ["a single newline", "\n"],
+    ["whitespace only", "  \n\t\n   \n"],
+  ])("TC-SLACKAPP-133 an %s --ids file approves NOTHING, it does not disable the filter", async (_label, contents) => {
+    // The distinction `readApprovedIds` carries is load-bearing and was asserted
+    // only indirectly: it returns `null` for an ABSENT `--ids`, and null means "no
+    // filter" at the call site. So an empty file must yield an empty Set — a Set
+    // that admits nothing — and never null. Inverting that one branch
+    // (`return set.size > 0 ? set : null`) makes a run holding an empty approved
+    // list delete every DELETE verdict it found and exit 0 reporting success,
+    // which the apply path itself names as this loop's worst failure mode.
+    //
+    // Every other `--ids` case writes a NON-empty file, so before this the
+    // inversion passed the whole suite (issue #141). Asserted through real
+    // `runCleanup` rather than on `readApprovedIds` directly, because the hazard
+    // is what the CALL SITE does with null, not what the reader returns.
+    const dir = tempDir();
+    const server = fakeServer([memory("d1", "x"), memory("d2", "y")]);
+    const llm = fakeLlm([
+      [
+        { id: "d1", verdict: "DELETE", reason: "noise", topic: "engineering" },
+        { id: "d2", verdict: "DELETE", reason: "noise", topic: "engineering" },
+      ],
+    ]);
+    const idsFile = join(dir, "approved.txt");
+    writeFileSync(idsFile, contents);
+    const deps = baseDeps(server, llm, dir);
+    const result = await runCleanup(baseOpts({ apply: true, idsFile }), deps);
+
+    // Both DELETE verdicts were found and both were withheld by the filter.
+    expect(result.skippedByFilter).toBe(2);
+    expect(result.capUsed).toBe(0);
+    expect(server.store.get("d1").state).toBe("active");
+    expect(server.store.get("d2").state).toBe("active");
+    // No write of ANY kind reached the server. The store check alone cannot see a
+    // batch-delete that was sent and rejected.
+    expect(server.calls.filter((c) => c.method !== "GET")).toEqual([]);
+  });
+
+  it("TC-SLACKAPP-133 an absent --ids file still means NO filter", async () => {
+    // The other half of the same branch, pinned so a fix for the case above cannot
+    // be written as "treat empty and absent alike". The operator CLI runs with no
+    // `--ids` at all and must keep deleting what it classified; only the
+    // Slack-triggered path requires a list, and it is refused earlier (a
+    // MEM9_APPROVAL_HASH with no `--ids` throws before any classification).
+    const dir = tempDir();
+    const server = fakeServer([memory("d1", "x"), memory("d2", "y")]);
+    const llm = fakeLlm([
+      [
+        { id: "d1", verdict: "DELETE", reason: "noise", topic: "engineering" },
+        { id: "d2", verdict: "DELETE", reason: "noise", topic: "engineering" },
+      ],
+    ]);
+    const result = await runCleanup(baseOpts({ apply: true }), baseDeps(server, llm, dir));
+
+    expect(result.skippedByFilter).toBe(0);
+    expect(server.store.get("d1").state).toBe("deleted");
+    expect(server.store.get("d2").state).toBe("deleted");
+  });
+
   it("TC-SLACKAPP-132 --ids refuses a MERGE outright, absorbed ids included", async () => {
     // The privilege-escalation hole this closes. `buildOfferedRecord` offers
     // DELETE verdicts only, so no MERGE can ever be in an approved list — but the

--- a/scripts/run-slack-approval-e2e.test.mjs
+++ b/scripts/run-slack-approval-e2e.test.mjs
@@ -34,6 +34,101 @@ afterEach(() => {
 });
 
 /**
+ * Taint-audit the harness source for the one property TC-SLACKAPP-090 pins: the
+ * signing secret, and anything assigned from it, may reach a child process only
+ * through the ENVIRONMENT — never as a command word.
+ *
+ * That distinction is the whole point. A prefix assignment
+ * (`NAME="$SECRET" cmd ...`) puts the value in the child's environment, readable
+ * through `/proc/PID/environ` by its owner alone. A command word (`cmd "$SECRET"`,
+ * `cmd -hmac "$SECRET"`, `cmd --key="$SECRET"`) puts it in `/proc/PID/cmdline`,
+ * which is world-readable — on a shared or self-hosted runner that is every other
+ * process on the box.
+ *
+ * Deliberately spelling-independent: it audits the POSITION each expansion holds
+ * in its line, not the flag preceding it, so no tool name or flag needs listing
+ * and a signer rewritten around a different tool is judged by the same rule.
+ *
+ * @param code the script with full-line comments already stripped
+ * @returns `taint` — every name transitively assigned from `SIGNING_SECRET`,
+ *          `SIGNING_SECRET` first; `uses` — how many expansions of a tainted name
+ *          were examined and `envUses` how many of those were prefix assignments
+ *          handing the value to a child, so the caller can reject a vacuous pass;
+ *          `violations` — each use of a tainted name that is not an assignment.
+ */
+function auditSecretTaint(code) {
+  const lines = code.split("\n");
+  const taint = new Set(["SIGNING_SECRET"]);
+  // `$NAME` or `${NAME}`, and NOT a longer name that merely starts with it —
+  // without the trailing guard, a taint on `KEY` would flag every `$KEYSTORE`.
+  const expansion = (name) =>
+    new RegExp(String.raw`\$(?:\{${name}\}|${name}(?![A-Za-z0-9_]))`, "u");
+  // Assignments anywhere a shell word can start, not only at a line's start: a
+  // launder hidden after `;` or `&&` (`if x; then B="$SECRET"; fi`) is still a
+  // launder.
+  const assignments = (line) =>
+    [...line.matchAll(/(?:^|[\s;&|(])(?:local\s+|export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(\S*)/gu)];
+
+  // Transitive closure over `NAME="$TAINTED"` / `NAME=$TAINTED`, repeated until it
+  // stops growing: a two-hop launder (`A="$SIGNING_SECRET"; B="$A"; cmd "$B"`) is
+  // no less an argv leak than a one-hop one.
+  for (let size = 0; size !== taint.size; ) {
+    size = taint.size;
+    for (const line of lines) {
+      for (const [, target, value] of assignments(line)) {
+        if ([...taint].some((name) => expansion(name).test(value))) taint.add(target);
+      }
+    }
+  }
+
+  const violations = [];
+  let uses = 0;
+  let envUses = 0;
+  for (const name of taint) {
+    const pattern = expansion(name);
+    for (const line of lines) {
+      // Every expansion of this name on this line, judged by what precedes it.
+      for (const match of line.matchAll(new RegExp(pattern, "gu"))) {
+        uses += 1;
+        const before = line.slice(0, match.index);
+        // An assignment — `NAME=$TAINTED`, whether standalone, `local`/`export`, or
+        // the prefix form `NAME="$TAINTED" cmd` — is the sanctioned channel. The
+        // `=` must be the last thing before the expansion for this to hold, so
+        // `cmd --key="$TAINTED"` (a command WORD containing `=`) does not qualify:
+        // a word starting with `-` is a flag, not an assignment target.
+        const isAssignment = /(?:^|\s)(?:local\s+|export\s+)?[A-Za-z_][A-Za-z0-9_]*=(?:"|')?$/u.test(
+          before,
+        );
+        // `[[ -z "$TAINTED" ]]` and `[[ "$TAINTED" == None ]]` — the emptiness
+        // guard that gates the skip. A test builtin forks no child, so there is no
+        // cmdline for the value to land in.
+        //
+        // Scoped to the test builtin the expansion is INSIDE, not to "a `[[`
+        // appeared earlier on this line": the latter excused everything after a
+        // guard, so `[[ -n "$X" ]] && cmd "$TAINTED"` passed. Closed by requiring no
+        // `]]`/`]` between the opening bracket and this expansion.
+        const opened = before.search(/(?:^|\s)\[\[?(?:\s|$)/u);
+        const isTestBuiltin =
+          opened !== -1 && !/(?:^|\s)\]\]?(?:\s|$|;|&|\|)/u.test(before.slice(opened));
+        if (isAssignment) {
+          // A PREFIX assignment — `NAME="$TAINTED" cmd ...` — is the sanctioned
+          // channel actually being exercised: it hands the value to a child through
+          // its environment. Counted so the caller can tell "the harness signs
+          // something with this secret" from "nothing here mentions it any more".
+          if (/\S/u.test(line.slice(match.index + match[0].length).replace(/^["']/u, ""))) {
+            envUses += 1;
+          }
+          continue;
+        }
+        if (isTestBuiltin) continue;
+        violations.push({ name, segment: line.trim() });
+      }
+    }
+  }
+  return { taint: [...taint], uses, envUses, violations };
+}
+
+/**
  * Run the harness with a fake `aws` and `curl`.
  *
  * Every knob is a MOCK_* env var read inside the fakes rather than a fixture
@@ -313,19 +408,38 @@ describe("Slack approval E2E harness (TC-SLACKAPP-090)", () => {
       .split("\n")
       .filter((line) => !/^\s*#/u.test(line))
       .join("\n");
-    const secretRefs = code.match(/[^\n]*\$\{?SIGNING_SECRET\}?[^\n]*/gu) ?? [];
-    expect(secretRefs.length).toBeGreaterThan(0);
-    for (const line of secretRefs) {
-      // Allowed: the SSM read that produces it, the emptiness check that gates
-      // the skip, and an `NAME="$SIGNING_SECRET"` environment assignment.
-      const isEnvAssignment = /\b[A-Z_]+="\$SIGNING_SECRET"/u.test(line);
-      const isGuard = /^\s*(SIGNING_SECRET=|if \[\[|.*-z "\$SIGNING_SECRET")/u.test(line);
-      expect(
-        isEnvAssignment || isGuard,
-        `the secret is interpolated into a command line: ${line.trim()}`,
-      ).toBe(true);
-    }
-    expect(code).not.toMatch(/-hmac\s+"?\$/u);
+
+    // Asserted as a TAINT property over the whole file, not as a per-line
+    // allowlist. The earlier version inspected only lines that mention
+    // `SIGNING_SECRET` and separately forbade the token `-hmac`, so one alias
+    // defeated it: after `SIG_KEY="$SIGNING_SECRET"`, the signing line no longer
+    // mentions the secret and is never inspected, the alias line itself reads as a
+    // legal env assignment, and any tool whose flag is not spelled `-hmac` puts the
+    // key on a world-readable argv with 16/16 still passing (issue #141). What
+    // matters is not which flag carries the value but WHICH CHANNEL: an assignment
+    // reaches the child through its environment (`/proc/PID/environ`, owner-only),
+    // a command word reaches it through `/proc/PID/cmdline`, which every user on
+    // the box can read.
+    const { uses, envUses, violations } = auditSecretTaint(code);
+    // The leak assertion comes FIRST so a real leak is reported as a leak. A
+    // signer rewritten to pass the key on argv also stops passing it through the
+    // environment, so it trips the non-vacuity check below too — and a failure
+    // reading "expected 0 to be greater than 0" would send the reader looking for a
+    // deleted signer rather than at the argv they just introduced.
+    expect(
+      violations,
+      `a name tainted by SIGNING_SECRET reaches a command argument (argv is world-readable):\n${violations
+        .map((v) => `  ${v.name}: ${v.segment}`)
+        .join("\n")}`,
+    ).toEqual([]);
+    // Non-vacuity, asserted on what was EXAMINED rather than on the taint set:
+    // `SIGNING_SECRET` is seeded by the auditor, so `taint` containing it proves
+    // nothing. A file-wide rename of the secret, or a signer deleted outright,
+    // drops these to zero and fails here rather than passing an audit of nothing.
+    // `envUses` is the positive half — the secret does still reach a child, and
+    // through the environment — so this cannot be satisfied by never using it.
+    expect(uses).toBeGreaterThan(0);
+    expect(envUses).toBeGreaterThan(0);
   });
 
   it("TC-SLACKAPP-090 a 200 on the INVALID signature fails the run", () => {

--- a/scripts/run-slack-approval-e2e.test.mjs
+++ b/scripts/run-slack-approval-e2e.test.mjs
@@ -47,18 +47,31 @@ afterEach(() => {
  *
  * Deliberately spelling-independent: it audits the POSITION each expansion holds
  * in its line, not the flag preceding it, so no tool name or flag needs listing
- * and a signer rewritten around a different tool is judged by the same rule.
+ * and a signer rewritten around a different tool is judged by the same rule. The
+ * position that exempts an expansion is the one a COMMAND could occupy — which is
+ * what separates the sanctioned `NAME="$SECRET" cmd` from an `=`-bearing argument
+ * to a command already underway (`awk -v key="$SECRET"`, `docker run -e K="$SECRET"`),
+ * whose two preceding characters are identical and which is a real argv leak.
  *
  * @param code the script with full-line comments already stripped
  * @returns `taint` — every name transitively assigned from `SIGNING_SECRET`,
  *          `SIGNING_SECRET` first; `uses` — how many expansions of a tainted name
  *          were examined and `envUses` how many of those were prefix assignments
  *          handing the value to a child, so the caller can reject a vacuous pass;
- *          `violations` — each use of a tainted name that is not an assignment.
+ *          `violations` — each use of a tainted name that is neither an assignment
+ *          nor inside a test builtin.
  */
 function auditSecretTaint(code) {
-  const lines = code.split("\n");
+  // Line continuations joined first, so every rule below sees a whole simple
+  // command. Split, `NAME="$SECRET" \` ends its line and the child on the next line
+  // is invisible — which would report the sanctioned form as reaching no child.
+  const lines = code.replace(/\\\n\s*/gu, " ").split("\n");
   const taint = new Set(["SIGNING_SECRET"]);
+  // One shell word of the form `NAME=value`, value double-quoted, single-quoted, or
+  // bare. Used twice: to recognise the assignment an expansion sits in, and to skip
+  // the assignments that may precede the command word in `A=1 B=2 cmd`.
+  const ASSIGNMENT_WORD = String.raw`[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|'[^']*'|[^\s"']*)`;
+  const DECLARATOR = String.raw`(?:local|export|declare|readonly)\s+`;
   // `$NAME` or `${NAME}`, and NOT a longer name that merely starts with it —
   // without the trailing guard, a taint on `KEY` would flag every `$KEYSTORE`.
   const expansion = (name) =>
@@ -92,11 +105,27 @@ function auditSecretTaint(code) {
         uses += 1;
         const before = line.slice(0, match.index);
         // An assignment — `NAME=$TAINTED`, whether standalone, `local`/`export`, or
-        // the prefix form `NAME="$TAINTED" cmd` — is the sanctioned channel. The
-        // `=` must be the last thing before the expansion for this to hold, so
-        // `cmd --key="$TAINTED"` (a command WORD containing `=`) does not qualify:
-        // a word starting with `-` is a flag, not an assignment target.
-        const isAssignment = /(?:^|\s)(?:local\s+|export\s+)?[A-Za-z_][A-Za-z0-9_]*=(?:"|')?$/u.test(
+        // the prefix form `NAME="$TAINTED" cmd` — is the sanctioned channel.
+        //
+        // Recognised by POSITION, not by the presence of an `=`: the `NAME=` must sit
+        // where a command could start, meaning everything between the last command
+        // boundary and it is itself an assignment word (`A=1 B="$T" cmd`) or a
+        // declarator. Checking only "an identifier and an `=` precede the expansion"
+        // is not enough — that also accepts an `=`-bearing argument to a command that
+        // has already started, and those are real argv leaks:
+        // `awk -v key="$TAINTED" ...` and `docker run -e SEC="$TAINTED" ...` both put
+        // the value on a world-readable cmdline while looking exactly like a prefix
+        // assignment from the two characters before it. Requiring the command
+        // position rejects them, and `cmd --key="$TAINTED"` with it.
+        const isAssignment = new RegExp(
+          String.raw`(?:^|[;&|(){]|\b(?:then|do|else|in)\s)\s*(?:${DECLARATOR})?` +
+            String.raw`(?:${ASSIGNMENT_WORD}\s+)*[A-Za-z_][A-Za-z0-9_]*=(?:"|')?$`,
+          "u",
+        ).test(before);
+        // `export NAME="$TAINTED"` reaches every later child's environment without a
+        // command on its own line, so it is an env use even though nothing follows.
+        // Tracked separately from the prefix form for exactly that reason.
+        const isExport = /(?:^|[;&|(]\s*)export\s+(?:[A-Za-z_][A-Za-z0-9_]*=\S*\s+)*[A-Za-z_][A-Za-z0-9_]*=(?:"|')?$/u.test(
           before,
         );
         // `[[ -z "$TAINTED" ]]` and `[[ "$TAINTED" == None ]]` — the emptiness
@@ -111,13 +140,22 @@ function auditSecretTaint(code) {
         const isTestBuiltin =
           opened !== -1 && !/(?:^|\s)\]\]?(?:\s|$|;|&|\|)/u.test(before.slice(opened));
         if (isAssignment) {
-          // A PREFIX assignment — `NAME="$TAINTED" cmd ...` — is the sanctioned
-          // channel actually being exercised: it hands the value to a child through
-          // its environment. Counted so the caller can tell "the harness signs
-          // something with this secret" from "nothing here mentions it any more".
-          if (/\S/u.test(line.slice(match.index + match[0].length).replace(/^["']/u, ""))) {
-            envUses += 1;
-          }
+          // A PREFIX assignment — `NAME="$TAINTED" cmd ...` — or an `export`, is the
+          // sanctioned channel actually being exercised: either one hands the value
+          // to a child through its environment. Counted so the caller can tell "the
+          // harness signs something with this secret" from "nothing here mentions it
+          // any more".
+          //
+          // A prefix assignment is only counted once a COMMAND is found after it —
+          // skipping any further assignment words, since `A="$T" B=2 cmd` is one
+          // prefix run. "Something follows on the line" is not the same test and does
+          // not support the claim: full-line comments are stripped before this, but
+          // TRAILING ones are not, so `K="$SECRET"  # alias` would count as handing
+          // the value to a child. A signer deleted with its alias left behind would
+          // then satisfy the non-vacuity check it exists to fail.
+          const after = line.slice(match.index + match[0].length).replace(/^["']/u, "");
+          const command = new RegExp(String.raw`^(?:\s+${ASSIGNMENT_WORD})*\s+[^\s#;&|)]`, "u");
+          if (isExport || command.test(after)) envUses += 1;
           continue;
         }
         if (isTestBuiltin) continue;
@@ -415,11 +453,11 @@ describe("Slack approval E2E harness (TC-SLACKAPP-090)", () => {
     // defeated it: after `SIG_KEY="$SIGNING_SECRET"`, the signing line no longer
     // mentions the secret and is never inspected, the alias line itself reads as a
     // legal env assignment, and any tool whose flag is not spelled `-hmac` puts the
-    // key on a world-readable argv with 16/16 still passing (issue #141). What
-    // matters is not which flag carries the value but WHICH CHANNEL: an assignment
-    // reaches the child through its environment (`/proc/PID/environ`, owner-only),
-    // a command word reaches it through `/proc/PID/cmdline`, which every user on
-    // the box can read.
+    // key on a world-readable argv with the whole suite still passing (issue #141).
+    // What matters is not which flag carries the value but WHICH CHANNEL: an
+    // assignment reaches the child through its environment (`/proc/PID/environ`,
+    // owner-only), a command word reaches it through `/proc/PID/cmdline`, which every
+    // user on the box can read.
     const { uses, envUses, violations } = auditSecretTaint(code);
     // The leak assertion comes FIRST so a real leak is reported as a leak. A
     // signer rewritten to pass the key on argv also stops passing it through the
@@ -434,10 +472,11 @@ describe("Slack approval E2E harness (TC-SLACKAPP-090)", () => {
     ).toEqual([]);
     // Non-vacuity, asserted on what was EXAMINED rather than on the taint set:
     // `SIGNING_SECRET` is seeded by the auditor, so `taint` containing it proves
-    // nothing. A file-wide rename of the secret, or a signer deleted outright,
-    // drops these to zero and fails here rather than passing an audit of nothing.
-    // `envUses` is the positive half — the secret does still reach a child, and
-    // through the environment — so this cannot be satisfied by never using it.
+    // nothing. A file-wide rename of the secret drops `uses` to zero and fails here
+    // rather than passing an audit of nothing. `envUses` is the positive half — the
+    // secret does still reach a child, and through the environment — so this cannot
+    // be satisfied by never using it, nor by deleting the signer and leaving the
+    // alias assignment behind (`envUses` requires a command after the prefix).
     expect(uses).toBeGreaterThan(0);
     expect(envUses).toBeGreaterThan(0);
   });

--- a/scripts/run-slack-approval-e2e.test.mjs
+++ b/scripts/run-slack-approval-e2e.test.mjs
@@ -48,18 +48,17 @@ afterEach(() => {
  * Deliberately spelling-independent: it audits the POSITION each expansion holds
  * in its line, not the flag preceding it, so no tool name or flag needs listing
  * and a signer rewritten around a different tool is judged by the same rule. The
- * position that exempts an expansion is the one a COMMAND could occupy — which is
- * what separates the sanctioned `NAME="$SECRET" cmd` from an `=`-bearing argument
- * to a command already underway (`awk -v key="$SECRET"`, `docker run -e K="$SECRET"`),
- * whose two preceding characters are identical and which is a real argv leak.
+ * exempting position is the one a COMMAND could occupy; `atCommandStart` below
+ * explains why that is stricter than "an identifier and an `=` precede the value",
+ * and has to be.
  *
  * @param code the script with full-line comments already stripped
  * @returns `taint` — every name transitively assigned from `SIGNING_SECRET`,
  *          `SIGNING_SECRET` first; `uses` — how many expansions of a tainted name
- *          were examined and `envUses` how many of those were prefix assignments
- *          handing the value to a child, so the caller can reject a vacuous pass;
- *          `violations` — each use of a tainted name that is neither an assignment
- *          nor inside a test builtin.
+ *          were examined and `envUses` how many of those actually handed the value
+ *          to a child through the environment, so the caller can reject a vacuous
+ *          pass; `violations` — each use of a tainted name that is neither an
+ *          assignment nor inside a test builtin.
  */
 function auditSecretTaint(code) {
   // Line continuations joined first, so every rule below sees a whole simple
@@ -71,21 +70,54 @@ function auditSecretTaint(code) {
   // bare. Used twice: to recognise the assignment an expansion sits in, and to skip
   // the assignments that may precede the command word in `A=1 B=2 cmd`.
   const ASSIGNMENT_WORD = String.raw`[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|'[^']*'|[^\s"']*)`;
-  const DECLARATOR = String.raw`(?:local|export|declare|readonly)\s+`;
-  // `$NAME` or `${NAME}`, and NOT a longer name that merely starts with it —
-  // without the trailing guard, a taint on `KEY` would flag every `$KEYSTORE`.
-  const expansion = (name) =>
-    new RegExp(String.raw`\$(?:\{${name}\}|${name}(?![A-Za-z0-9_]))`, "u");
+  // A `NAME=` standing exactly where a COMMAND could start: between it and the last
+  // command boundary lies nothing but other assignment words and an optional
+  // declarator. That POSITION, rather than the mere presence of an identifier and an
+  // `=`, is what separates the sanctioned prefix assignment from an `=`-bearing
+  // argument to a command already underway — `awk -v key="$TAINTED"` and
+  // `docker run -e SEC="$TAINTED"` are identical in the two characters before the
+  // expansion yet put the value on a world-readable cmdline. Requiring the command
+  // position rejects both, and `cmd --key="$TAINTED"` with them.
+  const atCommandStart = (declarator) =>
+    new RegExp(
+      String.raw`(?:^|[;&|(){]|\b(?:then|do|else|in)\s)\s*${declarator}` +
+        String.raw`(?:${ASSIGNMENT_WORD}\s+)*[A-Za-z_][A-Za-z0-9_]*=(?:"|')?$`,
+      "u",
+    );
+  // Any assignment — standalone, prefix, or declared — versus the `export` subset,
+  // which reaches every later child's environment without a command on its own line.
+  const ASSIGNMENT = atCommandStart(String.raw`(?:(?:local|export|declare|readonly)\s+)?`);
+  const EXPORT = atCommandStart(String.raw`export\s+`);
+  // The command a prefix assignment run hands the value to, past any further
+  // assignment words: `A="$T" B=2 cmd` is one prefix run, one command.
+  const COMMAND_AFTER_PREFIX = new RegExp(String.raw`^(?:\s+${ASSIGNMENT_WORD})*\s+[^\s#;&|)]`, "u");
+  // `$NAME`, or `${NAME` followed by ANY parameter-expansion operator — `${NAME}`,
+  // but equally `${NAME:-}`, `${NAME#}`, `${NAME%%x}`, `${NAME@Q}`, `${NAME:0:99}`,
+  // `${NAME^^}`, `${NAME//a/b}`. Matching only the bare `${NAME}` left the whole
+  // audit defeasible by ONE character: `"${SIGNING_SECRET#}"` on a command line is
+  // the secret, verbatim, yet went unseen — and unseen by `uses` too, so not even
+  // the non-vacuity counter noticed. The operator does not have to be meaningful to
+  // be an exfiltration route; it only has to be syntax the auditor did not enumerate,
+  // which is the same mistake the `-hmac` allowlist made one layer up.
+  //
+  // The trailing guard on the bare form keeps a taint on `KEY` from flagging every
+  // `$KEYSTORE`, and the braced form gets it too, so `${KEYSTORE}` is not read as a
+  // modified `${KEY}`. `${#NAME}` is deliberately NOT matched: that is the length,
+  // not the value.
+  const expansion = (name, flags = "u") =>
+    new RegExp(String.raw`\$(?:\{${name}(?![A-Za-z0-9_])[^}]*\}|${name}(?![A-Za-z0-9_]))`, flags);
   // Assignments anywhere a shell word can start, not only at a line's start: a
   // launder hidden after `;` or `&&` (`if x; then B="$SECRET"; fi`) is still a
-  // launder.
+  // launder. A declarator needs no clause of its own — the space after `local` or
+  // `readonly` is itself the boundary the target name follows.
   const assignments = (line) =>
-    [...line.matchAll(/(?:^|[\s;&|(])(?:local\s+|export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(\S*)/gu)];
+    [...line.matchAll(/(?:^|[\s;&|(])([A-Za-z_][A-Za-z0-9_]*)=(\S*)/gu)];
 
   // Transitive closure over `NAME="$TAINTED"` / `NAME=$TAINTED`, repeated until it
   // stops growing: a two-hop launder (`A="$SIGNING_SECRET"; B="$A"; cmd "$B"`) is
   // no less an argv leak than a one-hop one.
-  for (let size = 0; size !== taint.size; ) {
+  let size = 0;
+  while (size !== taint.size) {
     size = taint.size;
     for (const line of lines) {
       for (const [, target, value] of assignments(line)) {
@@ -98,36 +130,28 @@ function auditSecretTaint(code) {
   let uses = 0;
   let envUses = 0;
   for (const name of taint) {
-    const pattern = expansion(name);
     for (const line of lines) {
       // Every expansion of this name on this line, judged by what precedes it.
-      for (const match of line.matchAll(new RegExp(pattern, "gu"))) {
+      for (const match of line.matchAll(expansion(name, "gu"))) {
         uses += 1;
         const before = line.slice(0, match.index);
+        const after = line.slice(match.index + match[0].length).replace(/^["']/u, "");
         // An assignment — `NAME=$TAINTED`, whether standalone, `local`/`export`, or
-        // the prefix form `NAME="$TAINTED" cmd` — is the sanctioned channel.
-        //
-        // Recognised by POSITION, not by the presence of an `=`: the `NAME=` must sit
-        // where a command could start, meaning everything between the last command
-        // boundary and it is itself an assignment word (`A=1 B="$T" cmd`) or a
-        // declarator. Checking only "an identifier and an `=` precede the expansion"
-        // is not enough — that also accepts an `=`-bearing argument to a command that
-        // has already started, and those are real argv leaks:
-        // `awk -v key="$TAINTED" ...` and `docker run -e SEC="$TAINTED" ...` both put
-        // the value on a world-readable cmdline while looking exactly like a prefix
-        // assignment from the two characters before it. Requiring the command
-        // position rejects them, and `cmd --key="$TAINTED"` with it.
-        const isAssignment = new RegExp(
-          String.raw`(?:^|[;&|(){]|\b(?:then|do|else|in)\s)\s*(?:${DECLARATOR})?` +
-            String.raw`(?:${ASSIGNMENT_WORD}\s+)*[A-Za-z_][A-Za-z0-9_]*=(?:"|')?$`,
-          "u",
-        ).test(before);
-        // `export NAME="$TAINTED"` reaches every later child's environment without a
-        // command on its own line, so it is an env use even though nothing follows.
-        // Tracked separately from the prefix form for exactly that reason.
-        const isExport = /(?:^|[;&|(]\s*)export\s+(?:[A-Za-z_][A-Za-z0-9_]*=\S*\s+)*[A-Za-z_][A-Za-z0-9_]*=(?:"|')?$/u.test(
-          before,
-        );
+        // the prefix form `NAME="$TAINTED" cmd` — is the sanctioned channel, since it
+        // reaches the child through the environment. See `atCommandStart` for why the
+        // position and not the `=` is what is tested.
+        if (ASSIGNMENT.test(before)) {
+          // Counted so the caller can tell "the harness signs something with this
+          // secret" from "nothing here mentions it any more". A PREFIX assignment
+          // counts only once a COMMAND is found after it; an `export` counts on its
+          // own, having no command to wait for. "Something follows on the line" would
+          // not support the claim: full-line comments are stripped before this but
+          // TRAILING ones are not, so `K="$SECRET"  # alias` would read as handing the
+          // value to a child, and a signer deleted with its alias left behind would
+          // satisfy the very non-vacuity check that exists to fail it.
+          if (EXPORT.test(before) || COMMAND_AFTER_PREFIX.test(after)) envUses += 1;
+          continue;
+        }
         // `[[ -z "$TAINTED" ]]` and `[[ "$TAINTED" == None ]]` — the emptiness
         // guard that gates the skip. A test builtin forks no child, so there is no
         // cmdline for the value to land in.
@@ -137,28 +161,32 @@ function auditSecretTaint(code) {
         // guard, so `[[ -n "$X" ]] && cmd "$TAINTED"` passed. Closed by requiring no
         // `]]`/`]` between the opening bracket and this expansion.
         const opened = before.search(/(?:^|\s)\[\[?(?:\s|$)/u);
-        const isTestBuiltin =
+        const insideTestBuiltin =
           opened !== -1 && !/(?:^|\s)\]\]?(?:\s|$|;|&|\|)/u.test(before.slice(opened));
-        if (isAssignment) {
-          // A PREFIX assignment — `NAME="$TAINTED" cmd ...` — or an `export`, is the
-          // sanctioned channel actually being exercised: either one hands the value
-          // to a child through its environment. Counted so the caller can tell "the
-          // harness signs something with this secret" from "nothing here mentions it
-          // any more".
-          //
-          // A prefix assignment is only counted once a COMMAND is found after it —
-          // skipping any further assignment words, since `A="$T" B=2 cmd` is one
-          // prefix run. "Something follows on the line" is not the same test and does
-          // not support the claim: full-line comments are stripped before this, but
-          // TRAILING ones are not, so `K="$SECRET"  # alias` would count as handing
-          // the value to a child. A signer deleted with its alias left behind would
-          // then satisfy the non-vacuity check it exists to fail.
-          const after = line.slice(match.index + match[0].length).replace(/^["']/u, "");
-          const command = new RegExp(String.raw`^(?:\s+${ASSIGNMENT_WORD})*\s+[^\s#;&|)]`, "u");
-          if (isExport || command.test(after)) envUses += 1;
-          continue;
-        }
-        if (isTestBuiltin) continue;
+        if (insideTestBuiltin) continue;
+        // A here-string is not an argv either, and the rule was inverted for it:
+        // `cmd <<<"$TAINTED"` hands the value over on a file descriptor, which is
+        // strictly MORE private than the environment this test sanctions, yet it was
+        // reported as "argv is world-readable" about a line containing no argv. A
+        // maintainer hardening the signer that way would have hit a failure telling
+        // them to do the opposite, which is worse than a missing rule. Recognised by
+        // the redirection operator, so it stays a position rule.
+        if (/(?:<<<|(?:^|\s)<)\s*["']?$/u.test(before)) continue;
+        // Everything else is a violation, INCLUDING two shapes that are safe in
+        // practice and are rejected on purpose, because admitting them costs more
+        // than the false positive does:
+        //
+        // `printf '%s' "$TAINTED" | cmd` is safe only because `printf` is a bash
+        // builtin that forks nothing. The position alone cannot tell that: an
+        // external command in the same spot — `openssl dgst -hmac "$TAINTED" | tee` —
+        // is a genuine leak, and separating them means enumerating builtins, which is
+        // the vocabulary-dependence this whole audit exists to avoid. Piping from a
+        // builtin is a refactor nobody needs; a leak waved through is not recoverable.
+        //
+        // `sign() { ... }; sign "$TAINTED"` likewise forks no process, but exempting a
+        // call to a function defined in this file would only move the question inside
+        // it: whether `$1` then reaches a command word is an analysis this does not
+        // do, so the exemption would be a laundering route with a `()` for a key.
         violations.push({ name, segment: line.trim() });
       }
     }


### PR DESCRIPTION
Closes #141.

Both gaps the issue documents are closed, each verified the way the issue asks:
apply the mutation, run the suite, confirm it fails. Tests and docs only —
`scripts/memory-cleanup.mjs` and `scripts/run-slack-approval-e2e.sh` are
byte-identical to `main`.

## Gap 1 — an empty `--ids` file must approve nothing, not disable the filter

`readApprovedIds` returns `null` for an **absent** `--ids`, and null means "no
filter" at the call site. Every other `--ids` case in the suite writes a
non-empty file, so inverting that one branch to `return set.size > 0 ? set : null`
passed all 184 tests while making a run holding an empty approved list delete
every `DELETE` verdict it classified and exit 0 reporting success — which the
apply path itself names as this loop's worst failure mode.

`TC-SLACKAPP-133` covers an empty file, a lone newline and whitespace-only, plus
the converse (no `--ids` at all still means no filter) so a fix cannot be written
as "treat empty and absent alike" — the operator CLI runs without `--ids` and
must keep deleting what it classified.

Asserted through real `runCleanup` rather than on `readApprovedIds` directly,
because the hazard is what the **call site** does with null. That choice is what
makes it a barrier rather than a spelling check: it was verified against three
separate reintroduction sites — the reader's return, the call-site binding, and an
`approved.size > 0` short-circuit inside `applyDecisions`.

Review then found the same hazard reachable by a **more plausible** edit than the
one being guarded: `try { … } catch { return null; }` around the read, or an
`existsSync` guard, reads as ordinary defensive tidying and passed 188/188 — while
turning a typo in the `--ids` path into unapproved deletions with exit 0. That is
now pinned too.

## Gap 2 — the signing secret must never reach an argv

`/proc/PID/cmdline` is mode 444 and `/proc/PID/environ` is mode 400 (measured on
the runner, not assumed), so the channel is the whole property: an env prefix is
owner-only, a command word is readable by every process on the box.

The old assertion inspected only lines mentioning `SIGNING_SECRET` and separately
forbade the token `-hmac`. One alias defeated it — after `SIG_KEY="$SIGNING_SECRET"`
the signing line no longer mentions the secret and was never inspected, and any
tool whose flag is not spelled `-hmac` put the key on an argv with the suite green.

Replaced with `auditSecretTaint`: the transitive closure of every name assigned
from `SIGNING_SECRET`, with each expansion judged by the **position** it holds. It
names no tool and no flag, so a signer rewritten around a different tool is judged
by the same rule. Two counters keep it non-vacuous — `uses > 0` (a file-wide
rename cannot make it an audit of nothing) and `envUses > 0` (the secret must
still reach a child, through the environment). The leak assertion runs *before*
the counters, because an argv rewrite trips both and "expected 0 to be greater
than 0" would send the reader looking for a deleted signer.

Three holes in my own auditor were found by review and closed, each having been
verified as a **working leak that passed**:

- **`=`-bearing arguments to a command already underway.** The exemption only
  checked that an identifier and an `=` preceded the value, which is equally true
  of `awk -v key="$SECRET"` and `docker run -e SEC="$SECRET"` — both leaks, and
  both counted as `envUses`, so a leak *satisfied* the non-vacuity check. The
  exemption now requires the position a **command** could occupy.
- **Any parameter-expansion operator.** Matching only the bare `${NAME}` left the
  audit defeasible by one character: `"${SIGNING_SECRET#}"` is the secret verbatim,
  yields a byte-identical HMAC, and was invisible to the scan *and* to `uses`. It
  needed no alias, bypassing the closure entirely.
- **`envUses` counted a trailing comment as a child process,** so deleting the
  signer while leaving `SIG_KEY="$SIGNING_SECRET"  # unused` behind passed the
  check that exists to fail exactly that.

One inverted rule was also fixed: a here-string hands the value over on a file
descriptor — *more* private than the sanctioned env channel — yet was reported as
"argv is world-readable" about a line with no argv. Piping from a builtin and
calling a shell function stay rejected on purpose, with the reason recorded in the
code: position cannot separate `printf '%s' "$S" | cmd` from
`openssl dgst -hmac "$S" | tee`, and enumerating builtins is the
vocabulary-dependence this audit exists to avoid.

## Verification

Every claim below was produced by running the mutation, not by inspection.

- Documented mutations: gap 1 → 3 failures; gap 2 (both the `node`-argv and the
  `openssl -macopt "key:$KEY"` rewrites) → reported as leaks, naming the tainted
  alias.
- Additional leaks caught: 12 parameter-expansion operator forms, the aliased
  `${SIG_KEY:-}` rewrite, `awk -v key=`, `docker run -e SEC=`, `--key=`,
  multi-hop launders, launders after `;`/`&&`, `[[ -n "$X" ]] && cmd "$S"`, pipes.
- Non-vacuity fires: a deleted signer, a signer whose alias is kept, and a
  file-wide rename of the secret each fail.
- No false positives across 12 legitimate refactors: `export`-then-child, renamed
  prefix vars, `A=1 K="$S" B=2 cmd`, `local`/`readonly`/`declare`, line
  continuations, `export` after `then`, all three guard forms, `${#NAME}`,
  `${KEYSTORE}` against a taint on `KEY`, here-strings.
- Gates: 898 tests pass (was 893), `tsc --noEmit` clean, cleanup coverage 91.65%
  lines, all four CI shellcheck targets clean under shellcheck 0.11.0 (CI pins
  0.11.0.1), and `git diff --exit-code` confirms both implementation files
  unchanged.