### PR TITLE
fix(oauth-facade): advertise the façade's own issuer in RFC 8414 metadata (#143)

### DIFF
--- a/docs/test-cases/oauth-facade-metadata-issuer.md
+++ b/docs/test-cases/oauth-facade-metadata-issuer.md
@@ -1,0 +1,60 @@
+# Test cases: OAuth façade metadata issuer (RFC 8414 §3.3)
+
+The façade publishes itself as the authorization server in its RFC 9728
+protected-resource document (`authorization_servers: [<base>]`). RFC 8414 §3.3
+therefore requires the `issuer` in the metadata it serves at its own well-known
+paths to be **identical** to that same base URL:
+
+> The `issuer` value returned MUST be identical to the authorization server's
+> issuer identifier value into which the well-known URI string was inserted to
+> create the URL used to retrieve the metadata. If these values are not
+> identical, the data contained in the response MUST NOT be used.
+
+Before #143 both documents returned the **upstream Cognito** issuer instead. A
+client that enforces §3.3 (`rmcp >= 3.0.0`, e.g. Codex `0.147.0`) discards the
+whole document and fails MCP startup with `Authorization server issuer mismatch`.
+Clients that skip the check were unaffected, which is why the defect survived from
+the façade's first commit.
+
+Cognito remains the token issuer: minted JWTs still carry the Cognito `iss` claim,
+and the AgentCore Gateway's JWT authorizer still validates against Cognito's own
+discovery URL. Only the metadata *self-identifier* is the façade's.
+
+## Unit tests
+
+`infra/src/oauth-facade/handler.test.ts`
+
+| ID | Scenario | Expected |
+|---|---|---|
+| TC-MCPGW-079 | Fetch the protected-resource, AS-metadata, and OIDC-discovery documents on the **bare** well-known paths | `issuer` in both the AS and OIDC documents is identical to `authorization_servers[0]`, and neither equals the upstream Cognito issuer |
+| TC-MCPGW-079 | Same three documents on the **resource-suffixed** paths (`/.well-known/<doc>/mcp`) | Identical result — this is the path a spec-compliant client queries first (see TC-MCPGW-061c) |
+
+Both cases assert the **relationship between the two live documents** rather than a
+hardcoded hostname. A test pinning the literal expected host would keep passing if
+the two documents later drifted apart again, which is precisely the defect. The
+`not.toBe(UPSTREAM_ISSUER)` assertions additionally catch a partial fix that
+updates only one of the two handlers.
+
+## E2E / preview tests
+
+`scripts/run-oauth-facade-smoke.sh` (run by the `deploy-preview` job's
+"OAuth façade smoke (preview)" step)
+
+| ID | Scenario | Expected |
+|---|---|---|
+| TC-MCPGW-079 | Against the **deployed** façade, compare `.issuer` from `/.well-known/oauth-authorization-server` with `.authorization_servers[0]` from `/.well-known/oauth-protected-resource` | Identical; otherwise `::error::` and a non-zero exit |
+| TC-MCPGW-079 | Same comparison for `/.well-known/openid-configuration` | Identical; otherwise `::error::` and a non-zero exit |
+
+The script already validated `authorization_endpoint`, `token_endpoint`, S256,
+`registration_endpoint`, and the public-client auth method — but never `issuer`,
+so it could not have caught this. Verified by running the assertion block against
+two mock façades: one advertising its own base (passes, exit 0) and one
+reproducing the pre-fix shape (fails with the `::error::` line, exit 1).
+
+## Config
+
+`infra/src/oauth-facade/config.test.ts`
+
+| ID | Scenario | Expected |
+|---|---|---|
+| — | `loadConfig` with a required env var absent | Still throws `missing env <NAME>`. The case previously used the upstream-issuer env var; #143 removed that variable (nothing consumed it once the façade stopped advertising the upstream issuer), so the case was **re-pointed** to another required var rather than deleted |

--- a/docs/test-cases/oauth-facade-metadata-issuer.md
+++ b/docs/test-cases/oauth-facade-metadata-issuer.md
@@ -29,11 +29,39 @@ discovery URL. Only the metadata *self-identifier* is the façade's.
 | TC-MCPGW-079 | Fetch the protected-resource, AS-metadata, and OIDC-discovery documents on the **bare** well-known paths | `issuer` in both the AS and OIDC documents is identical to `authorization_servers[0]`, and neither equals the upstream Cognito issuer |
 | TC-MCPGW-079 | Same three documents on the **resource-suffixed** paths (`/.well-known/<doc>/mcp`) | Identical result — this is the path a spec-compliant client queries first (see TC-MCPGW-061c) |
 
-Both cases assert the **relationship between the two live documents** rather than a
-hardcoded hostname. A test pinning the literal expected host would keep passing if
-the two documents later drifted apart again, which is precisely the defect. The
-`not.toBe(UPSTREAM_ISSUER)` assertions additionally catch a partial fix that
-updates only one of the two handlers.
+Both cases assert **two things, because either alone is insufficient**:
+
+1. the **relationship** between the live documents (`issuer` ===
+   `authorization_servers[0]`) — this is what §3.3 actually requires, and it holds
+   on any host or stage; and
+2. an **absolute anchor** (`authorization_servers[0]` === the façade's own base) —
+   this is what rules out *coordinated* drift.
+
+Relationship-only would be strictly weaker: three documents that all agree on the
+**upstream** issuer satisfy §3.3 while sending clients to Cognito, which publishes
+no `registration_endpoint` — so DCR fails and #143's symptom returns by another
+route. Verified against a mock serving exactly that shape.
+
+The `not.toBe(UPSTREAM_ISSUER)` assertions additionally catch a partial fix that
+updates only one of the two handlers (verified by mutation: reverting either handler
+alone fails both cases).
+
+## Related asymmetry closed at the same time
+
+The defect shipped because one document was asserted and its twin was trusted. The
+same asymmetry existed two fields over, so `TC-MCPGW-080` now pins
+`authorization_endpoint`, `token_endpoint`, `registration_endpoint` (must be the
+façade's) and `jwks_uri`, `userinfo_endpoint`, `revocation_endpoint` (must be
+Cognito's) on **both** documents. Before it, pointing the OIDC document's
+`authorization_endpoint` or `token_endpoint` at upstream Cognito — or replacing
+`jwks_uri` with a garbage value — passed all 57 handler cases.
+
+`TC-MCPGW-081` covers the `WWW-Authenticate` rewrite on a 401 from upstream. That
+header is the RFC 9728 discovery *entry point* — it tells the client where the
+protected-resource document lives — and it embeds the same host-derived base under
+the same invariant, yet had no coverage: pointing it at an unrelated host also
+passed all 57 cases. Because discovery never starts if this URL is wrong, no
+metadata test can observe that failure.
 
 ## E2E / preview tests
 
@@ -42,14 +70,34 @@ updates only one of the two handlers.
 
 | ID | Scenario | Expected |
 |---|---|---|
-| TC-MCPGW-079 | Against the **deployed** façade, compare `.issuer` from `/.well-known/oauth-authorization-server` with `.authorization_servers[0]` from `/.well-known/oauth-protected-resource` | Identical; otherwise `::error::` and a non-zero exit |
+| TC-MCPGW-079 | Against the **deployed** façade, assert `.authorization_servers[0]` is the façade URL read from SSM (the absolute anchor; trailing slash normalized) | Identical; otherwise `::error::` and a non-zero exit |
+| TC-MCPGW-079 | Compare `.issuer` from `/.well-known/oauth-authorization-server` with `.authorization_servers[0]` | Identical; otherwise `::error::` and a non-zero exit |
 | TC-MCPGW-079 | Same comparison for `/.well-known/openid-configuration` | Identical; otherwise `::error::` and a non-zero exit |
+| TC-MCPGW-079 | Any of those fields **missing, null, or empty** in the live documents | `::error::` naming the field, then a non-zero exit |
+| TC-MCPGW-079 | `authorization_servers[0]` differs from the AS `issuer` only by a **trailing slash** | Fails the §3.3 comparison. The anchor check normalizes the trailing slash (SSM is deployment ground truth for the façade's own URL); the document-to-document comparison is byte-exact, because §3.3 requires *identical*, and a compliant client rejects on the byte difference |
 
 The script already validated `authorization_endpoint`, `token_endpoint`, S256,
 `registration_endpoint`, and the public-client auth method — but never `issuer`,
 so it could not have caught this. Verified by running the assertion block against
-two mock façades: one advertising its own base (passes, exit 0) and one
-reproducing the pre-fix shape (fails with the `::error::` line, exit 1).
+mock façades: one advertising its own base (passes, exit 0), one reproducing the
+pre-fix shape (fails with the `::error::` line, exit 1), and one where all three
+documents agree on the upstream issuer — §3.3-clean but functionally broken, which
+the anchor is what catches.
+
+The missing-field row is why each field is presence-checked on its own line before it
+is read. Two shorter forms were tried against a mock serving a null `.issuer` and both
+exit non-zero with **no `::error::` and no field named**, leaving an operator with
+truncated output and no cause: a bare `jq -er` inside the assignment lets `set -e` kill
+the script *at the assignment*, and hoisting the diagnostic into a helper invoked as
+`$(field ...)` only redirects that diagnostic into the captured stdout — the same
+silent failure, one level less obvious. The mock is also what caught it; the first two
+attempts read as correct.
+
+The mock harness asserts its extracted block contains every `::error::` string before
+it runs a single mode. An earlier run of it reported two spurious passes because the
+extraction had silently truncated at the first `fi`, so the checks under test were
+never in the file being exercised — a green result from a harness that isn't running
+the code is worse than a red one.
 
 ## Config
 

--- a/docs/test-cases/oauth-facade-metadata-issuer.md
+++ b/docs/test-cases/oauth-facade-metadata-issuer.md
@@ -93,6 +93,11 @@ the script *at the assignment*, and hoisting the diagnostic into a helper invoke
 silent failure, one level less obvious. The mock is also what caught it; the first two
 attempts read as correct.
 
+The block prints its own progress line (`checking metadata issuer identity`, then
+`issuer identity OK — …`) for the same reason. On the first preview run the step passed
+with no line of its own, so the only evidence the checks had executed was `set -e`
+having reached the next section — indistinguishable from a block that was skipped.
+
 The mock harness asserts its extracted block contains every `::error::` string before
 it runs a single mode. An earlier run of it reported two spurious passes because the
 extraction had silently truncated at the first `fi`, so the checks under test were

--- a/infra/oauth-facade.ts
+++ b/infra/oauth-facade.ts
@@ -204,7 +204,11 @@ export function oauthFacade(cognitoOut: CognitoOutputs): OauthFacadeOutputs {
       // the deploy stayed green. Neither loadConfig nor resolveSsm reads STAGE,
       // so nothing else in the config path would surface the omission.
       STAGE: stage,
-      COGNITO_ISSUER: cognitoOut.issuer,
+      // The upstream Cognito issuer is deliberately NOT passed to the façade: its
+      // metadata documents must advertise their OWN issuer (RFC 8414 §3.3), which
+      // left the upstream value with no consumer (#143). The Gateway's JWT
+      // authorizer builds its discoveryUrl from `cognitoOut.issuer` directly
+      // (infra/gateway.ts), so token validation does not depend on this env.
       COGNITO_AUTHORIZE_ENDPOINT: cognitoOut.authorizeEndpoint,
       COGNITO_TOKEN_ENDPOINT: cognitoOut.tokenEndpoint,
       COGNITO_USERINFO_ENDPOINT: cognitoOut.userInfoEndpoint,

--- a/infra/src/oauth-facade/config.test.ts
+++ b/infra/src/oauth-facade/config.test.ts
@@ -33,7 +33,6 @@ const fullSsm = {
 
 const baseEnv = {
   SSM_PREFIX: PREFIX,
-  COGNITO_ISSUER: "https://issuer",
   COGNITO_AUTHORIZE_ENDPOINT: "https://authz",
   COGNITO_TOKEN_ENDPOINT: "https://token",
   COGNITO_USERINFO_ENDPOINT: "https://userinfo",
@@ -81,7 +80,6 @@ describe("façade config loader (cycle-break SSM reads)", () => {
     expect(cfg.upstream).toBe("https://gw");
     expect(cfg.userClientId).toBe("cid");
     expect(cfg.userClientSecret).toBe("csecret");
-    expect(cfg.issuer).toBe("https://issuer");
     expect(cfg.hmacKey).toBe("the-key");
     expect(cfg.resourceScopes).toEqual([
       "example-mcp/query/read",
@@ -92,11 +90,15 @@ describe("façade config loader (cycle-break SSM reads)", () => {
     ]);
   });
 
+  // Asserts `reqEnv`'s fail-closed behavior via a representative required var.
+  // It used to name the upstream issuer var, which #143 removed once the façade
+  // stopped advertising that issuer — re-pointed rather than deleted so a missing
+  // required env keeps failing loudly at cold start.
   it("loadConfig throws when a required env var is missing", async () => {
-    const env = { ...baseEnv, COGNITO_ISSUER: undefined };
+    const env = { ...baseEnv, COGNITO_TOKEN_ENDPOINT: undefined };
     await expect(
       loadConfig({ ssm: ssmReturning(fullSsm), env }),
-    ).rejects.toThrow(/missing env COGNITO_ISSUER/);
+    ).rejects.toThrow(/missing env COGNITO_TOKEN_ENDPOINT/);
   });
 
   it("empty OAUTH_STATE_HMAC_KEY is preserved as the proxy-disabled sentinel", async () => {

--- a/infra/src/oauth-facade/config.ts
+++ b/infra/src/oauth-facade/config.ts
@@ -31,8 +31,6 @@ import { GetParametersCommand, SSMClient } from "@aws-sdk/client-ssm";
 export interface FacadeConfig {
   /** AgentCore Gateway URL the façade proxies to (`/mcp` + fallthrough). */
   upstream: string;
-  /** Cognito OIDC issuer. */
-  issuer: string;
   /** Cognito Hosted-UI authorize / token / userinfo / revocation / jwks. */
   authorize: string;
   token: string;
@@ -194,7 +192,6 @@ export async function loadConfig(
   const resolved = await resolveSsm(prefix, ssm);
   return {
     upstream: resolved.upstream,
-    issuer: reqEnv(env, "COGNITO_ISSUER"),
     authorize: reqEnv(env, "COGNITO_AUTHORIZE_ENDPOINT"),
     token: reqEnv(env, "COGNITO_TOKEN_ENDPOINT"),
     userinfo: reqEnv(env, "COGNITO_USERINFO_ENDPOINT"),

--- a/infra/src/oauth-facade/handler.test.ts
+++ b/infra/src/oauth-facade/handler.test.ts
@@ -1,5 +1,5 @@
 /**
- * Unit tests for the façade routing (TC-MCPGW-060..078).
+ * Unit tests for the façade routing (TC-MCPGW-060..081).
  * Exercised through the injected `route(event, cfg)` seam — no AWS/SSM.
  */
 
@@ -85,7 +85,7 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe("façade routing (TC-MCPGW-060..073)", () => {
+describe("façade routing (TC-MCPGW-060..081)", () => {
   it("TC-MCPGW-060: protected-resource metadata points at <base>/mcp", async () => {
     const res = await route(ev("/.well-known/oauth-protected-resource"), cfg());
     expect(res.statusCode).toBe(200);
@@ -126,6 +126,37 @@ describe("façade routing (TC-MCPGW-060..073)", () => {
     expect(b.scopes_supported).not.toContain("example-mcp/query/write");
   });
 
+  // TC-MCPGW-080. The OIDC document is a full peer of the RFC 8414 one — some
+  // clients only know this path — but only its scopes and `registration_endpoint`
+  // were ever asserted, while TC-MCPGW-061 pins the AS document's endpoints. That
+  // asymmetry (one document tested, its twin trusted) is exactly what let #143
+  // ship, so the same fields are pinned on both. Verified by mutation: pointing
+  // either OIDC endpoint at the upstream Cognito value passed all 57 cases before
+  // this was added.
+  it.each([
+    ["/.well-known/oauth-authorization-server", "RFC 8414"],
+    ["/.well-known/openid-configuration", "OIDC discovery"],
+  ])(
+    "TC-MCPGW-080: %s metadata routes authorize/token through the façade and passes the rest through to Cognito",
+    async (path) => {
+      const b = JSON.parse((await route(ev(path), cfg())).body);
+      // Must be OURS: these are the redirect-proxy routes. Sending a client
+      // straight to Cognito's own endpoints skips the state/PKCE proxy and the
+      // secret injection at /oauth/token.
+      expect(b.authorization_endpoint).toBe(`${BASE}/oauth/authorize`);
+      expect(b.token_endpoint).toBe(`${BASE}/oauth/token`);
+      // Must be OURS: Cognito publishes no registration_endpoint, so DCR only
+      // works through the façade.
+      expect(b.registration_endpoint).toBe(`${BASE}/register`);
+      // Must be COGNITO'S: the façade proxies none of these, and a client that
+      // fetches JWKS itself validates tokens against this URL. Untested until
+      // now — replacing jwks_uri with a garbage value passed all 57 cases.
+      expect(b.jwks_uri).toBe(cfg().jwks);
+      expect(b.userinfo_endpoint).toBe(cfg().userinfo);
+      expect(b.revocation_endpoint).toBe(cfg().revocation);
+    },
+  );
+
   it("TC-MCPGW-061c: resource-suffixed well-known paths (/.well-known/<doc>/mcp) return the FAÇADE metadata, not the raw Gateway", async () => {
     // A spec-compliant MCP client (RFC 9728/8414) queries the resource-suffixed
     // path first. Without normalization these fell through to the catch-all proxy
@@ -157,9 +188,45 @@ describe("façade routing (TC-MCPGW-060..073)", () => {
   // Cognito's issuer here made rmcp >= 3.0.0 clients discard the document and fail
   // MCP startup outright.
   //
-  // Asserted as a RELATIONSHIP between the two documents rather than against a
-  // hardcoded host: pinning the literal string would still pass if the two
-  // documents later drifted apart, which is exactly the bug being fixed.
+  // Asserted BOTH ways, because either alone is insufficient. The relationship
+  // (`as.issuer === pr.authorization_servers[0]`) is what §3.3 actually requires
+  // and survives a host/stage change. The absolute anchor (`advertisedAs === BASE`)
+  // is what rules out COORDINATED drift: three documents that agree on the upstream
+  // issuer satisfy §3.3 while sending clients to Cognito, which serves no
+  // `/register` — reproducing #143's symptom by another route.
+  // TC-MCPGW-081. The 401's `WWW-Authenticate` is the RFC 9728 discovery ENTRY
+  // POINT: it is how a client learns where the protected-resource document lives,
+  // so if this URL is wrong discovery never starts and no metadata test can see
+  // the breakage. It embeds `base` under the same host-agreement invariant as the
+  // metadata `issuer` this PR fixes, and had no coverage at all — pointing it at
+  // an unrelated host passed all 57 cases.
+  it("TC-MCPGW-081: a 401 from upstream advertises the FAÇADE's resource metadata, not the Gateway's", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      async () =>
+        new Response("unauthorized", {
+          status: 401,
+          // The raw Gateway points at its own Cognito-backed metadata, which has
+          // no /register — the value that must NOT survive the rewrite.
+          headers: {
+            "www-authenticate": `Bearer resource_metadata="${UPSTREAM_ISSUER}/.well-known/oauth-protected-resource"`,
+          },
+        }),
+    );
+    const res = await route(ev("/mcp", "POST", { body: "{}" }), cfg());
+    expect(res.statusCode).toBe(401);
+    expect(res.headers["www-authenticate"]).toBe(
+      `Bearer resource_metadata="${BASE}/.well-known/oauth-protected-resource"`,
+    );
+    // The advertised document must be the one the façade actually serves, so a
+    // client that follows this header reaches metadata naming us as the AS.
+    const pr = JSON.parse(
+      (await route(ev("/.well-known/oauth-protected-resource"), cfg())).body,
+    );
+    expect(res.headers["www-authenticate"]).toContain(
+      pr.authorization_servers[0],
+    );
+  });
+
   // The suffix is the only thing that varies — `wellKnown` strips a trailing
   // `/mcp` before matching, so both variants must hold the same property.
   it.each([

--- a/infra/src/oauth-facade/handler.test.ts
+++ b/infra/src/oauth-facade/handler.test.ts
@@ -180,20 +180,6 @@ describe("façade routing (TC-MCPGW-060..081)", () => {
     expect(oidc.registration_endpoint).toBe(`${BASE}/register`);
   });
 
-  // TC-MCPGW-079. RFC 8414 §3.3: the `issuer` a metadata document returns MUST be
-  // identical to the issuer identifier the client inserted the well-known string
-  // into to build the URL it fetched. We publish ourselves as the authorization
-  // server (`authorization_servers: [base]`), so that identifier is our own base —
-  // NOT Cognito's issuer, even though Cognito mints the tokens. Advertising
-  // Cognito's issuer here made rmcp >= 3.0.0 clients discard the document and fail
-  // MCP startup outright.
-  //
-  // Asserted BOTH ways, because either alone is insufficient. The relationship
-  // (`as.issuer === pr.authorization_servers[0]`) is what §3.3 actually requires
-  // and survives a host/stage change. The absolute anchor (`advertisedAs === BASE`)
-  // is what rules out COORDINATED drift: three documents that agree on the upstream
-  // issuer satisfy §3.3 while sending clients to Cognito, which serves no
-  // `/register` — reproducing #143's symptom by another route.
   // TC-MCPGW-081. The 401's `WWW-Authenticate` is the RFC 9728 discovery ENTRY
   // POINT: it is how a client learns where the protected-resource document lives,
   // so if this URL is wrong discovery never starts and no metadata test can see
@@ -227,6 +213,21 @@ describe("façade routing (TC-MCPGW-060..081)", () => {
     );
   });
 
+  // TC-MCPGW-079. RFC 8414 §3.3: the `issuer` a metadata document returns MUST be
+  // identical to the issuer identifier the client inserted the well-known string
+  // into to build the URL it fetched. We publish ourselves as the authorization
+  // server (`authorization_servers: [base]`), so that identifier is our own base —
+  // NOT Cognito's issuer, even though Cognito mints the tokens. Advertising
+  // Cognito's issuer here made rmcp >= 3.0.0 clients discard the document and fail
+  // MCP startup outright.
+  //
+  // Asserted BOTH ways, because either alone is insufficient. The relationship
+  // (`as.issuer === pr.authorization_servers[0]`) is what §3.3 actually requires
+  // and survives a host/stage change. The absolute anchor (`advertisedAs === BASE`)
+  // is what rules out COORDINATED drift: three documents that agree on the upstream
+  // issuer satisfy §3.3 while sending clients to Cognito, which serves no
+  // `/register` — reproducing #143's symptom by another route.
+  //
   // The suffix is the only thing that varies — `wellKnown` strips a trailing
   // `/mcp` before matching, so both variants must hold the same property.
   it.each([

--- a/infra/src/oauth-facade/handler.test.ts
+++ b/infra/src/oauth-facade/handler.test.ts
@@ -27,11 +27,16 @@ const HOST = "abc123.lambda-url.ap-northeast-1.on.aws";
 const BASE = `https://${HOST}`;
 const HMAC = "unit-test-hmac-key";
 const REMOTE_CALLBACK = "https://oauth.example.com/callback/app";
+/**
+ * The upstream Cognito issuer. Cognito still mints and signs every token, but the
+ * façade must never advertise this as the `issuer` of its OWN metadata documents
+ * (RFC 8414 §3.3) — see TC-MCPGW-079.
+ */
+const UPSTREAM_ISSUER = "https://cognito-idp.ap-northeast-1.amazonaws.com/pool";
 
 function cfg(overrides: Partial<FacadeConfig> = {}): FacadeConfig {
   return {
     upstream: "https://gateway.example/mcp-prefix",
-    issuer: "https://cognito-idp.ap-northeast-1.amazonaws.com/pool",
     authorize: "https://auth.example.com/oauth2/authorize",
     token: "https://auth.example.com/oauth2/token",
     userinfo: "https://auth.example.com/oauth2/userInfo",
@@ -143,6 +148,44 @@ describe("façade routing (TC-MCPGW-060..073)", () => {
     );
     expect(oidc.registration_endpoint).toBe(`${BASE}/register`);
   });
+
+  // TC-MCPGW-079. RFC 8414 §3.3: the `issuer` a metadata document returns MUST be
+  // identical to the issuer identifier the client inserted the well-known string
+  // into to build the URL it fetched. We publish ourselves as the authorization
+  // server (`authorization_servers: [base]`), so that identifier is our own base —
+  // NOT Cognito's issuer, even though Cognito mints the tokens. Advertising
+  // Cognito's issuer here made rmcp >= 3.0.0 clients discard the document and fail
+  // MCP startup outright.
+  //
+  // Asserted as a RELATIONSHIP between the two documents rather than against a
+  // hardcoded host: pinning the literal string would still pass if the two
+  // documents later drifted apart, which is exactly the bug being fixed.
+  // The suffix is the only thing that varies — `wellKnown` strips a trailing
+  // `/mcp` before matching, so both variants must hold the same property.
+  it.each([
+    ["bare", ""],
+    ["resource-suffixed", "/mcp"],
+  ])(
+    "TC-MCPGW-079: advertised issuer is identical to authorization_servers[0] on %s well-known paths",
+    async (_label, suffix) => {
+      const doc = async (name: string) =>
+        JSON.parse((await route(ev(`/.well-known/${name}${suffix}`), cfg())).body);
+      const pr = await doc("oauth-protected-resource");
+      const as = await doc("oauth-authorization-server");
+      const oidc = await doc("openid-configuration");
+
+      const advertisedAs = pr.authorization_servers[0];
+      expect(advertisedAs).toBe(BASE);
+      // Both documents self-identify as the AS the client was pointed at.
+      expect(as.issuer).toBe(advertisedAs);
+      expect(oidc.issuer).toBe(advertisedAs);
+
+      // Guards a partial fix that changes only one of the two handlers: neither
+      // document may leak the upstream issuer.
+      expect(as.issuer).not.toBe(UPSTREAM_ISSUER);
+      expect(oidc.issuer).not.toBe(UPSTREAM_ISSUER);
+    },
+  );
 
   it("TC-MCPGW-062: /oauth/authorize sends Cognito a short signed handle and stores client state in a signed cookie", async () => {
     const q = new URLSearchParams({

--- a/infra/src/oauth-facade/handler.ts
+++ b/infra/src/oauth-facade/handler.ts
@@ -293,7 +293,16 @@ export async function route(
   // façade so clients hit the redirect proxy; the rest pass through to Cognito.
   if (wellKnown === "/.well-known/oauth-authorization-server") {
     return json(200, {
-      issuer: cfg.issuer,
+      // RFC 8414 §3.3: this MUST be identical to the issuer identifier the client
+      // inserted the well-known string into to build the URL it just fetched. We
+      // publish ourselves as the authorization server above
+      // (`authorization_servers: [base]`), so that identifier is `base` — NOT
+      // Cognito's issuer, even though Cognito mints and signs every token. A
+      // client that enforces §3.3 (rmcp >= 3.0.0) discards the whole document on
+      // a mismatch and fails MCP startup. Tokens keep their Cognito `iss` claim
+      // and the Gateway keeps validating against Cognito's own discovery URL;
+      // only this self-identifier is ours.
+      issuer: base,
       authorization_endpoint: `${base}/oauth/authorize`,
       token_endpoint: `${base}/oauth/token`,
       userinfo_endpoint: cfg.userinfo,
@@ -321,7 +330,9 @@ export async function route(
   // OIDC discovery (some clients only know this path).
   if (wellKnown === "/.well-known/openid-configuration") {
     return json(200, {
-      issuer: cfg.issuer,
+      // Same self-identifier rule as the RFC 8414 document above — a client that
+      // discovers us through this path applies the identical check.
+      issuer: base,
       authorization_endpoint: `${base}/oauth/authorize`,
       token_endpoint: `${base}/oauth/token`,
       userinfo_endpoint: cfg.userinfo,

--- a/scripts/run-oauth-facade-smoke.sh
+++ b/scripts/run-oauth-facade-smoke.sh
@@ -28,6 +28,25 @@ echo "run-oauth-facade-smoke: checking /.well-known/oauth-protected-resource"
 PR=$(curl -fsS "${FACADE}/.well-known/oauth-protected-resource")
 echo "$PR" | jq -e '.resource | endswith("/mcp")' >/dev/null || { echo "::error::protected-resource.resource does not end with /mcp"; exit 1; }
 
+# TC-MCPGW-079. RFC 8414 §3.3: the AS metadata `issuer` MUST be identical to the
+# issuer identifier the client inserted the well-known string into — which is the
+# `authorization_servers` entry published above. A mismatch makes a compliant
+# client (rmcp >= 3.0.0) discard the document and fail MCP startup entirely. The
+# checks above validated every other advertised field but never this one, which is
+# why the façade advertised Cognito's issuer undetected. Compared as a relationship
+# between the two live documents, so it holds on any stage/domain.
+AS_ISSUER=$(echo "$AS" | jq -er '.issuer')
+ADVERTISED_AS=$(echo "$PR" | jq -er '.authorization_servers[0]')
+if [[ "$AS_ISSUER" != "$ADVERTISED_AS" ]]; then
+  echo "::error::AS metadata issuer (${AS_ISSUER}) != authorization_servers[0] (${ADVERTISED_AS}) — RFC 8414 §3.3 violation; compliant clients will refuse this façade"
+  exit 1
+fi
+OIDC_ISSUER=$(curl -fsS "${FACADE}/.well-known/openid-configuration" | jq -er '.issuer')
+if [[ "$OIDC_ISSUER" != "$ADVERTISED_AS" ]]; then
+  echo "::error::OIDC discovery issuer (${OIDC_ISSUER}) != authorization_servers[0] (${ADVERTISED_AS}) — clients discovering via openid-configuration will refuse this façade"
+  exit 1
+fi
+
 echo "run-oauth-facade-smoke: checking /register returns a public client (no secret)"
 DCR=$(curl -fsS -X POST -H 'Content-Type: application/json' -d '{"redirect_uris":["http://localhost:8080/cb"]}' "${FACADE}/register")
 echo "$DCR" | jq -e '.client_id | length > 0' >/dev/null || { echo "::error::DCR did not return client_id"; exit 1; }

--- a/scripts/run-oauth-facade-smoke.sh
+++ b/scripts/run-oauth-facade-smoke.sh
@@ -33,15 +33,34 @@ echo "$PR" | jq -e '.resource | endswith("/mcp")' >/dev/null || { echo "::error:
 # `authorization_servers` entry published above. A mismatch makes a compliant
 # client (rmcp >= 3.0.0) discard the document and fail MCP startup entirely. The
 # checks above validated every other advertised field but never this one, which is
-# why the façade advertised Cognito's issuer undetected. Compared as a relationship
-# between the two live documents, so it holds on any stage/domain.
-AS_ISSUER=$(echo "$AS" | jq -er '.issuer')
-ADVERTISED_AS=$(echo "$PR" | jq -er '.authorization_servers[0]')
+# why the façade advertised Cognito's issuer undetected.
+#
+# Each field is PRESENCE-CHECKED before it is read, in this shell, using the same
+# `jq -e ... || { echo; exit 1; }` idiom as the checks above. Neither shorter form
+# works: a bare `jq -er` in the assignment lets `set -e` kill the script AT the
+# assignment with no `::error::` and no field named, and moving the diagnostic into
+# a helper called as `$(field ...)` only swallows it into the captured stdout —
+# same silent non-zero exit. Verified against a mock serving a null `.issuer`.
+echo "$AS" | jq -e '(.issuer // "") != ""' >/dev/null || { echo "::error::authorization-server metadata .issuer is missing or empty"; exit 1; }
+echo "$PR" | jq -e '(.authorization_servers[0] // "") != ""' >/dev/null || { echo "::error::protected-resource .authorization_servers[0] is missing or empty"; exit 1; }
+AS_ISSUER=$(echo "$AS" | jq -r '.issuer')
+ADVERTISED_AS=$(echo "$PR" | jq -r '.authorization_servers[0]')
+# The relationship alone is NOT enough: documents that agree on the UPSTREAM issuer
+# satisfy §3.3 while pointing clients at Cognito, which publishes no
+# `registration_endpoint` — so DCR fails and #143's symptom returns by another
+# route. Anchor to the façade URL read from SSM above, which is deployment ground
+# truth rather than a hardcoded host, so this still holds on any stage/domain.
+if [[ "${ADVERTISED_AS%/}" != "${FACADE%/}" ]]; then
+  echo "::error::protected-resource authorization_servers[0] (${ADVERTISED_AS}) is not this façade (${FACADE}) — clients would be sent elsewhere for authorization"
+  exit 1
+fi
 if [[ "$AS_ISSUER" != "$ADVERTISED_AS" ]]; then
   echo "::error::AS metadata issuer (${AS_ISSUER}) != authorization_servers[0] (${ADVERTISED_AS}) — RFC 8414 §3.3 violation; compliant clients will refuse this façade"
   exit 1
 fi
-OIDC_ISSUER=$(curl -fsS "${FACADE}/.well-known/openid-configuration" | jq -er '.issuer')
+OIDC=$(curl -fsS "${FACADE}/.well-known/openid-configuration")
+echo "$OIDC" | jq -e '(.issuer // "") != ""' >/dev/null || { echo "::error::openid-configuration .issuer is missing or empty"; exit 1; }
+OIDC_ISSUER=$(echo "$OIDC" | jq -r '.issuer')
 if [[ "$OIDC_ISSUER" != "$ADVERTISED_AS" ]]; then
   echo "::error::OIDC discovery issuer (${OIDC_ISSUER}) != authorization_servers[0] (${ADVERTISED_AS}) — clients discovering via openid-configuration will refuse this façade"
   exit 1

--- a/scripts/run-oauth-facade-smoke.sh
+++ b/scripts/run-oauth-facade-smoke.sh
@@ -41,6 +41,11 @@ echo "$PR" | jq -e '.resource | endswith("/mcp")' >/dev/null || { echo "::error:
 # assignment with no `::error::` and no field named, and moving the diagnostic into
 # a helper called as `$(field ...)` only swallows it into the captured stdout —
 # same silent non-zero exit. Verified against a mock serving a null `.issuer`.
+#
+# This block prints its own progress line for the same reason: a green job is not
+# evidence that a specific assertion ran, and without a line of its own the only
+# proof these checks executed is `set -e` having reached the next section.
+echo "run-oauth-facade-smoke: checking metadata issuer identity (RFC 8414 §3.3)"
 echo "$AS" | jq -e '(.issuer // "") != ""' >/dev/null || { echo "::error::authorization-server metadata .issuer is missing or empty"; exit 1; }
 echo "$PR" | jq -e '(.authorization_servers[0] // "") != ""' >/dev/null || { echo "::error::protected-resource .authorization_servers[0] is missing or empty"; exit 1; }
 AS_ISSUER=$(echo "$AS" | jq -r '.issuer')
@@ -65,6 +70,7 @@ if [[ "$OIDC_ISSUER" != "$ADVERTISED_AS" ]]; then
   echo "::error::OIDC discovery issuer (${OIDC_ISSUER}) != authorization_servers[0] (${ADVERTISED_AS}) — clients discovering via openid-configuration will refuse this façade"
   exit 1
 fi
+echo "run-oauth-facade-smoke: issuer identity OK — AS and OIDC both self-identify as ${ADVERTISED_AS}"
 
 echo "run-oauth-facade-smoke: checking /register returns a public client (no secret)"
 DCR=$(curl -fsS -X POST -H 'Content-Type: application/json' -d '{"redirect_uris":["http://localhost:8080/cb"]}' "${FACADE}/register")


### PR DESCRIPTION
Fixes #143.

## What was wrong

The façade publishes **itself** as the authorization server in its RFC 9728
protected-resource document (`authorization_servers: [base]`), but returned the
**upstream Cognito** issuer as `issuer` in both the RFC 8414 authorization-server
metadata and the OIDC discovery document. RFC 8414 §3.3:

> The `issuer` value returned MUST be identical to the authorization server's issuer
> identifier value into which the well-known URI string was inserted to create the
> URL used to retrieve the metadata. If these values are not identical, the data
> contained in the response MUST NOT be used.

A client that enforces §3.3 therefore discards the whole document and fails MCP
startup with `Authorization server issuer mismatch`. In RFC 8414 the `issuer` is the
document's *self-identifier* — it must name whoever the client was told to talk to,
not whoever signs the JWTs.

**Not a regression from any recent PR.** All three lines date to the façade's first
commit; the later commits touching `handler.ts` never modified them. What changed is
the *client*: rmcp `1.8.0` → `3.0.0` began enforcing §3.3. Both statements hold at
once — the server has always been non-compliant, and the client used to let it pass.
Rolling back recent work fixes nothing; pinning the client only defers, since every
future §3.3-compliant client fails identically.

## The change

- `handler.ts` — `issuer: cfg.issuer` → `issuer: base` at both metadata sites.
- `COGNITO_ISSUER` removed end to end (`FacadeConfig` field, the `reqEnv` read, and
  the Pulumi env entry). It had **exactly** those two advertising consumers.
- The `config.test.ts` case that used it to prove `reqEnv` fails closed is
  **re-pointed** to another required var, not deleted.

**Token validation is untouched.** Cognito still mints and signs every token, JWTs
keep their Cognito `iss` claim, and the Gateway's JWT authorizer builds its
`discoveryUrl` from `cognitoOut.issuer` directly (`infra/gateway.ts:241`) — it never
reads façade metadata. Only the metadata self-identifier changes.

## Why it went unnoticed

**No test asserted the advertised `issuer`** — not in the 57-case handler suite, and
not in the preview smoke script, which validated `authorization_endpoint`,
`token_endpoint`, S256, DCR, and auth methods but never this field. Both gaps are
closed here.

`TC-MCPGW-079` asserts the **relationship between two live documents**
(`as.issuer === pr.authorization_servers[0]`) rather than a hardcoded host: a test
pinning the literal value would keep passing if the two documents drifted apart
again, which is precisely the defect. Two `not.toBe(UPSTREAM_ISSUER)` assertions
catch a partial fix that updates only one handler. Both well-known path shapes (bare
and resource-suffixed) are covered — the suffixed one is what a compliant client
queries first.

The same two-document comparison now runs against the **deployed** façade in the
`deploy-preview` smoke step, so this cannot regress silently at runtime either.

## Verification

Evidence for each of the issue's acceptance criteria is posted as a PR comment
below (the scoped token cannot write PR metadata).

## Out of scope

No change to how tokens are minted, signed, or validated. `authorization_servers`,
the resource identifier, and trailing slashes are unchanged — measured unnecessary,
since the client normalizes the trailing slash.
