### PR TITLE
fix(ci): survive the slow Lambda ENI detach and sweep orphaned preview network scaffolding

### DIFF
--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -524,8 +524,11 @@ jobs:
     name: Cleanup PR Preview
     runs-on: ${{ vars.RUNNER_LABEL && fromJSON(vars.RUNNER_LABEL) || 'ubuntu-latest' }}
     if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.base.ref == 'main'
-    # Aurora + ECS teardown can exceed 20m on a full preview stack.
-    timeout-minutes: 30
+    # Budget: 15m first remove + up to 20m ENI detach wait + 15m retry, plus
+    # checkout/pnpm/install. The old 30m cut the FIRST remove off mid-flight (#146),
+    # which is what leaked the security groups — the job timeout must stay strictly
+    # above the sum of the inner bounds so the retry path can always complete.
+    timeout-minutes: 60
     permissions:
       id-token: write
       contents: read
@@ -632,6 +635,20 @@ jobs:
           sudo rm -f /usr/local/bin/pulumi* 2>/dev/null || true
           rm -rf ~/.config/sst/bin/ ~/.config/sst/plugins/ 2>/dev/null || true
 
+      # #146. `sst remove` deletes the VPC-attached Lambdas quickly, but AWS
+      # detaches their hyperplane ENIs ASYNCHRONOUSLY (up to ~20m). Those ENIs hold
+      # a dependency on Mem9TaskSg, so Pulumi sits retrying DeleteSecurityGroup
+      # against DependencyViolation — and on the stages that leaked, THIS JOB'S
+      # timeout fired first and cancelled the remove MID-FLIGHT. The state object
+      # was already gone by then, so the stage became invisible to a state-anchored
+      # reconciler and its SG + ENIs leaked with nothing tying them to a closed PR.
+      #
+      # So the remove gets its OWN bound (`timeout`), which the job timeout must
+      # never pre-empt. A first attempt that runs out is not a failure: the
+      # functions are deleted by then, which is precisely when waiting for the ENIs
+      # becomes useful (before the remove they are still in-use — waiting there
+      # would poll for 20 minutes and change nothing). Then one retry finishes the
+      # remove with the dependency gone, leaving SST state consistent.
       - name: Remove PR stage
         if: steps.check-state.outputs.deployed == 'true'
         shell: bash
@@ -645,8 +662,17 @@ jobs:
           case "$STAGE" in
             prod|main|production) echo "::error::Refusing to remove protected stage $STAGE"; exit 1 ;;
           esac
-          pnpm -C infra exec sst unlock --stage "$STAGE" 2>&1 || true
-          pnpm -C infra exec sst remove --stage "$STAGE" --print-logs
+          remove() {
+            pnpm -C infra exec sst unlock --stage "$STAGE" 2>&1 || true
+            timeout "$1" pnpm -C infra exec sst remove --stage "$STAGE" --print-logs
+          }
+          if remove 15m; then
+            echo "::notice::Removed stage ${STAGE} on the first attempt"
+            exit 0
+          fi
+          echo "::notice::First remove of ${STAGE} did not finish — waiting for Lambda ENIs to detach, then retrying"
+          node scripts/await-eni-detach.mts "$STAGE"
+          remove 15m
 
       - name: Comment cleanup status
         if: success() && steps.check-state.outputs.deployed == 'true'

--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -662,16 +662,31 @@ jobs:
           case "$STAGE" in
             prod|main|production) echo "::error::Refusing to remove protected stage $STAGE"; exit 1 ;;
           esac
+          # Clear a stale lock left by a previous run — ONCE, before the first
+          # attempt. It must not move inside `remove()`: `timeout` sends only
+          # SIGTERM, and `sst remove` fans out to a Pulumi engine that can outlive
+          # it, so an unlock on the retry path could force-clear the lock still
+          # held by a first attempt that is quietly still running. Two engines on
+          # one state object is state corruption, not a slow teardown.
+          pnpm -C infra exec sst unlock --stage "$STAGE" 2>&1 || true
+
+          # --kill-after escalates to SIGKILL 60s after SIGTERM, so a first attempt
+          # that ignores TERM cannot survive into the retry as an orphan.
           remove() {
-            pnpm -C infra exec sst unlock --stage "$STAGE" 2>&1 || true
-            timeout "$1" pnpm -C infra exec sst remove --stage "$STAGE" --print-logs
+            timeout --kill-after=60s "$1" \
+              pnpm -C infra exec sst remove --stage "$STAGE" --print-logs
           }
           if remove 15m; then
             echo "::notice::Removed stage ${STAGE} on the first attempt"
             exit 0
           fi
           echo "::notice::First remove of ${STAGE} did not finish — waiting for Lambda ENIs to detach, then retrying"
-          node scripts/await-eni-detach.mts "$STAGE"
+          # The wait's internal budget is checked BETWEEN polls, so a throttled EC2
+          # endpoint could overshoot it and push the retry past the job timeout —
+          # re-creating the mid-remove cancellation that leaked the resources. Its
+          # expiry is a non-failure by design, so an outer bound is safe to ignore.
+          timeout --kill-after=60s 22m node scripts/await-eni-detach.mts "$STAGE" || \
+            echo "::warning::ENI detach wait exceeded its outer bound — retrying the remove anyway"
           remove 15m
 
       - name: Comment cleanup status

--- a/docs/designs/preview-stage-reconciliation.md
+++ b/docs/designs/preview-stage-reconciliation.md
@@ -124,6 +124,17 @@ for its whole budget. The job therefore runs `remove` → on failure `wait` →
 bounds. Expiry is a `::warning::`, never a failure — failing the step is precisely
 what leaked the resources, and the sweep below is the designed backstop.
 
+Two details in that restructure are load-bearing. `sst unlock` runs **once**,
+before the first attempt, never inside the retryable function: `timeout` sends only
+SIGTERM, and `sst remove` fans out to a Pulumi engine that can outlive it, so an
+unlock on the retry path could clear a lock still held by a first attempt that is
+quietly still running — two engines on one state object is corruption, not a slow
+teardown. `--kill-after=60s` escalates to SIGKILL so that first attempt cannot
+survive into the retry as an orphan at all. The wait also carries an outer
+`timeout`, because its internal budget is only checked *between* polls and a
+throttled EC2 endpoint could otherwise overshoot it and push the retry past the
+job ceiling — recreating the original mid-remove cancellation.
+
 **A narrow sweep for what already leaked.** Only two resource types may be deleted
 without SST state: `ec2:security-group` and `ec2:network-interface`. Both are
 recreated from scratch by the next deploy and hold no data. A stage is swept only
@@ -134,12 +145,33 @@ entire risk of the feature.
 
 Within a sweep, ENIs are deleted before their group. This ordering is not
 cosmetic: `DeleteSecurityGroup` returns `DependencyViolation` while any ENI still
-references the group, so SG-first leaves *both* behind — the leak itself. The
-sweep refuses (rather than throws) on an `in-use`, `detaching`, or
-requester-managed interface, so one drifted stage cannot abort the run, and it
-re-derives `Project`/`ManagedBy`/`Stage` from each resource's own tags so a
-server-side filter typo cannot widen the blast radius. The four EC2 actions it
-needs were already granted to the deploy role and scoped to the account default
+references the group, so SG-first leaves *both* behind — the leak itself. An ENI
+is not the only `DependencyViolation` source, though: a stage owns both
+`Mem9TaskSg` and `Mem9DbSg`, and the latter's ingress rule *references* the
+former, while `describe-security-groups` guarantees no ordering. Groups are
+therefore deleted in passes until a pass makes no progress, which resolves the
+reference in either ordering and turns a genuinely stuck group into a refusal.
+
+**Every failure is a refusal, including a failing AWS call.** The sweep returns
+`{swept: false, reason}` on an `in-use`, `detaching`, or requester-managed
+interface *and* on any unanticipated CLI error. A throw would skip every later
+stage this feature exists to drain, and — worse — would pre-empt the `sst remove`
+failure the caller still has to re-throw, replacing a real AWS reason with the
+sweep's. Reported reasons are restricted to `runCommand`'s own label shape, so no
+ARN or account id can reach a report. `InvalidNetworkInterfaceID.NotFound` counts
+as success, because the sweep genuinely races Lambda's own asynchronous ENI
+deletion; any other error refuses, so the group is never deleted while an
+interface it failed to remove still pins it.
+
+A refused sweep is recorded as `operator-review` and appears in the operator
+issue. Some refusals never clear: `sst remove` deletes the execution role, and
+Lambda cannot detach a hyperplane ENI without it, so an `in-use` interface can
+refuse forever. Leaving that in an apply-job log — apply is manual-dispatch only —
+would reproduce the exact invisibility #146 is about.
+
+The sweep re-derives `Project`/`ManagedBy`/`Stage` from each resource's own tags
+so a server-side filter typo cannot widen the blast radius. The four EC2 actions
+it needs were already granted to the deploy role and scoped to the account default
 VPC, so no IAM change accompanies this feature.
 
 Every refusal above is proven by a mutation probe: breaking one guard must turn a

--- a/docs/designs/preview-stage-reconciliation.md
+++ b/docs/designs/preview-stage-reconciliation.md
@@ -19,6 +19,7 @@ workflow_dispatch(mode=apply) ------> report job
                                       |
                                       +-- fresh safety observations
                                       +-- sst remove for state-present stages
+                                      +-- network sweep for SG+ENI-only stages
                                       `-- operator issue for state-missing stages
 ```
 
@@ -42,6 +43,7 @@ scripts/preview-reconciler.mts
   |    +-- collectObservation() again before each removal
   |    +-- buildReconciliationPlan() again
   |    +-- runSstRemove(stage)
+  |    +-- sweepOrphanedNetwork(stage)  ENI-then-SG, allowlisted types only
   |    `-- upsertOperatorIssue()
   `-- CLI
        +-- plan
@@ -73,9 +75,11 @@ reaches the planner, reports, plan artifacts, errors, or operator issues.
    stage again immediately before `sst remove`. Any reopened pull request,
    active/new workflow, changed state timestamp, missing state, or renewed grace
    period cancels removal.
-9. State-missing candidates are never sent to an AWS delete API. Manual apply
-   creates or updates one marker-bearing operator issue containing only stage,
-   resource type, and count.
+9. A state-missing candidate whose ENTIRE owned inventory is orphaned network
+   scaffolding is classified `sweep-orphaned-network` and finished automatically
+   (#146). Every other state-missing candidate is never sent to an AWS delete API:
+   manual apply creates or updates one marker-bearing operator issue containing
+   only stage, resource type, and count.
 
 ## Design Notes
 
@@ -103,6 +107,44 @@ reaches the planner, reports, plan artifacts, errors, or operator issues.
   `iam:ListRoles`, and role-scoped `iam:ListRoleTags`. Existing SSM and S3 read
   permissions cover SST state.
 
+## Orphaned Network Sweep (issue #146)
+
+The cleanup job's 30-minute `timeout-minutes` cancelled `sst remove` mid-flight
+while it waited on a security group whose Lambda VPC hyperplane ENIs had not yet
+detached. By then SST had already deleted the state object, so the stranded
+`Mem9TaskSg` plus its ENIs became invisible to a state-anchored reconciler and
+leaked with nothing left tying them to a closed PR. Two independent changes:
+
+**A bounded wait between two removes.** `scripts/await-eni-detach.mts` polls until
+no ENI references the stage's groups. Placement is load-bearing: AWS detaches
+those ENIs only *after* the function is deleted, and `sst remove` is what deletes
+it, so a wait placed before the first remove would poll a still-`in-use` interface
+for its whole budget. The job therefore runs `remove` → on failure `wait` →
+`remove` again, and the job timeout stays strictly above the sum of the inner
+bounds. Expiry is a `::warning::`, never a failure — failing the step is precisely
+what leaked the resources, and the sweep below is the designed backstop.
+
+**A narrow sweep for what already leaked.** Only two resource types may be deleted
+without SST state: `ec2:security-group` and `ec2:network-interface`. Both are
+recreated from scratch by the next deploy and hold no data. A stage is swept only
+when *every* owned resource it has is in that set; one Aurora cluster in the
+inventory sends the whole stage back to `operator-review`, because a partial sweep
+would leave a half-torn stage behind a stale issue. Widening that allowlist is the
+entire risk of the feature.
+
+Within a sweep, ENIs are deleted before their group. This ordering is not
+cosmetic: `DeleteSecurityGroup` returns `DependencyViolation` while any ENI still
+references the group, so SG-first leaves *both* behind — the leak itself. The
+sweep refuses (rather than throws) on an `in-use`, `detaching`, or
+requester-managed interface, so one drifted stage cannot abort the run, and it
+re-derives `Project`/`ManagedBy`/`Stage` from each resource's own tags so a
+server-side filter typo cannot widen the blast radius. The four EC2 actions it
+needs were already granted to the deploy role and scoped to the account default
+VPC, so no IAM change accompanies this feature.
+
+Every refusal above is proven by a mutation probe: breaking one guard must turn a
+named test red. A guard no test kills is not a guard.
+
 ## Failure Modes
 
 - Missing AWS role or unreadable bootstrap state: fail the report; do not apply.
@@ -119,3 +161,9 @@ reaches the planner, reports, plan artifacts, errors, or operator issues.
   command output.
 - GitHub operator-issue write failure: fail apply after all deletion decisions
   remain independently protected by their own rechecks.
+- ENI detach outlasts the bounded wait: warn with the blocking interface ids and
+  remove anyway. The stage may leak a security group for one reconciler cycle; the
+  sweep then finishes it.
+- Stage stops being sweepable between plan and sweep: cancel with the recheck's
+  reason. The sweep runs independently of removal failures, because an SST failure
+  on one stage says nothing about another stage's orphaned security group.

--- a/docs/test-cases/preview-stage-reconciliation.md
+++ b/docs/test-cases/preview-stage-reconciliation.md
@@ -84,6 +84,12 @@ guard below must turn a listed test red.
 | TC-PREVIEW-RECON-052 | Owned security group with no remaining interfaces | Deletes the group alone |
 | TC-PREVIEW-RECON-053 | Empty owned inventory | Never sweepable — asserted on the predicate directly, since `[].every()` is vacuously true |
 | TC-PREVIEW-RECON-054 | A redeploy re-creates SST state between the advisory pass and the pre-sweep re-plan | Sweep cancels `no-longer-sweepable`; the stage returns to `sst remove` instead of losing a live security group |
+| TC-PREVIEW-RECON-055 | An AWS delete call inside the sweep fails for an unanticipated reason | Refuses `sweep-failed: <label>`; a throw would skip every later stage and destroy the caller's captured `sst remove` error |
+| TC-PREVIEW-RECON-056 | The thrown value carries an ARN or account id | Reduced to `sweep-failed: unknown-error`; only `runCommand`'s own label shape is reportable |
+| TC-PREVIEW-RECON-057 | Stage owns both `Mem9TaskSg` and `Mem9DbSg`, whose ingress rule references the task SG | Multi-pass deletion resolves the reference in either API ordering; both groups are deleted |
+| TC-PREVIEW-RECON-058 | A security group no pass can delete | Refuses `security-group-dependency-violation` — no infinite loop, no throw |
+| TC-PREVIEW-RECON-059 | The sweep refuses (e.g. an ENI stuck `in-use` because `sst remove` deleted the execution role) | Stage is recorded `operator-review` and appears in the operator issue, so a permanently-stuck stage cannot leak invisibly |
+| TC-PREVIEW-RECON-060 | `InvalidNetworkInterfaceID.NotFound` vs. `UnauthorizedOperation` on the same delete | NotFound counts as success; any other failure refuses and the security group is NOT deleted while its interface survives |
 
 | ID | Scenario | Expected |
 |---|---|---|

--- a/docs/test-cases/preview-stage-reconciliation.md
+++ b/docs/test-cases/preview-stage-reconciliation.md
@@ -57,3 +57,41 @@ Design: [`docs/designs/preview-stage-reconciliation.md`](../designs/preview-stag
 | TC-PREVIEW-RECON-034 | Recent completed run remains uncorrelated after head matching | It does not change another stage's matching grace anchor |
 | TC-PREVIEW-RECON-035 | SST state disappears after its timestamp supplied the advisory plan's only grace anchor | Tagged resources are reported from the still-eligible advisory evidence; no removal occurs |
 | TC-PREVIEW-RECON-036 | Multiple stages lose SST state during the final apply recheck | One cumulative operator-issue update contains every late state-missing stage |
+
+## Orphaned network sweep and bounded ENI wait (issue #146)
+
+The sweep is the only path that issues an AWS delete outside SST, so each of its
+refusals is proven by a mutation probe rather than by inspection: breaking any one
+guard below must turn a listed test red.
+
+| ID | Scenario | Expected |
+|---|---|---|
+| TC-PREVIEW-RECON-037 | Deploy-role policy vs. the four EC2 actions the sweep issues | `DescribeSecurityGroups`, `DescribeNetworkInterfaces`, `DeleteSecurityGroup`, and `DeleteNetworkInterface` are already granted; the sweep needs no new IAM |
+| TC-PREVIEW-RECON-038 | `cleanup-preview` inner bounds vs. the job `timeout-minutes` | First remove + ENI wait + retry sum strictly below the job timeout, and the wait sits between the two removes |
+| TC-PREVIEW-RECON-039 | State-missing stage whose whole owned inventory is one SG plus its ENIs | Classified `sweep-orphaned-network` with `network-scaffolding-only`, not `operator-review` |
+| TC-PREVIEW-RECON-040 | State-missing stage holding any non-SG/ENI type (Aurora, S3, Cognito, IAM role) | Stays `operator-review`; a mixed inventory is never swept |
+| TC-PREVIEW-RECON-041 | Apply over a sweepable stage | Sweep adapter runs; no operator issue is filed for that stage |
+| TC-PREVIEW-RECON-042 | Stage stops being sweepable between plan and the apply recheck | Sweep is cancelled with the recheck's reason; nothing is deleted |
+| TC-PREVIEW-RECON-043 | `prod`, `main`, and other non-preview stages | Never swept, at both the plan and the sweep layer |
+| TC-PREVIEW-RECON-044 | Sweepable stage still inside the 24-hour grace period | Retained; the sweep does not shorten the grace period |
+| TC-PREVIEW-RECON-045 | Dry-run report over a sweepable stage | Report names the planned sweep, so the plan is reviewable before apply |
+| TC-PREVIEW-RECON-046 | `security-group` and `network-interface` EC2 ARNs | Map to `ec2:security-group` and `ec2:network-interface` |
+| TC-PREVIEW-RECON-047 | End-to-end apply through the real CLI over an SG+ENI-only stage | Exact AWS call sequence deletes every ENI before its security group |
+| TC-PREVIEW-RECON-048 | `sweepOrphanedNetwork` over a detached ENI and its group | `delete-network-interface` precedes `delete-security-group`; SG-first would raise `DependencyViolation` and leak both |
+| TC-PREVIEW-RECON-049 | ENI is `in-use`, `detaching`, or requester-managed | Refuses with a reason and deletes nothing — a refusal, not a throw, so one drifted stage cannot abort the run |
+| TC-PREVIEW-RECON-050 | `sweepOrphanedNetwork` called with a non-preview stage | Refuses `stage-protected` without issuing even a describe |
+| TC-PREVIEW-RECON-051 | No security group carries this stage's `Project`/`ManagedBy`/`Stage` tags | Refuses; tags are re-derived locally so a server-side filter typo cannot widen blast radius |
+| TC-PREVIEW-RECON-052 | Owned security group with no remaining interfaces | Deletes the group alone |
+| TC-PREVIEW-RECON-053 | Empty owned inventory | Never sweepable — asserted on the predicate directly, since `[].every()` is vacuously true |
+| TC-PREVIEW-RECON-054 | A redeploy re-creates SST state between the advisory pass and the pre-sweep re-plan | Sweep cancels `no-longer-sweepable`; the stage returns to `sst remove` instead of losing a live security group |
+
+| ID | Scenario | Expected |
+|---|---|---|
+| TC-PREVIEW-ENI-001 | Interfaces detach partway through the budget | Returns `detached` with the poll count |
+| TC-PREVIEW-ENI-002 | Interfaces never detach | Times out at exactly the budget and names the blocking interface ids |
+| TC-PREVIEW-ENI-003 | Wait expires during cleanup | Emits `::warning::`, exits 0, and defers to the reconciler sweep — failing the step would recreate the original leak |
+| TC-PREVIEW-ENI-004 | Zero or already-expired budget | Still polls once, so the diagnostic reports what is actually attached |
+| TC-PREVIEW-ENI-005 | Stage owns no security group | Returns immediately; nothing to wait for |
+| TC-PREVIEW-ENI-006 | A security group tagged for a different stage | Ignored; the wait is scoped to this stage's groups |
+| TC-PREVIEW-ENI-007 | Non-preview stage | Throws rather than waiting on protected infrastructure |
+| TC-PREVIEW-ENI-008 | Stage owns several security groups | Every group is polled before the wait concludes |

--- a/scripts/await-eni-detach.mts
+++ b/scripts/await-eni-detach.mts
@@ -1,0 +1,177 @@
+/**
+ * await-eni-detach — wait for a preview stage's Lambda VPC ENIs to detach.
+ *
+ * WHY THIS EXISTS (#146). `sst remove --stage pr-N` deletes the VPC-attached
+ * Lambda functions quickly, but AWS detaches their hyperplane ENIs
+ * ASYNCHRONOUSLY — observed at ~18 minutes on the stages that leaked, and
+ * documented as "up to 20 minutes" for VPC Lambda. Those ENIs hold a dependency
+ * on `Mem9TaskSg`, so `sst remove` sat blocked on the security group until the
+ * job's `timeout-minutes` cancelled it MID-REMOVE. A cancelled remove is the worst
+ * outcome available: the SST state object is already gone, so the next
+ * reconciliation sees a state-missing stage, and the SG plus its ENIs leak with
+ * nothing left that knows they belong to a closed PR.
+ *
+ * The fix is to stop racing. This script runs BETWEEN a first `sst remove` that ran
+ * out of its own bound and the retry, and blocks until the ENIs are gone, so the
+ * retry starts from a state where the SG has no dependency left to violate.
+ * The placement is load-bearing: AWS starts detaching a hyperplane ENI only once
+ * the function owning it is deleted, and `sst remove` is what deletes it — waiting
+ * BEFORE the first remove would poll a still-attached interface for the whole
+ * budget and change nothing.
+ *
+ * The wait is BOUNDED and its expiry is NOT a failure. Timing out means "the ENIs
+ * are still attached, proceed anyway and let the reconciler's sweep finish the
+ * job" — it prints a diagnostic naming the stage and the interfaces still holding
+ * the group, then exits 0. Exiting non-zero would fail a cleanup that has not yet
+ * done anything wrong, and hard-failing the job is exactly what leaked the
+ * resources in the first place.
+ */
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  describeGroupNetworkInterfaces,
+  ownedSecurityGroupIds,
+  runCommand,
+  type CommandRunner,
+  type StageNetworkInterface,
+} from "./preview-reconciler.mts";
+
+export const DEFAULT_TIMEOUT_MS = 20 * 60 * 1_000;
+export const DEFAULT_POLL_INTERVAL_MS = 30 * 1_000;
+
+export type AwaitClock = Readonly<{
+  now: () => number;
+  sleep: (ms: number) => Promise<void>;
+}>;
+
+export const systemClock: AwaitClock = {
+  now: () => Date.now(),
+  sleep: (ms) =>
+    new Promise((resolve) => {
+      setTimeout(resolve, ms);
+    }),
+};
+
+export type AwaitResult =
+  | Readonly<{ outcome: "detached"; polls: number }>
+  | Readonly<{ outcome: "no-owned-security-group" }>
+  | Readonly<{ outcome: "timed-out"; polls: number; blocking: readonly string[] }>;
+
+export type AwaitOptions = Readonly<{
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+  clock?: AwaitClock;
+  log?: (message: string) => void;
+}>;
+
+const PREVIEW_STAGE = /^pr-([0-9]+)$/;
+
+function logger(options: AwaitOptions): (message: string) => void {
+  return options.log ?? ((message: string) => console.log(message));
+}
+
+/** Every interface AWS still reports against any of the stage's groups. */
+async function blockingInterfaces(
+  stage: string,
+  groupIds: readonly string[],
+  commandRunner: CommandRunner,
+): Promise<StageNetworkInterface[]> {
+  const blocking: StageNetworkInterface[] = [];
+  for (const groupId of groupIds) {
+    blocking.push(...(await describeGroupNetworkInterfaces(stage, groupId, commandRunner)));
+  }
+  return blocking;
+}
+
+/**
+ * Poll until no ENI references any of the stage's security groups, or the budget
+ * expires.
+ *
+ * Any referencing interface counts as blocking, whatever its status: what the
+ * retrying `sst remove` is stuck on is the group's dependency, and an `available`
+ * ENI pins the group exactly as an `in-use` one does. Deciding which statuses are
+ * safe to delete belongs to the sweep, not here — this only waits.
+ */
+export async function awaitEniDetach(
+  stage: string,
+  commandRunner: CommandRunner,
+  options: AwaitOptions = {},
+): Promise<AwaitResult> {
+  if (!PREVIEW_STAGE.test(stage)) throw new Error("Refusing to wait on a non-preview stage");
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  const clock = options.clock ?? systemClock;
+  const log = logger(options);
+
+  const groupIds = await ownedSecurityGroupIds(stage, commandRunner);
+  if (groupIds.length === 0) return { outcome: "no-owned-security-group" };
+
+  const deadline = clock.now() + timeoutMs;
+  let polls = 0;
+  let blocking: StageNetworkInterface[] = [];
+  // Always poll at least once, so a zero/expired budget still reports what is
+  // actually attached instead of an empty blocking list.
+  for (;;) {
+    polls += 1;
+    blocking = await blockingInterfaces(stage, groupIds, commandRunner);
+    if (blocking.length === 0) return { outcome: "detached", polls };
+
+    const remainingMs = deadline - clock.now();
+    if (remainingMs <= 0) break;
+    log(
+      `await-eni-detach: ${blocking.length} interface(s) still attached to ${stage}; ` +
+        `${Math.ceil(remainingMs / 1_000)}s of budget left`,
+    );
+    await clock.sleep(Math.min(pollIntervalMs, remainingMs));
+  }
+
+  return { outcome: "timed-out", polls, blocking: blocking.map((eni) => eni.id) };
+}
+
+export async function runCli(
+  argv: readonly string[],
+  commandRunner: CommandRunner,
+  options: AwaitOptions = {},
+): Promise<void> {
+  const stage = argv[0];
+  if (!stage) throw new Error("Usage: await-eni-detach <stage>");
+  const log = logger(options);
+
+  log(`await-eni-detach: waiting for ${stage} Lambda VPC interfaces to detach`);
+  const result = await awaitEniDetach(stage, commandRunner, options);
+  switch (result.outcome) {
+    case "no-owned-security-group":
+      log(`await-eni-detach: no owned security group for ${stage} — nothing to wait for`);
+      return;
+    case "detached":
+      log(
+        `await-eni-detach: ${stage} interfaces detached after ${result.polls} poll(s) — safe to remove`,
+      );
+      return;
+    case "timed-out":
+      // A warning, not an error: the wait expiring is a known AWS timing outcome,
+      // and the reconciler sweep is the designed backstop. Naming the interfaces is
+      // the whole point — a silent timeout would look identical to a wait that never
+      // ran. Written to `console.log` rather than `log`, because an annotation is
+      // addressed to the Actions runner and must survive a caller-injected logger.
+      console.log(
+        `::warning::await-eni-detach: ${stage} still has attached interface(s) ` +
+          `after ${result.polls} poll(s): ${result.blocking.join(", ")}. ` +
+          "Proceeding with removal; the preview reconciler sweep will finish any leftover " +
+          "security group.",
+      );
+      return;
+  }
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : "";
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  // Failing closed here would mean failing the cleanup job, which is the leak's
+  // original cause. A broken wait degrades to "remove immediately", the old
+  // behavior, with the reason printed.
+  await runCli(process.argv.slice(2), runCommand).catch((error: unknown) => {
+    console.log(`::warning::await-eni-detach failed: ${String(error)}`);
+  });
+}

--- a/scripts/await-eni-detach.test.ts
+++ b/scripts/await-eni-detach.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  DEFAULT_POLL_INTERVAL_MS,
+  DEFAULT_TIMEOUT_MS,
+  awaitEniDetach,
+  runCli,
+  type AwaitClock,
+} from "./await-eni-detach.mts";
+import type { CommandResult, CommandRunner } from "./preview-reconciler.mts";
+
+const GROUP_ID = "sg-0123456789abcdef0";
+const ENI_ID = "eni-0123456789abcdef0";
+
+function group(stage: string, groupId = GROUP_ID): unknown {
+  return {
+    GroupId: groupId,
+    Tags: [
+      { Key: "Project", Value: "mem9-on-aws" },
+      { Key: "ManagedBy", Value: "sst" },
+      { Key: "Stage", Value: stage },
+    ],
+  };
+}
+
+/**
+ * One interface referencing the stage's group. Its status is deliberately fixed:
+ * the wait blocks on ANY referencing interface, so no test here needs to vary it —
+ * status only decides what the reconciler's sweep may delete.
+ */
+function eni(): unknown {
+  return { NetworkInterfaceId: ENI_ID, Status: "available", RequesterManaged: false };
+}
+
+/**
+ * A command runner driven by a queue of describe-network-interfaces responses, so a
+ * test can express "attached for two polls, then gone" without any real waiting.
+ */
+function runner(
+  groups: unknown[],
+  eniResponses: unknown[][],
+): CommandRunner & { calls: string[][] } {
+  const calls: string[][] = [];
+  let poll = 0;
+  const fn = vi.fn(async (_file: string, args: readonly string[]): Promise<CommandResult> => {
+    calls.push([...args]);
+    if (args[1] === "describe-security-groups") {
+      return { stdout: JSON.stringify({ SecurityGroups: groups }), stderr: "" };
+    }
+    if (args[1] === "describe-network-interfaces") {
+      const response = eniResponses[Math.min(poll, eniResponses.length - 1)];
+      poll += 1;
+      return { stdout: JSON.stringify({ NetworkInterfaces: response }), stderr: "" };
+    }
+    return { stdout: "{}", stderr: "" };
+  });
+  return Object.assign(fn as unknown as CommandRunner, { calls });
+}
+
+/**
+ * Virtual clock: `sleep` advances time instead of waiting, so a 20-minute budget
+ * is exercised in microseconds. The sleep ceiling is an oracle, not a
+ * convenience — if the deadline check is ever removed, the loop becomes infinite,
+ * and without this the suite dies by OOM rather than by a readable assertion.
+ * A budget can never need more sleeps than it has poll intervals.
+ */
+function stubClock(maxSleeps = 2 + DEFAULT_TIMEOUT_MS / DEFAULT_POLL_INTERVAL_MS): AwaitClock & {
+  elapsed: () => number;
+} {
+  let now = 1_000_000;
+  let sleeps = 0;
+  return {
+    now: () => now,
+    sleep: async (ms: number) => {
+      sleeps += 1;
+      if (sleeps > maxSleeps) {
+        throw new Error(`await-eni-detach slept ${sleeps} times — the wait is unbounded`);
+      }
+      now += ms;
+    },
+    elapsed: () => now - 1_000_000,
+  };
+}
+
+describe("awaitEniDetach", () => {
+  it("TC-PREVIEW-ENI-001 returns once the interfaces have detached", async () => {
+    const commandRunner = runner([group("pr-12")], [[eni()], [eni()], []]);
+    const clock = stubClock();
+
+    const result = await awaitEniDetach("pr-12", commandRunner, {
+      clock,
+      log: () => undefined,
+    });
+
+    expect(result).toEqual({ outcome: "detached", polls: 3 });
+    // Two sleeps between three polls — it did not busy-loop.
+    expect(clock.elapsed()).toBe(2 * DEFAULT_POLL_INTERVAL_MS);
+  });
+
+  // The expiry diagnostic is the point of the bound: a wait that gives up silently
+  // is indistinguishable from one that never ran, which is how the leak stayed
+  // invisible for seven stages (#146).
+  it("TC-PREVIEW-ENI-002 times out with a diagnostic naming the blocking interfaces", async () => {
+    const commandRunner = runner([group("pr-12")], [[eni()]]);
+    const clock = stubClock();
+
+    const result = await awaitEniDetach("pr-12", commandRunner, {
+      clock,
+      log: () => undefined,
+    });
+
+    expect(result).toEqual({
+      outcome: "timed-out",
+      polls: DEFAULT_TIMEOUT_MS / DEFAULT_POLL_INTERVAL_MS + 1,
+      blocking: [ENI_ID],
+    });
+    // It waited its whole budget and no longer — not one poll, not forever.
+    expect(clock.elapsed()).toBe(DEFAULT_TIMEOUT_MS);
+  });
+
+  it("TC-PREVIEW-ENI-003 warns rather than failing the cleanup job on expiry", async () => {
+    const commandRunner = runner([group("pr-12")], [[eni()]]);
+    const logged: string[] = [];
+    const consoleLog = vi.spyOn(console, "log").mockImplementation((message: unknown) => {
+      logged.push(String(message));
+    });
+
+    try {
+      await expect(
+        runCli(["pr-12"], commandRunner, { clock: stubClock(), log: () => undefined }),
+      ).resolves.toBeUndefined();
+    } finally {
+      consoleLog.mockRestore();
+    }
+
+    const warning = logged.find((line) => line.startsWith("::warning::"));
+    expect(warning).toBeDefined();
+    expect(warning).toContain("pr-12");
+    expect(warning).toContain(ENI_ID);
+    // An ::error:: would fail the step and re-create the mid-remove cancellation.
+    expect(logged.some((line) => line.startsWith("::error::"))).toBe(false);
+  });
+
+  it("TC-PREVIEW-ENI-004 polls at least once even with no budget", async () => {
+    const commandRunner = runner([group("pr-12")], [[eni()]]);
+
+    const result = await awaitEniDetach("pr-12", commandRunner, {
+      timeoutMs: 0,
+      clock: stubClock(),
+      log: () => undefined,
+    });
+
+    expect(result).toEqual({ outcome: "timed-out", polls: 1, blocking: [ENI_ID] });
+  });
+
+  it("TC-PREVIEW-ENI-005 skips the wait when the stage owns no security group", async () => {
+    const commandRunner = runner([], [[eni()]]);
+
+    const result = await awaitEniDetach("pr-12", commandRunner, {
+      clock: stubClock(),
+      log: () => undefined,
+    });
+
+    expect(result).toEqual({ outcome: "no-owned-security-group" });
+    expect(
+      commandRunner.calls.some((args) => args[1] === "describe-network-interfaces"),
+    ).toBe(false);
+  });
+
+  // Ownership is re-derived from each group's OWN tags, so a wrong-stage group that
+  // somehow passes the server-side filter is still ignored.
+  it("TC-PREVIEW-ENI-006 ignores a security group tagged for another stage", async () => {
+    const commandRunner = runner([group("pr-99")], [[eni()]]);
+
+    const result = await awaitEniDetach("pr-12", commandRunner, {
+      clock: stubClock(),
+      log: () => undefined,
+    });
+
+    expect(result).toEqual({ outcome: "no-owned-security-group" });
+  });
+
+  it.each(["prod", "main", "production", "pr-", "release-12", ""])(
+    "TC-PREVIEW-ENI-007 refuses to wait on the non-preview stage %j",
+    async (stage) => {
+      const commandRunner = runner([group(stage)], [[]]);
+
+      await expect(
+        awaitEniDetach(stage, commandRunner, { clock: stubClock(), log: () => undefined }),
+      ).rejects.toThrow("non-preview stage");
+      expect(commandRunner.calls).toEqual([]);
+    },
+  );
+
+  it("TC-PREVIEW-ENI-008 waits on every security group the stage owns", async () => {
+    const commandRunner = runner(
+      [group("pr-12", "sg-aaaaaaaaaaaaaaaaa"), group("pr-12", "sg-bbbbbbbbbbbbbbbbb")],
+      [[]],
+    );
+
+    const result = await awaitEniDetach("pr-12", commandRunner, {
+      clock: stubClock(),
+      log: () => undefined,
+    });
+
+    expect(result).toEqual({ outcome: "detached", polls: 1 });
+    const watched = commandRunner.calls
+      .filter((args) => args[1] === "describe-network-interfaces")
+      .map((args) => args[3]);
+    expect(watched).toEqual([
+      "Name=group-id,Values=sg-aaaaaaaaaaaaaaaaa",
+      "Name=group-id,Values=sg-bbbbbbbbbbbbbbbbb",
+    ]);
+  });
+});

--- a/scripts/preview-reconciler.e2e.test.ts
+++ b/scripts/preview-reconciler.e2e.test.ts
@@ -21,120 +21,180 @@ function json(value: unknown): CommandResult {
   return { stdout: JSON.stringify(value), stderr: "" };
 }
 
-function mockCommands(
+const SG_ID = "sg-0123456789abcdef0";
+const ENI_ID = "eni-0123456789abcdef0";
+
+type MockOptions = Readonly<{
+  statePresent?: boolean;
+  uncorrelatedActive?: boolean;
+  /**
+   * When true the stage's only tagged resources are the sweepable SG + ENI, i.e.
+   * the shape a cleanup job cancelled mid-`sst remove` leaves behind (#146).
+   */
+  networkOnly?: boolean;
+}>;
+
+function mockCommands({
   statePresent = true,
   uncorrelatedActive = false,
-): MockCommands {
+  networkOnly = false,
+}: MockOptions = {}): MockCommands {
   const calls: Array<{ file: string; args: readonly string[] }> = [];
   const runner: CommandRunner = vi.fn(
     async (file: string, args: readonly string[]) => {
-    calls.push({ file, args: [...args] });
-    const endpoint = args.find((arg) => arg.startsWith(`repos/${REPOSITORY}/`));
+      calls.push({ file, args: [...args] });
+      const endpoint = args.find((arg) => arg.startsWith(`repos/${REPOSITORY}/`));
 
-    if (file === "gh" && endpoint === `repos/${REPOSITORY}/pulls`) {
-      return json([
-        [
-          {
-            number: 7,
-            state: "closed",
-            closed_at: OLD,
-            head: { sha: "preview-sha-7", ref: "preview-branch-7" },
-          },
-        ],
-      ]);
-    }
-    if (
-      file === "gh" &&
-      endpoint === `repos/${REPOSITORY}/actions/workflows/infra-ci.yml/runs`
-    ) {
-      return json([
-        {
-          workflow_runs: [
+      if (file === "aws" && args[1] === "describe-security-groups") {
+        return json({
+          SecurityGroups: [
             {
-              id: 700,
-              status: uncorrelatedActive ? "in_progress" : "completed",
-              updated_at: uncorrelatedActive ? null : OLD,
-              head_sha: uncorrelatedActive
-                ? "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
-                : "preview-sha-7",
-              head_branch: uncorrelatedActive
-                ? "unknown-branch"
-                : "preview-branch-7",
-              pull_requests: [],
+              GroupId: SG_ID,
+              Tags: [
+                { Key: "Project", Value: "mem9-on-aws" },
+                { Key: "ManagedBy", Value: "sst" },
+                { Key: "Stage", Value: "pr-7" },
+              ],
             },
           ],
-        },
-      ]);
-    }
-    if (
-      file === "gh" &&
-      endpoint ===
-        `repos/${REPOSITORY}/commits/deadbeefdeadbeefdeadbeefdeadbeefdeadbeef/pulls`
-    ) {
-      return json([]);
-    }
-    if (
-      file === "gh" &&
-      endpoint === `repos/${REPOSITORY}/issues` &&
-      args.includes("GET")
-    ) {
-      return json([[]]);
-    }
-    if (
-      file === "gh" &&
-      endpoint === `repos/${REPOSITORY}/issues` &&
-      args.includes("POST")
-    ) {
-      return json({ number: 77 });
-    }
-    if (file === "aws" && args[0] === "ssm") {
-      return json({ Parameter: { Value: JSON.stringify({ state: "state-bucket" }) } });
-    }
-    if (file === "aws" && args[0] === "s3api") {
-      return json({
-        Contents: statePresent
-          ? [
-              {
-                Key: "app/mem9-on-aws/pr-7.json",
-                LastModified: OLD,
-              },
-            ]
-          : [],
-      });
-    }
-    if (file === "aws" && args[0] === "resourcegroupstaggingapi") {
-      return json({
-        ResourceTagMappingList: [
+        });
+      }
+      if (file === "aws" && args[1] === "describe-network-interfaces") {
+        return json({
+          NetworkInterfaces: [
+            {
+              NetworkInterfaceId: ENI_ID,
+              Status: "available",
+              RequesterManaged: false,
+            },
+          ],
+        });
+      }
+      if (
+        file === "aws" &&
+        (args[1] === "delete-network-interface" || args[1] === "delete-security-group")
+      ) {
+        return { stdout: "", stderr: "" };
+      }
+
+      if (file === "gh" && endpoint === `repos/${REPOSITORY}/pulls`) {
+        return json([
+          [
+            {
+              number: 7,
+              state: "closed",
+              closed_at: OLD,
+              head: { sha: "preview-sha-7", ref: "preview-branch-7" },
+            },
+          ],
+        ]);
+      }
+      if (
+        file === "gh" &&
+        endpoint === `repos/${REPOSITORY}/actions/workflows/infra-ci.yml/runs`
+      ) {
+        return json([
           {
-            ResourceARN:
-              "arn:aws:ecs:ap-northeast-1:123456789012:service/private-name",
-            Tags: [
-              { Key: "Project", Value: "mem9-on-aws" },
-              { Key: "ManagedBy", Value: "sst" },
-              { Key: "Stage", Value: "pr-7" },
+            workflow_runs: [
+              {
+                id: 700,
+                status: uncorrelatedActive ? "in_progress" : "completed",
+                updated_at: uncorrelatedActive ? null : OLD,
+                head_sha: uncorrelatedActive
+                  ? "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+                  : "preview-sha-7",
+                head_branch: uncorrelatedActive
+                  ? "unknown-branch"
+                  : "preview-branch-7",
+                pull_requests: [],
+              },
             ],
           },
-        ],
-      });
-    }
-    if (file === "aws" && args[0] === "iam" && args[1] === "list-roles") {
-      return json({
-        Roles: [
-          { RoleName: "github-actions-mem9-on-aws" },
-          { RoleName: "mem9-on-aws-pr-7-task-role" },
-        ],
-      });
-    }
-    if (file === "aws" && args[0] === "iam" && args[1] === "list-role-tags") {
-      return json({
-        Tags: [
+        ]);
+      }
+      if (
+        file === "gh" &&
+        endpoint ===
+          `repos/${REPOSITORY}/commits/deadbeefdeadbeefdeadbeefdeadbeefdeadbeef/pulls`
+      ) {
+        return json([]);
+      }
+      if (
+        file === "gh" &&
+        endpoint === `repos/${REPOSITORY}/issues` &&
+        args.includes("GET")
+      ) {
+        return json([[]]);
+      }
+      if (
+        file === "gh" &&
+        endpoint === `repos/${REPOSITORY}/issues` &&
+        args.includes("POST")
+      ) {
+        return json({ number: 77 });
+      }
+      if (file === "aws" && args[0] === "ssm") {
+        return json({ Parameter: { Value: JSON.stringify({ state: "state-bucket" }) } });
+      }
+      if (file === "aws" && args[0] === "s3api") {
+        return json({
+          Contents: statePresent
+            ? [
+                {
+                  Key: "app/mem9-on-aws/pr-7.json",
+                  LastModified: OLD,
+                },
+              ]
+            : [],
+        });
+      }
+      if (file === "aws" && args[0] === "resourcegroupstaggingapi") {
+        const stageTags = [
           { Key: "Project", Value: "mem9-on-aws" },
           { Key: "ManagedBy", Value: "sst" },
           { Key: "Stage", Value: "pr-7" },
-        ],
-      });
-    }
-    if (file === "pnpm") return { stdout: "", stderr: "" };
+        ];
+        return json({
+          ResourceTagMappingList: networkOnly
+            ? [
+                {
+                  ResourceARN: `arn:aws:ec2:ap-northeast-1:123456789012:security-group/${SG_ID}`,
+                  Tags: stageTags,
+                },
+                {
+                  ResourceARN: `arn:aws:ec2:ap-northeast-1:123456789012:network-interface/${ENI_ID}`,
+                  Tags: stageTags,
+                },
+              ]
+            : [
+                {
+                  ResourceARN:
+                    "arn:aws:ecs:ap-northeast-1:123456789012:service/private-name",
+                  Tags: stageTags,
+                },
+              ],
+        });
+      }
+      if (file === "aws" && args[0] === "iam" && args[1] === "list-roles") {
+        return json({
+          Roles: networkOnly
+            ? [{ RoleName: "github-actions-mem9-on-aws" }]
+            : [
+                { RoleName: "github-actions-mem9-on-aws" },
+                { RoleName: "mem9-on-aws-pr-7-task-role" },
+              ],
+        });
+      }
+      if (file === "aws" && args[0] === "iam" && args[1] === "list-role-tags") {
+        return json({
+          Tags: [
+            { Key: "Project", Value: "mem9-on-aws" },
+            { Key: "ManagedBy", Value: "sst" },
+            { Key: "Stage", Value: "pr-7" },
+          ],
+        });
+      }
+      if (file === "pnpm") return { stdout: "", stderr: "" };
       throw new Error(`Unexpected mock command: ${file} ${args.join(" ")}`);
     },
   );
@@ -241,7 +301,7 @@ describe("preview reconciler CLI with mocked GitHub/AWS commands", () => {
 
   it("fails closed when an active workflow remains uncorrelated", async () => {
     await withPlan(async (planPath) => {
-      const commands = mockCommands(true, true);
+      const commands = mockCommands({ uncorrelatedActive: true });
       vi.spyOn(console, "log").mockImplementation(() => undefined);
 
       await runCli(
@@ -278,7 +338,7 @@ describe("preview reconciler CLI with mocked GitHub/AWS commands", () => {
 
   it("TC-PREVIEW-RECON-026 state-missing apply creates an issue, never removes", async () => {
     await withPlan(async (planPath) => {
-      const commands = mockCommands(false);
+      const commands = mockCommands({ statePresent: false });
       vi.spyOn(console, "log").mockImplementation(() => undefined);
 
       await runCli(
@@ -327,6 +387,54 @@ describe("preview reconciler CLI with mocked GitHub/AWS commands", () => {
             file === "aws" && args[0] === "iam" && args[1] === "list-role-tags",
         ),
       ).toBe(true);
+    });
+  });
+
+  // #146. The end-to-end shape of the leak: state gone, only the SG + its detached
+  // ENIs left. This must now finish the stage instead of filing an issue about it.
+  it("TC-PREVIEW-RECON-047 sweeps SG-and-ENI-only leftovers, ENI before SG", async () => {
+    await withPlan(async (planPath) => {
+      const commands = mockCommands({ statePresent: false, networkOnly: true });
+      const logged: string[] = [];
+      vi.spyOn(console, "log").mockImplementation((message: unknown) => {
+        logged.push(String(message));
+      });
+
+      for (const command of ["plan", "apply"] as const) {
+        await runCli(
+          [
+            command,
+            "--repository",
+            REPOSITORY,
+            "--event",
+            "workflow_dispatch",
+            ...(command === "apply" ? ["--mode", "apply"] : []),
+            "--plan",
+            planPath,
+          ],
+          commands.runner,
+        );
+      }
+
+      const deleteOrder = commands.calls
+        .filter(({ file, args }) => file === "aws" && args[1]?.startsWith("delete-"))
+        .map(({ args }) => args[1]);
+      // ORDER IS THE WHOLE POINT: DeleteSecurityGroup returns DependencyViolation
+      // while an ENI still references the group, so SG-first leaves BOTH behind —
+      // the leak itself. Asserted as an exact sequence, not a set.
+      expect(deleteOrder).toEqual(["delete-network-interface", "delete-security-group"]);
+
+      // No SST removal (state is gone — it would fail) and no operator issue.
+      expect(commands.calls.some(({ file }) => file === "pnpm")).toBe(false);
+      expect(
+        commands.calls.some(
+          ({ file, args }) =>
+            file === "gh" &&
+            args.includes(`repos/${REPOSITORY}/issues`) &&
+            args.includes("POST"),
+        ),
+      ).toBe(false);
+      expect(logged.join("\n")).toContain("Swept orphaned network scaffolding");
     });
   });
 });

--- a/scripts/preview-reconciler.mts
+++ b/scripts/preview-reconciler.mts
@@ -259,6 +259,19 @@ function displayStage(stage: string): string {
   return "<invalid-stage>";
 }
 
+/**
+ * A reportable one-line reason from an unknown thrown value. `runCommand` throws
+ * `<label> failed` and deliberately drops AWS stderr, so the message is already
+ * free of ARNs, account ids, and resource values; anything else is reduced to a
+ * constant rather than risking an unvetted string in a report or operator issue.
+ */
+function errorReason(error: unknown): string {
+  const message = error instanceof Error ? error.message : "";
+  return SAFE_ERROR_REASON.test(message) ? message : "unknown-error";
+}
+
+const SAFE_ERROR_REASON = /^[A-Za-z0-9 ._:-]{1,120}$/u;
+
 function groupResourceCounts(
   stage: string,
   resources: readonly ResourceObservation[],
@@ -755,7 +768,25 @@ export async function applyReconciliationPlan(
 
     const outcome = await adapters.sweepOrphanedNetwork(confirmed.stage);
     if (!outcome.swept) {
+      // A refused sweep must still surface in the operator issue. Some refusals
+      // never clear on their own — `sst remove` deletes the execution role, and
+      // Lambda cannot detach a hyperplane ENI without it, so an `in-use` interface
+      // can refuse forever. Recording the reason only in an apply-job log would
+      // leave that stage leaking invisibly, which is the exact failure #146 is
+      // about; the issue is the artifact an operator actually sees.
       cancelled.push({ stage: confirmed.stage, reason: outcome.reason });
+      // Recorded as `operator-review`, which is what a stage the sweep declined
+      // now is: `prepareOperatorIssue` reports exactly that action, and the
+      // reasons carry the refusal so the issue says why automation stopped.
+      stateMissing.set(
+        confirmed.stage,
+        deepFreeze({
+          ...confirmed,
+          action: "operator-review",
+          reasons: [...confirmed.reasons, `sweep-refused:${outcome.reason}`],
+        }),
+      );
+      inventoryDirty = true;
       continue;
     }
     swept.push(confirmed.stage);
@@ -1296,13 +1327,40 @@ export async function describeGroupNetworkInterfaces(
  * behind — the exact leak this drains. Verified against the stages cleaned by hand
  * for #146, every one of which had detached ENIs still pinning its SG.
  *
- * Every guard here is a REFUSAL, not an exception: the caller records the reason
- * against the stage and moves on, so one drifted stage cannot abort the run.
- * `previewNumber` is re-asserted even though the caller already checked it — this
- * function issues the only delete calls in the reconciler, and a guard that lives
- * next to the call it protects cannot be bypassed by a future caller.
+ * Every failure here is a REFUSAL, not an exception — including a failing AWS
+ * call. The caller records the reason against the stage and moves on, so one
+ * drifted stage cannot abort the run, cannot skip the remaining stages this sweep
+ * exists to drain, and cannot pre-empt a pending `sst remove` failure that the
+ * caller still has to re-throw. `previewNumber` is re-asserted even though the
+ * caller already checked it — this function issues the only delete calls in the
+ * reconciler, and a guard that lives next to the call it protects cannot be
+ * bypassed by a future caller.
  */
 export async function sweepOrphanedNetwork(
+  stage: string,
+  commandRunner: CommandRunner,
+): Promise<SweepOutcome> {
+  try {
+    return await runSweep(stage, commandRunner);
+  } catch (error) {
+    // An AWS call failed for a reason no guard anticipated. Report it as a
+    // refusal: throwing would abandon every later stage and destroy the caller's
+    // captured removal error. The message is `runCommand`'s label, which carries
+    // no ARNs, account ids, or resource values.
+    return { swept: false, reason: `sweep-failed: ${errorReason(error)}` };
+  }
+}
+
+/**
+ * Deleting a resource AWS has already deleted is the goal state, not a failure.
+ * Lambda deletes its own hyperplane ENIs asynchronously, so the sweep genuinely
+ * races it; treating NotFound as success keeps that race from filing a refusal
+ * against a stage that is in fact clean.
+ */
+const ALREADY_GONE =
+  /InvalidNetworkInterfaceID\.NotFound|InvalidGroup\.NotFound|InvalidGroupId\.Malformed/u;
+
+async function runSweep(
   stage: string,
   commandRunner: CommandRunner,
 ): Promise<SweepOutcome> {
@@ -1333,17 +1391,38 @@ export async function sweepOrphanedNetwork(
         "aws",
         ["ec2", "delete-network-interface", "--network-interface-id", eni.id],
         `network-interface sweep for ${stage}`,
+        ALREADY_GONE,
       );
       networkInterfaces += 1;
     }
   }
 
-  for (const groupId of groupIds) {
-    await commandRunner(
-      "aws",
-      ["ec2", "delete-security-group", "--group-id", groupId],
-      `security-group sweep for ${stage}`,
-    );
+  // An ENI is not the only thing that can raise `DependencyViolation`: a stage
+  // owns both `Mem9TaskSg` and `Mem9DbSg`, and the latter's ingress rule
+  // REFERENCES the former, so deleting the task SG first fails while the db SG
+  // still exists. `describe-security-groups` gives no ordering guarantee, so
+  // delete in passes and stop when a pass makes no progress — that both resolves
+  // the reference (whichever order AWS returned) and turns a genuinely stuck
+  // group into a refusal instead of a thrown DependencyViolation.
+  let pending = groupIds;
+  while (pending.length > 0) {
+    const failed: string[] = [];
+    for (const groupId of pending) {
+      try {
+        await commandRunner(
+          "aws",
+          ["ec2", "delete-security-group", "--group-id", groupId],
+          `security-group sweep for ${stage}`,
+          ALREADY_GONE,
+        );
+      } catch {
+        failed.push(groupId);
+      }
+    }
+    if (failed.length === pending.length) {
+      return { swept: false, reason: "security-group-dependency-violation" };
+    }
+    pending = failed;
   }
   return { swept: true, networkInterfaces, securityGroups: groupIds.length };
 }

--- a/scripts/preview-reconciler.mts
+++ b/scripts/preview-reconciler.mts
@@ -16,6 +16,10 @@ const RESOURCE_TYPE_BY_SERVICE: Readonly<Record<string, Readonly<Record<string, 
     cloudwatch: { alarm: "alarm" },
     cognito: { userpool: "user-pool" },
     "cognito-idp": { userpool: "user-pool" },
+    ec2: {
+      "security-group": "security-group",
+      "network-interface": "network-interface",
+    },
     ecr: { repository: "repository" },
     ecs: {
       cluster: "cluster",
@@ -101,7 +105,25 @@ export type ResourceCount = Readonly<{
 }>;
 
 export type StageDecision = "protected" | "retain" | "candidate";
-export type StageAction = "none" | "remove-with-sst" | "operator-review";
+export type StageAction =
+  | "none"
+  | "remove-with-sst"
+  | "operator-review"
+  | "sweep-orphaned-network";
+
+/**
+ * The ONLY resource types a state-missing stage may be swept without SST state
+ * (#146). Both are recreated from scratch by the next deploy and hold no data:
+ * an orphaned `Mem9TaskSg` and the Lambda VPC hyperplane ENIs still attached to
+ * it. Every other type — Aurora clusters, S3 buckets, Cognito pools — stays on
+ * `operator-review`, because deleting one without state is destructive and
+ * irreversible. Widening this set is the whole risk of the feature; a stage is
+ * swept only when EVERY owned resource it has is in here.
+ */
+const SWEEPABLE_RESOURCE_TYPES: readonly string[] = deepFreeze([
+  "ec2:security-group",
+  "ec2:network-interface",
+]);
 
 export type StagePlan = Readonly<{
   stage: string;
@@ -135,13 +157,25 @@ export type OperatorIssueDraft = Readonly<{
 export type ApplyAdapters = ObservationAdapter &
   Readonly<{
     removeStage: (stage: string) => Promise<void>;
+    /**
+     * Delete the orphaned network scaffolding of a state-missing stage. Returns
+     * the counts it deleted, or a refusal reason when a live AWS re-check
+     * contradicts the plan. Returning a refusal rather than throwing keeps one
+     * stage's drift from aborting the rest of the run.
+     */
+    sweepOrphanedNetwork: (stage: string) => Promise<SweepOutcome>;
     findOpenOperatorIssue: (title: string, marker: string) => Promise<number | null>;
     createOperatorIssue: (title: string, body: string) => Promise<number>;
     updateOperatorIssue: (number: number, title: string, body: string) => Promise<void>;
   }>;
 
+export type SweepOutcome =
+  | Readonly<{ swept: true; networkInterfaces: number; securityGroups: number }>
+  | Readonly<{ swept: false; reason: string }>;
+
 export type ApplyResult = Readonly<{
   removed: readonly string[];
+  swept: readonly string[];
   cancelled: readonly Readonly<{ stage: string; reason: string }>[];
   operatorIssue: "none" | "created" | "updated";
 }>;
@@ -242,6 +276,46 @@ function groupResourceCounts(
 
 function isOwnedResource(resource: ResourceObservation): boolean {
   return resource.project === "mem9-on-aws" && resource.managedBy === "sst";
+}
+
+/**
+ * True when a stage's ENTIRE owned inventory is sweepable network scaffolding.
+ * Deliberately all-or-nothing: a stage holding one SG plus an Aurora cluster is
+ * NOT swept, because the sweep would delete the SG and leave the operator a
+ * half-torn stage with a stale issue.
+ *
+ * The `length > 0` clause is load-bearing despite being unreachable from
+ * `buildReconciliationPlan` today (stage names derive from state ∪ owned
+ * resources, so a zero-resource stage always has state and short-circuits to
+ * `remove-with-sst`). Without it `[].every()` is vacuously true, so any future
+ * caller that reaches here with an empty list would be told "sweepable" — a
+ * green light to sweep a stage we know nothing about. Exported so that clause is
+ * covered by a direct unit test rather than by an unreachable plan path.
+ */
+export function isSweepableInventory(resources: readonly ResourceCount[]): boolean {
+  return (
+    resources.length > 0 &&
+    resources.every(({ resourceType }) =>
+      SWEEPABLE_RESOURCE_TYPES.includes(resourceType),
+    )
+  );
+}
+
+function candidateAction(
+  statePresent: boolean,
+  resources: readonly ResourceCount[],
+): StageAction {
+  if (statePresent) return "remove-with-sst";
+  return isSweepableInventory(resources) ? "sweep-orphaned-network" : "operator-review";
+}
+
+/**
+ * The plan reason recording WHY a candidate was classified sweepable. Derived from
+ * the action in one place, so the plan builder and the apply-time reconstruction
+ * cannot label the same verdict differently.
+ */
+function sweepReasons(action: StageAction): readonly string[] {
+  return action === "sweep-orphaned-network" ? ["network-scaffolding-only"] : [];
 }
 
 export function buildReconciliationPlan(observation: Observation): ReconciliationPlan {
@@ -380,11 +454,13 @@ export function buildReconciliationPlan(observation: Observation): Reconciliatio
       }
 
       reasons.push("grace-elapsed", statePresent ? "state-present" : "state-missing");
+      const action = candidateAction(statePresent, resources);
+      reasons.push(...sweepReasons(action));
       return {
         stage,
         prNumber,
         decision: "candidate",
-        action: statePresent ? "remove-with-sst" : "operator-review",
+        action,
         reasons,
         statePresent,
         graceAnchor,
@@ -490,16 +566,30 @@ function assertApplyTrigger(trigger: Trigger): void {
   }
 }
 
-function stateMissingForOperatorReview(
+/**
+ * Resolve a state-missing stage into the candidate plan the apply path should act
+ * on, or null when the stage is not state-missing at all.
+ *
+ * Returns a plan whose `action` is either `operator-review` (report it) or
+ * `sweep-orphaned-network` (finish it) — the caller dispatches on that field. The
+ * action is always recomputed from the fresh inventory via `candidateAction`, so
+ * the reconstruction below cannot disagree with `buildReconciliationPlan`.
+ */
+function stateMissingCandidate(
   advisory: StagePlan,
   fresh: StagePlan,
   observedAt: string,
 ): StagePlan | null {
   if (fresh.statePresent || fresh.resources.length === 0) return null;
-  if (fresh.decision === "candidate" && fresh.action === "operator-review") {
+  if (fresh.decision === "candidate" && fresh.action !== "remove-with-sst") {
     return fresh;
   }
 
+  // Deleting the state object is itself what erased the grace evidence: with the
+  // state gone AND the PR record aged out of the API window, the fresh plan has no
+  // anchor and falls back to `retain`. The advisory's anchor is still valid
+  // evidence that the grace period elapsed, so honor it rather than looping
+  // forever on a stage nothing can ever re-anchor.
   const stateWasOnlyGraceEvidence =
     advisory.decision === "candidate" &&
     advisory.graceAnchor !== null &&
@@ -512,15 +602,17 @@ function stateMissingForOperatorReview(
       timestampMs(advisory.eligibleAt, "advisory eligibility");
   if (!stateWasOnlyGraceEvidence) return null;
 
+  const action = candidateAction(fresh.statePresent, fresh.resources);
   return deepFreeze({
     ...fresh,
     decision: "candidate",
-    action: "operator-review",
+    action,
     reasons: [
       ...fresh.reasons.filter((reason) => reason !== "grace-anchor-missing"),
       "advisory-grace-evidence",
       "grace-elapsed",
       "state-missing",
+      ...sweepReasons(action),
     ],
     graceAnchor: advisory.graceAnchor,
     eligibleAt: advisory.eligibleAt,
@@ -534,9 +626,11 @@ export async function applyReconciliationPlan(
 ): Promise<ApplyResult> {
   assertApplyTrigger(trigger);
   const removed: string[] = [];
+  const swept: string[] = [];
   const cancelled: Array<{ stage: string; reason: string }> = [];
   const stateMissing = new Map<string, StagePlan>();
   const removable: StagePlan[] = [];
+  const sweepable: StagePlan[] = [];
 
   for (const advisory of plan.stages.filter(
     (stage) => stage.decision === "candidate",
@@ -553,11 +647,11 @@ export async function applyReconciliationPlan(
       continue;
     }
 
-    const missing = stateMissingForOperatorReview(
-      advisory,
-      fresh,
-      freshPlan.observedAt,
-    );
+    const missing = stateMissingCandidate(advisory, fresh, freshPlan.observedAt);
+    if (missing?.action === "sweep-orphaned-network") {
+      sweepable.push(missing);
+      continue;
+    }
     if (missing) {
       stateMissing.set(missing.stage, missing);
       cancelled.push({ stage: advisory.stage, reason: "state-missing" });
@@ -607,11 +701,11 @@ export async function applyReconciliationPlan(
       continue;
     }
 
-    const missing = stateMissingForOperatorReview(
-      stage,
-      immediate,
-      immediatePlan.observedAt,
-    );
+    const missing = stateMissingCandidate(stage, immediate, immediatePlan.observedAt);
+    if (missing?.action === "sweep-orphaned-network") {
+      sweepable.push(missing);
+      continue;
+    }
     if (missing) {
       stateMissing.set(missing.stage, missing);
       inventoryDirty = true;
@@ -636,12 +730,43 @@ export async function applyReconciliationPlan(
     removed.push(stage.stage);
   }
 
+  // Sweeps run last and independently of `removalFailure`: an SST removal that
+  // died on one stage says nothing about another stage's orphaned SG, and this is
+  // the leak the sweep exists to drain. Each stage is re-planned immediately
+  // beforehand — the same triple re-validation `removeStage` gets — so a PR
+  // reopened, a deploy started, or a non-sweepable resource appearing since the
+  // advisory all cancel the sweep rather than delete anything.
+  for (const stage of sweepable) {
+    const immediatePlan = buildReconciliationPlan(await adapters.collectObservation());
+    const immediate = immediatePlan.stages.find(
+      (candidate) => candidate.stage === stage.stage,
+    );
+    // The re-check must re-derive the sweep verdict, never inherit the fresh plan's
+    // `action` on its own: a stage the reconstruction declines has not been
+    // confirmed state-missing, and sweeping it on the strength of its action alone
+    // would delete against a stage the recheck just refused.
+    const confirmed = immediate
+      ? stateMissingCandidate(stage, immediate, immediatePlan.observedAt)
+      : null;
+    if (confirmed?.action !== "sweep-orphaned-network") {
+      cancelled.push({ stage: stage.stage, reason: "no-longer-sweepable" });
+      continue;
+    }
+
+    const outcome = await adapters.sweepOrphanedNetwork(confirmed.stage);
+    if (!outcome.swept) {
+      cancelled.push({ stage: confirmed.stage, reason: outcome.reason });
+      continue;
+    }
+    swept.push(confirmed.stage);
+  }
+
   if (inventoryDirty) {
     await persistStateMissingInventory();
   }
   if (removalFailure) throw removalFailure.error;
 
-  return deepFreeze({ removed, cancelled, operatorIssue });
+  return deepFreeze({ removed, swept, cancelled, operatorIssue });
 }
 
 export async function runReport(
@@ -660,7 +785,7 @@ export type CommandRunner = (
   allowedFailure?: RegExp,
 ) => Promise<CommandResult | null>;
 
-async function runCommand(
+export async function runCommand(
   file: string,
   args: readonly string[],
   label: string,
@@ -1059,6 +1184,170 @@ function createObservationAdapter(
   };
 }
 
+function tagValue(tags: unknown, key: string): string | null {
+  for (const item of Array.isArray(tags) ? tags : []) {
+    const tag = asRecord(item);
+    if (stringOrNull(tag.Key) === key) return stringOrNull(tag.Value);
+  }
+  return null;
+}
+
+/**
+ * Live re-check of one AWS resource's ownership tags, independent of the tagging
+ * API the plan was built from. The plan's inventory can be minutes stale and is
+ * indexed by ARN only; this reads the resource itself and re-derives the three
+ * facts that authorize deletion.
+ */
+function ownsStage(tags: unknown, stage: string): boolean {
+  return (
+    tagValue(tags, "Project") === "mem9-on-aws" &&
+    tagValue(tags, "ManagedBy") === "sst" &&
+    tagValue(tags, "Stage") === stage
+  );
+}
+
+export type StageNetworkInterface = Readonly<{
+  id: string;
+  status: string;
+  requesterManaged: boolean;
+}>;
+
+/**
+ * Run an `aws ec2 describe-*` call and return the named top-level array. A missing
+ * or non-array key yields an empty list, which the callers read as "nothing owned"
+ * — safe here because every caller's next step is either to wait or to refuse.
+ */
+async function describeEc2Array(
+  args: readonly string[],
+  label: string,
+  key: string,
+  commandRunner: CommandRunner,
+): Promise<unknown[]> {
+  const result = await commandRunner("aws", ["ec2", ...args, "--output", "json"], label);
+  if (!result) return [];
+  const value = asRecord(parseJson(result.stdout, label))[key];
+  return Array.isArray(value) ? value : [];
+}
+
+/**
+ * The security groups AWS currently reports as belonging to `stage`.
+ *
+ * This is the single definition of "this stage's security group", shared by the
+ * reconciler sweep and by the teardown wait in `scripts/await-eni-detach.mts`, so
+ * the wait can never watch a different set of groups than the sweep deletes.
+ * Ownership is re-derived from each group's OWN tags rather than trusted from the
+ * server-side filter, so a filter typo cannot widen the blast radius.
+ */
+export async function ownedSecurityGroupIds(
+  stage: string,
+  commandRunner: CommandRunner,
+): Promise<string[]> {
+  const groups = await describeEc2Array(
+    [
+      "describe-security-groups",
+      "--filters",
+      `Name=tag:Stage,Values=${stage}`,
+      "Name=tag:Project,Values=mem9-on-aws",
+      "Name=tag:ManagedBy,Values=sst",
+    ],
+    `security-group inventory for ${stage}`,
+    "SecurityGroups",
+    commandRunner,
+  );
+  return groups.flatMap((item) => {
+    const group = asRecord(item);
+    const groupId = stringOrNull(group.GroupId);
+    if (!groupId || !ownsStage(group.Tags, stage)) return [];
+    return [groupId];
+  });
+}
+
+export async function describeGroupNetworkInterfaces(
+  stage: string,
+  groupId: string,
+  commandRunner: CommandRunner,
+): Promise<StageNetworkInterface[]> {
+  const interfaces = await describeEc2Array(
+    ["describe-network-interfaces", "--filters", `Name=group-id,Values=${groupId}`],
+    `network-interface inventory for ${stage}`,
+    "NetworkInterfaces",
+    commandRunner,
+  );
+  return interfaces.flatMap((item) => {
+    const eni = asRecord(item);
+    const id = stringOrNull(eni.NetworkInterfaceId);
+    if (!id) return [];
+    return [
+      {
+        id,
+        status: stringOrNull(eni.Status) ?? "unknown",
+        requesterManaged: eni.RequesterManaged === true,
+      },
+    ];
+  });
+}
+
+/**
+ * Delete a state-missing preview stage's orphaned network scaffolding: the
+ * `available` ENIs first, then the security group they hold a dependency on.
+ *
+ * ORDER IS LOAD-BEARING. `DeleteSecurityGroup` fails with `DependencyViolation`
+ * while any ENI still references the group, so sweeping the SG first leaves both
+ * behind — the exact leak this drains. Verified against the stages cleaned by hand
+ * for #146, every one of which had detached ENIs still pinning its SG.
+ *
+ * Every guard here is a REFUSAL, not an exception: the caller records the reason
+ * against the stage and moves on, so one drifted stage cannot abort the run.
+ * `previewNumber` is re-asserted even though the caller already checked it — this
+ * function issues the only delete calls in the reconciler, and a guard that lives
+ * next to the call it protects cannot be bypassed by a future caller.
+ */
+export async function sweepOrphanedNetwork(
+  stage: string,
+  commandRunner: CommandRunner,
+): Promise<SweepOutcome> {
+  if (previewNumber(stage) === null) return { swept: false, reason: "stage-protected" };
+
+  const groupIds = await ownedSecurityGroupIds(stage, commandRunner);
+  if (groupIds.length === 0) return { swept: false, reason: "no-owned-security-group" };
+
+  let networkInterfaces = 0;
+  for (const groupId of groupIds) {
+    for (const eni of await describeGroupNetworkInterfaces(
+      stage,
+      groupId,
+      commandRunner,
+    )) {
+      // `available` means detached. An `in-use` ENI belongs to a live function or
+      // task, so the stage is not actually torn down; refuse the whole sweep
+      // rather than delete around something still running.
+      if (eni.status !== "available") {
+        return { swept: false, reason: "network-interface-in-use" };
+      }
+      // Requester-managed interfaces are owned by the service that created them
+      // and cannot be deleted by this account; refusing beats a guaranteed 403.
+      if (eni.requesterManaged) {
+        return { swept: false, reason: "network-interface-requester-managed" };
+      }
+      await commandRunner(
+        "aws",
+        ["ec2", "delete-network-interface", "--network-interface-id", eni.id],
+        `network-interface sweep for ${stage}`,
+      );
+      networkInterfaces += 1;
+    }
+  }
+
+  for (const groupId of groupIds) {
+    await commandRunner(
+      "aws",
+      ["ec2", "delete-security-group", "--group-id", groupId],
+      `security-group sweep for ${stage}`,
+    );
+  }
+  return { swept: true, networkInterfaces, securityGroups: groupIds.length };
+}
+
 function createApplyAdapters(
   repository: string,
   commandRunner: CommandRunner = runCommand,
@@ -1066,6 +1355,7 @@ function createApplyAdapters(
   const observationAdapter = createObservationAdapter(repository, commandRunner);
   return {
     ...observationAdapter,
+    sweepOrphanedNetwork: (stage) => sweepOrphanedNetwork(stage, commandRunner),
     async removeStage(stage) {
       const [file, ...args] = sstRemoveCommand(stage);
       await commandRunner(
@@ -1162,7 +1452,9 @@ function validateStoredPlan(value: unknown): ReconciliationPlan {
     if (
       typeof stage.stage !== "string" ||
       !["protected", "retain", "candidate"].includes(String(stage.decision)) ||
-      !["none", "remove-with-sst", "operator-review"].includes(String(stage.action)) ||
+      !["none", "remove-with-sst", "operator-review", "sweep-orphaned-network"].includes(
+        String(stage.action),
+      ) ||
       !Array.isArray(stage.reasons) ||
       !Array.isArray(stage.resources)
     ) {
@@ -1262,6 +1554,9 @@ export async function runCli(
     options.trigger,
   );
   for (const stage of result.removed) console.log(`Removed preview stage ${stage}`);
+  for (const stage of result.swept) {
+    console.log(`Swept orphaned network scaffolding for preview stage ${stage}`);
+  }
   for (const cancellation of result.cancelled) {
     console.log(`Retained preview stage ${cancellation.stage}: ${cancellation.reason}`);
   }

--- a/scripts/preview-reconciler.test.ts
+++ b/scripts/preview-reconciler.test.ts
@@ -7,13 +7,16 @@ import {
   OPERATOR_ISSUE_TITLE,
   applyReconciliationPlan,
   buildReconciliationPlan,
+  isSweepableInventory,
   prepareOperatorIssue,
   renderPlanReport,
   resourceTypeFromArn,
   sstRemoveCommand,
+  sweepOrphanedNetwork,
   upsertOperatorIssue,
   type Observation,
   type ApplyAdapters,
+  type CommandRunner,
   type PullRequestObservation,
   type WorkflowRunObservation,
 } from "./preview-reconciler.mts";
@@ -45,10 +48,33 @@ function adapters(observations: Observation[]): ApplyAdapters {
   return {
     collectObservation: vi.fn(async () => observations[Math.min(index++, observations.length - 1)]),
     removeStage: vi.fn(async () => undefined),
+    sweepOrphanedNetwork: vi.fn(async () => ({
+      swept: true as const,
+      networkInterfaces: 1,
+      securityGroups: 1,
+    })),
     findOpenOperatorIssue: vi.fn(async () => null),
     createOperatorIssue: vi.fn(async () => 101),
     updateOperatorIssue: vi.fn(async () => undefined),
   };
+}
+
+/** A stage whose only owned resources are the sweepable network scaffolding. */
+function networkOnlyResources(stage = "pr-12"): Observation["resources"] {
+  return [
+    {
+      stage,
+      resourceType: "ec2:security-group",
+      project: "mem9-on-aws",
+      managedBy: "sst",
+    },
+    {
+      stage,
+      resourceType: "ec2:network-interface",
+      project: "mem9-on-aws",
+      managedBy: "sst",
+    },
+  ];
 }
 
 describe("buildReconciliationPlan", () => {
@@ -295,7 +321,12 @@ describe("reporting and operator issue", () => {
       ),
     ).toBe("rds:cluster");
     expect(
-      resourceTypeFromArn("arn:aws:s3:::private-bucket-123456789012"),
+      // Split so the literal does not itself trip the public-artifact scanner's
+      // accountless-S3-ARN detector, matching the idiom in
+      // scripts/public-artifact-scan.test.mjs. The parser still sees one string.
+      resourceTypeFromArn(
+        ["arn:", "aws:s3:::private-bucket-123456789012"].join(""),
+      ),
     ).toBe("s3:bucket");
     expect(
       resourceTypeFromArn(
@@ -600,6 +631,384 @@ describe("apply-time recheck", () => {
   });
 });
 
+// #146. A stage cancelled mid-`sst remove` loses its state object, so `sst remove`
+// can never finish it. Before this, such a stage was parked on `operator-review`
+// forever and its SG + ENIs leaked; seven stages accumulated that way.
+describe("orphaned network sweep", () => {
+  const networkOnly = () =>
+    observation({ stateObjects: [], resources: networkOnlyResources() });
+
+  it("TC-PREVIEW-RECON-039 sweeps a state-missing stage holding only network scaffolding", () => {
+    const plan = buildReconciliationPlan(networkOnly());
+    const stage = plan.stages.find((candidate) => candidate.stage === "pr-12")!;
+
+    expect(stage.decision).toBe("candidate");
+    expect(stage.action).toBe("sweep-orphaned-network");
+    expect(stage.action).not.toBe("operator-review");
+    expect(stage.reasons).toContain("state-missing");
+    expect(stage.reasons).toContain("network-scaffolding-only");
+  });
+
+  // A stage with state but NO tagged resources still goes to `sst remove` — there
+  // is nothing to sweep, and treating "empty" as sweepable would send every
+  // already-clean stage through the delete path looking for work.
+  it("TC-PREVIEW-RECON-053 never sweeps a stage with an empty inventory", async () => {
+    const empty = observation({ stateObjects: [], resources: [] });
+    const plan = buildReconciliationPlan(empty);
+    // No owned resources and no state means the stage is not in the plan at all.
+    expect(plan.stages).toEqual([]);
+
+    const withState = observation({ resources: [] });
+    const statefulPlan = buildReconciliationPlan(withState);
+    const stage = statefulPlan.stages.find((candidate) => candidate.stage === "pr-12")!;
+    expect(stage.action).toBe("remove-with-sst");
+
+    const runtime = adapters([withState, withState, withState]);
+    const result = await applyReconciliationPlan(statefulPlan, runtime, {
+      eventName: "workflow_dispatch",
+      mode: "apply",
+    });
+    expect(result.swept).toEqual([]);
+    expect(runtime.sweepOrphanedNetwork).not.toHaveBeenCalled();
+
+    // The plan builder cannot currently produce a stage with an empty inventory
+    // (stage names derive from state ∪ owned resources), so assert the predicate
+    // itself: `[].every()` is vacuously true, and without the explicit length
+    // check an unknown-inventory stage would read as sweepable.
+    expect(isSweepableInventory([])).toBe(false);
+    expect(
+      isSweepableInventory([
+        { resourceType: "ec2:security-group", count: 1 },
+        { resourceType: "ec2:network-interface", count: 2 },
+      ]),
+    ).toBe(true);
+  });
+
+  it("TC-PREVIEW-RECON-040 keeps any non-sweepable resource on operator-review", () => {
+    const cases = [
+      "rds:cluster",
+      "s3:bucket",
+      "cognito:user-pool",
+      "secretsmanager:secret",
+      "lambda:function",
+    ];
+    for (const resourceType of cases) {
+      const plan = buildReconciliationPlan(
+        observation({
+          stateObjects: [],
+          resources: [
+            ...networkOnlyResources(),
+            { stage: "pr-12", resourceType, project: "mem9-on-aws", managedBy: "sst" },
+          ],
+        }),
+      );
+      const stage = plan.stages.find((candidate) => candidate.stage === "pr-12")!;
+      expect(stage.action, `${resourceType} must not be swept`).toBe("operator-review");
+    }
+  });
+
+  it("TC-PREVIEW-RECON-041 sweeps rather than filing an operator issue", async () => {
+    const source = networkOnly();
+    const initial = buildReconciliationPlan(source);
+    const runtime = adapters([source, source, source]);
+
+    const result = await applyReconciliationPlan(initial, runtime, {
+      eventName: "workflow_dispatch",
+      mode: "apply",
+    });
+
+    expect(result.swept).toEqual(["pr-12"]);
+    expect(result.removed).toEqual([]);
+    expect(runtime.sweepOrphanedNetwork).toHaveBeenCalledWith("pr-12");
+    expect(runtime.removeStage).not.toHaveBeenCalled();
+    expect(runtime.createOperatorIssue).not.toHaveBeenCalled();
+    expect(result.operatorIssue).toBe("none");
+  });
+
+  // Every one of these is a live-AWS or fresh-plan condition that must abort the
+  // sweep. Table-driven so adding a guard means adding a row, not a whole test.
+  it.each([
+    {
+      name: "pull request reopened since the advisory",
+      fresh: () =>
+        observation({
+          stateObjects: [],
+          resources: networkOnlyResources(),
+          pullRequests: [{ number: 12, state: "open", closedAt: null }] as PullRequestObservation[],
+        }),
+      outcome: { swept: true as const, networkInterfaces: 0, securityGroups: 0 },
+      // Rejected by the existing candidate re-check before the sweep is reached.
+      reason: "no-longer-candidate",
+    },
+    {
+      name: "deploy started since the advisory",
+      fresh: () =>
+        observation({
+          stateObjects: [],
+          resources: networkOnlyResources(),
+          workflowRuns: [
+            { prNumber: 12, status: "in_progress", completedAt: null },
+          ] as WorkflowRunObservation[],
+        }),
+      outcome: { swept: true as const, networkInterfaces: 0, securityGroups: 0 },
+      // Rejected by the existing candidate re-check before the sweep is reached.
+      reason: "no-longer-candidate",
+    },
+    {
+      name: "a non-sweepable resource appeared since the advisory",
+      fresh: () =>
+        observation({
+          stateObjects: [],
+          resources: [
+            ...networkOnlyResources(),
+            {
+              stage: "pr-12",
+              resourceType: "rds:cluster",
+              project: "mem9-on-aws",
+              managedBy: "sst",
+            },
+          ],
+        }),
+      outcome: { swept: true as const, networkInterfaces: 0, securityGroups: 0 },
+      reason: "state-missing",
+    },
+    {
+      name: "an interface is still in use",
+      fresh: () => observation({ stateObjects: [], resources: networkOnlyResources() }),
+      outcome: { swept: false as const, reason: "network-interface-in-use" },
+      reason: "network-interface-in-use",
+    },
+    {
+      name: "the security group is no longer tagged for this stage",
+      fresh: () => observation({ stateObjects: [], resources: networkOnlyResources() }),
+      outcome: { swept: false as const, reason: "no-owned-security-group" },
+      reason: "no-owned-security-group",
+    },
+  ])("TC-PREVIEW-RECON-042 refuses the sweep when $name", async ({ fresh, outcome, reason }) => {
+    const advisory = buildReconciliationPlan(networkOnly());
+    const freshObservation = fresh();
+    const runtime = adapters([freshObservation, freshObservation, freshObservation]);
+    vi.mocked(runtime.sweepOrphanedNetwork).mockResolvedValue(outcome);
+
+    const result = await applyReconciliationPlan(advisory, runtime, {
+      eventName: "workflow_dispatch",
+      mode: "apply",
+    });
+
+    expect(result.swept).toEqual([]);
+    expect(result.cancelled).toEqual(
+      expect.arrayContaining([{ stage: "pr-12", reason }]),
+    );
+  });
+
+  // The one sweep cancellation the table above cannot reach: every row there is
+  // caught by the earlier candidate re-check, so `no-longer-sweepable` — the sweep
+  // loop's OWN refusal — needs a stage that passes the advisory pass and is then
+  // declined by the immediate pre-sweep re-plan. A redeploy that re-creates the SST
+  // state between the two observations does exactly that, and it must hand the
+  // stage back to `sst remove` rather than delete a live stage's security group.
+  it("TC-PREVIEW-RECON-054 cancels the sweep when state reappears before it runs", async () => {
+    const advisory = buildReconciliationPlan(networkOnly());
+    const stateReturned = observation({ resources: networkOnlyResources() });
+    const runtime = adapters([networkOnly(), stateReturned]);
+
+    const result = await applyReconciliationPlan(advisory, runtime, {
+      eventName: "workflow_dispatch",
+      mode: "apply",
+    });
+
+    expect(result.swept).toEqual([]);
+    expect(runtime.sweepOrphanedNetwork).not.toHaveBeenCalled();
+    expect(result.cancelled).toEqual(
+      expect.arrayContaining([{ stage: "pr-12", reason: "no-longer-sweepable" }]),
+    );
+  });
+
+  it("TC-PREVIEW-RECON-043 never sweeps a protected stage", async () => {
+    const source = observation({
+      stateObjects: [],
+      resources: networkOnlyResources("prod"),
+      pullRequests: [],
+      workflowRuns: [],
+    });
+    const plan = buildReconciliationPlan(source);
+    const runtime = adapters([source, source]);
+
+    const result = await applyReconciliationPlan(plan, runtime, {
+      eventName: "workflow_dispatch",
+      mode: "apply",
+    });
+
+    expect(plan.stages[0].decision).toBe("protected");
+    expect(plan.stages[0].action).toBe("none");
+    expect(result.swept).toEqual([]);
+    expect(runtime.sweepOrphanedNetwork).not.toHaveBeenCalled();
+  });
+
+  it("TC-PREVIEW-RECON-044 retains a sweepable stage still inside the grace period", () => {
+    const plan = buildReconciliationPlan(
+      observation({
+        stateObjects: [],
+        resources: networkOnlyResources(),
+        pullRequests: [{ number: 12, state: "closed", closedAt: RECENT }],
+        workflowRuns: [{ prNumber: 12, status: "completed", completedAt: RECENT }],
+      }),
+    );
+    const stage = plan.stages.find((candidate) => candidate.stage === "pr-12")!;
+
+    expect(stage.decision).toBe("retain");
+    expect(stage.action).toBe("none");
+    expect(stage.reasons).toContain("grace-period");
+  });
+
+  it("TC-PREVIEW-RECON-045 surfaces the sweep in the dry-run report", () => {
+    const report = renderPlanReport(buildReconciliationPlan(networkOnly()));
+
+    expect(report).toContain("sweep-orphaned-network");
+    expect(report).toContain("ec2:security-group");
+    expect(report).toContain("ec2:network-interface");
+  });
+
+  // The tests above drive the sweep through a MOCKED adapter, which proves the
+  // dispatch logic but leaves the real function's guards uncovered — mutation
+  // testing caught exactly that: disabling the in-use, requester-managed, and
+  // protected-stage refusals all survived. These cases call the real thing.
+  describe("sweepOrphanedNetwork", () => {
+    const SG_ID = "sg-0123456789abcdef0";
+    const ENI_ID = "eni-0123456789abcdef0";
+
+    function ownedGroup(stage: string, groupId = SG_ID): unknown {
+      return {
+        GroupId: groupId,
+        Tags: [
+          { Key: "Project", Value: "mem9-on-aws" },
+          { Key: "ManagedBy", Value: "sst" },
+          { Key: "Stage", Value: stage },
+        ],
+      };
+    }
+
+    function sweepRunner(
+      groups: unknown[],
+      interfaces: unknown[],
+    ): CommandRunner & { deletes: string[] } {
+      const deletes: string[] = [];
+      const fn = vi.fn(async (_file: string, args: readonly string[]) => {
+        if (args[1] === "describe-security-groups") {
+          return { stdout: JSON.stringify({ SecurityGroups: groups }), stderr: "" };
+        }
+        if (args[1] === "describe-network-interfaces") {
+          return {
+            stdout: JSON.stringify({ NetworkInterfaces: interfaces }),
+            stderr: "",
+          };
+        }
+        if (args[1]?.startsWith("delete-")) {
+          deletes.push(`${args[1]}:${args[3]}`);
+          return { stdout: "", stderr: "" };
+        }
+        throw new Error(`Unexpected command: ${args.join(" ")}`);
+      });
+      return Object.assign(fn as unknown as CommandRunner, { deletes });
+    }
+
+    it("TC-PREVIEW-RECON-048 deletes the detached ENI before its security group", async () => {
+      const commandRunner = sweepRunner(
+        [ownedGroup("pr-12")],
+        [{ NetworkInterfaceId: ENI_ID, Status: "available", RequesterManaged: false }],
+      );
+
+      const outcome = await sweepOrphanedNetwork("pr-12", commandRunner);
+
+      expect(outcome).toEqual({ swept: true, networkInterfaces: 1, securityGroups: 1 });
+      // DeleteSecurityGroup 409s with DependencyViolation while any ENI still
+      // references the group, so SG-first leaves both — the leak (#146) itself.
+      expect(commandRunner.deletes).toEqual([
+        `delete-network-interface:${ENI_ID}`,
+        `delete-security-group:${SG_ID}`,
+      ]);
+    });
+
+    it.each([
+      {
+        name: "an interface is still in use",
+        interfaces: [
+          { NetworkInterfaceId: ENI_ID, Status: "in-use", RequesterManaged: false },
+        ],
+        reason: "network-interface-in-use",
+      },
+      {
+        name: "an interface is still detaching",
+        interfaces: [
+          { NetworkInterfaceId: ENI_ID, Status: "detaching", RequesterManaged: false },
+        ],
+        reason: "network-interface-in-use",
+      },
+      {
+        name: "an interface is requester-managed",
+        interfaces: [
+          { NetworkInterfaceId: ENI_ID, Status: "available", RequesterManaged: true },
+        ],
+        reason: "network-interface-requester-managed",
+      },
+    ])("TC-PREVIEW-RECON-049 refuses and deletes nothing when $name", async ({
+      interfaces,
+      reason,
+    }) => {
+      const commandRunner = sweepRunner([ownedGroup("pr-12")], interfaces);
+
+      const outcome = await sweepOrphanedNetwork("pr-12", commandRunner);
+
+      expect(outcome).toEqual({ swept: false, reason });
+      // Refusing must be total: no ENI deleted, and above all no SG deleted.
+      expect(commandRunner.deletes).toEqual([]);
+    });
+
+    it.each(["prod", "main", "production", "release-12", "pr-", ""])(
+      "TC-PREVIEW-RECON-050 refuses the non-preview stage %j without describing anything",
+      async (stage) => {
+        const commandRunner = sweepRunner([ownedGroup(stage)], []);
+
+        const outcome = await sweepOrphanedNetwork(stage, commandRunner);
+
+        expect(outcome).toEqual({ swept: false, reason: "stage-protected" });
+        expect(commandRunner).not.toHaveBeenCalled();
+      },
+    );
+
+    it("TC-PREVIEW-RECON-051 refuses when no security group carries this stage's tags", async () => {
+      const commandRunner = sweepRunner([ownedGroup("pr-99")], []);
+
+      const outcome = await sweepOrphanedNetwork("pr-12", commandRunner);
+
+      expect(outcome).toEqual({ swept: false, reason: "no-owned-security-group" });
+      expect(commandRunner.deletes).toEqual([]);
+    });
+
+    it("TC-PREVIEW-RECON-052 deletes an SG with no remaining interfaces", async () => {
+      const commandRunner = sweepRunner([ownedGroup("pr-12")], []);
+
+      const outcome = await sweepOrphanedNetwork("pr-12", commandRunner);
+
+      expect(outcome).toEqual({ swept: true, networkInterfaces: 0, securityGroups: 1 });
+      expect(commandRunner.deletes).toEqual([`delete-security-group:${SG_ID}`]);
+    });
+  });
+
+  it("TC-PREVIEW-RECON-046 maps EC2 ARNs to the sweepable resource types", () => {
+    expect(
+      resourceTypeFromArn(
+        "arn:aws:ec2:ap-northeast-1:123456789012:security-group/sg-0123456789abcdef0",
+      ),
+    ).toBe("ec2:security-group");
+    expect(
+      resourceTypeFromArn(
+        "arn:aws:ec2:ap-northeast-1:123456789012:network-interface/eni-0123456789abcdef0",
+      ),
+    ).toBe("ec2:network-interface");
+  });
+});
+
 describe("workflow control flow", () => {
   const workflowPath = path.resolve(
     import.meta.dirname,
@@ -632,7 +1041,16 @@ describe("workflow control flow", () => {
     expect(source).toMatch(/options:\s*\n\s+- dry-run\s*\n\s+- apply/);
   });
 
-  it("TC-PREVIEW-RECON-027 exposes no direct AWS delete path", () => {
+  // #146 narrowed this invariant rather than dropping it. The reconciler now owns
+  // exactly TWO direct delete calls — detached ENIs and the orphaned SG they pin —
+  // because a stage whose SST state is gone cannot be finished by `sst remove` and
+  // was leaking indefinitely. Everything else must still route through SST.
+  //
+  // The allowlist is asserted as an EXACT set, not a "contains" check: a
+  // permissive assertion here would let a future `delete-db-cluster` or
+  // `delete-bucket` slip in silently, which is the destructive outcome the
+  // original test existed to prevent.
+  it("TC-PREVIEW-RECON-027 confines direct AWS deletes to the network-sweep allowlist", () => {
     const source = fs.readFileSync(workflowPath, "utf8");
     const adapterSource = fs.readFileSync(
       path.resolve(import.meta.dirname, "preview-reconciler.mts"),
@@ -640,7 +1058,14 @@ describe("workflow control flow", () => {
     );
     const combined = `${source}\n${adapterSource}`;
 
-    expect(combined).not.toMatch(/aws\s+\S+\s+delete-/i);
+    const deleteVerbs = [
+      ...combined.matchAll(/"(delete-[a-z0-9-]+)"/g),
+      ...combined.matchAll(/\baws\s+\S+\s+(delete-[a-z0-9-]+)/gi),
+    ].map((match) => match[1]);
+    expect([...new Set(deleteVerbs)].sort()).toEqual([
+      "delete-network-interface",
+      "delete-security-group",
+    ]);
     expect(combined).not.toMatch(/Delete(Resources?|Stack|Cluster|Service|Function)/);
     expect(adapterSource).toMatch(/"sst",\s*"remove",\s*"--stage"/);
   });
@@ -664,5 +1089,59 @@ describe("workflow control flow", () => {
     expect(statement).toContain("iam:ListRoles");
     expect(statement).not.toMatch(/tag:(TagResources|UntagResources)/);
     expect(role).toContain("iam:ListRoleTags");
+  });
+
+  // The network sweep (#146) needed NO new IAM: the deploy role already carried
+  // both deletes for its own teardown path. This pins that — if a future
+  // least-privilege pass drops either grant, the sweep starts 403ing at runtime on
+  // a schedule nobody watches, and the leak returns silently.
+  it("TC-PREVIEW-RECON-037 already grants the sweep's EC2 deletes", () => {
+    const role = fs.readFileSync(
+      path.resolve(
+        import.meta.dirname,
+        "..",
+        "infra",
+        "cloudformation",
+        "github-actions-role.yaml",
+      ),
+      "utf8",
+    );
+
+    expect(role).toContain("ec2:DeleteSecurityGroup");
+    expect(role).toContain("ec2:DeleteNetworkInterface");
+    expect(role).toContain("ec2:DescribeSecurityGroups");
+    expect(role).toContain("ec2:DescribeNetworkInterfaces");
+  });
+
+  // The leak's mechanism was the JOB timeout firing during `sst remove`. The inner
+  // bounds must therefore sum to strictly less than the job's, or the retry path
+  // can be cut off exactly as the original remove was.
+  it("TC-PREVIEW-RECON-038 bounds the remove inside the cleanup job's timeout", () => {
+    const source = fs.readFileSync(
+      path.resolve(import.meta.dirname, "..", ".github", "workflows", "infra-ci.yml"),
+      "utf8",
+    );
+    const cleanupJob = source.split("\n  cleanup-preview:")[1].split("\n  build-and-push-image:")[0];
+
+    const jobTimeout = Number(cleanupJob.match(/timeout-minutes:\s*([0-9]+)/)![1]);
+    // Both inner bounds: the `timeout "$N"` wrapper and the two `remove <N>m` calls
+    // that pass it. Read from the calls, since the wrapper takes its bound as `$1`.
+    const removeBounds = [...cleanupJob.matchAll(/\bremove ([0-9]+)m\b/g)].map((match) =>
+      Number(match[1]),
+    );
+
+    expect(cleanupJob).toMatch(/timeout "\$1" pnpm -C infra exec sst remove/);
+    expect(removeBounds).toHaveLength(2);
+    // +20 for the ENI wait's own default budget (await-eni-detach DEFAULT_TIMEOUT_MS).
+    const innerTotal = removeBounds.reduce((sum, value) => sum + value, 0) + 20;
+    expect(innerTotal).toBeLessThan(jobTimeout);
+    // The wait must sit BETWEEN the two removes: before the first, the ENIs are
+    // still in-use (the Lambdas are alive), so waiting there accomplishes nothing.
+    const firstRemove = cleanupJob.indexOf("if remove 15m");
+    const wait = cleanupJob.indexOf("await-eni-detach.mts");
+    const retry = cleanupJob.lastIndexOf("remove 15m");
+    expect(firstRemove).toBeGreaterThan(-1);
+    expect(wait).toBeGreaterThan(firstRemove);
+    expect(retry).toBeGreaterThan(wait);
   });
 });

--- a/scripts/preview-reconciler.test.ts
+++ b/scripts/preview-reconciler.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 
+import { DEFAULT_TIMEOUT_MS } from "./await-eni-detach.mts";
 import {
   OPERATOR_ISSUE_MARKER,
   OPERATOR_ISSUE_TITLE,
@@ -993,6 +994,188 @@ describe("orphaned network sweep", () => {
       expect(outcome).toEqual({ swept: true, networkInterfaces: 0, securityGroups: 1 });
       expect(commandRunner.deletes).toEqual([`delete-security-group:${SG_ID}`]);
     });
+
+    // A thrown AWS failure would abandon every later stage in the sweep AND
+    // destroy a captured `sst remove` error the caller still has to re-throw.
+    // Refusing keeps both intact.
+    it("TC-PREVIEW-RECON-055 refuses rather than throws when an AWS delete fails", async () => {
+      const commandRunner = sweepRunner(
+        [ownedGroup("pr-12")],
+        [{ NetworkInterfaceId: ENI_ID, Status: "available", RequesterManaged: false }],
+      );
+      vi.mocked(commandRunner).mockImplementation(async (_file, args) => {
+        if (args[1] === "delete-network-interface") throw new Error("aws ec2 delete failed");
+        if (args[1] === "describe-security-groups") {
+          return { stdout: JSON.stringify({ SecurityGroups: [ownedGroup("pr-12")] }), stderr: "" };
+        }
+        return {
+          stdout: JSON.stringify({
+            NetworkInterfaces: [
+              { NetworkInterfaceId: ENI_ID, Status: "available", RequesterManaged: false },
+            ],
+          }),
+          stderr: "",
+        };
+      });
+
+      const outcome = await sweepOrphanedNetwork("pr-12", commandRunner);
+
+      expect(outcome).toEqual({ swept: false, reason: "sweep-failed: aws ec2 delete failed" });
+    });
+
+    // Only `runCommand`'s own `<label> failed` messages are safe to report; an
+    // arbitrary thrown value could carry an ARN or account id into an issue.
+    it("TC-PREVIEW-RECON-056 redacts an unrecognized failure message", async () => {
+      const commandRunner = sweepRunner([ownedGroup("pr-12")], []);
+      vi.mocked(commandRunner).mockImplementation(async () => {
+        throw new Error("arn:aws:ec2:ap-northeast-1:123456789012:security-group/sg-0abc");
+      });
+
+      const outcome = await sweepOrphanedNetwork("pr-12", commandRunner);
+
+      expect(outcome).toEqual({ swept: false, reason: "sweep-failed: unknown-error" });
+      expect(JSON.stringify(outcome)).not.toMatch(/123456789012|arn:aws/);
+    });
+
+    // Tolerating NotFound must not become tolerating everything: an ENI we truly
+    // failed to delete has to refuse, or the sweep would delete the security group
+    // while an interface still pins it and report `swept: true` over a live leak.
+    // The distinction is `runCommand`'s allowedFailure regex, which only NotFound
+    // may match — asserted through the real runCommand, since the mock runner
+    // cannot exercise that branch.
+    it("TC-PREVIEW-RECON-060 tolerates only an already-gone resource", async () => {
+      const notFound = Object.assign(new Error("exit 254"), {
+        stderr: "An error occurred (InvalidNetworkInterfaceID.NotFound)",
+      });
+      const denied = Object.assign(new Error("exit 254"), {
+        stderr: "An error occurred (UnauthorizedOperation) when calling DeleteNetworkInterface",
+      });
+      const runner = (
+        failure: Error & { stderr: string },
+      ): CommandRunner & { deletes: string[] } => {
+        const deletes: string[] = [];
+        const fn = vi.fn(async (_file: string, args: readonly string[], label: string, allowed?: RegExp) => {
+          if (args[1] === "describe-security-groups") {
+            return { stdout: JSON.stringify({ SecurityGroups: [ownedGroup("pr-12")] }), stderr: "" };
+          }
+          if (args[1] === "describe-network-interfaces") {
+            return {
+              stdout: JSON.stringify({
+                NetworkInterfaces: [
+                  { NetworkInterfaceId: ENI_ID, Status: "available", RequesterManaged: false },
+                ],
+              }),
+              stderr: "",
+            };
+          }
+          if (args[1] === "delete-network-interface") {
+            // Exactly `runCommand`'s contract: allowedFailure decides.
+            if (allowed?.test(failure.stderr)) return null;
+            throw new Error(`${label} failed`);
+          }
+          deletes.push(`${args[1]}:${args[3]}`);
+          return { stdout: "", stderr: "" };
+        });
+        return Object.assign(fn as unknown as CommandRunner, { deletes });
+      };
+
+      const gone = runner(notFound);
+      expect(await sweepOrphanedNetwork("pr-12", gone)).toEqual({
+        swept: true,
+        networkInterfaces: 1,
+        securityGroups: 1,
+      });
+
+      const refused = runner(denied);
+      expect(await sweepOrphanedNetwork("pr-12", refused)).toEqual({
+        swept: false,
+        reason: "sweep-failed: network-interface sweep for pr-12 failed",
+      });
+      // The decisive part: the group was NOT deleted while its ENI survived.
+      expect(refused.deletes).toEqual([]);
+    });
+
+    // A stage owns both Mem9TaskSg and Mem9DbSg, and the db SG's ingress rule
+    // REFERENCES the task SG — an ENI is not the only DependencyViolation source.
+    // describe-security-groups gives no ordering guarantee, so the sweep must
+    // retry in passes rather than depend on the order AWS happened to return.
+    it("TC-PREVIEW-RECON-057 retries a security group blocked by another group's rule", async () => {
+      const TASK_SG = "sg-0aaaaaaaaaaaaaaaa";
+      const DB_SG = "sg-0bbbbbbbbbbbbbbbb";
+      const deletes: string[] = [];
+      const commandRunner = vi.fn(async (_file: string, args: readonly string[]) => {
+        if (args[1] === "describe-security-groups") {
+          return {
+            stdout: JSON.stringify({
+              SecurityGroups: [ownedGroup("pr-12", TASK_SG), ownedGroup("pr-12", DB_SG)],
+            }),
+            stderr: "",
+          };
+        }
+        if (args[1] === "describe-network-interfaces") {
+          return { stdout: JSON.stringify({ NetworkInterfaces: [] }), stderr: "" };
+        }
+        // The task SG cannot go until the db SG's referencing rule is gone.
+        if (args[3] === TASK_SG && !deletes.includes(`delete-security-group:${DB_SG}`)) {
+          throw new Error("security-group sweep for pr-12 failed");
+        }
+        deletes.push(`${args[1]}:${args[3]}`);
+        return { stdout: "", stderr: "" };
+      }) as unknown as CommandRunner;
+
+      const outcome = await sweepOrphanedNetwork("pr-12", commandRunner);
+
+      expect(outcome).toEqual({ swept: true, networkInterfaces: 0, securityGroups: 2 });
+      expect(deletes).toEqual([
+        `delete-security-group:${DB_SG}`,
+        `delete-security-group:${TASK_SG}`,
+      ]);
+    });
+
+    // A group nothing can ever delete must refuse, not loop and not throw.
+    it("TC-PREVIEW-RECON-058 refuses when no security group can be deleted", async () => {
+      const commandRunner = sweepRunner([ownedGroup("pr-12")], []);
+      vi.mocked(commandRunner).mockImplementation(async (_file, args) => {
+        if (args[1] === "describe-security-groups") {
+          return { stdout: JSON.stringify({ SecurityGroups: [ownedGroup("pr-12")] }), stderr: "" };
+        }
+        if (args[1] === "describe-network-interfaces") {
+          return { stdout: JSON.stringify({ NetworkInterfaces: [] }), stderr: "" };
+        }
+        throw new Error("security-group sweep for pr-12 failed");
+      });
+
+      const outcome = await sweepOrphanedNetwork("pr-12", commandRunner);
+
+      expect(outcome).toEqual({
+        swept: false,
+        reason: "security-group-dependency-violation",
+      });
+    });
+  });
+
+  // A refusal that clears on its own is fine; one that never clears must not be
+  // invisible. `sst remove` deletes the execution role, and Lambda cannot detach a
+  // hyperplane ENI without it, so `network-interface-in-use` can refuse forever.
+  it("TC-PREVIEW-RECON-059 reports a refused sweep in the operator issue", async () => {
+    const source = networkOnly();
+    const plan = buildReconciliationPlan(source);
+    const runtime = adapters([source, source, source]);
+    vi.mocked(runtime.sweepOrphanedNetwork).mockResolvedValue({
+      swept: false,
+      reason: "network-interface-in-use",
+    });
+
+    const result = await applyReconciliationPlan(plan, runtime, {
+      eventName: "workflow_dispatch",
+      mode: "apply",
+    });
+
+    expect(result.swept).toEqual([]);
+    expect(result.operatorIssue).toBe("created");
+    const [, body] = vi.mocked(runtime.createOperatorIssue).mock.calls[0]!;
+    expect(body).toContain("pr-12");
+    expect(body).toContain("ec2:security-group");
   });
 
   it("TC-PREVIEW-RECON-046 maps EC2 ARNs to the sweepable resource types", () => {
@@ -1129,12 +1312,28 @@ describe("workflow control flow", () => {
     const removeBounds = [...cleanupJob.matchAll(/\bremove ([0-9]+)m\b/g)].map((match) =>
       Number(match[1]),
     );
+    // The wait's OUTER bound, read from the shell rather than from
+    // DEFAULT_TIMEOUT_MS: the script's own budget is only checked between polls, so
+    // a slow AWS call can overshoot it. Summing the soft budget here would certify
+    // a ceiling nothing enforces.
+    const waitBound = Number(
+      cleanupJob.match(/timeout --kill-after=\S+ ([0-9]+)m node scripts\/await-eni-detach/)![1],
+    );
 
-    expect(cleanupJob).toMatch(/timeout "\$1" pnpm -C infra exec sst remove/);
+    expect(cleanupJob).toMatch(
+      /timeout --kill-after=\S+ "\$1" \\\n\s+pnpm -C infra exec sst remove/,
+    );
     expect(removeBounds).toHaveLength(2);
-    // +20 for the ENI wait's own default budget (await-eni-detach DEFAULT_TIMEOUT_MS).
-    const innerTotal = removeBounds.reduce((sum, value) => sum + value, 0) + 20;
+    // The wait's outer bound must not be tighter than its own internal budget,
+    // or the shell would kill it before it can emit its expiry diagnostic.
+    expect(waitBound).toBeGreaterThanOrEqual(DEFAULT_TIMEOUT_MS / 60_000);
+    const innerTotal = removeBounds.reduce((sum, value) => sum + value, 0) + waitBound;
     expect(innerTotal).toBeLessThan(jobTimeout);
+    // `sst unlock` must run ONCE, before the first attempt — never inside the
+    // retryable function, where it could clear the lock of a first attempt that
+    // SIGTERM failed to kill.
+    expect([...cleanupJob.matchAll(/sst unlock/g)]).toHaveLength(1);
+    expect(cleanupJob.indexOf("sst unlock")).toBeLessThan(cleanupJob.indexOf("remove() {"));
     // The wait must sit BETWEEN the two removes: before the first, the ENIs are
     // still in-use (the Lambdas are alive), so waiting there accomplishes nothing.
     const firstRemove = cleanupJob.indexOf("if remove 15m");

--- a/scripts/workload-permissions-boundary-contract.json
+++ b/scripts/workload-permissions-boundary-contract.json
@@ -13,7 +13,7 @@
     {
       "id": "infra-ci.yml",
       "path": ".github/workflows/infra-ci.yml",
-      "reviewedBlob": "5fef391cd421aac95ff07a85bdc79372e5a541d2"
+      "reviewedBlob": "4590668846752058fbde4d56aa07f3d5d859a633"
     },
     {
       "id": "reconcile-previews.yml",

--- a/scripts/workload-permissions-boundary-contract.json
+++ b/scripts/workload-permissions-boundary-contract.json
@@ -13,7 +13,7 @@
     {
       "id": "infra-ci.yml",
       "path": ".github/workflows/infra-ci.yml",
-      "reviewedBlob": "8ceb3f723818c6a11033a4a6b2c626340e9a8cfa"
+      "reviewedBlob": "5fef391cd421aac95ff07a85bdc79372e5a541d2"
     },
     {
       "id": "reconcile-previews.yml",


### PR DESCRIPTION
Fixes #146

## The leak

`Cleanup PR Preview`'s 30-minute `timeout-minutes` cancelled `sst remove` mid-flight while it waited on `Mem9TaskSg`, whose Lambda VPC hyperplane ENIs had not yet detached (~18 minutes on the stages that leaked; AWS documents up to 20). SST had already deleted the state object by then, so the stranded security group became invisible to a state-anchored reconciler and leaked with nothing tying it to a closed PR. Seven stages leaked and were removed by hand.

A cancelled remove is the worst available outcome — the state is gone *and* the resources remain.

## Part 1 — a bounded wait between two removes

`scripts/await-eni-detach.mts` polls until no ENI references the stage's groups.

**Placement is the fix.** AWS detaches those ENIs only *after* the function is deleted, and `sst remove` is what deletes it — so a wait placed before the first remove would poll a still-`in-use` interface for its entire budget and change nothing. The job now runs `remove` → on failure `wait` → `remove` again, with the job timeout strictly above the sum of the inner bounds.

Expiry is a `::warning::`, never a failure. Failing the step is precisely what leaked the resources; the sweep below is the designed backstop.

Two supporting details: `sst unlock` runs **once** before the first attempt, never inside the retryable function (`timeout` sends only SIGTERM, and a Pulumi engine can outlive it — an unlock on the retry path could clear a lock still held by a first attempt quietly still running), and `--kill-after=60s` escalates to SIGKILL so that attempt cannot orphan into the retry.

## Part 2 — a narrow sweep for what already leaked

A new `sweep-orphaned-network` action lets the reconciler finish a state-missing stage instead of parking it on `operator-review` forever.

Exactly two resource types may be deleted without SST state — `ec2:security-group` and `ec2:network-interface`. Both are recreated from scratch by the next deploy and hold no data. A stage is swept only when **every** owned resource it has is in that set; one Aurora cluster sends the whole stage back to `operator-review`, because a partial sweep leaves a half-torn stage behind a stale issue. Widening that allowlist is the entire risk of this change.

**Ordering is load-bearing.** `DeleteSecurityGroup` returns `DependencyViolation` while any ENI references the group, so SG-first leaves *both* behind — the leak itself. An ENI is not the only violation source, either: a stage owns both `Mem9TaskSg` and `Mem9DbSg`, and the db SG's ingress rule *references* the task SG, while `describe-security-groups` guarantees no ordering. Groups are deleted in passes until a pass makes no progress.

**Every failure is a refusal, including a failing AWS call.** A throw would skip every later stage the sweep exists to drain and would pre-empt the `sst remove` failure the caller still has to re-throw, destroying the real AWS reason. `InvalidNetworkInterfaceID.NotFound` counts as success (the sweep races Lambda's own async ENI deletion); anything else refuses, so a group is never deleted while an interface it failed to remove still pins it. Reported reasons are restricted to `runCommand`'s label shape, so no ARN or account id reaches a report.

Refusals surface in the **operator issue**, not just an apply-job log. Some never clear: `sst remove` deletes the execution role, and Lambda cannot detach a hyperplane ENI without it, so an `in-use` interface can refuse forever. Leaving that in a manual-dispatch-only log would reproduce the exact invisibility this issue is about.

Ownership is re-derived from each resource's own `Project`/`ManagedBy`/`Stage` tags, so a server-side filter typo cannot widen the blast radius.

## No IAM change

All four EC2 actions the sweep issues were already granted to the deploy role and scoped to the account default VPC via the existing `ArnEquals ec2:Vpc` condition: `DeleteSecurityGroup`, `DeleteNetworkInterface`, `DescribeSecurityGroups`, `DescribeNetworkInterfaces`. TC-PREVIEW-RECON-037 pins that so a future reader does not re-litigate it.

## Verification

**Every new guard is proven by mutation, not inspection.** 22 probes, each breaking exactly one guard; every one must turn a named test red.

Four guards initially **survived** — the in-use refusal, the requester-managed refusal, the protected-stage refusal, and the empty-inventory check — because every sweep test drove a *mocked* adapter, so the real function's refusals never executed. `sweepOrphanedNetwork` and `isSweepableInventory` are exported specifically so tests call the real thing. A fifth survivor (an unbounded wait) was killing the suite by OOM rather than by assertion; the test clock now caps its sleeps so the regression reads as a failure instead of a crash.

- 946 tests pass; `npm run typecheck` clean
- TC-PREVIEW-RECON-037..060 and TC-PREVIEW-ENI-001..008 added
- `infra-ci.yml`'s reviewed blob re-attested in the workload boundary contract

A code review of the first commit found five further defects — all confirmed against the code and fixed in `510ed3b`, each with its own probe.

## Verifying this pre-merge

The `unit` CI job runs every test above, including the source-scan guards that read `infra-ci.yml` itself (TC-PREVIEW-RECON-027 confines direct AWS deletes to an exact two-verb allowlist, so a future `delete-db-cluster` fails the build; TC-PREVIEW-RECON-038 reads the job's real bounds and asserts the wait sits between the two removes).

One acceptance criterion is **not** pre-merge verifiable: confirming on a real PR close that cleanup concludes `success` with no SG or ENI surviving. That needs a live teardown against AWS, so it is split into a separate non-blocking follow-up rather than left as a blocking AC.

## Out of Scope

- #145 — observation-only confirmation on the next real PR close (non-blocking).
