### PR TITLE
fix(region): derive application plane from SST provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,30 +17,33 @@ AWS_PROFILE=your-aws-profile
 # Leave false in persistent config. For the guarded one-time migration, pause
 # application deployments and set this true only on the command invocation.
 # WORKLOAD_BOUNDARY_MAINTENANCE_ACK=false
-# ECR repositories + Bedrock Mantle Project live in the app region (Tokyo).
-# ECR_REGION=ap-northeast-1
+# ECR repositories and the primary Bedrock Mantle Project default to the
+# application region declared in sst.config.ts. ECR_REGION is accepted only
+# when it matches that provider region.
 # Required only while adopting or updating the registry scanning singleton.
 # Set true only after the account owner pauses every other registry-config writer.
 # ECR_SCAN_EXCLUSIVE_WRITER_ACK=false
 # Optional protected path for direct drift-repair rollback. The file must not
 # already exist; the default is a timestamped, gitignored repo-root file.
 # ECR_SCAN_BACKUP_FILE=/path/to/ecr-registry-scanning-rollback.local.json
-# Application VPC discovery remains independently configurable.
-# PROJECT_REGION=ap-northeast-1
+# Application VPC discovery follows the provider region in sst.config.ts.
 # MEM9_VPC_ID=vpc-xxxxxxxxxxxxxxxxx
 # --- llm-proxy Responses route (OpenAI gpt-5.6 terra/luna; optional) ---
 # These models serve ONLY via the Responses API in us-west-2/us-east-1. To
 # enable: (1) create the regional Mantle project:
 #   PROJECT_REGION=us-west-2 scripts/deploy-bedrock-mantle-project.sh
-# (2) re-run the boundary rollout (it auto-detects the project stack in
-#     WORKLOAD_BOUNDARY_OPENAI_PROJECT_REGION, default us-west-2);
+# (2) re-run the boundary rollout (it uses MEM9_LLM_RESPONSES_REGION, default
+#     us-west-2, to find the regional project stack);
 # (3) set the CI variables: MEM9_BEDROCK_PROJECT_OPENAI (regional project id,
-#     feeds the task-role grant + OpenAI-Project header) and MEM9_LLM_MODEL
-#     (e.g. openai.gpt-5.6-terra) — both consumed by infra/ecs.ts at deploy.
-# The THREE region knobs must agree (all default us-west-2):
-#   MEM9_LLM_RESPONSES_REGION (task-role grant + LLM_PROXY_RESPONSES_REGION),
-#   WORKLOAD_BOUNDARY_OPENAI_PROJECT_REGION (boundary ARN sourcing).
-# WORKLOAD_BOUNDARY_OPENAI_PROJECT_REGION=us-west-2
+#     feeds the task-role grant + OpenAI-Project header),
+#     MEM9_LLM_RESPONSES_REGION (only needed to override us-west-2), and
+#     MEM9_LLM_MODEL (e.g. openai.gpt-5.6-terra).
+# The provisioning selector and canonical runtime/boundary knob must agree (both
+# default us-west-2):
+#   PROJECT_REGION (one-command Mantle Project provisioning selector),
+#   MEM9_LLM_RESPONSES_REGION (task-role grant, proxy route, boundary sourcing).
+# WORKLOAD_BOUNDARY_OPENAI_PROJECT_REGION is a compatibility override; when set
+# with MEM9_LLM_RESPONSES_REGION it must match.
 # Optional production OAuth façade hostname. For local SST deploys only; GitHub
 # Actions reads the domain, token, and zone ID from repository secrets.
 # The token needs Zone:Read + DNS:Edit for only the matching Cloudflare zone.

--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -35,6 +35,8 @@
 #   MEM9_CONSOLIDATION_SCHEDULE_ENABLED — set to 1 only after the one-shot
 #                  cleanup and an actionable report-only consolidation run.
 #                  Unset keeps the production weekly schedule absent.
+#   MEM9_LLM_RESPONSES_REGION — independent fallback region for selected OpenAI
+#                  GPT models. Unset keeps the runtime/boundary default us-west-2.
 #
 # Workload-boundary maintenance gate revision: 1
 
@@ -106,7 +108,6 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-  AWS_REGION: ap-northeast-1
   ROLE_NAME: github-actions-mem9-on-aws
   # The out-of-band ECR repo namespace (infra/cloudformation/ecr-repositories.yaml).
   # build-and-push-image builds four images under it: <ns>/mnemo-server,
@@ -115,6 +116,58 @@ env:
   ECR_NS: mem9-on-aws
 
 jobs:
+  application-region:
+    name: Resolve application region
+    runs-on: ${{ vars.RUNNER_LABEL && fromJSON(vars.RUNNER_LABEL) || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+    outputs:
+      cleanup_region: ${{ steps.resolve.outputs.cleanup_region }}
+      region: ${{ steps.resolve.outputs.region }}
+      region_changed: ${{ steps.resolve.outputs.region_changed }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.head.sha || github.sha }}
+      - uses: actions/checkout@v5
+        if: github.event_name == 'pull_request'
+        with:
+          path: .application-region-base
+          ref: ${{ github.event.pull_request.base.sha }}
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+      - name: Resolve SST AWS provider region
+        id: resolve
+        env:
+          EVENT_ACTION: ${{ github.event.action }}
+          EVENT_NAME: ${{ github.event_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          region="$(node scripts/resolve-application-region.mjs)"
+          cleanup_region="$region"
+          region_changed=false
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            base_region="$(
+              node scripts/resolve-application-region.mjs \
+                --config .application-region-base/sst.config.ts
+            )"
+            cleanup_region="$base_region"
+            if [[ "$region" != "$base_region" ]]; then
+              region_changed=true
+            fi
+          fi
+          {
+            echo "cleanup_region=$cleanup_region"
+            echo "region=$region"
+            echo "region_changed=$region_changed"
+          } >> "$GITHUB_OUTPUT"
+          if [[ "$region_changed" == "true" && "$EVENT_ACTION" != "closed" ]]; then
+            echo "::error::Application region changes cannot deploy PR previews. Remove old-region previews and use the dedicated live migration process."
+            exit 1
+          fi
+
   # ───────────────────────────────────────────────────────────────────────────
   # typecheck — runs on every PR (except closed) + push-to-main. No AWS needed.
   # ───────────────────────────────────────────────────────────────────────────
@@ -180,7 +233,8 @@ jobs:
       - name: Validate ECR registry scanning template
         run: |
           python -m pip install --disable-pip-version-check 'cfn-lint>=1.39,<2'
-          cfn-lint infra/cloudformation/ecr-registry-scanning.yaml --regions ap-northeast-1
+          application_region="$(node scripts/resolve-application-region.mjs)"
+          cfn-lint infra/cloudformation/ecr-registry-scanning.yaml --regions "$application_region"
           cfn-lint infra/cloudformation/github-actions-role.yaml --regions us-west-2
           cfn-lint infra/cloudformation/workload-permissions-boundary.yaml --regions us-west-2
 
@@ -210,7 +264,7 @@ jobs:
     runs-on: ${{ vars.RUNNER_LABEL && fromJSON(vars.RUNNER_LABEL) || 'ubuntu-latest' }}
     # Depends on the image build so the preview pulls this PR's freshly-built
     # workload images.
-    needs: [typecheck, build-and-push-image]
+    needs: [application-region, typecheck, build-and-push-image]
     if: github.event_name == 'pull_request' && github.event.action != 'closed' && github.event.pull_request.base.ref == 'main'
     # Full-stack fresh preview: Aurora (~13m) + the 3-container ECS task (the
     # ~1.2 GB qwen3 image pull + 180s health-check startPeriod, plus the tiny
@@ -224,6 +278,8 @@ jobs:
       contents: read
       pull-requests: write
     env:
+      AWS_REGION: ${{ needs.application-region.outputs.region }}
+      MEM9_LLM_RESPONSES_REGION: ${{ vars.MEM9_LLM_RESPONSES_REGION }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
       - name: Deployment maintenance gate
@@ -323,9 +379,9 @@ jobs:
           # scripts/deploy-bedrock-mantle-project.sh; empty → the proxy omits the
           # header (still functional, just untagged).
           MEM9_BEDROCK_PROJECT: ${{ vars.MEM9_BEDROCK_PROJECT }}
-          # llm-proxy Responses route (OpenAI gpt-5.6 terra/luna): the regional
-          # (us-west-2) Mantle project id + the model selector. Unset vars pass
-          # through empty → feature off / GLM-5 default.
+          # llm-proxy Responses route (OpenAI gpt-5.6 terra/luna): the fallback
+          # region's Mantle project id + model selector. The region itself is a
+          # job-level variable and defaults to us-west-2 when unset.
           MEM9_BEDROCK_PROJECT_OPENAI: ${{ vars.MEM9_BEDROCK_PROJECT_OPENAI }}
           MEM9_LLM_MODEL: ${{ vars.MEM9_LLM_MODEL }}
           # The image applies the repeatable atomic-ingest migration before the
@@ -422,7 +478,6 @@ jobs:
         if: steps.gate.outputs.skip != 'true' && steps.deploy.outputs.stage != ''
         env:
           STAGE: ${{ steps.deploy.outputs.stage }}
-          AWS_REGION: ap-northeast-1
         run: bash scripts/run-oauth-facade-smoke.sh
 
       - name: Slack approval E2E (preview)
@@ -445,7 +500,6 @@ jobs:
         shell: bash
         env:
           STAGE: ${{ steps.deploy.outputs.stage }}
-          AWS_REGION: ap-northeast-1
         run: bash scripts/run-slack-approval-e2e.sh
 
       - name: Auto-cleanup on deploy failure
@@ -486,7 +540,7 @@ jobs:
               `|------|-------|`,
               `| Stage | \`${stage}\` |`,
               `| Status | ${status} |`,
-              `| Region | \`${process.env.AWS_REGION || 'ap-northeast-1'}\` |`,
+              `| Region | \`${process.env.AWS_REGION}\` |`,
               `| Run | [View logs](${runUrl}) |`,
               '',
               `SSM parameters deployed by this stage: \`/mem9-on-aws/${stage}/...\``,
@@ -523,6 +577,7 @@ jobs:
   cleanup-preview:
     name: Cleanup PR Preview
     runs-on: ${{ vars.RUNNER_LABEL && fromJSON(vars.RUNNER_LABEL) || 'ubuntu-latest' }}
+    needs: [application-region]
     if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.base.ref == 'main'
     # Budget: 15m first remove + up to 20m ENI detach wait + 15m retry, plus
     # checkout/pnpm/install. The old 30m cut the FIRST remove off mid-flight (#146),
@@ -534,6 +589,7 @@ jobs:
       contents: read
       pull-requests: write
     env:
+      AWS_REGION: ${{ needs.application-region.outputs.cleanup_region }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
       - name: Deployment maintenance gate
@@ -612,6 +668,8 @@ jobs:
 
       - uses: actions/checkout@v5
         if: steps.check-state.outputs.deployed == 'true'
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
 
       - uses: pnpm/action-setup@v5
         if: steps.check-state.outputs.deployed == 'true'
@@ -714,7 +772,7 @@ jobs:
   build-and-push-image:
     name: Build & push workload images
     runs-on: ${{ vars.RUNNER_LABEL && fromJSON(vars.RUNNER_LABEL) || 'ubuntu-latest' }}
-    needs: typecheck
+    needs: [application-region, typecheck]
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.action != 'closed' && github.event.pull_request.base.ref == 'main')
     # arm64 build: native on the self-hosted arm64 pool, QEMU-emulated on
     # ubuntu-latest (slower). Give the go build + emulation headroom.
@@ -722,6 +780,8 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    env:
+      AWS_REGION: ${{ needs.application-region.outputs.region }}
     outputs:
       # The per-commit tag, or empty when skipped (PR with no AWS_ROLE_ARN) so
       # downstream jobs can fall back to `latest`.
@@ -892,7 +952,7 @@ jobs:
   deploy-prod:
     name: Deploy prod
     runs-on: ${{ vars.RUNNER_LABEL && fromJSON(vars.RUNNER_LABEL) || 'ubuntu-latest' }}
-    needs: [typecheck, build-and-push-image]
+    needs: [application-region, typecheck, build-and-push-image]
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     environment: prod
     # Full-stack prod: Aurora + the 3-container ECS task (qwen3 image pull + 180s
@@ -904,6 +964,9 @@ jobs:
       id-token: write
       contents: read
       issues: write
+    env:
+      AWS_REGION: ${{ needs.application-region.outputs.region }}
+      MEM9_LLM_RESPONSES_REGION: ${{ vars.MEM9_LLM_RESPONSES_REGION }}
     steps:
       - name: Deployment maintenance gate
         env:
@@ -1077,9 +1140,9 @@ jobs:
           # (infra/ecs.ts BEDROCK_PROJECT). Repo variable set out-of-band by
           # scripts/deploy-bedrock-mantle-project.sh.
           MEM9_BEDROCK_PROJECT: ${{ vars.MEM9_BEDROCK_PROJECT }}
-          # llm-proxy Responses route (OpenAI gpt-5.6 terra/luna): the regional
-          # (us-west-2) Mantle project id + the model selector. Unset vars pass
-          # through empty → feature off / GLM-5 default.
+          # llm-proxy Responses route (OpenAI gpt-5.6 terra/luna): the fallback
+          # region's Mantle project id + model selector. The region itself is a
+          # job-level variable and defaults to us-west-2 when unset.
           MEM9_BEDROCK_PROJECT_OPENAI: ${{ vars.MEM9_BEDROCK_PROJECT_OPENAI }}
           MEM9_LLM_MODEL: ${{ vars.MEM9_LLM_MODEL }}
           # Explicitly false before migration. The guarded migration changes it
@@ -1147,7 +1210,6 @@ jobs:
       - name: OAuth façade smoke (prod)
         env:
           STAGE: prod
-          AWS_REGION: ap-northeast-1
         run: bash scripts/run-oauth-facade-smoke.sh
 
       - name: Create issue on prod deploy failure

--- a/.github/workflows/reconcile-previews.yml
+++ b/.github/workflows/reconcile-previews.yml
@@ -25,12 +25,26 @@ concurrency:
   group: preview-stage-reconciliation
   cancel-in-progress: false
 
-env:
-  AWS_REGION: ap-northeast-1
-
 jobs:
+  application-region:
+    name: Resolve application region
+    runs-on: ${{ vars.RUNNER_LABEL && fromJSON(vars.RUNNER_LABEL) || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+    outputs:
+      region: ${{ steps.resolve.outputs.region }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+      - name: Resolve SST AWS provider region
+        id: resolve
+        run: echo "region=$(node scripts/resolve-application-region.mjs)" >> "$GITHUB_OUTPUT"
+
   report:
     name: Report stale preview stages
+    needs: [application-region]
     if: vars.WORKLOAD_BOUNDARY_PROD_ENABLED == 'true'
     runs-on: ${{ vars.RUNNER_LABEL && fromJSON(vars.RUNNER_LABEL) || 'ubuntu-latest' }}
     timeout-minutes: 10
@@ -40,6 +54,8 @@ jobs:
       actions: read
       pull-requests: read
       issues: read
+    env:
+      AWS_REGION: ${{ needs.application-region.outputs.region }}
     steps:
       - name: Deployment maintenance gate
         env:
@@ -82,7 +98,7 @@ jobs:
 
   apply:
     name: Revalidate and reconcile preview stages
-    needs: report
+    needs: [application-region, report]
     if: github.event_name == 'workflow_dispatch' && inputs.mode == 'apply' && vars.WORKLOAD_BOUNDARY_PROD_ENABLED == 'true'
     runs-on: ${{ vars.RUNNER_LABEL && fromJSON(vars.RUNNER_LABEL) || 'ubuntu-latest' }}
     timeout-minutes: 45
@@ -92,6 +108,8 @@ jobs:
       actions: read
       pull-requests: read
       issues: write
+    env:
+      AWS_REGION: ${{ needs.application-region.outputs.region }}
     steps:
       - name: Deployment maintenance gate
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,17 +49,23 @@ them, update the file rather than silently diverging.
 
 ## Region topology
 
-- This deployment is region-heterogeneous. Never treat `ap-northeast-1`,
+- This deployment is region-heterogeneous. Never treat the application region,
   `us-west-2`, or one ambient `AWS_REGION` as a universal region for every
   component.
 - The application plane (SST resources, ECR images, primary Mantle route, and
-  VPC) must use one internally consistent application region. The current IaC
-  pins that plane to `ap-northeast-1`; moving it requires a coordinated code,
-  workflow, bootstrap-stack, and permissions-boundary change.
+  VPC) uses `providers.aws.region` in `sst.config.ts` as its single source of
+  truth. Changing that value retargets all application-plane consumers together
+  for a fresh deployment; it does not relocate existing regional resources.
+- An existing IAM ownership stack records its application region. A mismatch
+  with `sst.config.ts` must fail before mutation. Live relocation requires a
+  dedicated dual-region migration after every old-region preview is removed;
+  never update the boundary or deploy role in place to force the move.
 - The account-global IAM ownership stacks are intentionally hosted in
   `us-west-2`. The optional Mantle Responses route has its own independently
-  configured region and regional Project. Do not "normalize" either to the
-  application region.
+  configured region and regional Project (default `us-west-2`). OpenAI GPT
+  models selected by the configured prefix use that route when unavailable in
+  the application region. Do not "normalize" either plane to the application
+  region.
 - For operator commands, identify the component first and pass its specific
   region variable. Preserve service-specific region settings when editing
   examples or automation.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ citations.
 | Dimension          | Decision                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | IaC                | **SST v4**                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| Region topology    | **Region-heterogeneous**: the current application plane and retained ECR repositories are in `ap-northeast-1`; account-global IAM ownership stacks are hosted in `us-west-2`; the optional Mantle Responses route uses its own configured region (default `us-west-2`) and regional Project.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| Region topology    | **Region-heterogeneous**: `sst.config.ts` selects the application plane and retained ECR repository region; account-global IAM ownership stacks are hosted in `us-west-2`; the optional Mantle Responses route uses its own configured region (default `us-west-2`) and regional Project.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | Container registry | Four retained ECR repositories plus guarded registry-level BASIC scan-on-push for `mem9-on-aws/*`, both managed out of band                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | Compute            | **ECS Fargate**, **arm64**, single task (`desiredCount=1`)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | Database           | **Aurora PostgreSQL Serverless v2** + `pgvector` (mem9 `postgres` backend). `mnemo-server` and bootstrap connect directly to the cluster writer endpoint with a Secrets Manager credential. **RDS Proxy is not deployed.**                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
@@ -73,20 +73,30 @@ This is not a single-region deployment where one `AWS_REGION` applies to every
 resource. Treat each plane independently:
 
 - **Application plane:** SST resources, VPC, ECR images, and the primary Mantle
-  route must agree on one application region. The current IaC pins this plane to
-  `ap-northeast-1`; moving it is a coordinated IaC, workflow, bootstrap-stack,
-  and permissions-boundary change, not an ambient environment override.
+  route use `providers.aws.region` in `sst.config.ts` as their single source of
+  truth. Changing that value retargets every application consumer for a fresh
+  deployment. An ambient environment override does not move the application.
 - **IAM ownership plane:** the GitHub Actions role and workload-boundary
   CloudFormation stacks are intentionally hosted in `us-west-2`. IAM is
   account-global, while the fixed stack region prevents duplicate ownership.
 - **Optional Responses plane:** the Responses model route, its task-role grant,
   workload-boundary Project ARN, Mantle bearer, and `OpenAI-Project` value use
   their own region. The default is `us-west-2`, independently of the application
-  region.
+  region. Selecting a configured OpenAI GPT model routes it here when that model
+  is unavailable in the application region.
 
 Operator commands must use the region of the component they address. Do not
 replace these service-specific regions with one global value. A hosted OAuth
 callback may run in any region; only its exact public HTTPS URL is allowlisted.
+
+Changing the provider region does not relocate an existing live deployment:
+AWS regional resources remain in their original region. The retained workload
+boundary and GitHub Actions role record the application region and fail before
+mutation when it differs from `sst.config.ts`. Remove all old-region previews
+first, then use a separately reviewed dual-region data/resource migration.
+Region-changing PRs are blocked before AWS deployment, and closed-PR cleanup
+uses the base region so an earlier preview is not orphaned. There is
+intentionally no one-command in-place production region switch.
 
 ## Cost attribution and monthly estimate
 
@@ -256,9 +266,10 @@ The AgentCore Gateway exposes four tools over MCP (Cognito-authenticated):
   allow-all OAuth facade compliance authorizer; it is disabled by default.
   Roll out the reviewed workload-boundary update before enabling it.
 - `scripts/deploy-github-role.sh` always owns its account-global IAM stack in
-  `us-west-2` and ignores ambient `AWS_REGION`. `PROJECT_REGION` selects the
-  application region used for VPC discovery and regional bootstrap resources;
-  it does not move the SST application by itself.
+  `us-west-2` and ignores ambient `AWS_REGION`. Application VPC discovery and
+  regional bootstrap resources resolve `providers.aws.region` from
+  `sst.config.ts`. `PROJECT_REGION` is only an explicit selector when creating a
+  separate regional Mantle Project, such as the OpenAI Responses fallback.
 - Agent contributors: see [`AGENTS.md`](AGENTS.md) for repo conventions and hard rules.
 
 ### Optional hosted OAuth callback URLs
@@ -604,7 +615,7 @@ below must never be committed.
 
 ```bash
 export AWS_PROFILE="<aws-profile>"
-export AWS_REGION="<aws-region>"
+export AWS_REGION="$(node scripts/resolve-application-region.mjs)"
 export SOURCE_CLUSTER="<source-db-cluster-identifier>"
 export RESTORED_CLUSTER="<new-db-cluster-identifier>"
 export RESTORED_INSTANCE="<new-db-instance-identifier>"
@@ -1040,8 +1051,7 @@ for exit zero, and reads only its content-free `CONSOLIDATION_REVIEW_LIST`
 summary from the exact CloudWatch log stream:
 
 ```bash
-STAGE=prod AWS_REGION="<application-region>" \
-  bash scripts/run-consolidation-task.sh
+STAGE=prod bash scripts/run-consolidation-task.sh
 ```
 
 Individual `CONSOLIDATION_REVIEW` records contain memory ids, snippets, and

--- a/docker/llm-proxy/Dockerfile
+++ b/docker/llm-proxy/Dockerfile
@@ -19,8 +19,8 @@ WORKDIR /app
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates curl \
     && curl --fail --silent --show-error \
-      https://truststore.pki.rds.amazonaws.com/ap-northeast-1/ap-northeast-1-bundle.pem \
-      --output /app/ap-northeast-1-bundle.pem \
+      https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem \
+      --output /app/global-bundle.pem \
     && rm -rf /var/lib/apt/lists/*
 
 # Deps first (layer cache). The sidecar uses the token dependencies; the
@@ -43,6 +43,7 @@ COPY docker/llm-proxy/server.mjs ./
 COPY docker/llm-proxy/server.mjs /app/docker/llm-proxy/server.mjs
 COPY scripts/memory-cleanup.mjs /app/scripts/memory-cleanup.mjs
 COPY scripts/memory-consolidation.mjs /app/scripts/memory-consolidation.mjs
+COPY scripts/lib/application-region.mjs /app/scripts/lib/application-region.mjs
 
 # Fail the BUILD, not the weekly run, if that import graph ever breaks again.
 # Per entrypoint, not once: both COPY the sidecar as `../docker/llm-proxy/`, but a
@@ -60,5 +61,5 @@ RUN node --input-type=module \
 # http://localhost:8082/v1. Not published outside the task — localhost only.
 EXPOSE 8082
 ENV NODE_ENV=production
-ENV NODE_EXTRA_CA_CERTS=/app/ap-northeast-1-bundle.pem
+ENV NODE_EXTRA_CA_CERTS=/app/global-bundle.pem
 ENTRYPOINT ["node", "server.mjs"]

--- a/docker/llm-proxy/model-routing.test.mjs
+++ b/docker/llm-proxy/model-routing.test.mjs
@@ -76,7 +76,7 @@ function responsesReply(overrides = {}) {
 
 describe("readConfig responses-route fields", () => {
   it("defaults: gpt-5.6 prefix, us-west-2, derived base, high effort, 16384 cap", () => {
-    const c = readConfig({});
+    const c = readConfig({ AWS_REGION: "ap-southeast-1" });
     expect(c.responsesModelPrefixes).toEqual(["openai.gpt-5.6-"]);
     expect(c.responsesRegion).toBe("us-west-2");
     expect(c.responsesBase).toBe("https://bedrock-mantle.us-west-2.api.aws/openai/v1");
@@ -87,6 +87,7 @@ describe("readConfig responses-route fields", () => {
 
   it("honors overrides and comma-separated prefixes with empties ignored (TC-MMROUTE-002)", () => {
     const c = readConfig({
+      AWS_REGION: "ap-southeast-1",
       LLM_PROXY_RESPONSES_MODEL_PREFIXES: "openai., ,custom.reasoner-",
       LLM_PROXY_RESPONSES_REGION: "us-east-1",
       LLM_PROXY_REASONING_EFFORT: "medium",
@@ -102,7 +103,12 @@ describe("readConfig responses-route fields", () => {
   });
 
   it("rejects an invalid reasoning effort at startup", () => {
-    expect(() => readConfig({ LLM_PROXY_REASONING_EFFORT: "max" })).toThrow(/effort/i);
+    expect(() =>
+      readConfig({
+        AWS_REGION: "ap-southeast-1",
+        LLM_PROXY_REASONING_EFFORT: "max",
+      }),
+    ).toThrow(/effort/i);
   });
 });
 

--- a/docker/llm-proxy/request-policy.test.mjs
+++ b/docker/llm-proxy/request-policy.test.mjs
@@ -104,7 +104,7 @@ afterEach(() => {
 
 describe("GLM request policy", () => {
   it("TC-GLM-RETRY-001: uses the bounded production defaults", () => {
-    const cfg = readConfig({});
+    const cfg = readConfig({ AWS_REGION: "ap-southeast-1" });
     expect(cfg).toMatchObject({
       overallDeadlineMs: 110_000,
       maxCallMs: 108_000,

--- a/docker/llm-proxy/server.mjs
+++ b/docker/llm-proxy/server.mjs
@@ -103,7 +103,10 @@ function positiveInteger(raw, fallback, name) {
 
 // ── Config from env (read once) ──────────────────────────────────────────────
 export function readConfig(env = process.env) {
-  const region = env.LLM_PROXY_REGION || env.AWS_REGION || "ap-northeast-1";
+  const region = env.LLM_PROXY_REGION || env.AWS_REGION;
+  if (!region) {
+    throw new Error("LLM_PROXY_REGION or AWS_REGION is required");
+  }
   return {
     port: Number(env.LLM_PROXY_PORT || 8082),
     region,
@@ -175,8 +178,8 @@ function readResponsesRouteConfig(env) {
       DEFAULT_RESPONSES_MAX_OUTPUT_TOKENS,
       "LLM_PROXY_RESPONSES_MAX_OUTPUT_TOKENS",
     ),
-    // Mantle projects are REGIONAL: the Tokyo project id means nothing in the
-    // responses region, so each route carries its own (never cross-applied).
+    // Mantle projects are REGIONAL: the application-region project id means
+    // nothing in the responses region, so routes never cross-apply projects.
     responsesOpenaiProject: env.LLM_PROXY_RESPONSES_OPENAI_PROJECT || "",
   };
 }
@@ -445,7 +448,7 @@ function requestLog(request, now, log, attempt, startedAt, fields) {
     request_id: request.id,
     attempt,
     // Two upstreams in two regions: failures must be route-attributable or a
-    // us-west-2 outage reads like Tokyo chat traffic in the logs.
+    // fallback-region outage reads like primary chat traffic in the logs.
     ...(request.route ? { route: request.route.kind, region: request.route.region } : {}),
     ...fields,
     duration_ms: Math.max(0, Math.round(now() - startedAt)),

--- a/docker/llm-proxy/server.test.mjs
+++ b/docker/llm-proxy/server.test.mjs
@@ -92,15 +92,22 @@ describe("readConfig", () => {
   });
 
   it("defaults the token TTL to 12h and refresh to 1h", () => {
-    const c = readConfig({});
+    const c = readConfig({ AWS_REGION: "ap-southeast-1" });
     expect(c.tokenTtlSeconds).toBe(43200); // getToken max/default
     expect(c.refreshIntervalMs).toBe(3_600_000);
     expect(c.maxBodyBytes).toBe(1_048_576);
     expect(c.maxTokens).toBe(4096);
   });
 
+  it("fails when the application region is absent", () => {
+    expect(() => readConfig({})).toThrow(
+      /LLM_PROXY_REGION or AWS_REGION is required/u,
+    );
+  });
+
   it("honors an explicit upstream override + project", () => {
     const c = readConfig({
+      AWS_REGION: "ap-southeast-1",
       LLM_PROXY_UPSTREAM_BASE: "https://x/v1",
       LLM_PROXY_OPENAI_PROJECT: "p1",
       LLM_PROXY_MAX_BODY_BYTES: "2048",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -42,6 +42,16 @@ mnemo-server
   -> Aurora PostgreSQL cluster writer endpoint:5432
 ```
 
+The application plane uses `providers.aws.region` in `sst.config.ts` as its
+single source of truth. SST resources, ECR image references, VPC discovery,
+primary Mantle routing, workflows, and operator scripts derive that value. The
+account-global IAM ownership stacks remain in `us-west-2`, while the optional
+Responses route has its own independently configured region and Project.
+This retargets fresh deployments; it does not relocate existing regional
+resources. Existing ownership stacks fail closed when their recorded
+`ApplicationRegion` differs, because a live move needs a dedicated dual-region
+migration after old-region previews are removed.
+
 AWS documents the Lambda target configuration used here:
 [AgentCore Lambda target configuration](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-add-target-api-target-config.html).
 The proxy function uses Lambda VPC access to reach private resources:
@@ -109,9 +119,10 @@ points to `http://localhost:8082/v1`. The local `llm-proxy`:
 The proxy routes by the requested `model`. Ids matching
 `LLM_PROXY_RESPONSES_MODEL_PREFIXES` (default `openai.gpt-5.6-` — terra/luna)
 go to the **Responses API** at `openai/v1/responses` in
-`LLM_PROXY_RESPONSES_REGION` (default us-west-2; these models are not served
-in Tokyo and reject every chat-completions path). The proxy translates
-chat-completions ⇄ Responses both ways (system → `instructions`,
+`LLM_PROXY_RESPONSES_REGION` (default `us-west-2`). This is the independent
+fallback region for selected OpenAI GPT models that are unavailable in the
+application region; they also reject every chat-completions path. The proxy
+translates chat-completions ⇄ Responses both ways (system → `instructions`,
 `max_tokens` → `max_output_tokens` capped at
 `LLM_PROXY_RESPONSES_MAX_OUTPUT_TOKENS` = 16384, `reasoning.effort` from
 `LLM_PROXY_REASONING_EFFORT` = high), so mem9 sees a normal chat-completions
@@ -507,16 +518,22 @@ also does not replace the direct-write rollback procedure above: retained state
 remains active after CloudFormation relinquishes ownership.
 
 For conflicts, export the current state with
-`aws ecr get-registry-scanning-configuration --region ap-northeast-1`, have the
-account-level owner update the complete ruleset, and rerun the wrapper. Do not
-copy sibling filters into this project's template.
+the application region resolved from `sst.config.ts`, have the account-level
+owner update the complete ruleset, and rerun the wrapper. Do not copy sibling
+filters into this project's template:
+
+```bash
+APPLICATION_REGION="$(node scripts/resolve-application-region.mjs)"
+aws ecr get-registry-scanning-configuration --region "$APPLICATION_REGION"
+```
 
 After an image push and scan completion, an operator can inspect findings
 without starting or changing a scan:
 
 ```bash
+APPLICATION_REGION="$(node scripts/resolve-application-region.mjs)"
 aws ecr describe-image-scan-findings \
-  --region ap-northeast-1 \
+  --region "$APPLICATION_REGION" \
   --repository-name mem9-on-aws/mnemo-server \
   --image-id imageTag=<image-tag> \
   --query '{status:imageScanStatus.status,counts:imageScanFindings.findingSeverityCounts,findings:imageScanFindings.findings}'
@@ -524,7 +541,7 @@ aws ecr describe-image-scan-findings \
 
 The operator identity selected by `AWS_PROFILE` must have
 `ecr:GetRegistryScanningConfiguration` and
-`ecr:PutRegistryScanningConfiguration` in `ap-northeast-1`; the read-only
+`ecr:PutRegistryScanningConfiguration` in the application region; the read-only
 findings query additionally needs `ecr:DescribeImageScanFindings` on the four
 project repository ARNs. These account-level mutation permissions are
 intentionally absent from the GitHub Actions deploy role: its OIDC trust includes
@@ -684,7 +701,7 @@ to the GitHub Actions deploy role.
       "Resource": "*",
       "Condition": {
         "StringEquals": {
-          "aws:RequestedRegion": "ap-northeast-1"
+          "aws:RequestedRegion": "<application-region>"
         }
       }
     },
@@ -693,10 +710,10 @@ to the GitHub Actions deploy role.
       "Effect": "Allow",
       "Action": "ecr:DescribeImageScanFindings",
       "Resource": [
-        "arn:aws:ecr:ap-northeast-1:<aws-account-id>:repository/mem9-on-aws/mnemo-server",
-        "arn:aws:ecr:ap-northeast-1:<aws-account-id>:repository/mem9-on-aws/qwen3-embed",
-        "arn:aws:ecr:ap-northeast-1:<aws-account-id>:repository/mem9-on-aws/bootstrap",
-        "arn:aws:ecr:ap-northeast-1:<aws-account-id>:repository/mem9-on-aws/llm-proxy"
+        "arn:aws:ecr:<application-region>:<aws-account-id>:repository/mem9-on-aws/mnemo-server",
+        "arn:aws:ecr:<application-region>:<aws-account-id>:repository/mem9-on-aws/qwen3-embed",
+        "arn:aws:ecr:<application-region>:<aws-account-id>:repository/mem9-on-aws/bootstrap",
+        "arn:aws:ecr:<application-region>:<aws-account-id>:repository/mem9-on-aws/llm-proxy"
       ]
     }
   ]
@@ -724,6 +741,11 @@ to the GitHub Actions deploy role.
 
 ## Locked decisions
 
+- `providers.aws.region` in `sst.config.ts` is the application-plane region
+  source of truth for fresh deployments; application consumers do not carry
+  independent defaults. Existing live deployments cannot be moved in place.
+- Account-global IAM ownership stacks remain in `us-west-2`. The selected
+  OpenAI GPT route uses its independent Responses region, default `us-west-2`.
 - Aurora PostgreSQL plus pgvector is the database engine.
 - Aurora automated backup retention is 14 days in production and 1 day in every
   non-production stage; PITR restores to a separate cluster.

--- a/docs/designs/ingest-prescreen.md
+++ b/docs/designs/ingest-prescreen.md
@@ -161,7 +161,8 @@ is not extraction-only.
 
 The daily inputs are reproducible with fixed UTC boundaries. Each command
 returns daily `Sum` datapoints; sort `Datapoints` by `Timestamp` before joining
-the three series:
+the three series. This dated dataset was collected in `ap-northeast-1`, so the
+historical query keeps that region rather than following the current provider:
 
 ```bash
 export AWS_REGION="ap-northeast-1"

--- a/docs/designs/llm-proxy-multi-model.md
+++ b/docs/designs/llm-proxy-multi-model.md
@@ -6,8 +6,9 @@ Status: Approved (interactive session)
 
 ## Problem
 
-The proxy today speaks exactly one dialect: chat-completions against the
-regional (Tokyo) Mantle endpoint. The OpenAI reasoning models
+Before this change, the proxy spoke exactly one dialect: chat-completions
+against the application-region Mantle endpoint (Tokyo in the 2026-08-01
+deployment). The OpenAI reasoning models
 (`openai.gpt-5.6-terra`, `openai.gpt-5.6-luna`) are only available in
 us-west-2 / us-east-1 and ONLY via the **Responses API** at the
 `openai/v1/responses` path (probed live 2026-08-01: `/v1/chat/completions`,
@@ -26,7 +27,7 @@ The `model` field of each incoming chat-completions request selects a route:
 
 | Route | Match | Upstream | API |
 |---|---|---|---|
-| `chat` (default) | everything else (e.g. `zai.glm-5`) | `https://bedrock-mantle.<region>.api.aws/v1` (Tokyo) | chat-completions passthrough (current behavior, byte-identical) |
+| `chat` (default) | everything else (e.g. `zai.glm-5`) | `https://bedrock-mantle.<region>.api.aws/v1` (application region) | chat-completions passthrough (current behavior, byte-identical) |
 | `responses` | model starts with a configured prefix (default `openai.gpt-5.6-`) | `https://bedrock-mantle.<responsesRegion>.api.aws/openai/v1` (default us-west-2) | chat-completions ⇄ Responses translation |
 
 Switching models = change `MNEMO_LLM_MODEL` (env, task-def) or send a
@@ -41,7 +42,7 @@ different `model` per request. No proxy restart semantics change.
 | `LLM_PROXY_RESPONSES_BASE` | derived from region | Override for tests |
 | `LLM_PROXY_REASONING_EFFORT` | `high` | `reasoning.effort` when the request doesn't carry `reasoning_effort` (mem9 can't) |
 | `LLM_PROXY_RESPONSES_MAX_OUTPUT_TOKENS` | `16384` | Cap/default for `max_output_tokens` — reasoning burns output tokens first, so the chat route's 4096 cap would truncate JSON (the GLM failure mode) |
-| `LLM_PROXY_RESPONSES_OPENAI_PROJECT` | empty | `OpenAI-Project` for the responses region (projects are regional; the Tokyo id is meaningless in us-west-2). Empty → header omitted (untagged) |
+| `LLM_PROXY_RESPONSES_OPENAI_PROJECT` | empty | `OpenAI-Project` for the responses region (projects are regional; the application-region id is not reused). Empty → header omitted (untagged) |
 
 Existing chat-route config is untouched; issue #46's provider-boundary
 controls (4096 cap, byte limit, deadlines) still govern the chat route.
@@ -97,7 +98,8 @@ Cross-region calls authorize against the **requesting region's** project
 resource, and Mantle projects are regional (different ids per region):
 
 - **Task role (infra/ecs.ts)**: when `MEM9_BEDROCK_PROJECT_OPENAI` (the
-  us-west-2 project id) is set, add a second `bedrock-mantle:CreateInference`
+  Responses-region project id) is set, add a second
+  `bedrock-mantle:CreateInference`
   resource `arn:aws:bedrock-mantle:<responsesRegion>:<acct>:project/<id>` and
   inject `LLM_PROXY_RESPONSES_OPENAI_PROJECT`. Unset → no new grant; prod
   calls to the responses route would 403 (documented, fail-loud).
@@ -106,13 +108,15 @@ resource, and Mantle projects are regional (different ids per region):
   `DenyProjectRuntimeOutsideResources` NotResource list via `Fn::If`.
   Rollout = operator re-runs `deploy-workload-permissions-boundary.sh`
   (same out-of-band ownership as today).
-- **Mantle project in us-west-2**: created with the existing out-of-band
-  script (`PROJECT_REGION=us-west-2 scripts/deploy-bedrock-mantle-project.sh`).
+- **Mantle project in the Responses region**: created with the existing
+  out-of-band script (for the default,
+  `PROJECT_REGION=us-west-2 scripts/deploy-bedrock-mantle-project.sh`).
 - `bedrock-mantle:CallWithBearerToken` is already `Resource: "*"` in both the
   task role and the boundary ceiling — no change.
 
-Default posture is unchanged: GLM-5 in Tokyo, no new grants exercised until
-an operator both configures the OpenAI project AND flips the model.
+The checked-in default posture remains GLM-5 in the `sst.config.ts` application
+region. No fallback-region grant is exercised until an operator both configures
+the OpenAI project and selects the GPT model.
 
 ## Out of scope
 
@@ -120,8 +124,9 @@ an operator both configures the OpenAI project AND flips the model.
 - The Anthropic Messages surface.
 - memory-cleanup script routing through the proxy (it runs outside the task;
   its own Responses wrapper already exists for operator use).
-- Automatic model fallback (a failed responses call does not silently
-  downgrade to GLM — fail loud, mem9 retries).
+- Automatic model downgrade after a failed Responses call. Region fallback is
+  deterministic model-prefix routing; an upstream failure does not silently
+  switch the request to GLM.
 
 ## Test hooks
 

--- a/docs/designs/workload-permissions-boundary.md
+++ b/docs/designs/workload-permissions-boundary.md
@@ -203,7 +203,7 @@ verify exact reviewed workflow blobs, clean exact-head checkout, and idle runs
   -> for each exact legacy role: re-read, update to Lambda-only, and read back
   -> read the complete boundary ownership stack in us-west-2
   -> require its ApplicationRegion and BedrockProjectArn parameters
-  -> read prod cluster/service/bootstrap parameters in ap-northeast-1
+  -> read prod cluster/service/bootstrap parameters in the sst.config.ts application region
   -> inspect every service deployment, RUNNING/PENDING task, and bootstrap task definition
   -> require MEM9_DB_SECRET and MEM9_TENANT_ID to reference current-account,
      current-region mem9-on-aws-* Secrets Manager ARNs

--- a/docs/test-cases/application-region.md
+++ b/docs/test-cases/application-region.md
@@ -1,0 +1,53 @@
+# Application region source of truth
+
+The SST AWS provider in `sst.config.ts` is the single source of truth for the
+application plane. Changing that one region must move SST resources, ECR image
+references, the primary Mantle route, CI deployment commands, and operator
+scripts together. Account-global IAM ownership stacks and the optional OpenAI
+Responses route remain independently regional.
+
+## Resolution
+
+| ID | Scenario | Expected result |
+| --- | --- | --- |
+| TC-APPREGION-001 | Resolve the checked-in SST configuration | The resolver prints the AWS provider region and nothing else on stdout |
+| TC-APPREGION-002 | Resolve a fixture whose SST provider uses `ap-southeast-1` | Every resolver caller receives `ap-southeast-1` without another source edit |
+| TC-APPREGION-003 | The SST provider region is missing, non-string, or malformed | Resolution fails before any AWS command runs |
+| TC-APPREGION-004 | Two callers resolve different SST fixtures concurrently | Temporary `$config` shims are serialized and the caller's original global is restored |
+
+## Consumers
+
+| ID | Scenario | Expected result |
+| --- | --- | --- |
+| TC-APPREGION-010 | Synthesize ECR image URIs, the primary Mantle Project ARN, proxy environment, and dashboard widgets | They use the active AWS provider region rather than a copied literal |
+| TC-APPREGION-011 | Render the out-of-band IAM templates | `ApplicationRegion` is required and every application-plane ARN interpolates it |
+| TC-APPREGION-012 | Run CI deployment or preview reconciliation | A resolver job reads `sst.config.ts`; all AWS jobs consume that output |
+| TC-APPREGION-013 | Run an operator script without a region override | The script resolves the application region from `sst.config.ts` |
+| TC-APPREGION-014 | Run the LLM proxy without `LLM_PROXY_REGION` but with the ECS-provided `AWS_REGION` | The primary chat route uses `AWS_REGION`; absence of both values fails instead of silently selecting Tokyo |
+| TC-APPREGION-015 | Build the LLM proxy image for a non-Tokyo application region | The image trusts the documented RDS global CA bundle |
+| TC-APPREGION-016 | A PR changes the application region after an earlier preview | Non-closed deploy events fail before AWS work; on close, cleanup uses the PR base region and base configuration where the prior preview was deployed |
+
+## Independent model route
+
+| ID | Scenario | Expected result |
+| --- | --- | --- |
+| TC-APPREGION-020 | The selected OpenAI GPT model is unavailable in the application region | Prefix routing sends it to the separately configured Responses region |
+| TC-APPREGION-021 | No Responses region is configured | The existing fallback remains `us-west-2`, with that region's bearer, IAM grant, and Bedrock Project |
+| TC-APPREGION-022 | The application region is also `us-west-2` | Primary and Responses routes may share a token, but route selection and Project configuration remain explicit |
+| TC-APPREGION-023 | Set the `MEM9_LLM_RESPONSES_REGION` repository variable | Preview/prod synthesis and boundary verification receive the same custom fallback region |
+| TC-APPREGION-024 | Build the shared `llm-proxy` image after consolidation imports the region resolver | Every relative module in the copied entrypoint graph is also copied into the image |
+| TC-APPREGION-025 | Provision a Mantle Project with explicit `PROJECT_REGION` | The operator output names `MEM9_BEDROCK_PROJECT_OPENAI`; application-region provisioning names `MEM9_BEDROCK_PROJECT` |
+| TC-APPREGION-026 | Start a boundary rollout against a retained stack from another application region | The read-only boundary-region preflight rejects the mismatch before quarantine or any IAM mutation |
+
+## Existing deployments
+
+| ID | Scenario | Expected result |
+| --- | --- | --- |
+| TC-APPREGION-040 | `sst.config.ts` differs from an existing workload-boundary stack's `ApplicationRegion` | Verification and guarded rollout fail before any mutation; live relocation requires a dedicated dual-region migration after old-region previews are removed |
+
+## Documentation
+
+| ID | Scenario | Expected result |
+| --- | --- | --- |
+| TC-APPREGION-030 | Read current deployment and operator guidance | It refers to the `sst.config.ts` application region rather than presenting Tokyo as immutable |
+| TC-APPREGION-031 | Read empirical or rejected-alternative records | The original observed region and date remain intact |

--- a/docs/test-cases/deploy-role-stack-region.md
+++ b/docs/test-cases/deploy-role-stack-region.md
@@ -3,8 +3,8 @@
 ## Scope
 
 Verify that the out-of-band GitHub Actions IAM ownership stack always uses
-`us-west-2`, while application VPC discovery remains controlled by
-`PROJECT_REGION`. Tests execute the real shell wrapper against a fake AWS CLI and
+`us-west-2`, while application VPC discovery follows `providers.aws.region` in
+`sst.config.ts`. Tests execute the real shell wrapper against a fake AWS CLI and
 perform no live AWS mutations.
 
 ## Cases
@@ -25,8 +25,18 @@ perform no live AWS mutations.
 
 ### TC-DEPLOY-ROLE-003: Application region remains independent
 
-- Set `AWS_REGION=us-east-2` and `PROJECT_REGION=eu-west-1`.
+- Set the fixture `sst.config.ts` provider to `eu-west-1`.
+- Set unrelated `AWS_REGION=us-east-2` and `PROJECT_REGION=us-east-1`.
 - Run the wrapper against the fake AWS CLI.
 - Expect EC2 VPC and subnet discovery to use `eu-west-1`.
 - Expect the CloudFormation `ApplicationRegion` parameter to be `eu-west-1`.
 - Expect all CloudFormation stack operations to remain in `us-west-2`.
+
+### TC-DEPLOY-ROLE-004: Existing live region cannot be retargeted in place
+
+- Set the fixture `sst.config.ts` provider to `eu-west-1`.
+- Model an existing ownership stack whose `ApplicationRegion` is
+  `ap-northeast-1`.
+- Run the wrapper with `--update`.
+- Expect failure before `UpdateStack`; live relocation requires a separately
+  reviewed dual-region migration after old-region previews are removed.

--- a/docs/test-cases/ecr-registry-scanning.md
+++ b/docs/test-cases/ecr-registry-scanning.md
@@ -32,7 +32,7 @@ Design: [`docs/designs/ecr-registry-scanning.md`](../designs/ecr-registry-scanni
 | TC-ECR-SCAN-019 | Scan changed documentation and examples | No account ID, live ARN, API key, private repository reference, or comment permalink is present |
 | TC-ECR-SCAN-020 | Stack-owned drift but CloudFormation reports no template update | Exclusively capture the prior complete configuration in a protected local rollback file; write the exact complete declaration, never the drifted current state; a collision blocks mutation, and write/read-back failure prints a shell-escaped same-profile restore command |
 | TC-ECR-SCAN-021 | Registry state changes between initial preflight and mutation | Read and decide again immediately before mutation; external sibling rules fail closed |
-| TC-ECR-SCAN-022 | Inspect the operator identity boundary | Registry get/put belongs to the operator's `AWS_PROFILE` identity in `ap-northeast-1`, never the GitHub Actions role |
+| TC-ECR-SCAN-022 | Inspect the operator identity boundary | Registry get/put belongs to the operator's `AWS_PROFILE` identity in the `sst.config.ts` application region, never the GitHub Actions role |
 | TC-ECR-SCAN-023 | CI CloudFormation validation | After all core typechecks and unit tests run, `actions/setup-python` provides pip and a non-optional `cfn-lint` command performs schema validation; both PR and push path filters re-include the dedicated template after the general CloudFormation exclusion |
 | TC-ECR-SCAN-024 | Registry still differs after a successful owned update | Read-back verification exits nonzero instead of reporting convergence |
 | TC-ECR-SCAN-025 | Dedicated stack loses ownership after adoption | Read-back verification exits nonzero instead of accepting external state |

--- a/docs/test-cases/llm-proxy-multi-model.md
+++ b/docs/test-cases/llm-proxy-multi-model.md
@@ -8,7 +8,8 @@ I/O is faked via injected deps.
 ## Route resolution
 
 - **TC-MMROUTE-001** — `zai.glm-5` (and any unmatched model) resolves to the
-  `chat` route with the Tokyo base; `openai.gpt-5.6-terra` and
+  `chat` route with the configured application-region base;
+  `openai.gpt-5.6-terra` and
   `openai.gpt-5.6-luna` resolve to the `responses` route with the
   `openai/v1` base in the responses region.
 - **TC-MMROUTE-002** — `LLM_PROXY_RESPONSES_MODEL_PREFIXES` accepts a comma
@@ -62,7 +63,8 @@ I/O is faked via injected deps.
 - **TC-MMROUTE-031** — the refresh timer refreshes every region minted so
   far; a region never used is never minted.
 - **TC-MMROUTE-032** — 401 on the responses route re-mints the RESPONSES
-  region bearer (not Tokyo's) and retries once (policy unchanged).
+  region bearer (not the application route's) and retries once (policy
+  unchanged).
 - **TC-MMROUTE-033** — health/readiness still keys on the default-region
   token only (startup semantics unchanged).
 - **TC-MMROUTE-034** — a failed lazy responses-region mint 502s that request,

--- a/infra/bootstrap.test.ts
+++ b/infra/bootstrap.test.ts
@@ -70,6 +70,7 @@ function installGlobals(stage: string) {
   };
   (globalThis as Record<string, unknown>).aws = {
     getCallerIdentityOutput: () => ({ accountId: out("123456789012") }),
+    getRegionOutput: () => ({ name: out("ap-northeast-1") }),
     ec2: {
       getVpcOutput: () => ({ id: out("vpc-test") }),
       getSubnetsOutput: () => ({ ids: out(["subnet-a", "subnet-b", "subnet-c"]) }),

--- a/infra/cloudformation/bedrock-mantle-project.yaml
+++ b/infra/cloudformation/bedrock-mantle-project.yaml
@@ -7,10 +7,10 @@ Description: >
   not attribute the GLM-5 spend, so this repository uses a Bedrock Project.
 
   NOT SST-managed — managed out-of-band (like the ECR repos + the GitHub Actions
-  role) so `sst remove` on a PR stage can't drop the shared project. Deploy in
-  ap-northeast-1 (where the ECS task calls Mantle) via
-  scripts/deploy-bedrock-mantle-project.sh, then feed the ProjectId output to CI
-  as the MEM9_BEDROCK_PROJECT env the deploy reads (infra/ecs.ts BEDROCK_PROJECT).
+  role) so `sst remove` on a PR stage can't drop the shared project. The deploy
+  script defaults to the application region from sst.config.ts; an explicitly
+  selected secondary region can host the independent Responses route. Feed the
+  ProjectId output to CI as the matching project environment value.
 
 Parameters:
   ProjectName:

--- a/infra/cloudformation/ecr-repositories.yaml
+++ b/infra/cloudformation/ecr-repositories.yaml
@@ -5,7 +5,7 @@ Description: >
   bootstrap (schema-bootstrap task, §8), llm-proxy (LLM smart-ingest sidecar, §7).
   CI tags mem9-<sha>/latest (release) + pr-<sha> (preview); each repo's lifecycle
   keeps them on separate schedules.
-  Deploy via scripts/deploy-ecr-repositories.sh in ap-northeast-1. See §4.
+  Deploy via scripts/deploy-ecr-repositories.sh in the application region. See §4.
 
 Parameters:
   ProjectName:

--- a/infra/cloudformation/github-actions-role.yaml
+++ b/infra/cloudformation/github-actions-role.yaml
@@ -45,7 +45,7 @@ Parameters:
       account is allowed).
   ApplicationRegion:
     Type: String
-    Default: ap-northeast-1
+    AllowedPattern: "^[a-z]{2}(-[a-z0-9]+)+-[0-9]+$"
     Description: AWS Region where the SST application and its Lambda VPC ENIs run.
   ApplicationVpcArn:
     Type: String
@@ -998,8 +998,9 @@ Resources:
   # CI PUSH surface. Its own ManagedPolicy so (a) ComputePolicy stays under IAM's
   # 6144-byte per-policy cap, and (b) the "who can push images" footprint is
   # auditable in one place. GetAuthorizationToken is already granted (ECRPull).
-  # Push actions are scoped to the four workload repository ARNs in Tokyo. The
-  # role stack itself is in us-west-2, but ECR ARNs are regional.
+  # Push actions are scoped to the four workload repository ARNs in the
+  # application region. The role stack itself is in us-west-2, but ECR ARNs are
+  # regional.
   #
   # OUT-OF-BAND DEPLOY REQUIREMENT: apply this policy with
   # scripts/deploy-github-role.sh before CI builds need new ECR grants.
@@ -1035,10 +1036,10 @@ Resources:
               - ecr:PutImage
               - ecr:DescribeRepositories
             Resource:
-              - !Sub arn:aws:ecr:ap-northeast-1:${AWS::AccountId}:repository/${ProjectName}/mnemo-server
-              - !Sub arn:aws:ecr:ap-northeast-1:${AWS::AccountId}:repository/${ProjectName}/qwen3-embed
-              - !Sub arn:aws:ecr:ap-northeast-1:${AWS::AccountId}:repository/${ProjectName}/bootstrap
-              - !Sub arn:aws:ecr:ap-northeast-1:${AWS::AccountId}:repository/${ProjectName}/llm-proxy
+              - !Sub arn:${AWS::Partition}:ecr:${ApplicationRegion}:${AWS::AccountId}:repository/${ProjectName}/mnemo-server
+              - !Sub arn:${AWS::Partition}:ecr:${ApplicationRegion}:${AWS::AccountId}:repository/${ProjectName}/qwen3-embed
+              - !Sub arn:${AWS::Partition}:ecr:${ApplicationRegion}:${AWS::AccountId}:repository/${ProjectName}/bootstrap
+              - !Sub arn:${AWS::Partition}:ecr:${ApplicationRegion}:${AWS::AccountId}:repository/${ProjectName}/llm-proxy
   # ───────────────────────────────────────────────────────────────────────────
   # Policy 7 — MCP proxy Lambda (infra/gateway.ts): the VPC-attached proxy Lambda
   # (nodejs24.x) the AgentCore Gateway invokes to reach mnemo-server privately over
@@ -1306,9 +1307,9 @@ Resources:
               - apigateway:TagResource
               - apigateway:UntagResource
             Resource:
-              # Region wildcard: the CFN stack lives in us-west-2 but the app
-              # deploys to ap-northeast-1. API Gateway ARNs carry no account-id
-              # (empty field between the double colons), only the region matters.
+              # Region wildcard: the CFN stack lives in us-west-2 but the app can
+              # deploy elsewhere. API Gateway ARNs carry no account-id (empty
+              # field between the double colons), only the region matters.
               - "arn:aws:apigateway:*::/apis"
               - "arn:aws:apigateway:*::/apis/*"
               - "arn:aws:apigateway:*::/domainnames"

--- a/infra/cloudformation/workload-permissions-boundary.yaml
+++ b/infra/cloudformation/workload-permissions-boundary.yaml
@@ -6,8 +6,7 @@ Description: >
 Parameters:
   ApplicationRegion:
     Type: String
-    Default: ap-northeast-1
-    AllowedPattern: "^[a-z]{2}(-gov)?-[a-z]+-[0-9]$"
+    AllowedPattern: "^[a-z]{2}(-[a-z0-9]+)+-[0-9]+$"
     Description: Region containing the mem9-on-aws workload resources.
   BedrockProjectArn:
     Type: String

--- a/infra/config.test.ts
+++ b/infra/config.test.ts
@@ -12,15 +12,19 @@ import { describe, expect, it } from "vitest";
  * not by our CI-only shim. So the root config is type-checked at `sst deploy`
  * time, not in this unit run (mirrors the sister project's approach). Instead
  * we read it as text and pin the locked facts, so a future edit that silently
- * changes region / prod-protection / the Lambda runtime trips this test.
+ * removes the region / prod-protection / Lambda runtime trips this test.
  */
 
 const here = dirname(fileURLToPath(import.meta.url));
 const src = readFileSync(resolve(here, "../sst.config.ts"), "utf8");
 
 describe("sst.config.ts locked facts", () => {
-  it("pins region ap-northeast-1", () => {
-    expect(src).toMatch(/region:\s*["']ap-northeast-1["']/);
+  it("declares one valid AWS provider region", () => {
+    const regions = [
+      ...src.matchAll(/region:\s*["']([^"']+)["']/gu),
+    ].map((match) => match[1]);
+    expect(regions).toHaveLength(1);
+    expect(regions[0]).toMatch(/^[a-z]{2}(?:-[a-z0-9]+)+-[0-9]+$/u);
   });
 
   it("retains + protects prod state and removes non-prod state", () => {

--- a/infra/consolidation.ts
+++ b/infra/consolidation.ts
@@ -1,7 +1,7 @@
 import type { DbOutputs } from "./db";
 import type { EcsOutputs } from "./ecs";
 import { resolveVpc } from "./vpc";
-import { accountId, ECR_REGION, ecrImage } from "./ecr";
+import { accountId, applicationRegion, ecrImage } from "./ecr";
 import type { TenantIdentityOutputs } from "./tenant-identity";
 import { taskFailureAlarm } from "./task-failure-alarm";
 
@@ -111,7 +111,7 @@ export function consolidation(
       actions: ["bedrock-mantle:CreateInference"],
       resources: [
         BEDROCK_PROJECT
-          ? $interpolate`arn:aws:bedrock-mantle:${ECR_REGION}:${accountId()}:project/${BEDROCK_PROJECT}`
+          ? $interpolate`arn:aws:bedrock-mantle:${applicationRegion()}:${accountId()}:project/${BEDROCK_PROJECT}`
           : "*",
         // A reasoning model is served from RESPONSES_REGION, whose project is a
         // DIFFERENT resource. Without this the task 403s on inference even though

--- a/infra/ecr.ts
+++ b/infra/ecr.ts
@@ -9,12 +9,16 @@
  * comes from the caller identity (never hardcoded) and region = the app region.
  *
  * Centralized here so ecs.ts (mnemo-server, qwen3-embed, and llm-proxy) and
- * bootstrap.ts share one composition and the same region constant.
+ * bootstrap.ts share one composition and the active provider region.
  */
 
-// Must match sst.config.ts providers.aws.region and the ECR bootstrap region
-// (scripts/deploy-ecr-repositories.sh). Tokyo — Fargate pulls same-region.
-export const ECR_REGION = "ap-northeast-1";
+let regionOut: Output<string> | undefined;
+export function applicationRegion(): Output<string> {
+  if (!regionOut) {
+    regionOut = aws.getRegionOutput().name;
+  }
+  return regionOut;
+}
 
 // Cache the caller-identity Output so repeated ecrImage()/accountId() calls don't
 // each create a new getCallerIdentityOutput invoke. Exported so ecs.ts can build
@@ -31,5 +35,5 @@ export function accountId(): Output<string> {
  * @param tag e.g. "mem9-abc1234" or "latest"
  */
 export function ecrImage(namespace: string, tag: string): Output<string> {
-  return $interpolate`${accountId()}.dkr.ecr.${ECR_REGION}.amazonaws.com/${namespace}:${tag}`;
+  return $interpolate`${accountId()}.dkr.ecr.${applicationRegion()}.amazonaws.com/${namespace}:${tag}`;
 }

--- a/infra/ecs.test.ts
+++ b/infra/ecs.test.ts
@@ -114,6 +114,7 @@ function installGlobals(stage: string) {
     // ecs() composes the ECR image URI from the caller's account id — never a
     // hardcoded 12-digit account number in committed code.
     getCallerIdentityOutput: () => ({ accountId: out("123456789012") }),
+    getRegionOutput: () => ({ name: out("ap-northeast-1") }),
     ec2: {
       getVpcOutput: () => ({ id: out("vpc-test") }),
       getSubnetsOutput: () => ({ ids: out(["subnet-a", "subnet-b", "subnet-c"]) }),
@@ -689,7 +690,7 @@ describe("ecs stack", () => {
     const proxy = containersByName()["llm-proxy"];
     const env = proxy.environment as Record<string, unknown>;
     expect(env.LLM_PROXY_PORT).toBe("8082"); // matches MNEMO_LLM_BASE_URL localhost:8082
-    expect(env.LLM_PROXY_REGION).toBe("ap-northeast-1"); // pinned Mantle region
+    expect(materialize(env.LLM_PROXY_REGION)).toBe("ap-northeast-1");
     // GLM-5 request bounds (TC-GLM-BOUND-021, issue #46): both proxy controls
     // are explicit in the production task definition.
     expect(env.LLM_PROXY_MAX_BODY_BYTES).toBe("1048576");

--- a/infra/ecs.ts
+++ b/infra/ecs.ts
@@ -52,14 +52,14 @@
 
 import { resolveVpc } from "./vpc";
 import type { DbOutputs } from "./db";
-import { ecrImage, accountId, ECR_REGION } from "./ecr";
+import { ecrImage, accountId, applicationRegion } from "./ecr";
 import { observability } from "./observability";
 import type { TenantIdentityOutputs } from "./tenant-identity";
 import { disableMnemoServerPseudoTerminal } from "./ecs-task-definition";
 
-// Bedrock Mantle is called in the app region (= the ECR/app region, Tokyo). Used
-// only to scope the bedrock-mantle:CreateInference project ARN.
-const region = ECR_REGION;
+// The primary Mantle route follows the active SST AWS provider. The optional
+// OpenAI Responses route below remains independently regional.
+const region = applicationRegion();
 
 // Image tags. CI (push-to-main) sets MEM9_IMAGE_TAG to the exact `mem9-<sha7>` it
 // just built + pushed, so prod runs that precise commit's images; CI PR previews
@@ -113,11 +113,9 @@ const BEDROCK_PROJECT = process.env.MEM9_BEDROCK_PROJECT || "";
 // Unset → no extra IAM grant and no project env, so responses-route calls run
 // untagged where the boundary permits them and 403 where it does not.
 const BEDROCK_PROJECT_OPENAI = process.env.MEM9_BEDROCK_PROJECT_OPENAI || "";
-// OPERATOR INVARIANT: this must agree with the boundary rollout's
-// WORKLOAD_BOUNDARY_OPENAI_PROJECT_REGION (both default us-west-2). A
-// mismatch grants CreateInference in one region while the boundary's
-// NotResource lists the project of another → every responses call 403s with
-// no single place revealing why. See .env.example.
+// The boundary bootstrap consumes this same variable. The legacy
+// WORKLOAD_BOUNDARY_OPENAI_PROJECT_REGION override is accepted only when it
+// agrees, so the task grant and boundary Project cannot silently diverge.
 const RESPONSES_REGION = process.env.MEM9_LLM_RESPONSES_REGION || "us-west-2";
 
 export interface EcsOutputs {
@@ -442,10 +440,9 @@ export function ecs(dbOut: DbOutputs, identity: TenantIdentityOutputs): EcsOutpu
         image: llmProxyImage,
         environment: {
           LLM_PROXY_PORT: String(LLM_PROXY_PORT),
-          // The proxy derives the Mantle upstream from the region (AWS_REGION is
-          // set by Fargate); pin it explicitly so a region change can't silently
-          // point it at the wrong Mantle endpoint.
-          LLM_PROXY_REGION: "ap-northeast-1",
+          // Pin the provider-derived application region explicitly. The proxy
+          // must not infer its primary route from an unrelated fallback region.
+          LLM_PROXY_REGION: region,
           LLM_PROXY_MAX_BODY_BYTES: String(LLM_PROXY_MAX_BODY_BYTES),
           LLM_PROXY_MAX_TOKENS: String(LLM_PROXY_MAX_TOKENS),
           LLM_PROXY_OVERALL_DEADLINE_MS: String(LLM_PROXY_OVERALL_DEADLINE_MS),

--- a/infra/observability.test.ts
+++ b/infra/observability.test.ts
@@ -56,6 +56,7 @@ function installGlobals() {
     out(JSON.stringify(materialize(value)));
   (globalThis as Record<string, unknown>).aws = {
     getCallerIdentityOutput: () => ({ accountId: out("123456789012") }),
+    getRegionOutput: () => ({ name: out("ap-northeast-1") }),
     cloudwatch: {
       LogMetricFilter: class {
         constructor(logicalName: string, args: Record<string, unknown>) {

--- a/infra/observability.ts
+++ b/infra/observability.ts
@@ -1,4 +1,4 @@
-import { ECR_REGION } from "./ecr";
+import { applicationRegion } from "./ecr";
 
 // Observability: CloudWatch metrics, dashboard, alarms, and Slack alerting for
 // the mnemo-server container (issues #26, #47, and #55). Only created for `prod`
@@ -75,6 +75,7 @@ export function observability(
   const namespace = "mem9-on-aws";
   const durableNamespace = "mem9-on-aws/DurableIngest";
   const failureQueueRetentionSeconds = 14 * 24 * 60 * 60;
+  const region = applicationRegion();
 
   // ─── Metric filters ──────────────────────────────────────────────────────
 
@@ -281,7 +282,7 @@ export function observability(
           height: 6,
           properties: {
             title: "Inference outcomes",
-            region: ECR_REGION,
+            region,
             period: 300,
             metrics: [
               providerMetric("Inferences"),
@@ -297,7 +298,7 @@ export function observability(
           height: 6,
           properties: {
             title: "Token volume",
-            region: ECR_REGION,
+            region,
             period: 300,
             metrics: [
               providerMetric("TotalInputTokens"),
@@ -321,7 +322,7 @@ export function observability(
           height: 6,
           properties: {
             title: "Job outcomes",
-            region: ECR_REGION,
+            region,
             period: 300,
             metrics: [
               durableMetric("JobsAccepted", "accepted"),
@@ -339,7 +340,7 @@ export function observability(
           height: 6,
           properties: {
             title: "Queue and telemetry health",
-            region: ECR_REGION,
+            region,
             period: 300,
             metrics: [
               durableMetric("SamplerHeartbeat"),
@@ -358,7 +359,7 @@ export function observability(
           height: 6,
           properties: {
             title: "Application phase duration",
-            region: ECR_REGION,
+            region,
             period: 300,
             metrics: [
               durableMetric("PlanDurationMs", "succeeded", "Average"),
@@ -375,7 +376,7 @@ export function observability(
           height: 6,
           properties: {
             title: "Retries and warnings",
-            region: ECR_REGION,
+            region,
             period: 300,
             metrics: [
               ...retryTransitions(),
@@ -393,7 +394,7 @@ export function observability(
           height: 6,
           properties: {
             title: "Extraction and pre-screen outcomes",
-            region: ECR_REGION,
+            region,
             period: 300,
             metrics: [
               durableMetric("ZeroFactSuccess"),

--- a/infra/slack-approval.ts
+++ b/infra/slack-approval.ts
@@ -64,7 +64,7 @@ import type { EcsOutputs } from "./ecs";
 import type { OauthFacadeOutputs } from "./oauth-facade";
 import type { TenantIdentityOutputs } from "./tenant-identity";
 import { taskFailureAlarm } from "./task-failure-alarm";
-import { accountId, ECR_REGION, ecrImage } from "./ecr";
+import { accountId, applicationRegion, ecrImage } from "./ecr";
 import { resolveVpc } from "./vpc";
 
 const IMAGE_TAG = process.env.MEM9_IMAGE_TAG || "latest";
@@ -250,7 +250,7 @@ export function slackApproval(
         actions: ["bedrock-mantle:CreateInference"],
         resources: [
           BEDROCK_PROJECT
-            ? $interpolate`arn:aws:bedrock-mantle:${ECR_REGION}:${accountId()}:project/${BEDROCK_PROJECT}`
+            ? $interpolate`arn:aws:bedrock-mantle:${applicationRegion()}:${accountId()}:project/${BEDROCK_PROJECT}`
             : "*",
           // A reasoning model is served from RESPONSES_REGION, whose project is a
           // DIFFERENT resource — without this the task 403s on inference.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "mem9-on-aws",
   "private": true,
+  "type": "module",
   "engines": {
     "node": ">=24"
   },

--- a/scripts/application-region.test.mjs
+++ b/scripts/application-region.test.mjs
@@ -1,0 +1,358 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { spawnSync } from "node:child_process";
+import { afterEach, describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = resolve(here, "..");
+const resolverPath = resolve(here, "resolve-application-region.mjs");
+const tempDirs = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function fixtureConfig(regionExpression, { preamble = [] } = {}) {
+  const dir = mkdtempSync(join(tmpdir(), "mem9-app-region-"));
+  tempDirs.push(dir);
+  const path = join(dir, "sst.config.ts");
+  writeFileSync(
+    path,
+    [
+      ...preamble,
+      "export default $config({",
+      "  app() {",
+      "    return {",
+      "      providers: { aws: {",
+      `        region: ${regionExpression},`,
+      "      } },",
+      "    };",
+      "  },",
+      "  run() {},",
+      "});",
+      "",
+    ].join("\n"),
+  );
+  return path;
+}
+
+async function loadResolver() {
+  return import(
+    pathToFileURL(resolve(here, "lib/application-region.mjs")).href
+  );
+}
+
+describe("application region resolver", () => {
+  it("TC-APPREGION-001: reads the checked-in SST AWS provider", async () => {
+    const { resolveApplicationRegion } = await loadResolver();
+    const region = await resolveApplicationRegion();
+    expect(region).toMatch(/^[a-z]{2}(?:-[a-z0-9]+)+-[0-9]+$/u);
+
+    const cli = spawnSync(process.execPath, [resolverPath], {
+      cwd: root,
+      encoding: "utf8",
+    });
+    expect(cli.status, cli.stderr).toBe(0);
+    expect(cli.stdout).toBe(`${region}\n`);
+  });
+
+  it("TC-APPREGION-002: follows a non-Tokyo SST provider region", async () => {
+    const { resolveApplicationRegion } = await loadResolver();
+    const configPath = fixtureConfig('"ap-southeast-1"');
+
+    await expect(resolveApplicationRegion({ configPath })).resolves.toBe(
+      "ap-southeast-1",
+    );
+
+    const cli = spawnSync(
+      process.execPath,
+      [resolverPath, "--config", configPath],
+      { cwd: root, encoding: "utf8" },
+    );
+    expect(cli.status, cli.stderr).toBe(0);
+    expect(cli.stdout).toBe("ap-southeast-1\n");
+  });
+
+  it.each([
+    ["missing", "undefined"],
+    ["non-string", "42"],
+    ["malformed", '"tokyo"'],
+  ])("TC-APPREGION-003: rejects a %s provider region", async (_name, value) => {
+    const { resolveApplicationRegion } = await loadResolver();
+    const configPath = fixtureConfig(value);
+
+    await expect(resolveApplicationRegion({ configPath })).rejects.toThrow(
+      /AWS provider region/u,
+    );
+  });
+
+  it("TC-APPREGION-004: serializes concurrent imports and restores $config", async () => {
+    const { resolveApplicationRegion } = await loadResolver();
+    let releaseFirst;
+    let releaseSecond;
+    const firstRelease = new Promise((resolvePromise) => {
+      releaseFirst = resolvePromise;
+    });
+    const secondRelease = new Promise((resolvePromise) => {
+      releaseSecond = resolvePromise;
+    });
+    const firstPath = fixtureConfig('"eu-west-1"', {
+      preamble: [
+        "globalThis.__applicationRegionFirstEntered = true;",
+        "await globalThis.__applicationRegionFirstRelease;",
+      ],
+    });
+    const secondPath = fixtureConfig('"ap-southeast-1"', {
+      preamble: ["await globalThis.__applicationRegionSecondRelease;"],
+    });
+    const previousConfig = globalThis.$config;
+    const sentinel = () => {
+      throw new Error("test sentinel must never evaluate an SST config");
+    };
+    globalThis.$config = sentinel;
+    globalThis.__applicationRegionFirstRelease = firstRelease;
+    globalThis.__applicationRegionSecondRelease = secondRelease;
+
+    try {
+      const first = resolveApplicationRegion({ configPath: firstPath });
+      while (globalThis.__applicationRegionFirstEntered !== true) {
+        await new Promise((resolvePromise) => setImmediate(resolvePromise));
+      }
+      const second = resolveApplicationRegion({ configPath: secondPath });
+      releaseFirst();
+      await expect(first).resolves.toBe("eu-west-1");
+      releaseSecond();
+      await expect(second).resolves.toBe("ap-southeast-1");
+      expect(globalThis.$config).toBe(sentinel);
+    } finally {
+      releaseFirst();
+      releaseSecond();
+      delete globalThis.__applicationRegionFirstEntered;
+      delete globalThis.__applicationRegionFirstRelease;
+      delete globalThis.__applicationRegionSecondRelease;
+      if (previousConfig === undefined) delete globalThis.$config;
+      else globalThis.$config = previousConfig;
+    }
+  });
+});
+
+describe("application region consumers", () => {
+  it("TC-APPREGION-010/011: removes copied application-region literals", () => {
+    const literalFreeFiles = [
+      ".env.example",
+      ".github/workflows/infra-ci.yml",
+      ".github/workflows/reconcile-previews.yml",
+      "infra/ecr.ts",
+      "infra/ecs.ts",
+      "infra/cloudformation/bedrock-mantle-project.yaml",
+      "infra/cloudformation/ecr-repositories.yaml",
+      "infra/cloudformation/github-actions-role.yaml",
+      "infra/cloudformation/workload-permissions-boundary.yaml",
+      "scripts/deploy-bedrock-mantle-project.sh",
+      "scripts/deploy-ecr-registry-scanning.sh",
+      "scripts/deploy-ecr-repositories.sh",
+      "scripts/deploy-github-role.sh",
+      "scripts/deploy-workload-permissions-boundary.sh",
+      "scripts/rollout-workload-permissions-boundary.sh",
+      "scripts/run-bootstrap-task.sh",
+      "scripts/run-consolidation-task.sh",
+      "scripts/run-mcp-e2e.sh",
+      "scripts/run-oauth-facade-smoke.sh",
+      "scripts/run-slack-approval-e2e.sh",
+    ];
+
+    for (const relativePath of literalFreeFiles) {
+      expect(
+        readFileSync(resolve(root, relativePath), "utf8"),
+        relativePath,
+      ).not.toContain("ap-northeast-1");
+    }
+  });
+
+  it("TC-APPREGION-012: passes the resolved region to every AWS workflow job", () => {
+    for (const workflowName of ["infra-ci.yml", "reconcile-previews.yml"]) {
+      const workflow = parse(
+        readFileSync(resolve(root, ".github/workflows", workflowName), "utf8"),
+      );
+      const regionJob = workflow.jobs?.["application-region"];
+      expect(regionJob, workflowName).toBeDefined();
+      expect(JSON.stringify(regionJob)).toContain(
+        "node scripts/resolve-application-region.mjs",
+      );
+      if (workflowName === "infra-ci.yml") {
+        expect(regionJob.steps[0].with?.ref).toContain(
+          "github.event.pull_request.head.sha",
+        );
+        expect(regionJob.outputs.cleanup_region).toContain(
+          "steps.resolve.outputs.cleanup_region",
+        );
+        expect(JSON.stringify(regionJob)).toContain(
+          ".application-region-base/sst.config.ts",
+        );
+        expect(JSON.stringify(regionJob)).toContain(
+          "Application region changes cannot deploy PR previews",
+        );
+      }
+
+      for (const [jobName, job] of Object.entries(workflow.jobs ?? {})) {
+        const configuresAws = (job.steps ?? []).some(
+          ({ uses }) =>
+            typeof uses === "string" &&
+            uses.startsWith("aws-actions/configure-aws-credentials@"),
+        );
+        if (!configuresAws) continue;
+        expect(job.needs, `${workflowName}:${jobName}`).toContain(
+          "application-region",
+        );
+        const regionOutput =
+          jobName === "cleanup-preview" ? "cleanup_region" : "region";
+        expect(job.env?.AWS_REGION, `${workflowName}:${jobName}`).toContain(
+          `needs.application-region.outputs.${regionOutput}`,
+        );
+      }
+    }
+  });
+
+  it("TC-APPREGION-013: operator scripts resolve their application default", () => {
+    for (const relativePath of [
+      "scripts/deploy-bedrock-mantle-project.sh",
+      "scripts/deploy-ecr-registry-scanning.sh",
+      "scripts/deploy-ecr-repositories.sh",
+      "scripts/deploy-github-role.sh",
+      "scripts/deploy-workload-permissions-boundary.sh",
+      "scripts/memory-cleanup.mjs",
+      "scripts/memory-consolidation.mjs",
+      "scripts/rollout-workload-permissions-boundary.sh",
+      "scripts/run-bootstrap-task.sh",
+      "scripts/run-consolidation-task.sh",
+      "scripts/run-mcp-e2e.sh",
+      "scripts/run-oauth-facade-smoke.sh",
+      "scripts/run-slack-approval-e2e.sh",
+    ]) {
+      expect(
+        readFileSync(resolve(root, relativePath), "utf8"),
+        relativePath,
+      ).toContain("application-region.mjs");
+    }
+  });
+
+  it("TC-APPREGION-014: never gives the runtime proxy a Tokyo fallback", () => {
+    const server = readFileSync(
+      resolve(root, "docker/llm-proxy/server.mjs"),
+      "utf8",
+    );
+    expect(server).not.toMatch(
+      /LLM_PROXY_REGION\s*\|\|\s*env\.AWS_REGION\s*\|\|\s*["']ap-northeast-1/u,
+    );
+  });
+
+  it("TC-APPREGION-015: uses the commercial-region RDS CA bundle", () => {
+    const dockerfile = readFileSync(
+      resolve(root, "docker/llm-proxy/Dockerfile"),
+      "utf8",
+    );
+    expect(dockerfile).toContain(
+      "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem",
+    );
+    expect(dockerfile).toContain("NODE_EXTRA_CA_CERTS=/app/global-bundle.pem");
+    expect(dockerfile).toContain(
+      "COPY scripts/lib/application-region.mjs /app/scripts/lib/application-region.mjs",
+    );
+  });
+
+  it("TC-APPREGION-020/021: keeps the Responses fallback independent", () => {
+    for (const relativePath of [
+      "infra/ecs.ts",
+      "infra/consolidation.ts",
+      "infra/slack-approval.ts",
+      "docker/llm-proxy/server.mjs",
+    ]) {
+      const source = readFileSync(resolve(root, relativePath), "utf8");
+      expect(source, relativePath).toMatch(
+        /RESPONSES_REGION[\s\S]{0,120}us-west-2/u,
+      );
+    }
+  });
+
+  it("TC-APPREGION-023: passes a custom Responses region through CI", () => {
+    const workflow = parse(
+      readFileSync(
+        resolve(root, ".github/workflows/infra-ci.yml"),
+        "utf8",
+      ),
+    );
+    for (const jobName of ["deploy-preview", "deploy-prod"]) {
+      const job = workflow.jobs[jobName];
+      expect(
+        job.env?.MEM9_LLM_RESPONSES_REGION,
+        `${jobName}:runtime region`,
+      ).toContain("vars.MEM9_LLM_RESPONSES_REGION");
+    }
+    const boundaryScript = readFileSync(
+      resolve(root, "scripts/deploy-workload-permissions-boundary.sh"),
+      "utf8",
+    );
+    expect(boundaryScript).toContain(
+      'openai_project_region="${MEM9_LLM_RESPONSES_REGION:-',
+    );
+    const projectScript = readFileSync(
+      resolve(root, "scripts/deploy-bedrock-mantle-project.sh"),
+      "utf8",
+    );
+    expect(projectScript).toContain(
+      'PROJECT_VARIABLE="MEM9_BEDROCK_PROJECT_OPENAI"',
+    );
+    expect(projectScript).toContain(
+      'PROJECT_VARIABLE="MEM9_BEDROCK_PROJECT"',
+    );
+  });
+
+  it("TC-APPREGION-016: closes previews in the PR base region", () => {
+    const workflow = parse(
+      readFileSync(
+        resolve(root, ".github/workflows/infra-ci.yml"),
+        "utf8",
+      ),
+    );
+    const cleanup = workflow.jobs["cleanup-preview"];
+    expect(cleanup.env.AWS_REGION).toContain(
+      "needs.application-region.outputs.cleanup_region",
+    );
+    const checkout = cleanup.steps.find(
+      ({ uses }) => uses === "actions/checkout@v5",
+    );
+    expect(checkout.with.ref).toContain("github.event.pull_request.base.sha");
+  });
+
+  it("TC-APPREGION-030/031: separates current guidance from historical facts", () => {
+    for (const relativePath of [
+      "README.md",
+      "AGENTS.md",
+      "docs/ARCHITECTURE.md",
+    ]) {
+      const source = readFileSync(resolve(root, relativePath), "utf8");
+      expect(source, relativePath).toContain("sst.config.ts");
+      expect(source, relativePath).not.toContain(
+        "PROJECT_REGION selects the application region",
+      );
+      expect(source, relativePath).not.toContain(
+        "pins that plane to `ap-northeast-1`",
+      );
+      expect(source, relativePath).not.toContain(
+        "--region ap-northeast-1",
+      );
+    }
+
+    const facts = readFileSync(
+      resolve(root, "docs/mem9-facts.md"),
+      "utf8",
+    );
+    expect(facts).toContain("empirically live 2026-07-12");
+    expect(facts).toContain("bedrock-mantle.ap-northeast-1.api.aws");
+  });
+});

--- a/scripts/cleanup-image-contract.test.mjs
+++ b/scripts/cleanup-image-contract.test.mjs
@@ -60,7 +60,17 @@ function bareSpecifiers(source) {
  */
 function copiedEntrypoints() {
   return [
-    ...dockerfile.matchAll(/^COPY\s+(scripts\/\S+\.mjs)\s+\/app\/scripts\/\S+$/gmu),
+    ...dockerfile.matchAll(
+      /^COPY\s+(scripts\/[^/\s]+\.mjs)\s+\/app\/scripts\/[^/\s]+$/gmu,
+    ),
+  ].map((match) => match[1]);
+}
+
+function relativeSpecifiers(source) {
+  return [
+    ...source.matchAll(
+      /(?:\bfrom\s*|\bimport\s*\(\s*)["'](\.\.?\/[^"']+)["']/gu,
+    ),
   ].map((match) => match[1]);
 }
 
@@ -85,6 +95,19 @@ describe("the llm-proxy image can run the entrypoints copied into it (TC-SLACKAP
     // omitting one a path does take kills the run after the approval is spent. The
     // cheap rule is "if the file can name it, the image has it".
     expect(missing).toEqual([]);
+  });
+
+  it("ships every relative module in the copied entrypoints' static graph", () => {
+    for (const relative of copiedEntrypoints()) {
+      for (const specifier of relativeSpecifiers(read(relative))) {
+        const resolved = new URL(specifier, new URL(relative, root));
+        const sourcePath = resolved.pathname.slice(root.pathname.length);
+        expect(
+          dockerfile,
+          `${relative} imports an image file that is not copied: ${sourcePath}`,
+        ).toContain(`COPY ${sourcePath} /app/${sourcePath}`);
+      }
+    }
   });
 
   it("keeps the lockfile in agreement so `npm ci` cannot fail the image build", () => {

--- a/scripts/deploy-bedrock-mantle-project.sh
+++ b/scripts/deploy-bedrock-mantle-project.sh
@@ -8,12 +8,12 @@
 # out-of-band (like the ECR repos + the GitHub Actions role) means `sst remove
 # --stage pr-N` cannot drop the shared project or its accumulated cost history.
 #
-# Bootstrap ONCE per AWS account (in the Tokyo region — where the ECS task calls
-# Mantle), and RE-RUN only if bedrock-mantle-project.yaml changes.
+# Bootstrap ONCE per AWS account and region, and RE-RUN only if
+# bedrock-mantle-project.yaml changes.
 #
-# Region: ap-northeast-1 (Tokyo) — MUST match the SST app region so the project
-# is in the same region the llm-proxy sidecar targets. Hard-coded (not the
-# ambient AWS_REGION) so a leftover AWS_REGION can't create it in the wrong one.
+# Region: defaults to the SST application region. PROJECT_REGION deliberately
+# selects another region for an independent model route such as OpenAI
+# Responses. Ambient AWS_REGION is ignored.
 #
 # Config: set AWS_PROFILE (and any overrides) in a gitignored .env at the repo
 # root — copy .env.example.
@@ -34,10 +34,15 @@ _repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 STACK_NAME="${STACK_NAME:-bedrock-mantle-project-mem9-on-aws}"
 TEMPLATE_FILE="infra/cloudformation/bedrock-mantle-project.yaml"
-# Tokyo — MUST equal sst.config.ts's providers.aws.region. Hard-coded, NOT read
-# from the ambient AWS_REGION (a stray value would create it in the wrong region).
-# Override deliberately with PROJECT_REGION only if the whole app moves regions.
-REGION="${PROJECT_REGION:-ap-northeast-1}"
+APPLICATION_REGION="$(node "$_repo_root/scripts/resolve-application-region.mjs")"
+REGION="${PROJECT_REGION:-$APPLICATION_REGION}"
+if [[ -n "${PROJECT_REGION:-}" ]]; then
+  PROJECT_VARIABLE="MEM9_BEDROCK_PROJECT_OPENAI"
+  PROXY_PROJECT_VARIABLE="LLM_PROXY_RESPONSES_OPENAI_PROJECT"
+else
+  PROJECT_VARIABLE="MEM9_BEDROCK_PROJECT"
+  PROXY_PROJECT_VARIABLE="LLM_PROXY_OPENAI_PROJECT"
+fi
 
 MODE=""
 for arg in "$@"; do
@@ -125,6 +130,6 @@ echo "ProjectId: $PROJECT_ID"
 echo
 echo "Next steps:"
 echo "  1. Set the CI variable so deploys inject it into the llm-proxy sidecar:"
-echo "       gh variable set MEM9_BEDROCK_PROJECT --repo zxkane/mem9-on-aws --body \"$PROJECT_ID\""
-echo "  2. infra/ecs.ts reads MEM9_BEDROCK_PROJECT → LLM_PROXY_OPENAI_PROJECT →"
+echo "       gh variable set $PROJECT_VARIABLE --repo zxkane/mem9-on-aws --body \"$PROJECT_ID\""
+echo "  2. infra/ecs.ts reads $PROJECT_VARIABLE → $PROXY_PROJECT_VARIABLE →"
 echo "     the OpenAI-Project header on calls from that configured deployment."

--- a/scripts/deploy-ecr-registry-scanning.sh
+++ b/scripts/deploy-ecr-registry-scanning.sh
@@ -17,7 +17,7 @@
 # .env. This script is operator-run and is not part of SST or CI deployment.
 #
 # Overrides:
-#   ECR_REGION              default ap-northeast-1
+#   ECR_REGION              compatibility override; must match sst.config.ts
 #   ECR_SCAN_EXCLUSIVE_WRITER_ACK
 #                           must be true before a mutation; set only after the
 #                           account owner pauses other registry config writers
@@ -42,7 +42,12 @@ project_name="mem9-on-aws"
 # falling back under the pull-request-capable role's broad CFN permissions.
 # The preflight CLI owns project-name validation before any mutation decision.
 stack_name="ecr-registry-scanning-${project_name}"
-region="${ECR_REGION:-ap-northeast-1}"
+application_region="$(node "$repo_root/scripts/resolve-application-region.mjs")"
+region="${ECR_REGION:-$application_region}"
+if [[ "$region" != "$application_region" ]]; then
+  echo "ECR_REGION must match the sst.config.ts application region." >&2
+  exit 2
+fi
 template_file="$repo_root/infra/cloudformation/ecr-registry-scanning.yaml"
 preflight="$repo_root/scripts/lib/ecr-registry-scanning-preflight.mjs"
 

--- a/scripts/deploy-ecr-repositories.sh
+++ b/scripts/deploy-ecr-repositories.sh
@@ -6,14 +6,13 @@
 # repositories; it references them read-only. Owning them out-of-band means
 # `sst remove --stage pr-N` cannot wipe the image history prod runs on.
 #
-# Bootstrap ONCE per AWS account (in the Tokyo region — ECR is regional and
+# Bootstrap ONCE per AWS account in the application region (ECR is regional and
 # Fargate pulls same-region), and RE-RUN only if
 # infra/cloudformation/ecr-repositories.yaml changes.
 #
-# Region: ap-northeast-1 (Tokyo) — MUST match the SST app region (sst.config.ts)
-# so Fargate pulls the images from the same region (no cross-region pull cost /
-# latency). This is unlike deploy-github-role.sh, which pins us-west-2 for the
-# global IAM role stack; ECR repositories are regional data resources.
+# Region: resolved from the SST AWS provider in sst.config.ts. This is unlike
+# deploy-github-role.sh, which pins us-west-2 for the global IAM role stack; ECR
+# repositories are regional data resources.
 #
 # Config: set AWS_PROFILE (and any overrides) in a gitignored .env at the repo
 # root — copy .env.example. Targets account <aws-account-id>.
@@ -31,13 +30,15 @@ _repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 STACK_NAME="${STACK_NAME:-ecr-repositories-mem9-on-aws}"
 TEMPLATE_FILE="infra/cloudformation/ecr-repositories.yaml"
-# Tokyo — MUST equal sst.config.ts's providers.aws.region so Fargate pulls the
-# image same-region. Hard-coded, NOT read from the ambient AWS_REGION: a stray
-# AWS_REGION in the shell (e.g. left over from deploy-github-role.sh's us-west-2)
-# would silently create the repo in the wrong region, and Fargate would then pull
-# cross-region (cost + latency) or fail. Override deliberately with ECR_REGION
-# only if the whole app moves regions.
-REGION="${ECR_REGION:-ap-northeast-1}"
+# Do not read ambient AWS_REGION: a value left over from the us-west-2 IAM stack
+# would create the repositories in the wrong region. ECR_REGION remains an
+# explicit compatibility override, but must agree with the SST provider.
+APPLICATION_REGION="$(node "$_repo_root/scripts/resolve-application-region.mjs")"
+REGION="${ECR_REGION:-$APPLICATION_REGION}"
+if [[ "$REGION" != "$APPLICATION_REGION" ]]; then
+  echo "Error: ECR_REGION must match the sst.config.ts application region." >&2
+  exit 2
+fi
 
 MODE=""
 for arg in "$@"; do

--- a/scripts/deploy-github-role.sh
+++ b/scripts/deploy-github-role.sh
@@ -39,10 +39,10 @@ TEMPLATE_FILE="infra/cloudformation/github-actions-role.yaml"
 # in different regions (EntityAlreadyExists rollback). Keep all GitHub Actions
 # role stacks in one region so they share one OIDC provider collision-free.
 readonly STACK_REGION="us-west-2"
-# The application remains regional even though the IAM stack is pinned elsewhere.
-# Match infra/vpc.ts: use MEM9_VPC_ID when configured, otherwise the default VPC,
-# and authorize only the NAT-routed private-1* subnets selected by the app.
-APPLICATION_REGION="${PROJECT_REGION:-ap-northeast-1}"
+# The application remains regional even though the IAM stack is pinned
+# elsewhere. Resolve the same provider region SST uses, then discover the VPC
+# and private-1* subnets selected by the app.
+APPLICATION_REGION="$(node "$_repo_root/scripts/resolve-application-region.mjs")"
 
 MODE=""
 for arg in "$@"; do
@@ -63,6 +63,48 @@ done
 if [[ ! -f "$TEMPLATE_FILE" ]]; then
   echo "Error: template not found at $TEMPLATE_FILE (run from repo root)" >&2
   exit 2
+fi
+
+read_existing_application_region() {
+  aws cloudformation describe-stacks \
+    --stack-name "$STACK_NAME" \
+    --region "$STACK_REGION" \
+    --query "Stacks[0].Parameters[?ParameterKey=='ApplicationRegion'].ParameterValue | [0]" \
+    --output text
+}
+
+require_matching_existing_region() {
+  local existing_region="$1"
+  if [[ ! "$existing_region" =~ ^[a-z]{2}(-gov)?-[a-z0-9-]+-[0-9]+$ ]]; then
+    echo "Error: existing GitHub Actions role has no valid ApplicationRegion; no mutation was attempted." >&2
+    return 1
+  fi
+  if [[ "$existing_region" != "$APPLICATION_REGION" ]]; then
+    echo "Error: Existing GitHub Actions role belongs to application region ${existing_region}; no mutation was attempted." >&2
+    echo "Relocating a live deployment requires a dedicated dual-region migration after old-region previews are removed." >&2
+    return 1
+  fi
+}
+
+# Auto-detect create vs update before uploading a large template or touching any
+# other service. An existing owner cannot be retargeted in place.
+if [[ -z "$MODE" ]]; then
+  set +e
+  EXISTING_APPLICATION_REGION="$(read_existing_application_region 2>/dev/null)"
+  DESCRIBE_EXIT=$?
+  set -e
+  if [[ $DESCRIBE_EXIT -eq 0 ]]; then
+    require_matching_existing_region "$EXISTING_APPLICATION_REGION"
+    MODE="update"
+  else
+    MODE="create"
+  fi
+elif [[ "$MODE" == "update" ]]; then
+  if ! EXISTING_APPLICATION_REGION="$(read_existing_application_region)"; then
+    echo "Error: could not read the existing GitHub Actions role region; no mutation was attempted." >&2
+    exit 1
+  fi
+  require_matching_existing_region "$EXISTING_APPLICATION_REGION"
 fi
 
 echo "Stack:    $STACK_NAME"
@@ -183,18 +225,6 @@ PARAMS_JSON=$(printf \
   "$APPLICATION_VPC_ARN" \
   "$APPLICATION_SUBNET_ARNS")
 echo "ENI scope: $APPLICATION_REGION, one VPC, ${#PRIVATE_SUBNET_IDS[@]} private subnet(s)"
-
-# Auto-detect create vs update when the caller did not pass --create / --update.
-if [[ -z "$MODE" ]]; then
-  if aws cloudformation describe-stacks \
-      --stack-name "$STACK_NAME" \
-      --region "$STACK_REGION" \
-      >/dev/null 2>&1; then
-    MODE="update"
-  else
-    MODE="create"
-  fi
-fi
 
 case "$MODE" in
   create)

--- a/scripts/deploy-workload-permissions-boundary.sh
+++ b/scripts/deploy-workload-permissions-boundary.sh
@@ -26,7 +26,12 @@ fi
 # IAM is global, but CloudFormation ownership is regional. Keep this stack
 # pinned beside the deploy-role stack so another region cannot claim the name.
 region="us-west-2"
-application_region="${WORKLOAD_BOUNDARY_APPLICATION_REGION:-${PROJECT_REGION:-ap-northeast-1}}"
+configured_application_region="$(node "$repo_root/scripts/resolve-application-region.mjs")"
+application_region="${WORKLOAD_BOUNDARY_APPLICATION_REGION:-$configured_application_region}"
+if [[ "$application_region" != "$configured_application_region" ]]; then
+  echo "Application region must match sst.config.ts." >&2
+  exit 2
+fi
 bedrock_stack_name="${BEDROCK_PROJECT_STACK_NAME:-bedrock-mantle-project-mem9-on-aws}"
 template_file="$repo_root/infra/cloudformation/workload-permissions-boundary.yaml"
 contract_file="$repo_root/scripts/workload-permissions-boundary-contract.json"
@@ -88,6 +93,38 @@ if [[ "$partition" == "aws-cn" ]]; then
 else
   url_suffix="amazonaws.com"
 fi
+
+set +e
+describe_output="$(aws cloudformation describe-stacks \
+  --stack-name "$stack_name" \
+  --region "$region" 2>&1)"
+describe_exit=$?
+set -e
+if [[ $describe_exit -eq 0 ]]; then
+  if ! existing_application_region="$(jq -er '
+      .Stacks
+      | select(type == "array" and length == 1)
+      | .[0].Parameters
+      | select(type == "array")
+      | map(
+          select(
+            .ParameterKey == "ApplicationRegion" and
+            (.ParameterValue | type) == "string"
+          )
+        )
+      | select(length == 1)
+      | .[0].ParameterValue
+    ' <<<"$describe_output" 2>/dev/null)"; then
+    echo "Existing workload boundary has no unique ApplicationRegion; no mutation was attempted." >&2
+    exit 1
+  fi
+  if [[ "$existing_application_region" != "$application_region" ]]; then
+    echo "Existing workload boundary belongs to application region ${existing_application_region}; no mutation was attempted." >&2
+    echo "Relocating a live deployment requires a dedicated dual-region migration after old-region previews are removed." >&2
+    exit 1
+  fi
+fi
+
 # Read the out-of-band Mantle project ARN for one region. Prints the ARN on
 # stdout when the stack exists and its output is this account's project in
 # that region; prints nothing when the stack does not exist. Any OTHER
@@ -131,7 +168,13 @@ fi
 # region. Absent stack → feature off, empty parameter, boundary unchanged.
 # Same-region as the application would duplicate the primary ARN in the
 # boundary NotResource list (an exact-document verify failure) — treat as off.
-openai_project_region="${WORKLOAD_BOUNDARY_OPENAI_PROJECT_REGION:-us-west-2}"
+if [[ -n "${MEM9_LLM_RESPONSES_REGION:-}" &&
+      -n "${WORKLOAD_BOUNDARY_OPENAI_PROJECT_REGION:-}" &&
+      "$MEM9_LLM_RESPONSES_REGION" != "$WORKLOAD_BOUNDARY_OPENAI_PROJECT_REGION" ]]; then
+  echo "Responses region settings disagree; no mutation was attempted." >&2
+  exit 2
+fi
+openai_project_region="${MEM9_LLM_RESPONSES_REGION:-${WORKLOAD_BOUNDARY_OPENAI_PROJECT_REGION:-us-west-2}}"
 if [[ "$openai_project_region" == "$application_region" ]]; then
   openai_bedrock_project_arn=""
 else
@@ -149,13 +192,6 @@ if ! aws cloudformation validate-template \
   echo "Boundary template validation failed; no stack mutation attempted." >&2
   exit 1
 fi
-
-set +e
-describe_output="$(aws cloudformation describe-stacks \
-  --stack-name "$stack_name" \
-  --region "$region" 2>&1)"
-describe_exit=$?
-set -e
 
 policy_arn=""
 policy_revision="r1"

--- a/scripts/deployment-workflow.test.mjs
+++ b/scripts/deployment-workflow.test.mjs
@@ -21,6 +21,14 @@ const workflowsDirectory = resolve(root, ".github/workflows");
 const workflowPath = resolve(root, ".github/workflows/infra-ci.yml");
 const rolePath = resolve(root, "infra/cloudformation/github-actions-role.yaml");
 const deployRolePath = resolve(here, "deploy-github-role.sh");
+const applicationRegionResolverPath = resolve(
+  here,
+  "resolve-application-region.mjs",
+);
+const applicationRegionLibraryPath = resolve(
+  here,
+  "lib/application-region.mjs",
+);
 const deployRoleFixturePath = resolve(
   here,
   "test-fixtures/deploy-github-role/mock-aws.mjs",
@@ -58,20 +66,41 @@ function runFixture(name) {
   return { result, callRecords };
 }
 
-function runDeployRoleFixture(args = []) {
+function runDeployRoleFixture(args = [], { existingApplicationRegion } = {}) {
   const dir = mkdtempSync(join(tmpdir(), "mem9-deploy-role-"));
   tempDirs.push(dir);
   const isolatedRoot = join(dir, "repo");
   const isolatedScripts = join(isolatedRoot, "scripts");
+  const isolatedLibrary = join(isolatedScripts, "lib");
   const mockAws = join(dir, "aws");
   const wrapperUnderTest = join(isolatedScripts, "deploy-github-role.sh");
   const calls = join(dir, "calls.jsonl");
-  mkdirSync(isolatedScripts, { recursive: true });
+  mkdirSync(isolatedLibrary, { recursive: true });
   mkdirSync(join(isolatedRoot, "infra", "cloudformation"), {
     recursive: true,
   });
   copyFileSync(deployRoleFixturePath, mockAws);
   copyFileSync(deployRolePath, wrapperUnderTest);
+  copyFileSync(
+    applicationRegionResolverPath,
+    join(isolatedScripts, "resolve-application-region.mjs"),
+  );
+  copyFileSync(
+    applicationRegionLibraryPath,
+    join(isolatedLibrary, "application-region.mjs"),
+  );
+  writeFileSync(
+    join(isolatedRoot, "sst.config.ts"),
+    [
+      "export default $config({",
+      "  app() {",
+      '    return { providers: { aws: { region: "eu-west-1" } } };',
+      "  },",
+      "  run() {},",
+      "});",
+      "",
+    ].join("\n"),
+  );
   copyFileSync(
     rolePath,
     join(isolatedRoot, "infra", "cloudformation", "github-actions-role.yaml"),
@@ -87,8 +116,9 @@ function runDeployRoleFixture(args = []) {
       AWS_CALL_LOG: calls,
       AWS_PROFILE: "fixture-operator",
       AWS_REGION: "us-east-2",
-      PROJECT_REGION: "eu-west-1",
+      PROJECT_REGION: "us-east-1",
       MEM9_TEMPLATE_BUCKET: "fixture-template-bucket",
+      MOCK_APPLICATION_REGION: existingApplicationRegion ?? "eu-west-1",
     },
   });
   const callRecords = readFileSync(calls, "utf8")
@@ -573,8 +603,9 @@ describe("Lambda VPC IAM", () => {
     const script = readFileSync(deployRolePath, "utf8");
 
     expect(script).toContain(
-      'APPLICATION_REGION="${PROJECT_REGION:-ap-northeast-1}"',
+      'APPLICATION_REGION="$(node "$_repo_root/scripts/resolve-application-region.mjs")"',
     );
+    expect(script).not.toContain('APPLICATION_REGION="${PROJECT_REGION');
     expect(script).toContain('APPLICATION_VPC_ID="${MEM9_VPC_ID:-}"');
     expect(script).toContain('"Name=tag:Name,Values=private-1*"');
     for (const parameter of [
@@ -671,6 +702,28 @@ describe("deploy-role stack region", () => {
         ({ args }) => optionValue(args, "--region") === "us-west-2",
       ),
     ).toBe(true);
+  });
+
+  it("refuses to retarget the existing IAM owner during a live region move", () => {
+    const { result, callRecords } = runDeployRoleFixture(["--update"], {
+      existingApplicationRegion: "ap-northeast-1",
+    });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "Existing GitHub Actions role belongs to application region ap-northeast-1",
+    );
+    expect(
+      callRecords.some(
+        ({ args }) => args.slice(0, 2).join(" ") ===
+          "cloudformation update-stack",
+      ),
+    ).toBe(false);
+    expect(
+      callRecords.filter(
+        ({ args }) =>
+          args.slice(0, 2).join(" ") !== "cloudformation describe-stacks",
+      ),
+    ).toEqual([]);
   });
 });
 

--- a/scripts/ecr-registry-scanning.test.mjs
+++ b/scripts/ecr-registry-scanning.test.mjs
@@ -22,12 +22,23 @@ import {
   repositoryMatchesFilter,
   uncoveredProjectRepositories,
 } from "./lib/ecr-registry-scanning-preflight.mjs";
+import { resolveApplicationRegion } from "./lib/application-region.mjs";
 
 const scriptsDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = dirname(scriptsDir);
+const configuredApplicationRegion = await resolveApplicationRegion();
 const fixtureDir = join(scriptsDir, "test-fixtures", "ecr-registry-scanning");
 const wrapper = join(scriptsDir, "deploy-ecr-registry-scanning.sh");
 const preflight = join(scriptsDir, "lib", "ecr-registry-scanning-preflight.mjs");
+const applicationRegionResolver = join(
+  scriptsDir,
+  "resolve-application-region.mjs",
+);
+const applicationRegionLibrary = join(
+  scriptsDir,
+  "lib",
+  "application-region.mjs",
+);
 const tempDirs = [];
 const cloudFormationTags = [
   ...["!Ref", "!Sub", "!GetAtt"].map((tag) => ({ tag, resolve: (value) => value })),
@@ -113,6 +124,9 @@ async function runWrapper(fixture, stackState, options = {}) {
   const putInputFile = join(dir, "put-input.json");
   let wrapperUnderTest = wrapper;
   let operatorBackupFile = null;
+  const applicationRegion = options.repoEnv
+    ? "ap-southeast-1"
+    : (options.ecrRegion ?? configuredApplicationRegion);
   await copyFile(join(fixtureDir, "mock-aws.sh"), mockAws);
   await chmod(mockAws, 0o755);
   if (options.existingRollback) {
@@ -134,6 +148,14 @@ async function runWrapper(fixture, stackState, options = {}) {
         join(isolatedScripts, "lib", "ecr-registry-scanning-preflight.mjs"),
       ),
       copyFile(
+        applicationRegionResolver,
+        join(isolatedScripts, "resolve-application-region.mjs"),
+      ),
+      copyFile(
+        applicationRegionLibrary,
+        join(isolatedScripts, "lib", "application-region.mjs"),
+      ),
+      copyFile(
         join(repoRoot, "infra", "cloudformation", "ecr-registry-scanning.yaml"),
         join(
           isolatedRepo,
@@ -143,10 +165,22 @@ async function runWrapper(fixture, stackState, options = {}) {
         ),
       ),
       writeFile(
+        join(isolatedRepo, "sst.config.ts"),
+        [
+          "export default $config({",
+          "  app() {",
+          `    return { providers: { aws: { region: "${applicationRegion}" } } };`,
+          "  },",
+          "  run() {},",
+          "});",
+          "",
+        ].join("\n"),
+      ),
+      writeFile(
         join(isolatedRepo, ".env"),
         [
           "AWS_PROFILE=operator-real-profile",
-          "ECR_REGION=us-east-1",
+          `ECR_REGION=${applicationRegion}`,
           `ECR_SCAN_BACKUP_FILE=${operatorBackupFile}`,
           "",
         ].join("\n"),
@@ -182,7 +216,7 @@ async function runWrapper(fixture, stackState, options = {}) {
       ECR_SCAN_EXCLUSIVE_WRITER_ACK: options.exclusiveWriterAck ?? "true",
       ECR_SCAN_BACKUP_FILE: rollbackFile,
       ECR_SCAN_STACK_NAME: options.stackName ?? "",
-      ECR_REGION: options.ecrRegion ?? "ap-northeast-1",
+      ECR_REGION: options.ecrRegion ?? applicationRegion,
       AWS_PROFILE: options.awsProfile ?? "test-operator",
       PROJECT_NAME: options.projectName ?? "mem9-on-aws",
     },
@@ -245,7 +279,11 @@ function repositoryTokenDigest(token) {
 function expectRollback(
   result,
   expectedConfiguration,
-  { guidance = false, profile = "test-operator" } = {},
+  {
+    guidance = false,
+    profile = "test-operator",
+    region = configuredApplicationRegion,
+  } = {},
 ) {
   expect(JSON.parse(result.rollback)).toEqual(expectedConfiguration);
   expect(result.rollbackMode).toBe(0o600);
@@ -256,7 +294,7 @@ function expectRollback(
       "Restore the captured baseline while the exclusive-writer window remains active:",
     );
     expect(result.stderr).toContain(
-      `aws${profileArgument} ecr put-registry-scanning-configuration --region ap-northeast-1 --cli-input-json file://${result.rollbackFile}`,
+      `aws${profileArgument} ecr put-registry-scanning-configuration --region ${region} --cli-input-json file://${result.rollbackFile}`,
     );
   }
 }
@@ -706,7 +744,7 @@ describe("CloudFormation declarations", () => {
       Resource: "*",
       Condition: {
         StringEquals: {
-          "aws:RequestedRegion": "ap-northeast-1",
+          "aws:RequestedRegion": "<application-region>",
         },
       },
     });
@@ -720,7 +758,7 @@ describe("CloudFormation declarations", () => {
       Resource: projectRepositories("mem9-on-aws")
         .map(
           (repository) =>
-            `arn:aws:ecr:ap-northeast-1:<aws-account-id>:repository/${repository}`,
+            `arn:aws:ecr:<application-region>:<aws-account-id>:repository/${repository}`,
         )
         .sort(),
     });
@@ -953,7 +991,10 @@ describe("deployment wrapper fixture adapter", () => {
       else process.env.ECR_REGION = originalRegion;
     }
     expect(isolated.status).toBe(4);
-    expectRollback(isolated, driftedConfiguration, { guidance: true });
+    expectRollback(isolated, driftedConfiguration, {
+      guidance: true,
+      region: "ap-southeast-1",
+    });
     expect(isolated.operatorBackup).toBeNull();
     expect(isolated.stderr).not.toContain("operator-real-profile");
     expect(isolated.stderr).not.toContain("us-east-1");
@@ -968,7 +1009,7 @@ describe("deployment wrapper fixture adapter", () => {
     expect(JSON.parse(loaded.operatorBackup)).toEqual(driftedConfiguration);
     expect(loaded.rollback).toBe("");
     expect(loaded.stderr).toContain("--profile operator-real-profile");
-    expect(loaded.stderr).toContain("--region us-east-1");
+    expect(loaded.stderr).toContain("--region ap-southeast-1");
     expect(loaded.stderr).toContain(`file://${loaded.operatorBackupFile}`);
   });
 

--- a/scripts/lib/application-region.mjs
+++ b/scripts/lib/application-region.mjs
@@ -1,0 +1,54 @@
+import { resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const DEFAULT_CONFIG_PATH = fileURLToPath(
+  new URL("../../sst.config.ts", import.meta.url),
+);
+const AWS_REGION_PATTERN = /^[a-z]{2}(?:-[a-z0-9]+)+-[0-9]+$/u;
+let importSequence = 0;
+let configImportTail = Promise.resolve();
+
+async function importWithConfigShim(configUrl) {
+  let releaseImport;
+  const precedingImport = configImportTail;
+  configImportTail = new Promise((resolvePromise) => {
+    releaseImport = resolvePromise;
+  });
+  await precedingImport;
+
+  const priorConfig = globalThis.$config;
+  globalThis.$config = (config) => config;
+  try {
+    return await import(configUrl.href);
+  } finally {
+    if (priorConfig === undefined) delete globalThis.$config;
+    else globalThis.$config = priorConfig;
+    releaseImport();
+  }
+}
+
+/**
+ * Resolve the application plane's region from the SST AWS provider.
+ *
+ * `$config` is an SST compile-time global. Supplying an identity shim lets Node
+ * evaluate app() without running the resource-producing run() function.
+ */
+export async function resolveApplicationRegion({
+  configPath = DEFAULT_CONFIG_PATH,
+} = {}) {
+  const configUrl = pathToFileURL(resolve(configPath));
+  configUrl.searchParams.set("application-region-read", String(++importSequence));
+
+  const configModule = await importWithConfigShim(configUrl);
+
+  const app = configModule.default?.app;
+  if (typeof app !== "function") {
+    throw new Error("sst.config.ts must expose an app() function");
+  }
+  const region = app({ stage: "application-region-resolution" })?.providers
+    ?.aws?.region;
+  if (typeof region !== "string" || !AWS_REGION_PATTERN.test(region)) {
+    throw new Error("sst.config.ts AWS provider region is missing or malformed");
+  }
+  return region;
+}

--- a/scripts/lib/workload-permissions-boundary-aws.mjs
+++ b/scripts/lib/workload-permissions-boundary-aws.mjs
@@ -218,9 +218,7 @@ export async function resolveAwsIdentity(invokeAws = invokeAwsCli) {
 
 export function createAwsCliAdapter({
   identity,
-  applicationRegion = process.env.WORKLOAD_BOUNDARY_APPLICATION_REGION ??
-    process.env.PROJECT_REGION ??
-    "ap-northeast-1",
+  applicationRegion = process.env.WORKLOAD_BOUNDARY_APPLICATION_REGION,
   invokeAws = invokeAwsCli,
   deployBoundary = deployBoundaryStack,
   deployEnforcement = deployRoleEnforcement,
@@ -410,6 +408,46 @@ export function createAwsCliAdapter({
     );
   }
 
+  async function readBoundaryStackParameters() {
+    const boundaryStackResponse = await invokeAwsCommand([
+      "cloudformation",
+      "describe-stacks",
+      "--stack-name",
+      WORKLOAD_BOUNDARY_STACK_NAME,
+      "--region",
+      OPERATOR_STACK_REGION,
+    ]);
+    if (
+      !Array.isArray(boundaryStackResponse.Stacks) ||
+      boundaryStackResponse.Stacks.length !== 1
+    ) {
+      throw new Error("workload boundary stack response is malformed");
+    }
+    const boundaryStack = boundaryStackResponse.Stacks[0];
+    if (
+      !boundaryStack ||
+      !["CREATE_COMPLETE", "UPDATE_COMPLETE"].includes(
+        boundaryStack.StackStatus,
+      ) ||
+      !Array.isArray(boundaryStack.Parameters)
+    ) {
+      throw new Error("workload boundary stack response is malformed");
+    }
+    const boundaryParameters = new Map();
+    for (const parameter of boundaryStack.Parameters) {
+      if (
+        !parameter ||
+        typeof parameter.ParameterKey !== "string" ||
+        typeof parameter.ParameterValue !== "string" ||
+        boundaryParameters.has(parameter.ParameterKey)
+      ) {
+        throw new Error("workload boundary stack response is malformed");
+      }
+      boundaryParameters.set(parameter.ParameterKey, parameter.ParameterValue);
+    }
+    return boundaryParameters;
+  }
+
   const adapter = {
     async putQuarantine(request) {
       await putQuarantine(invokeAwsCommand, request);
@@ -419,46 +457,15 @@ export function createAwsCliAdapter({
       return verifyQuarantine(invokeAwsCommand);
     },
 
+    async verifyBoundaryRegion() {
+      const boundaryParameters = await readBoundaryStackParameters();
+      if (boundaryParameters.get("ApplicationRegion") !== applicationRegion) {
+        throw new Error("workload boundary application region is mismatched");
+      }
+    },
+
     async verifyProductionRuntimeBindings() {
-      const boundaryStackResponse = await invokeAwsCommand([
-        "cloudformation",
-        "describe-stacks",
-        "--stack-name",
-        WORKLOAD_BOUNDARY_STACK_NAME,
-        "--region",
-        OPERATOR_STACK_REGION,
-      ]);
-      if (
-        !Array.isArray(boundaryStackResponse.Stacks) ||
-        boundaryStackResponse.Stacks.length !== 1
-      ) {
-        throw new Error("workload boundary stack response is malformed");
-      }
-      const boundaryStack = boundaryStackResponse.Stacks[0];
-      if (
-        !boundaryStack ||
-        !["CREATE_COMPLETE", "UPDATE_COMPLETE"].includes(
-          boundaryStack.StackStatus,
-        ) ||
-        !Array.isArray(boundaryStack.Parameters)
-      ) {
-        throw new Error("workload boundary stack response is malformed");
-      }
-      const boundaryParameters = new Map();
-      for (const parameter of boundaryStack.Parameters) {
-        if (
-          !parameter ||
-          typeof parameter.ParameterKey !== "string" ||
-          typeof parameter.ParameterValue !== "string" ||
-          boundaryParameters.has(parameter.ParameterKey)
-        ) {
-          throw new Error("workload boundary stack response is malformed");
-        }
-        boundaryParameters.set(
-          parameter.ParameterKey,
-          parameter.ParameterValue,
-        );
-      }
+      const boundaryParameters = await readBoundaryStackParameters();
       if (
         boundaryParameters.get("ApplicationRegion") !== applicationRegion ||
         !boundaryParameters.has("BedrockProjectArn")

--- a/scripts/lib/workload-permissions-boundary.mjs
+++ b/scripts/lib/workload-permissions-boundary.mjs
@@ -1618,10 +1618,17 @@ export async function runBoundaryRollout(
   ) {
     throw new Error("final GitHub interlock configuration is invalid");
   }
+  if (typeof adapter.verifyBoundaryRegion !== "function") {
+    throw new Error("boundary region preflight configuration is invalid");
+  }
   const boundedAdapter = createDeadlineAdapter(adapter, deadlineAt);
   let quarantineAttempted = false;
   let quarantineRemoved = false;
   try {
+    // Catch a retained stack from another application region before quarantine
+    // or any other IAM mutation. The full runtime binding read still runs below,
+    // immediately before boundary attachment.
+    await boundedAdapter.verifyBoundaryRegion();
     quarantineAttempted = true;
     await boundedAdapter.putQuarantine({
       roleName: deployRoleName,

--- a/scripts/memory-cleanup.mjs
+++ b/scripts/memory-cleanup.mjs
@@ -1932,7 +1932,10 @@ export async function runCleanup(opts, deps) {
  */
 export function buildCompleteChat(opts, deps) {
   const model = opts.model || process.env.MEM9_LLM_MODEL || DEFAULT_CHAT_MODEL;
-  const appRegion = opts.region || "ap-northeast-1";
+  const appRegion = opts.region || process.env.AWS_REGION;
+  if (!appRegion) {
+    throw new Error("application region is required for cleanup inference");
+  }
   // A CLOSED object, never a spread of process.env: `readProxyConfig` is
   // written for a container where the whole LLM_PROXY_* namespace is set by
   // infra/ecs.ts. Spreading the operator's shell in would make every sidecar
@@ -3025,8 +3028,16 @@ async function productionDatabaseMutex(stage, region, runtime = {}) {
  * them would make a read-only listing fail on unrelated configuration. The
  * shared mutex is passed only for an actual `--apply`, matching cleanup.
  */
+async function resolveRuntimeApplicationRegion() {
+  if (process.env.AWS_REGION) return process.env.AWS_REGION;
+  const { resolveApplicationRegion } = await import(
+    "./lib/application-region.mjs"
+  );
+  return resolveApplicationRegion();
+}
+
 async function recoveryDeps(opts) {
-  const region = process.env.AWS_REGION || "ap-northeast-1";
+  const region = await resolveRuntimeApplicationRegion();
   const database = await productionDatabaseMutex(opts.stage, region);
   const adapter = inactiveMemoryAdapter(database.db);
   return {
@@ -3189,7 +3200,7 @@ function buildReportOutcome(opts, claim, runtime) {
  * for the length of its own failure, blocking the weekly consolidation.
  */
 export async function createCleanupDeps(opts, runtime = {}) {
-  const region = process.env.AWS_REGION || "ap-northeast-1";
+  const region = await resolveRuntimeApplicationRegion();
 
   // The explicit flag WINS over the env var: a stale MEM9_TENANT_ID from a
   // preview shell must not silently redirect an --apply aimed at another stage.

--- a/scripts/memory-consolidation.mjs
+++ b/scripts/memory-consolidation.mjs
@@ -10,6 +10,7 @@ import {
   contentHash,
   sharedCleanupMutexKey,
 } from "./memory-cleanup.mjs";
+import { resolveApplicationRegion } from "./lib/application-region.mjs";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const DEFAULT_CAP = 20;
@@ -924,7 +925,9 @@ function restAdapter(baseUrl, tenantId, fetchImpl = fetch) {
 }
 
 export async function createProductionDeps(options, runtime = {}) {
-  const region = process.env.AWS_REGION || "ap-northeast-1";
+  const region =
+    process.env.AWS_REGION ||
+    (await resolveApplicationRegion());
   const dbSecret = parseJsonObject(process.env.MEM9_DB_SECRET);
   const tenantId = process.env.MEM9_TENANT_ID;
   const baseUrl = process.env.MEM9_BASE_URL;

--- a/scripts/resolve-application-region.mjs
+++ b/scripts/resolve-application-region.mjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+import { resolveApplicationRegion } from "./lib/application-region.mjs";
+
+let configPath;
+for (let index = 2; index < process.argv.length; index += 1) {
+  const argument = process.argv[index];
+  if (argument === "--config" && process.argv[index + 1]) {
+    configPath = process.argv[++index];
+    continue;
+  }
+  console.error(`Unknown or incomplete option: ${argument}`);
+  process.exit(2);
+}
+
+try {
+  console.log(await resolveApplicationRegion({ configPath }));
+} catch (error) {
+  console.error(error?.message ?? error);
+  process.exit(1);
+}

--- a/scripts/rollout-workload-permissions-boundary.mjs
+++ b/scripts/rollout-workload-permissions-boundary.mjs
@@ -389,6 +389,7 @@ export function createGithubMaintenanceController({
 }
 
 export async function executeBoundaryRollout({
+  applicationRegion = process.env.WORKLOAD_BOUNDARY_APPLICATION_REGION,
   invokeAws,
   deployBoundary,
   deployEnforcement,
@@ -425,6 +426,7 @@ export async function executeBoundaryRollout({
     `arn:${identity.partition}:iam::${identity.accountId}:policy/` +
     WORKLOAD_BOUNDARY_POLICY_NAME;
   const adapter = createAdapter({
+    applicationRegion,
     identity,
     invokeAws,
     deployBoundary,

--- a/scripts/rollout-workload-permissions-boundary.sh
+++ b/scripts/rollout-workload-permissions-boundary.sh
@@ -48,11 +48,10 @@ fi
 if [[ "$maintenance_ack_override_set" == "x" ]]; then
   export WORKLOAD_BOUNDARY_MAINTENANCE_ACK="$maintenance_ack_override"
 fi
-effective_application_region="${WORKLOAD_BOUNDARY_APPLICATION_REGION:-${PROJECT_REGION:-ap-northeast-1}}"
-if [[ -n "${WORKLOAD_BOUNDARY_APPLICATION_REGION:-}" &&
-      -n "${PROJECT_REGION:-}" &&
-      "$WORKLOAD_BOUNDARY_APPLICATION_REGION" != "$PROJECT_REGION" ]]; then
-  echo "Application region settings disagree; no mutation was attempted." >&2
+configured_application_region="$(node "$repo_root/scripts/resolve-application-region.mjs")"
+effective_application_region="${WORKLOAD_BOUNDARY_APPLICATION_REGION:-$configured_application_region}"
+if [[ "$effective_application_region" != "$configured_application_region" ]]; then
+  echo "Application region must match sst.config.ts; no mutation was attempted." >&2
   exit 2
 fi
 if [[ ! "$effective_application_region" =~ ^[a-z]{2}(-gov)?-[a-z0-9-]+-[0-9]+$ ]]; then
@@ -60,7 +59,6 @@ if [[ ! "$effective_application_region" =~ ^[a-z]{2}(-gov)?-[a-z0-9-]+-[0-9]+$ ]
   exit 2
 fi
 export WORKLOAD_BOUNDARY_APPLICATION_REGION="$effective_application_region"
-export PROJECT_REGION="$effective_application_region"
 
 if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
   sed -n '2,/^$/p' "$0" | sed 's/^# \?//'
@@ -338,8 +336,9 @@ write_resume_assignment() {
       AWS_CONFIG_FILE \
       AWS_SHARED_CREDENTIALS_FILE \
       AWS_CA_BUNDLE \
+      MEM9_LLM_RESPONSES_REGION \
       WORKLOAD_BOUNDARY_APPLICATION_REGION \
-      PROJECT_REGION \
+      WORKLOAD_BOUNDARY_OPENAI_PROJECT_REGION \
       BEDROCK_PROJECT_STACK_NAME \
       MEM9_TEMPLATE_BUCKET \
       MEM9_VPC_ID \

--- a/scripts/run-bootstrap-task.sh
+++ b/scripts/run-bootstrap-task.sh
@@ -15,12 +15,13 @@
 # Env:
 #   STAGE       (required) — e.g. prod / pr-7. Selects the /mem9-on-aws/<stage>/
 #               bootstrap/* SSM params.
-#   AWS_REGION  (optional) — defaults to ap-northeast-1 (the app region).
+#   AWS_REGION  (optional) — defaults to the SST application region.
 
 set -euo pipefail
 
 STAGE="${STAGE:?STAGE is required (e.g. prod or pr-7)}"
-REGION="${AWS_REGION:-ap-northeast-1}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REGION="${AWS_REGION:-$(node "$REPO_ROOT/scripts/resolve-application-region.mjs")}"
 PREFIX="/mem9-on-aws/${STAGE}/bootstrap"
 
 echo "run-bootstrap: reading run inputs from SSM ${PREFIX}/* (region ${REGION})"

--- a/scripts/run-consolidation-task.sh
+++ b/scripts/run-consolidation-task.sh
@@ -5,7 +5,8 @@
 set -euo pipefail
 
 STAGE="${STAGE:?STAGE is required (for example, prod or pr-103)}"
-REGION="${AWS_REGION:-ap-northeast-1}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REGION="${AWS_REGION:-$(node "$REPO_ROOT/scripts/resolve-application-region.mjs")}"
 PREFIX="/mem9-on-aws/${STAGE}/consolidation"
 CONTAINER_NAME="Mem9Consolidation"
 

--- a/scripts/run-mcp-e2e.sh
+++ b/scripts/run-mcp-e2e.sh
@@ -20,7 +20,7 @@
 #
 # Env:
 #   STAGE       (required) — e.g. prod / pr-7.
-#   AWS_REGION  (optional) — defaults to ap-northeast-1.
+#   AWS_REGION  (optional) — defaults to the SST application region.
 #   E2E_COGNITO_CLIENT_PREFIX (optional) — SSM prefix containing client-id and
 #               client-secret. Defaults to /mem9-on-aws/<stage>/cognito. Recovery
 #               uses a dedicated client under a separate prefix.
@@ -32,7 +32,8 @@
 set -euo pipefail
 
 STAGE="${STAGE:?STAGE is required (e.g. prod or pr-7)}"
-REGION="${AWS_REGION:-ap-northeast-1}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REGION="${AWS_REGION:-$(node "$REPO_ROOT/scripts/resolve-application-region.mjs")}"
 PREFIX="/mem9-on-aws/${STAGE}"
 COGNITO_CLIENT_PREFIX="${E2E_COGNITO_CLIENT_PREFIX:-${PREFIX}/cognito}"
 SOFT="${E2E_SOFT:-0}"

--- a/scripts/run-oauth-facade-smoke.sh
+++ b/scripts/run-oauth-facade-smoke.sh
@@ -4,7 +4,8 @@
 # metadata, registration, and the authorize redirect/cookie response.
 set -euo pipefail
 STAGE="${STAGE:?STAGE is required}"
-REGION="${AWS_REGION:-ap-northeast-1}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REGION="${AWS_REGION:-$(node "$REPO_ROOT/scripts/resolve-application-region.mjs")}"
 PREFIX="/mem9-on-aws/${STAGE}"
 ssm() { aws ssm get-parameter --name "$1" --region "$REGION" --query Parameter.Value --output text; }
 

--- a/scripts/run-slack-approval-e2e.sh
+++ b/scripts/run-slack-approval-e2e.sh
@@ -23,7 +23,8 @@
 set -euo pipefail
 
 STAGE="${STAGE:?STAGE is required (for example, prod or pr-123)}"
-REGION="${AWS_REGION:-ap-northeast-1}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REGION="${AWS_REGION:-$(node "$REPO_ROOT/scripts/resolve-application-region.mjs")}"
 PREFIX="/mem9-on-aws/${STAGE}"
 
 # Disposable stages only, refused BEFORE the first write, and one pattern rather

--- a/scripts/test-fixtures/deploy-github-role/mock-aws.mjs
+++ b/scripts/test-fixtures/deploy-github-role/mock-aws.mjs
@@ -52,7 +52,11 @@ switch (command) {
     break;
   case "cloudformation describe-stacks": {
     const region = optionValue("--region");
-    if (optionValue("--query")) {
+    const query = optionValue("--query");
+    if (query?.includes("ApplicationRegion")) {
+      respond(process.env.MOCK_APPLICATION_REGION ?? "eu-west-1");
+    }
+    if (query) {
       respond("arn:aws:iam::<aws-account-id>:role/github-actions-mem9-on-aws");
     }
     if (region === "us-west-2") respond("{}");

--- a/scripts/workload-permissions-boundary-contract.json
+++ b/scripts/workload-permissions-boundary-contract.json
@@ -13,12 +13,12 @@
     {
       "id": "infra-ci.yml",
       "path": ".github/workflows/infra-ci.yml",
-      "reviewedBlob": "4590668846752058fbde4d56aa07f3d5d859a633"
+      "reviewedBlob": "3e8a8fccea16f47d91ed9189f0c8b5b4893c3872"
     },
     {
       "id": "reconcile-previews.yml",
       "path": ".github/workflows/reconcile-previews.yml",
-      "reviewedBlob": "082330244d9773cb55949f54deb2659c5d999506"
+      "reviewedBlob": "f284aaa2d87f14df3160ac03805664120ae010e7"
     }
   ],
   "nonterminalWorkflowStatuses": [

--- a/scripts/workload-permissions-boundary.test.mjs
+++ b/scripts/workload-permissions-boundary.test.mjs
@@ -34,7 +34,7 @@ import {
   AWS_CLI_TIMEOUT_MS,
   DEPLOY_COMMAND_TIMEOUT_MS,
   QUARANTINE_PROBE_ACTIONS,
-  createAwsCliAdapter,
+  createAwsCliAdapter as createAwsCliAdapterForRegion,
   invokeAwsCli,
   resolveAwsIdentity,
 } from "./lib/workload-permissions-boundary-aws.mjs";
@@ -112,6 +112,11 @@ const boundaryContract = {
     "arn:aws:bedrock-mantle:ap-northeast-1:123456789012:project/proj_test",
   partition,
 };
+const createAwsCliAdapter = (options) =>
+  createAwsCliAdapterForRegion({
+    applicationRegion: boundaryContract.applicationRegion,
+    ...options,
+  });
 const patterns = expectedRolePatterns({ partition, accountId });
 const consolidationSchedulerRolePattern =
   `arn:${partition}:iam::${accountId}:role/` +
@@ -588,6 +593,7 @@ function optionValues(args, name) {
 }
 
 async function runBoundaryDeployMock({
+  boundaryOpenAiRegion,
   boundarySimulationBadProbe = "",
   boundarySimulationMalformedProbe = "",
   defaultVersionDriftsAfterSimulation = false,
@@ -597,7 +603,9 @@ async function runBoundaryDeployMock({
   quarantineLostAfterSimulation = false,
   quarantine = true,
   quarantineSimulation,
+  responsesRegion,
   simulationCommandFails = false,
+  stackApplicationRegion = boundaryContract.applicationRegion,
   stackExists = true,
   stackStatus = "UPDATE_COMPLETE",
   verifyOnly = false,
@@ -928,7 +936,18 @@ case "$command" in
     elif [[ "$query" == "Stacks[0].Parameters[?ParameterKey=='PolicyRevision'].ParameterValue | [0]" ]]; then
       printf '%s\\n' 'r1'
     else
-      printf '{"Stacks":[{"StackStatus":"%s"}]}\\n' "$MOCK_STACK_STATUS"
+      jq -cn \
+        --arg region "$MOCK_STACK_APPLICATION_REGION" \
+        --arg status "$MOCK_STACK_STATUS" \
+        '{
+          Stacks: [{
+            StackStatus: $status,
+            Parameters: [{
+              ParameterKey: "ApplicationRegion",
+              ParameterValue: $region
+            }]
+          }]
+        }'
     fi
     ;;
   "cloudformation describe-stack-resources")
@@ -1070,10 +1089,20 @@ esac
           MOCK_SIMULATION: simulationPath,
           MOCK_SIMULATION_COMPLETE: simulationCompletePath,
           MOCK_SIMULATION_COMMAND_FAILS: String(simulationCommandFails),
+          MOCK_STACK_APPLICATION_REGION: stackApplicationRegion,
           MOCK_STACK_EXISTS: String(stackExists),
           MOCK_STACK_STATUS: stackStatus,
           MOCK_UPDATED: updatedPath,
           PATH: `${directory}:${dirname(process.execPath)}:${process.env.PATH}`,
+          ...(boundaryOpenAiRegion === undefined
+            ? {}
+            : {
+                WORKLOAD_BOUNDARY_OPENAI_PROJECT_REGION:
+                  boundaryOpenAiRegion,
+              }),
+          ...(responsesRegion === undefined
+            ? {}
+            : { MEM9_LLM_RESPONSES_REGION: responsesRegion }),
           WORKLOAD_BOUNDARY_MAINTENANCE_ACK: guarded ? "true" : "",
           WORKLOAD_BOUNDARY_SKIP_DOTENV: "true",
         },
@@ -1098,6 +1127,8 @@ async function runRolloutGateMock({
   dirtyWorktree = false,
   dotenvAck,
   dotenvApplicationRegion,
+  dotenvOpenAiProjectRegion,
+  dotenvResponsesRegion,
   dotenvProfile,
   dotenvProjectRegion,
   dotenvTemplateBucket,
@@ -1117,6 +1148,7 @@ async function runRolloutGateMock({
   interruptSignal,
   timeout = "30s",
   clockStepMs = 0,
+  configuredApplicationRegion = dotenvApplicationRegion ?? "ap-northeast-1",
   nodeExit = 0,
 } = {}) {
   const directory = await mkdtemp(join(tmpdir(), "mem9-boundary-pause-"));
@@ -1133,6 +1165,8 @@ async function runRolloutGateMock({
   if (
     dotenvAck !== undefined ||
     dotenvApplicationRegion !== undefined ||
+    dotenvOpenAiProjectRegion !== undefined ||
+    dotenvResponsesRegion !== undefined ||
     dotenvProfile !== undefined ||
     dotenvProjectRegion !== undefined ||
     dotenvTemplateBucket !== undefined ||
@@ -1154,6 +1188,14 @@ async function runRolloutGateMock({
           : [
               `WORKLOAD_BOUNDARY_APPLICATION_REGION=${dotenvApplicationRegion}`,
             ]),
+        ...(dotenvOpenAiProjectRegion === undefined
+          ? []
+          : [
+              `WORKLOAD_BOUNDARY_OPENAI_PROJECT_REGION=${dotenvOpenAiProjectRegion}`,
+            ]),
+        ...(dotenvResponsesRegion === undefined
+          ? []
+          : [`MEM9_LLM_RESPONSES_REGION=${dotenvResponsesRegion}`]),
         ...(dotenvProjectRegion === undefined
           ? []
           : [`PROJECT_REGION=${dotenvProjectRegion}`]),
@@ -1316,6 +1358,8 @@ esac
 set -euo pipefail
 if [[ "\${1:-}" == "-p" ]]; then
   printf '24\\n'
+elif [[ "\${1:-}" == *"/resolve-application-region.mjs" ]]; then
+  printf '%s\\n' "$MOCK_CONFIGURED_APPLICATION_REGION"
 else
   printf 'node invoked profile=%s region=%s project_region=%s vpc=%s bucket=%s %s\\n' \
     "\${AWS_PROFILE-}" \
@@ -1360,6 +1404,7 @@ printf '%s\\n' "$((now + MOCK_CLOCK_STEP_MS * 1000000))" > "$MOCK_CLOCK"
     ...process.env,
     MOCK_CALLER_ACCOUNT: callerAccount,
     MOCK_CALLER_PARTITION: callerPartition,
+    MOCK_CONFIGURED_APPLICATION_REGION: configuredApplicationRegion,
     MOCK_NODE_EXIT: String(nodeExit),
     MOCK_NODE_WAIT_SIGNAL: String(interruptSignal !== undefined),
     MOCK_ACTIVE_WORKFLOW: activeWorkflow,
@@ -1390,10 +1435,12 @@ printf '%s\\n' "$((now + MOCK_CLOCK_STEP_MS * 1000000))" > "$MOCK_CLOCK"
   };
   for (const name of [
     "AWS_PROFILE",
+    "MEM9_LLM_RESPONSES_REGION",
     "MEM9_TEMPLATE_BUCKET",
     "MEM9_VPC_ID",
     "PROJECT_REGION",
     "WORKLOAD_BOUNDARY_APPLICATION_REGION",
+    "WORKLOAD_BOUNDARY_OPENAI_PROJECT_REGION",
   ]) {
     delete childEnv[name];
   }
@@ -1491,6 +1538,12 @@ function makeAdapter(options = {}) {
   const adapter = {
     calls,
     state,
+    async verifyBoundaryRegion() {
+      calls.push("verify-boundary-region");
+      if (options.failBoundaryRegionPreflight) {
+        throw new Error("workload boundary application region is mismatched");
+      }
+    },
     async putQuarantine({ roleName, policyName, policyDocument }) {
       calls.push(`quarantine:${roleName}:${policyName}`);
       if (options.failQuarantine) throw new Error("quarantine failed");
@@ -2355,6 +2408,46 @@ describe("production task-definition secret preflight", () => {
     ).toEqual(Object.values(productionTaskDefinitions).sort());
   });
 
+  it("preflights the retained owner region before any IAM call", async () => {
+    const calls = [];
+    const adapter = createAwsCliAdapter({
+      identity: { accountId, partition },
+      invokeAws: (args) => {
+        calls.push(args);
+        return productionPreflightAws(args);
+      },
+    });
+
+    await expect(adapter.verifyBoundaryRegion()).resolves.toBeUndefined();
+    expect(calls).toEqual([
+      [
+        "cloudformation",
+        "describe-stacks",
+        "--stack-name",
+        WORKLOAD_BOUNDARY_STACK_NAME,
+        "--region",
+        "us-west-2",
+      ],
+    ]);
+  });
+
+  it("rejects a retained owner with another application region", async () => {
+    const adapter = createAwsCliAdapter({
+      identity: { accountId, partition },
+      invokeAws: (args) => {
+        const response = structuredClone(productionPreflightAws(args));
+        response.Stacks[0].Parameters.find(
+          ({ ParameterKey }) => ParameterKey === "ApplicationRegion",
+        ).ParameterValue = "eu-west-1";
+        return response;
+      },
+    });
+
+    await expect(adapter.verifyBoundaryRegion()).rejects.toThrow(
+      /application region is mismatched/u,
+    );
+  });
+
   it.each([
     ["boundary stack read", "cloudformation describe-stacks", { Stacks: [] }],
     ["parameter read", "ssm get-parameters", { Parameters: [] }],
@@ -2410,12 +2503,13 @@ describe("guarded rollout", () => {
     ]),
   );
 
-  it("runs quarantine first and removes it only after complete verification", async () => {
+  it("preflights before quarantine and removes quarantine only after complete verification", async () => {
     const adapter = makeAdapter();
     const result = await runBoundaryRollout(adapter, options);
 
     expect(result).toEqual({ verifiedRoleCount: 3, status: "complete" });
-    expect(adapter.calls[0]).toBe(
+    expect(adapter.calls[0]).toBe("verify-boundary-region");
+    expect(adapter.calls[1]).toBe(
       `quarantine:${options.deployRoleName}:${QUARANTINE_POLICY_NAME}`,
     );
     expect(adapter.calls.indexOf("deploy-boundary")).toBeGreaterThan(
@@ -2748,7 +2842,8 @@ describe("guarded rollout", () => {
         call.startsWith("list-attached:"),
       );
       if (
-        quarantineIndex !== 0 ||
+        adapter.calls[0] !== "verify-boundary-region" ||
+        quarantineIndex !== 1 ||
         discoveryIndex < 0 ||
         quarantineIndex >= discoveryIndex
       ) {
@@ -2845,7 +2940,19 @@ describe("guarded rollout", () => {
     await expect(runBoundaryRollout(adapter, options)).rejects.toThrow(
       /quarantine failed/u,
     );
-    expect(adapter.calls).toHaveLength(1);
+    expect(adapter.calls).toEqual([
+      "verify-boundary-region",
+      `quarantine:${options.deployRoleName}:${QUARANTINE_POLICY_NAME}`,
+    ]);
+  });
+
+  it("rejects an existing application-region mismatch before IAM mutation", async () => {
+    const adapter = makeAdapter({ failBoundaryRegionPreflight: true });
+    await expect(runBoundaryRollout(adapter, options)).rejects.toThrow(
+      /application region is mismatched/u,
+    );
+    expect(adapter.calls).toEqual(["verify-boundary-region"]);
+    expect(adapter.state.quarantineInstalled).toBe(false);
   });
 
   it("fails closed before enforcement when no workload role is discovered", async () => {
@@ -3033,6 +3140,7 @@ describe("guarded rollout", () => {
       /secret preflight/u,
     );
     expect(adapter.calls).toContain("verify-prod-bindings");
+    expect(adapter.state.quarantineInstalled).toBe(true);
     expect(adapter.calls.some((call) => call.startsWith("put-boundary:"))).toBe(
       false,
     );
@@ -5742,6 +5850,7 @@ const shutdown = installSubprocessSignalHandlers();
 let outcome = "unexpected success";
 try {
   const adapter = createAwsCliAdapter({
+    applicationRegion: "ap-northeast-1",
     consistencyAttempts: 10,
     deadlineAt: Date.now() + 60_000,
     identity: { accountId: "123456789012", partition: "aws" },
@@ -6791,6 +6900,8 @@ describe("operator entry point", () => {
     const { calls, result, resumeState } = await runRolloutGateMock({
       dotenvAck: "true",
       dotenvApplicationRegion: "eu-west-1",
+      dotenvOpenAiProjectRegion: "us-east-1",
+      dotenvResponsesRegion: "us-east-1",
       dotenvProfile: "custom-operator",
       dotenvProjectRegion: "eu-west-1",
       dotenvTemplateBucket: "reviewed-template-bucket",
@@ -6804,7 +6915,13 @@ describe("operator entry point", () => {
     expect(resumeState).toContain(
       "WORKLOAD_BOUNDARY_APPLICATION_REGION=eu-west-1",
     );
-    expect(resumeState).toContain("PROJECT_REGION=eu-west-1");
+    expect(resumeState).not.toMatch(/^PROJECT_REGION=/mu);
+    expect(resumeState).toContain(
+      "WORKLOAD_BOUNDARY_OPENAI_PROJECT_REGION=us-east-1",
+    );
+    expect(resumeState).toContain(
+      "MEM9_LLM_RESPONSES_REGION=us-east-1",
+    );
     expect(resumeState).toContain(
       "MEM9_TEMPLATE_BUCKET=reviewed-template-bucket",
     );
@@ -6814,14 +6931,30 @@ describe("operator entry point", () => {
     );
   });
 
-  it("rejects conflicting application region selectors before mutation", async () => {
+  it("does not treat the independent Project region as an application selector", async () => {
     const { calls, result, resumeState } = await runRolloutGateMock({
       dotenvAck: "true",
       dotenvApplicationRegion: "eu-west-1",
       dotenvProjectRegion: "ap-northeast-1",
+      nodeExit: 9,
+    });
+    expect(result.status).toBe(9);
+    expect(result.stderr).not.toContain("Application region settings disagree");
+    expect(calls).toContain("aws sts get-caller-identity");
+    expect(calls).toContain(
+      "node invoked profile= region=eu-west-1 project_region=ap-northeast-1",
+    );
+    expect(resumeState).not.toMatch(/^PROJECT_REGION=/mu);
+  });
+
+  it("rejects an application override that disagrees with sst.config.ts", async () => {
+    const { calls, result, resumeState } = await runRolloutGateMock({
+      configuredApplicationRegion: "ap-northeast-1",
+      dotenvAck: "true",
+      dotenvApplicationRegion: "eu-west-1",
     });
     expect(result.status).toBe(2);
-    expect(result.stderr).toContain("Application region settings disagree");
+    expect(result.stderr).toContain("Application region must match sst.config.ts");
     expect(calls).not.toContain("aws sts get-caller-identity");
     expect(calls).not.toContain("workflow disable");
     expect(resumeState).toBe("");
@@ -6848,6 +6981,38 @@ describe("operator entry point", () => {
     expect(
       calls.some((call) => call.startsWith("cloudformation update-stack")),
     ).toBe(false);
+  });
+
+  it("TC-APPREGION-040: refuses an in-place application-region migration", async () => {
+    const { calls, result } = await runBoundaryDeployMock({
+      guarded: true,
+      stackApplicationRegion: "eu-west-1",
+    });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "Existing workload boundary belongs to application region eu-west-1",
+    );
+    expect(
+      calls.some((call) =>
+        /cloudformation (create-stack|update-stack)/u.test(call),
+      ),
+    ).toBe(false);
+    expect(calls.some((call) => call.startsWith("iam "))).toBe(false);
+  });
+
+  it("rejects conflicting Responses region aliases before mutation", async () => {
+    const { calls, result } = await runBoundaryDeployMock({
+      boundaryOpenAiRegion: "us-west-2",
+      responsesRegion: "us-east-1",
+    });
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain("Responses region settings disagree");
+    expect(
+      calls.some((call) =>
+        /cloudformation (create-stack|update-stack)/u.test(call),
+      ),
+    ).toBe(false);
+    expect(calls.some((call) => call.startsWith("iam "))).toBe(false);
   });
 
   it("refuses any existing policy update outside the guarded rollout", async () => {
@@ -8249,6 +8414,7 @@ describe("boundary and deploy-role templates", () => {
       resolve(root, "scripts/lib/workload-permissions-boundary-aws.mjs"),
       "utf8",
     );
+    expect(awsAdapter).not.toContain("resolveApplicationRegion");
     const rolloutModule = readFileSync(rolloutModulePath, "utf8");
     expect(awsAdapter).toContain(
       "{ signal, timeoutMs = AWS_CLI_TIMEOUT_MS } = {}",


### PR DESCRIPTION
## Summary
- derive application-plane AWS settings, ECR references, workflows, and operator scripts from `providers.aws.region` in `sst.config.ts`
- preserve the account-global IAM ownership stacks in `us-west-2` and keep the OpenAI GPT Responses route independently regional with a `us-west-2` default
- block in-place live region retargeting and region-changing PR previews while cleaning closed previews in their original base region
- retain dated Tokyo references only where they document empirical evidence or test fixtures

## Operational Note
Changing `sst.config.ts` retargets fresh deployments. Existing regional resources require a dedicated dual-region migration after old-region previews are removed.

## Test Plan
- [x] Test cases documented (`docs/test-cases/application-region.md`)
- [x] Root typecheck and unit tests pass (970 tests)
- [x] Infra typecheck and unit tests pass (319 tests)
- [x] Coverage thresholds pass
- [x] arm64 `llm-proxy` image builds with both entrypoint import guards
- [x] ShellCheck, workflow YAML parsing, and CloudFormation lint pass
- [x] Independent code review passed
- [x] CI checks pass
- [x] Preview smoke/E2E checks pass