### PR TITLE
feat(cleanup): schedule the cleanup scan and bound the offer to 72h (#149)

### DIFF
--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -35,6 +35,16 @@
 #   MEM9_CONSOLIDATION_SCHEDULE_ENABLED — set to 1 only after the one-shot
 #                  cleanup and an actionable report-only consolidation run.
 #                  Unset keeps the production weekly schedule absent.
+#   MEM9_CLEANUP_SCAN_SCHEDULE_ENABLED — set to 1 only after an operator-initiated
+#                  memory-cleanup.mjs dry run has posted an actionable approval
+#                  list by hand. Unset keeps the weekly scan schedule, its
+#                  Scheduler role, and its group absent; the apply half of the
+#                  Slack loop still works from a manual offer. Separate from
+#                  MEM9_SLACK_APPROVAL_ENABLED because the apply half is inert
+#                  until a human clicks while the scan runs unattended and spends
+#                  two reasoning-model passes a week. Requires the scan Scheduler
+#                  role's iam:PassRole widening in the deploy role
+#                  (github-actions-role.yaml) to be rolled out FIRST.
 #   MEM9_LLM_RESPONSES_REGION — independent fallback region for selected OpenAI
 #                  GPT models. Unset keeps the runtime/boundary default us-west-2.
 #
@@ -409,6 +419,13 @@ jobs:
           MEM9_SLACK_APPROVAL_CHANNEL: ${{ vars.MEM9_SLACK_APPROVAL_CHANNEL }}
           SST_SECRET_SlackBotToken: ${{ secrets.SLACK_BOT_TOKEN }}
           SST_SECRET_SlackSigningSecret: ${{ secrets.SLACK_SIGNING_SECRET }}
+          # Synthesize the weekly scan's schedule, group, and Scheduler role for
+          # infra coverage — infra/slack-approval.ts keeps every non-prod schedule
+          # DISABLED, so a preview stage cannot start a classification run against
+          # the corpus prod's operator is reviewing. Literal "1" (unlike the
+          # approval flag above) because the scan block is INSIDE the approval gate:
+          # a repo that has not seeded a Slack app synthesizes nothing either way.
+          MEM9_CLEANUP_SCAN_SCHEDULE_ENABLED: "1"
         run: |
           # PR_NUMBER comes from GitHub's pull_request payload (integer);
           # validate to short-circuit any injection risk.
@@ -1155,6 +1172,14 @@ jobs:
           # Explicit opt-in. Missing/empty keeps the schedule and Scheduler role
           # absent; the task definition remains available for report-only runs.
           MEM9_CONSOLIDATION_SCHEDULE_ENABLED: ${{ vars.MEM9_CONSOLIDATION_SCHEDULE_ENABLED }}
+          # The cleanup scan's own opt-in (#149). Missing/empty keeps the weekly
+          # scan schedule, its group, and its Scheduler role absent while leaving
+          # the apply half of the Slack loop intact — so an operator can post an
+          # approval list by hand, see it work, and turn the schedule on afterwards.
+          # Roll the deploy role's Scheduler iam:PassRole widening out FIRST
+          # (scripts/deploy-github-role.sh): without it this deploy AccessDenies on
+          # CreateSchedule's PassRole after creating the role and group.
+          MEM9_CLEANUP_SCAN_SCHEDULE_ENABLED: ${{ vars.MEM9_CLEANUP_SCAN_SCHEDULE_ENABLED }}
           # Compliance authorizer on the OAuth façade routes — see the preview
           # deploy step above for the full rationale. Must be set here too: the
           # flag is read at synth time, so a prod deploy without it strips the

--- a/docs/test-cases/slack-approval-loop.md
+++ b/docs/test-cases/slack-approval-loop.md
@@ -198,6 +198,112 @@ concurrent applies of the same ids.
   another stage is refused. Same reasoning as #102's decision-file stage guard: a
   preview approval must never apply to prod.
 
+## Offer expiry: the 72h window (#149)
+
+A matching hash proves the list has not been *regenerated*; it says nothing about
+how old it is. Nothing else expires it either — `approvals/offered` is overwritten
+only by the next review run, so on a week the run failed (or a scan that was never
+scheduled) a matching Approve button stays clickable indefinitely, against a corpus
+that has moved on. Scheduling the scan makes that concrete rather than theoretical:
+the operator now has a button they did not ask for, arriving at 03:00 on a Saturday.
+
+The window is 72h, chosen against the weekly cadence: shorter than the gap between
+scans, so a scheduled run never collides with a live offer.
+
+The rule is enforced on **both** sides of the loop and stamped on one, and the two
+sides deliberately fail in **opposite** directions for an unjudgeable record:
+
+| | absent/unparseable `issuedAt` | why |
+| --- | --- | --- |
+| callback (`slack-interactions.ts`) | **expired** | never apply against a record of unknown age |
+| scan (`memory-cleanup.mjs`) | **replaceable** | never wedge the weekly scan on a record nobody can act on |
+
+Fail-closed on both sides deadlocks: every record written before #149 has no
+`issuedAt`, so it would be neither appliable nor replaceable and the loop would
+stop permanently with no error anywhere. The combination is safe *because* no click
+can succeed against a record the scan skipped past.
+
+- **TC-SLACKAPP-134** — a click past the window is refused, the reply names the
+  expiry and the age, and no claim is written and no task started. The reply says
+  what to do next ("the next scheduled scan will post a fresh list"), because the
+  operator has just clicked a destructive button and "nothing was applied" alone
+  reads as a fault.
+- **TC-SLACKAPP-135** — the window is inclusive at **exactly** 72h and closed one
+  millisecond later, asserted as a pair on the boundary itself. `>` versus `>=` is
+  invisible to every test not sitting on the millisecond, and the same pair is
+  asserted on the *stamping* side by TC-SLACKAPP-142 — an off-by-one that disagreed
+  across the two would leave a record the scan still protects and the facade already
+  refuses.
+- **TC-SLACKAPP-136** — a record with no `issuedAt`, or an unparseable one, is
+  refused rather than treated as unbounded. This is the fail-closed half of the
+  table above, and it is also what correctly refuses a pre-#149 record left in SSM
+  across the deploy that adds the check. The reply says "an unknown time ago", never
+  `NaNh`.
+
+  Both sides take the stamp as `unknown` and require a **string** rather than
+  handing it to `Date.parse`, which coerces. A number is a shape a hand-edited
+  parameter genuinely has, and while an epoch value yields `NaN` and would be
+  refused either way, a small one does not: `Date.parse(2027)` reads `2027` as a
+  **year** and returns a date in the future. That is a negative age and a record
+  that never expires — on the callback side a click accepted indefinitely, on the
+  scan side a pending offer it refuses to replace every week from now on. So `2027`
+  is a case in both TC-SLACKAPP-136 and TC-SLACKAPP-143; it is the only value that
+  distinguishes the guard from a cast, since every other one is already `NaN`.
+- **TC-SLACKAPP-137** — the TTL the script **stamps** is the one the facade
+  **enforces**, asserted by importing both constants. The value is duplicated for the
+  same reason `claimParameterName` is (TC-SLACKAPP-131): the Lambda bundle and the
+  container script share no module. A drift is silent in both directions — a longer
+  facade value accepts clicks the scan already considers replaceable, so the record
+  may be gone; a shorter one refuses clicks the scan still protects, so the list
+  expires with nothing able to apply it.
+- **TC-SLACKAPP-138** — a **regenerated** list is told it was regenerated, not that
+  it expired. The expiry gate sits after the hash check on purpose, and the ordering
+  is the operator's: "regenerated" means click the newer message, "expired" means
+  wait for the next scan. Backwards, it sends them hunting for a message that does
+  not exist.
+- **TC-SLACKAPP-139** — the refusal is logged with the expiry cause and the hash,
+  and never the ids. Same argument as TC-SLACKAPP-089: the log is a wider audience
+  than the parameter the ids legitimately live in, and the hash already identifies
+  the list.
+- **TC-SLACKAPP-140** — the review run refuses to overwrite an offer still inside
+  its window, **before writing anything**. Operator-initiated, the clobber was a
+  footnote — the human running the scan is the human holding the pending approval.
+  Unattended it is a live approval destroyed at 03:00 by a scan nobody watched, and
+  the operator's later click is then refused as "regenerated", pointing at a message
+  they never saw. A guard that threw after the first write would have already
+  destroyed the record it was protecting, so the read-before-write ordering is
+  asserted on a shared event log rather than a call count.
+- **TC-SLACKAPP-141** — that refusal names the age, the window, and the list size,
+  and never the ids. This message is the whole diagnosis: the run exits non-zero and
+  the alarm says only "task failed", so this line is what separates "a human is
+  mid-review, do nothing" from a real fault. The hash identifies the list; the ids
+  stay out, because a log line is a copy too.
+- **TC-SLACKAPP-142** — an offer past its window **is** replaced, and one exactly at
+  the boundary is still protected. Refusing forever would wedge the loop, and
+  replacing an expired record costs nothing because the facade refuses a click
+  against it first. Asserted as a pair for the same reason as TC-SLACKAPP-135:
+  either bound alone passes with the comparison inverted or the window doubled.
+- **TC-SLACKAPP-143** — every record the scan cannot judge is treated as
+  replaceable: no `issuedAt`, an unparseable one, a numeric one, a **year-shaped**
+  one (see TC-SLACKAPP-136), not JSON, not an object, another stage's record, and one
+  with no ids left to approve. The fail-open half of the table, and each case also
+  asserts the log renders no `NaN` — "expired 4 hours ago" computed from an unparsed
+  date is worse than silence.
+- **TC-SLACKAPP-144** — a `GetParameters` that **throws** does not block the offer,
+  and the warning carries the parameter name and the error class but not the SDK's
+  message. A throwing read is not evidence of no pending offer, so this fails open
+  and says so; treating a transient SSM error as "something is pending" would stop
+  the weekly scan on an `AccessDenied` that may have nothing to do with approvals.
+  The message is dropped because a `ValidationException` quotes the value it
+  rejected, and this parameter's value is the id list.
+- **TC-SLACKAPP-145** — `buildOfferedRecord` **refuses** to build a record without
+  a parseable `issuedAt` rather than defaulting one. Both plausible defaults are
+  wrong in ways that appear only on the replay path: `generatedAt` dates the record
+  to the *file's* stamp, so a `--decisions` repost of a four-day-old review posts a
+  list already expired on arrival (TC-SLACKAPP-119 is why that field cannot be
+  reused); and `new Date()` inside the builder makes the stamp untestable and
+  ignores the run's own clock.
+
 ## Idempotency and the apply trigger
 
 - **TC-SLACKAPP-030** — a duplicate delivery of the same interaction enqueues
@@ -608,6 +714,95 @@ agreed with policy.
   whose `alarmActions` is `[undefined]` fails CREATE for the whole stack, which
   would cost every preview stage its cleanup loop to gain paging it has no topic
   for.
+
+## Scheduling the scan (#149)
+
+Everything above is reachable only from a click, and nothing produced the thing to
+click on: the weekly consolidation schedule runs `memory-consolidation.mjs`, while
+the approval loop lives in `memory-cleanup.mjs` and was operator-initiated. These
+cover the EventBridge Scheduler schedule that closes that gap, behind its own flag
+(`MEM9_CLEANUP_SCAN_SCHEDULE_ENABLED`) nested inside the approval flag.
+
+Two flags rather than one because the halves have different risk: the apply half is
+inert until a human clicks, while the scan runs unattended and spends two
+reasoning-model passes a week. The scan block sits *inside* the approval gate, so a
+repo with no Slack app synthesizes nothing either way.
+
+The scan is a **dry run**: no `--apply` and no `--ids`. It offers by virtue of being
+configured for a Slack channel, which is what `buildPostApproval` keys on. That is
+also what makes it safe to schedule — `runCleanup`'s dry-run branch returns before
+both the lockfile and the shared database mutex, so an unattended scan cannot
+contend with the weekly consolidation and cannot delete.
+
+- **TC-SLACKAPP-146** — with the scan flag unset, the apply half is built and there
+  is **no** schedule, schedule group, scheduler role, or scan alarm; the apply
+  failure alarm is the only alarm left. And with the scan flag set but the approval
+  loop disabled, nothing at all is built — the nesting, asserted rather than left to
+  the reading order of two `if`s.
+- **TC-SLACKAPP-147** — the schedule runs weekly on **Saturday** (`cron(0 3 ? * SAT
+  *)`), in UTC, with a flexible time window of `OFF`, on **its own** schedule group,
+  and `ENABLED` only on prod. Saturday and not Sunday: consolidation holds
+  `cron(0 3 ? * SUN *)`, and two reasoning-model workloads at the same hour is a
+  quota collision for no reason. The retry policy is one attempt inside an hour —
+  a scan is worth retrying once, and a scan retried all day would post duplicate
+  approval lists.
+- **TC-SLACKAPP-148** — the scheduler role trusts `scheduler.amazonaws.com` for
+  **this schedule group only**, by `aws:SourceAccount` and `aws:SourceArn`, with
+  `StringEquals` and no wildcard. The `SourceArn` is the **group** ARN, which is what
+  the service documents: scoping it to a schedule name or a name prefix is
+  explicitly unsupported and fails at CREATE.
+
+  A separate role rather than reusing consolidation's, and the reason is the *trust
+  policy*, not the permissions: reuse means either widening that role's
+  `aws:SourceArn` to two groups — weakening a control already deployed — or sharing
+  consolidation's group, which makes its `TargetErrorCount` alarm ambiguous across
+  two unrelated schedules, since the alarm dimensions on `ScheduleGroup`.
+- **TC-SLACKAPP-149** — the scheduler role gets `ecs:RunTask` on the **exact task
+  definition revision** and `iam:PassRole` on the task and execution roles only,
+  conditioned on `iam:PassedToService = ecs-tasks.amazonaws.com`. The action set is
+  pinned exactly, so a third action cannot be added silently.
+- **TC-SLACKAPP-150** — the container override is a dry run: **no** `--apply`, no
+  `--ids`, no `--cap`; `--consensus-passes` present and at least 2; and `--out`
+  outside `/app`. Each of those is a distinct failure. `--apply` on a schedule is an
+  unattended deletion with no human in the loop at all. `--ids` is worse than it
+  looks: `readApprovedIds` treats an absent file as "no filter", so `--ids` on a path
+  that writes nothing would apply *everything* — which is only safe because both
+  flags are absent together. Dropping `--consensus-passes` weakens the quorum that
+  `consensusDecisions` needs (one pass reproduced only 66% of its own DELETE set on
+  re-run), and unattended is exactly when nobody is watching for that. And `--out`
+  must be `/tmp/...` because `snippetLogDir` refuses a path inside the script tree,
+  which in the image *is* `/app`. The command is asserted whole, not additively.
+- **TC-SLACKAPP-151** — an invocation that never STARTS a task alarms
+  (`TargetErrorCount`, `treatMissingData: notBreaching`), dimensioned on the scan's
+  **own** group — the failure mode no task-level alarm can see, because a schedule
+  that fails to invoke produces no task to fail. A stage with no alerts topic gets no
+  alarm and still gets the schedule, for the same reason as TC-SLACKAPP-087.
+- **TC-SLACKAPP-152** — the group's `namePrefix` fits Scheduler's 38-character cap
+  and the role name IAM's 64, both budgeted against Pulumi's 26-character suffix, and
+  synthesis **throws** rather than truncating for a stage that overruns. The #127
+  trap: a name that fits on its own still fails at CREATE once the suffix is added,
+  after the rest of the stack deployed. The role name is additionally asserted to be
+  matched by the glob in the deployed deploy-role policy — a rename that fits every
+  limit and no longer matches is a deploy that fails on `iam:PassRole`.
+- **TC-SLACKAPP-153** — the task role's `ssm:PutParameter` is inside the **deployed**
+  boundary, asserted against `workload-permissions-boundary.yaml` rather than
+  reasoned about: every task action is admitted by the ceiling, and the write is
+  scoped to `{prefix}/approvals/*`, which is exactly what
+  `DenyPutParameterOutsideApprovalRecords`'s `NotResource` permits. Widened to the
+  stage prefix it would be denied by that statement at runtime — a policy that
+  synthesizes, deploys, and then fails on the first scheduled scan. **No boundary
+  change is needed for #149**; this case is what says so measurably.
+- **TC-SLACKAPP-154** — the scan scheduler role is named in **both** deploy-role
+  statements that gate a Scheduler pass: the `PassRoleConstrained` grant and the
+  paired `DenyConsolidationSchedulerRolePassToOtherServices`. This is the one
+  out-of-band step #149 needs: `PassRoleConstrained` conditions
+  `iam:PassedToService` on `lambda.amazonaws.com` and `ecs-tasks.amazonaws.com`
+  only, so it does not cover `scheduler.amazonaws.com`, and the deploy role's own
+  CloudFormation stack is not deployed by the pipeline it gates.
+  **`scripts/deploy-github-role.sh` must be rolled out BEFORE the stack first
+  deploys with the scan flag set**, or the deploy fails creating the schedule. The
+  Sids are asserted unchanged, because a renamed Sid is a silently different
+  statement to the boundary auditor that reads them.
 
 ## Offering the list: the loop's entry point
 
@@ -1087,6 +1282,43 @@ fail the run.
     `stoppedReason` was fetched, printed, and never asserted; a task killed by OOM
     can stop with a reason set, and only `Essential container in task exited` is
     benign here.
+
+- **TC-SLACKAPP-155** — the 72h window, end to end against a deployed façade. The
+  harness seeds `approvals/offered` **twice** with the same ids — therefore the same
+  hash — differing only in `issuedAt`: once 96h old, once now. The first click must
+  be refused and the second accepted, so what is proven is the TTL rather than the
+  stale-hash guard.
+
+  The unstamped seed was a real break, not a hypothetical one. Before this, the
+  harness wrote `generatedAt` alone, and `offerExpiry` reads an absent `issuedAt` as
+  **expired** (TC-SLACKAPP-136) — so the signed click was refused, and the run died
+  four steps later at "no approval record after a 200", a message that names the
+  claim write and sends the reader to the Lambda's SSM grants.
+
+  Four decisions in the expiry step are load-bearing:
+
+  - **It runs after the 401 and before the live click.** "An expired approval wrote
+    no claim" is only assertable while no claim exists; below the successful click it
+    would pass vacuously against the record that click created. Same ordering
+    argument as the invalid-signature POST, asserted rather than left to a comment.
+  - **The refusal is an HTTP 200.** Every refusal the handler makes goes through
+    `reply()`, because Slack renders a non-200 as its own "operation failed" notice
+    and shows the operator no reason at all. So the status cannot distinguish a
+    refusal from an acceptance — and a facade that refused correctly with a 5xx has a
+    gate whose output nobody can see, which is a separate case here.
+  - **The reply is matched on `expire`**, the one word no other refusal uses.
+    "Regenerated", "names stage", "could not be read" and "already been applied" are
+    all 200s with a body too, so a generic "nothing was applied" match would pass on
+    a stale-hash refusal and prove nothing about the TTL.
+  - **The claim is read back by name afterwards.** A refusal that still claimed the
+    approval — right message, apply started anyway — is invisible to the reply
+    assertion. This is the same positive-assertion discipline as the 401 step.
+
+  The fake `curl` therefore models the window itself, reading the seeded record from
+  where the real `loadOffered` reads it, and can be made wrong about it in three ways
+  (no gate at all, a cosmetic refusal, a 5xx refusal). Without a fake that *can* be
+  wrong, the whole step passes against a façade with no TTL check — the exact
+  regression the gate exists to prevent.
 
 ## Exit codes
 

--- a/docs/test-cases/slack-approval-loop.md
+++ b/docs/test-cases/slack-approval-loop.md
@@ -289,13 +289,20 @@ can succeed against a record the scan skipped past.
   with no ids left to approve. The fail-open half of the table, and each case also
   asserts the log renders no `NaN` — "expired 4 hours ago" computed from an unparsed
   date is worse than silence.
-- **TC-SLACKAPP-144** — a `GetParameters` that **throws** does not block the offer,
-  and the warning carries the parameter name and the error class but not the SDK's
-  message. A throwing read is not evidence of no pending offer, so this fails open
-  and says so; treating a transient SSM error as "something is pending" would stop
-  the weekly scan on an `AccessDenied` that may have nothing to do with approvals.
-  The message is dropped because a `ValidationException` quotes the value it
-  rejected, and this parameter's value is the id list.
+- **TC-SLACKAPP-144** — a `GetParameters` that **throws** blocks the offer, and the
+  refusal carries the parameter name and the error class but not the SDK's message.
+  This is the one case on this side that fails **closed**, and the boundary of
+  TC-SLACKAPP-143's table: every case there judges a record the scan actually saw
+  and found unactionable, whereas a throwing read means it saw nothing, so "no
+  pending offer" is an absence of evidence rather than a finding. Offering anyway
+  overwrites whatever is there, and if that is a list a human is mid-review on
+  their click is then refused as "regenerated" with nothing reporting the loss —
+  against one skipped week that exits 1 and trips the task-exit alarm. The error
+  class survives because `AccessDenied` and `ValidationException` point at
+  different faults; the message is dropped because a `ValidationException` quotes
+  the value it rejected, and this parameter's value is the id list. Read-before-write
+  is re-asserted here for TC-SLACKAPP-140's reason — a refusal landing after the
+  first write would have destroyed the record it was protecting.
 - **TC-SLACKAPP-145** — `buildOfferedRecord` **refuses** to build a record without
   a parseable `issuedAt` rather than defaulting one. Both plausible defaults are
   wrong in ways that appear only on the replay path: `generatedAt` dates the record

--- a/infra/cloudformation/github-actions-role.yaml
+++ b/infra/cloudformation/github-actions-role.yaml
@@ -241,11 +241,17 @@ Resources:
               StringNotEquals:
                 iam:PassedToService: ecs-tasks.amazonaws.com
           - Sid: DenyConsolidationSchedulerRolePassToOtherServices
+            # Both Scheduler roles, in ONE statement: the Sid is load-bearing
+            # (scripts/lib/workload-permissions-boundary.mjs looks the statement up
+            # by it, and the deployed rollout state records it), so #149's cleanup
+            # scan role was added to this Resource list rather than given a second
+            # statement under a new Sid.
             Effect: Deny
             Action:
               - iam:PassRole
             Resource:
               - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/mem9-on-a*-*Mem9ConsolidationSchedulerRole-*
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/mem9-on-a*-*Mem9CleanupSchedulerRole-*
             Condition:
               StringNotEquals:
                 iam:PassedToService: scheduler.amazonaws.com
@@ -510,11 +516,23 @@ Resources:
             Resource:
               - !Sub arn:${AWS::Partition}:scheduler:${ApplicationRegion}:${AWS::AccountId}:schedule-group/mem9-on-aws-*
           - Sid: PassConsolidationSchedulerRole
+            # Every Scheduler role this project creates. PassRoleConstrained above
+            # does NOT cover them: it conditions on iam:PassedToService in
+            # [lambda, ecs-tasks] only, so a scheduler.amazonaws.com pass needs this
+            # statement. Adding the #149 cleanup-scan role here (rather than under a
+            # new Sid) keeps the Sid the boundary audit looks up unchanged.
+            #
+            # ROLLOUT ORDER: this file is deployed OUT OF BAND by
+            # scripts/deploy-github-role.sh, so this widening must land BEFORE the
+            # first bounded deploy that synthesizes Mem9CleanupSchedulerRole —
+            # otherwise the deploy AccessDenies on CreateSchedule's PassRole after
+            # having already created the role and group.
             Effect: Allow
             Action:
               - iam:PassRole
             Resource:
               - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/mem9-on-a*-*Mem9ConsolidationSchedulerRole-*
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/mem9-on-a*-*Mem9CleanupSchedulerRole-*
             Condition:
               StringEquals:
                 iam:PassedToService: scheduler.amazonaws.com

--- a/infra/slack-approval.test.ts
+++ b/infra/slack-approval.test.ts
@@ -206,6 +206,29 @@ function installGlobals(stage: string) {
         }
       },
     },
+    // The #149 weekly scan's schedule. Same stubs consolidation.test.ts installs;
+    // the ScheduleGroup returns a NAME derived from its own namePrefix so the
+    // TargetErrorCount alarm's dimension can be proven to point at THIS group
+    // rather than at consolidation's.
+    scheduler: {
+      ScheduleGroup: class {
+        arn: Output<string>;
+        name: Output<string>;
+        constructor(logicalName: string, args: Record<string, unknown>) {
+          const name = `${String(materialize(args.namePrefix))}fixture`;
+          this.arn = out(
+            `arn:aws:scheduler:ap-northeast-1:123456789012:schedule-group/${name}`,
+          );
+          this.name = out(name);
+          record("ScheduleGroup", logicalName, args);
+        }
+      },
+      Schedule: class {
+        constructor(logicalName: string, args: Record<string, unknown>) {
+          record("Schedule", logicalName, args);
+        }
+      },
+    },
     // The apply task's failure signal — the SAME stub set consolidation.test.ts
     // installs, because both stacks build these six resources through
     // `taskFailureAlarm`.
@@ -279,6 +302,20 @@ function installGlobals(stage: string) {
   };
 }
 
+/**
+ * Drop the SST/Pulumi globals `installGlobals` planted.
+ *
+ * A case that synthesizes twice (a preview stage and then prod, say) must clear
+ * them between runs: `installGlobals` is what carries `$app.stage`, so a second
+ * `installGlobals` over live globals would leave the first stage's `$interpolate`
+ * closures reachable and the assertions would read a mixture of the two.
+ */
+function clearGlobals() {
+  for (const key of ["$app", "$interpolate", "$jsonStringify", "aws", "sst"]) {
+    delete (globalThis as Record<string, unknown>)[key];
+  }
+}
+
 async function loadModule() {
   vi.resetModules();
   return import("./slack-approval");
@@ -307,41 +344,42 @@ function list(value: unknown): string[] {
 }
 
 /**
- * Statements of the OPERATOR-OWNED boundary that this stack's role must survive.
+ * An OPERATOR-OWNED CloudFormation template, parsed with the intrinsic tags this
+ * repo's templates use.
  *
- * Read from the deployed CloudFormation template rather than from the exported
- * helper in `scripts/lib/workload-permissions-boundary.mjs`: `infra/tsconfig.json`
- * has no `allowJs`, so importing the untyped `.mjs` fails `pnpm -C infra
- * typecheck` — a CI gate. This is the same idiom TC-CONSOL-032 uses.
+ * Read from the deployed template rather than from the exported helpers in
+ * `scripts/lib/workload-permissions-boundary.mjs`: `infra/tsconfig.json` has no
+ * `allowJs`, so importing the untyped `.mjs` fails `pnpm -C infra typecheck` — a
+ * CI gate. Same idiom, and same tag list, as TC-CONSOL-031/032.
  */
+function cloudFormationTemplate(path: string) {
+  return parse(readFileSync(new URL(path, import.meta.url), "utf8"), {
+    customTags: [
+      { tag: "!Ref", resolve: (value: string) => ({ Ref: value }) },
+      { tag: "!Sub", resolve: (value: string) => ({ "Fn::Sub": value }) },
+      {
+        tag: "!Equals",
+        collection: "seq",
+        resolve: (value) => ({ "Fn::Equals": value.toJSON() }),
+      },
+      {
+        tag: "!If",
+        collection: "seq",
+        resolve: (value) => ({ "Fn::If": value.toJSON() }),
+      },
+      {
+        tag: "!GetAtt",
+        resolve: (value: string) => ({ "Fn::GetAtt": value.split(".") }),
+      },
+    ],
+  }) as { Resources: Record<string, { Properties: Record<string, any> }> };
+}
+
+/** Statements of the boundary that this stack's roles must survive. */
 function boundaryStatements(): Array<Record<string, any>> {
-  const template = parse(
-    readFileSync(
-      new URL("./cloudformation/workload-permissions-boundary.yaml", import.meta.url),
-      "utf8",
-    ),
-    {
-      customTags: [
-        { tag: "!Ref", resolve: (value: string) => ({ Ref: value }) },
-        { tag: "!Sub", resolve: (value: string) => ({ "Fn::Sub": value }) },
-        {
-          tag: "!Equals",
-          collection: "seq",
-          resolve: (value) => ({ "Fn::Equals": value.toJSON() }),
-        },
-        {
-          tag: "!If",
-          collection: "seq",
-          resolve: (value) => ({ "Fn::If": value.toJSON() }),
-        },
-        {
-          tag: "!GetAtt",
-          resolve: (value: string) => ({ "Fn::GetAtt": value.split(".") }),
-        },
-      ],
-    },
-  ) as { Resources: Record<string, { Properties: Record<string, any> }> };
-  return template.Resources.WorkloadPermissionsBoundary.Properties.PolicyDocument
+  return cloudFormationTemplate(
+    "./cloudformation/workload-permissions-boundary.yaml",
+  ).Resources.WorkloadPermissionsBoundary.Properties.PolicyDocument
     .Statement as Array<Record<string, any>>;
 }
 
@@ -380,6 +418,7 @@ const ENV_KEYS = [
   "MEM9_BEDROCK_PROJECT",
   "MEM9_BEDROCK_PROJECT_OPENAI",
   "MEM9_CLEANUP_CAP",
+  "MEM9_CLEANUP_SCAN_SCHEDULE_ENABLED",
 ];
 
 function enable() {
@@ -387,6 +426,24 @@ function enable() {
   process.env.MEM9_SLACK_APPROVAL_CHANNEL = CHANNEL_ID;
   process.env.SST_SECRET_SlackBotToken = BOT_TOKEN;
   process.env.SST_SECRET_SlackSigningSecret = SIGNING_SECRET;
+}
+
+/**
+ * The weekly scan's own gate, on TOP of `enable()`. Separate because the loop's
+ * two halves are separately enabled: the apply half is inert until a human
+ * clicks, the scan half runs unattended and spends reasoning-model passes.
+ */
+function enableScan() {
+  process.env.MEM9_CLEANUP_SCAN_SCHEDULE_ENABLED = "1";
+}
+
+/** The scan schedule's `target.input`, parsed. */
+function scanContainerOverride(): Record<string, any> {
+  const schedule = materialize(one("Schedule", "Mem9CleanupScan").args) as
+    Record<string, any>;
+  const input = JSON.parse(String(schedule.target.input));
+  expect(input.containerOverrides).toHaveLength(1);
+  return input.containerOverrides[0];
 }
 
 beforeEach(() => {
@@ -397,9 +454,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  for (const key of ["$app", "$interpolate", "$jsonStringify", "aws", "sst"]) {
-    delete (globalThis as Record<string, unknown>)[key];
-  }
+  clearGlobals();
   for (const key of ENV_KEYS) delete process.env[key];
   vi.resetModules();
 });
@@ -587,9 +642,7 @@ describe("slack approval infrastructure", () => {
         module.slackApproval(fakeEcs(), fakeDb(), fakeIdentity(), fakeFacade()),
       ).toThrow(/Slack/i);
       expect(resources).toEqual([]);
-      for (const key of ["$app", "$interpolate", "$jsonStringify", "aws", "sst"]) {
-        delete (globalThis as Record<string, unknown>)[key];
-      }
+      clearGlobals();
     }
   });
 
@@ -621,9 +674,7 @@ describe("slack approval infrastructure", () => {
     expect(args.environment.MEM9_SLACK_APPROVAL_CHANNEL).toBe(CHANNEL_ID);
 
     resources = [];
-    for (const key of ["$app", "$interpolate", "$jsonStringify", "aws", "sst"]) {
-      delete (globalThis as Record<string, unknown>)[key];
-    }
+    clearGlobals();
     installGlobals("prod");
     enable();
     delete process.env.MEM9_SLACK_APPROVAL_CHANNEL;
@@ -854,6 +905,429 @@ describe("slack approval infrastructure", () => {
     expect(all("Task")).toHaveLength(1);
   });
 
+  it("TC-SLACKAPP-146: builds the apply half with no schedule, group, role, or scan alarm while the scan flag is unset", async () => {
+    installGlobals("prod");
+    enable();
+    await loadAndRun();
+
+    // The two halves are separately enabled on purpose: an operator seeding a
+    // Slack app runs the loop by hand first. So "approval enabled" must not
+    // conscript the account into a weekly reasoning-model spend, and the scan's
+    // absence must be TOTAL — a schedule left DISABLED is a schedule an
+    // UpdateSchedule call can enable without a deploy.
+    expect(all("Schedule")).toEqual([]);
+    expect(all("ScheduleGroup")).toEqual([]);
+    expect(all("Role")).toEqual([]);
+    expect(
+      all("MetricAlarm").map(({ logicalName }) => logicalName),
+    ).toEqual(["CleanupApplyFailureAlarm"]);
+    // …and the apply half is untouched, which is the point of the split.
+    expect(all("Task")).toHaveLength(1);
+  });
+
+  it("TC-SLACKAPP-146: builds nothing at all when the scan flag is set but the loop is not enabled", async () => {
+    installGlobals("prod");
+    // The scan flag is INSIDE the approval gate, not beside it. A scan with no
+    // Slack channel configured would classify the whole corpus every week and
+    // then have nowhere to post it — `buildPostApproval` returns no poster, so
+    // the run is pure spend with no output.
+    enableScan();
+    await loadAndRun();
+
+    expect(resources).toEqual([]);
+  });
+
+  it("TC-SLACKAPP-147: schedules the scan weekly on its own group, enabled only on prod", async () => {
+    installGlobals("pr-103");
+    enable();
+    enableScan();
+    const module = await loadAndRun();
+
+    const group = materialize(
+      one("ScheduleGroup", "Mem9CleanupScanScheduleGroup").args,
+    ) as Record<string, any>;
+    expect(group).toMatchObject({
+      namePrefix: "mem9-on-aws-pr-103-cleanup-scan-",
+      tags: { ManagedBy: "sst", Project: "mem9-on-aws", Stage: "pr-103" },
+    });
+
+    let schedule = materialize(one("Schedule", "Mem9CleanupScan").args) as
+      Record<string, any>;
+    // Saturday, NOT consolidation's Sunday. Both tasks classify the same corpus
+    // through the same model and both take the shared database mutex on apply, so
+    // an overlap has one of them lose the mutex and exit 3. A day EARLIER because
+    // consolidation rewrites what a cleanup scan would classify, and the 72h offer
+    // window then closes on Tuesday — well before the next Saturday.
+    expect(schedule.scheduleExpression).toBe(module.CLEANUP_SCAN_CRON);
+    expect(schedule.scheduleExpression).toBe("cron(0 3 ? * SAT *)");
+    expect(schedule.scheduleExpression).not.toContain("SUN");
+    expect(schedule.scheduleExpressionTimezone).toBe("UTC");
+    expect(schedule.flexibleTimeWindow).toEqual({ mode: "OFF" });
+    // Its OWN group, not consolidation's: the TargetErrorCount alarm below
+    // dimensions on ScheduleGroup, so a shared group makes one alarm fire for
+    // either schedule and name neither.
+    expect(schedule.groupName).toBe("mem9-on-aws-pr-103-cleanup-scan-fixture");
+    expect(schedule.groupName).not.toContain("consolidation");
+    // A preview stage synthesizes the schedule for coverage but must not RUN it:
+    // a pr-N stage sharing the prod corpus would post a second offer against the
+    // record prod's operator is still looking at.
+    expect(schedule.state).toBe("DISABLED");
+
+    expect(schedule.target.ecsParameters).toMatchObject({
+      launchType: "FARGATE",
+      taskCount: 1,
+      taskDefinitionArn:
+        "arn:aws:ecs:ap-northeast-1:123456789012:task-definition/mem9-cleanup:1",
+      networkConfiguration: {
+        assignPublicIp: false,
+        securityGroups: ["sg-task"],
+        // Passed as an Output, so Pulumi resolves the nested Outputs before the
+        // API call. Joining them writes "Calling [toString] on an [Output<T>] is
+        // not supported." into the request — the defect that reached two live
+        // stacks.
+        subnets: ["subnet-a", "subnet-b"],
+      },
+    });
+    expect(JSON.stringify(schedule.target.ecsParameters)).not.toMatch(
+      /Calling \[toString\]|Output<T>/u,
+    );
+    // Bounded retry: a second full classification costs a second reasoning pass,
+    // and the refuse-to-overwrite guard makes a retry AFTER a successful post fail
+    // loudly rather than clobber the offer it just made.
+    expect(schedule.target.retryPolicy).toEqual({
+      maximumEventAgeInSeconds: 3600,
+      maximumRetryAttempts: 1,
+    });
+
+    resources = [];
+    clearGlobals();
+    installGlobals("prod");
+    enable();
+    enableScan();
+    await loadAndRun();
+    schedule = materialize(one("Schedule", "Mem9CleanupScan").args) as
+      Record<string, any>;
+    expect(schedule.state).toBe("ENABLED");
+  });
+
+  it("TC-SLACKAPP-148: trusts Scheduler only for THIS schedule group, by account and source arn", async () => {
+    installGlobals("prod");
+    enable();
+    enableScan();
+    await loadAndRun();
+
+    const role = materialize(one("Role", "Mem9CleanupSchedulerRole").args) as
+      Record<string, any>;
+    // A fixed `name` containing the token both the deploy role and the boundary
+    // audit match on. Pulumi caps a role `name_prefix` at 38 and any prefix
+    // carrying `Mem9CleanupSchedulerRole-` is longer, so a namePrefix here is a
+    // CREATE-time failure; and dropping `mem9-on-aws-` AccessDenies on
+    // iam:CreateRole, which is scoped to `role/mem9-on-aws-*`.
+    expect(role.name).toBe("mem9-on-aws-prod-Mem9CleanupSchedulerRole-role");
+    expect(role.namePrefix).toBeUndefined();
+
+    const trust = JSON.parse(String(role.assumeRolePolicy));
+    expect(trust.Statement).toHaveLength(1);
+    expect(trust.Statement[0]).toEqual({
+      Effect: "Allow",
+      Principal: { Service: "scheduler.amazonaws.com" },
+      Action: "sts:AssumeRole",
+      Condition: {
+        StringEquals: {
+          "aws:SourceAccount": "123456789012",
+          // The schedule GROUP arn, and this is a REQUIREMENT rather than a
+          // choice: AWS's confused-deputy guidance for Scheduler says not to
+          // scope aws:SourceArn to a specific schedule or a schedule-name
+          // prefix. Hence StringEquals with no wildcard — and hence a role of
+          // its own, since reusing consolidation's would mean widening a
+          // deployed trust policy to a second group.
+          "aws:SourceArn":
+            "arn:aws:scheduler:ap-northeast-1:123456789012:schedule-group/mem9-on-aws-prod-cleanup-scan-fixture",
+        },
+      },
+    });
+    // Both keys present, and neither replaced by a wildcard: SourceAccount alone
+    // lets any schedule in the account assume this role, and a wildcard SourceArn
+    // is the confused-deputy hole the condition exists to close.
+    expect(JSON.stringify(trust)).not.toContain("StringLike");
+    expect(trust.Statement[0].Condition.StringEquals["aws:SourceArn"]).not.toContain(
+      "*",
+    );
+  });
+
+  it("TC-SLACKAPP-149: grants the scheduler role RunTask on one task definition and a conditioned PassRole", async () => {
+    installGlobals("prod");
+    enable();
+    enableScan();
+    await loadAndRun();
+
+    const policy = all("RolePolicy").filter(
+      ({ logicalName }) => logicalName === "Mem9CleanupSchedulerPolicy",
+    );
+    expect(policy).toHaveLength(1);
+    const document = JSON.parse(String(materialize(policy[0].args.policy)));
+    expect(document.Statement).toEqual([
+      {
+        Effect: "Allow",
+        Action: "ecs:RunTask",
+        // The exact revision, not the cluster: RunTask scoped to a cluster would
+        // let this role start the mnemo server or the consolidation task.
+        Resource:
+          "arn:aws:ecs:ap-northeast-1:123456789012:task-definition/mem9-cleanup:1",
+      },
+      {
+        Effect: "Allow",
+        Action: "iam:PassRole",
+        Resource: [
+          "arn:aws:iam::123456789012:role/cleanup-task",
+          "arn:aws:iam::123456789012:role/cleanup-execution",
+        ],
+        // Unconditioned iam:PassRole on an ECS role is a privilege-escalation
+        // primitive — the same role could be handed to any service willing to
+        // assume it. Same condition the facade's PassCleanupTaskRoles carries.
+        Condition: {
+          StringEquals: { "iam:PassedToService": "ecs-tasks.amazonaws.com" },
+        },
+      },
+    ]);
+    // Nothing else. In particular no ssm:*, no ecs:StopTask, and no iam:PassRole
+    // for scheduler.amazonaws.com — this role is passed TO Scheduler, it does not
+    // pass roles to Scheduler itself.
+    const actions = document.Statement.flatMap((statement: Record<string, any>) =>
+      list(statement.Action),
+    );
+    expect(actions.sort()).toEqual(["ecs:RunTask", "iam:PassRole"]);
+  });
+
+  it("TC-SLACKAPP-150: overrides the command with a DRY run: no --apply, no --ids, a quorum, and an out-dir outside /app", async () => {
+    installGlobals("prod");
+    enable();
+    enableScan();
+    const module = await loadAndRun();
+
+    const override = scanContainerOverride();
+    // The container name the override targets. A rename makes RunTask reject the
+    // override, and for the SCHEDULE that surfaces as a silent week with no
+    // approval message — which looks exactly like a week with nothing to delete.
+    expect(override.name).toBe(module.CLEANUP_CONTAINER_NAME);
+    expect(override.name).toBe("Mem9Cleanup");
+
+    const command = override.command as string[];
+    expect(command[0]).toBe("/app/scripts/memory-cleanup.mjs");
+
+    // THE safety property of this schedule. `runCleanup` returns at the dry-run
+    // branch before it takes either the lockfile or the shared database mutex, so
+    // an unattended run cannot delete and cannot make the weekly consolidation
+    // exit 3. `--ids` must be absent for a second, independent reason:
+    // `readApprovedIds` treats an absent file as "no filter", which is only safe
+    // on a path that writes nothing.
+    expect(command).not.toContain("--apply");
+    expect(command).not.toContain("--ids");
+    expect(command).not.toContain("--cap");
+
+    // With no human reading the list before it is offered, the quorum is the only
+    // thing narrowing it: one pass reproduced just 66% of its own DELETE set on
+    // re-run. `consensusDecisions` needs >= 2 usable passes and the flag's `min`
+    // is 2, so this cannot be weakened to 1 without the parser refusing.
+    const passesIndex = command.indexOf("--consensus-passes");
+    expect(passesIndex).toBeGreaterThan(0);
+    expect(Number(command[passesIndex + 1])).toBe(
+      module.CLEANUP_SCAN_CONSENSUS_PASSES,
+    );
+    expect(Number(command[passesIndex + 1])).toBeGreaterThanOrEqual(2);
+
+    // `snippetLogDir` REFUSES a path inside the script tree because the log holds
+    // memory snippets, and in the image /app IS that tree — so `--out /app/...`
+    // throws before the scan starts and the schedule fails every week.
+    const outIndex = command.indexOf("--out");
+    expect(outIndex).toBeGreaterThan(0);
+    const outDir = command[outIndex + 1];
+    expect(outDir).toBe(module.CLEANUP_SCAN_OUT_DIR);
+    expect(outDir.startsWith("/app")).toBe(false);
+    expect(outDir.startsWith("/tmp/")).toBe(true);
+
+    // A FULL command, not an addition: ECS replaces `command` wholesale, so every
+    // argument the scan needs must appear here even when the task definition
+    // already sets it.
+    const stageIndex = command.indexOf("--stage");
+    expect(stageIndex).toBeGreaterThan(0);
+    expect(command[stageIndex + 1]).toBe("prod");
+    const baseUrlIndex = command.indexOf("--base-url");
+    expect(baseUrlIndex).toBeGreaterThan(0);
+    expect(command[baseUrlIndex + 1]).toBe("http://mnemo.mem9-prod.local:8080");
+
+    // No environment override at all. MEM9_SLACK_APPROVAL_CHANNEL is already in
+    // the definition and is what makes `buildPostApproval` return a poster, so the
+    // scan offers by virtue of being configured for Slack. MEM9_APPROVAL_HASH must
+    // NOT appear: it means "this run came from a click", and setting it with no
+    // `--ids` is a hard error in `createCleanupDeps`.
+    expect(override.environment).toBeUndefined();
+    const taskArgs = materialize(one("Task", "Mem9Cleanup").args) as
+      Record<string, any>;
+    expect(Object.keys(taskArgs.environment)).not.toContain("MEM9_APPROVAL_HASH");
+    expect(taskArgs.environment.MEM9_SLACK_APPROVAL_CHANNEL).toBe(CHANNEL_ID);
+    expect(JSON.stringify(override)).not.toContain("MEM9_APPROVAL_HASH");
+  });
+
+  it("TC-SLACKAPP-151: alarms on an invocation that never STARTS a task, dimensioned on the scan's own group", async () => {
+    installGlobals("prod");
+    enable();
+    enableScan();
+    await loadAndRun();
+
+    // Distinct from the apply task's exit-code alarm, which cannot see this at
+    // all: with maximumRetryAttempts 1, two failed RunTask calls (IAM drift,
+    // capacity, a task definition a teardown removed) are dropped silently. No
+    // task, no STOPPED event, no alarm — and the only symptom is a missing Slack
+    // message, indistinguishable from a clean week.
+    const alarm = materialize(
+      one("MetricAlarm", "CleanupScanScheduleTargetErrorAlarm").args,
+    ) as Record<string, any>;
+    expect(alarm).toMatchObject({
+      namespace: "AWS/Scheduler",
+      metricName: "TargetErrorCount",
+      statistic: "Sum",
+      threshold: 1,
+      comparisonOperator: "GreaterThanOrEqualToThreshold",
+      // A week with no invocation emits no datapoint, and that is not an error.
+      treatMissingData: "notBreaching",
+      alarmActions: [
+        "arn:aws:sns:ap-northeast-1:123456789012:mem9-on-aws-prod-alerts",
+      ],
+    });
+    // THIS group. Consolidation's alarm carries the same namespace and metric, so
+    // a dimension pointing at its group would page for consolidation failures and
+    // stay silent for the scan's.
+    expect(alarm.dimensions).toEqual({
+      ScheduleGroup: "mem9-on-aws-prod-cleanup-scan-fixture",
+    });
+    expect(String(alarm.dimensions.ScheduleGroup)).not.toContain("consolidation");
+  });
+
+  it("TC-SLACKAPP-151: still schedules the scan on a stage with no alerts topic", async () => {
+    installGlobals("prod");
+    enable();
+    enableScan();
+    const module = await loadModule();
+    // An alarm whose alarmActions is [undefined] fails CREATE for the whole
+    // stack, which would cost every preview stage its scan to gain paging it has
+    // no topic for.
+    module.slackApproval(
+      { ...fakeEcs(), alertsTopicArn: undefined } as unknown as EcsOutputs,
+      fakeDb(),
+      fakeIdentity(),
+      fakeFacade(),
+    );
+    expect(all("MetricAlarm")).toEqual([]);
+    expect(all("Schedule")).toHaveLength(1);
+    expect(all("ScheduleGroup")).toHaveLength(1);
+    expect(all("Role")).toHaveLength(1);
+  });
+
+  it("TC-SLACKAPP-153: keeps the task role's approval write inside the DEPLOYED boundary", async () => {
+    installGlobals("prod");
+    enable();
+    enableScan();
+    await loadAndRun();
+
+    // The scan is the apply task definition under a command override, so the task
+    // that posts the offer needs `ssm:PutParameter`. #149 claims this needs no
+    // boundary rollout; that claim is MEASURED here against the same template the
+    // operator deploys, because the alternative is discovering it as an opaque
+    // AccessDenied on the first scheduled Saturday.
+    const taskArgs = materialize(one("Task", "Mem9Cleanup").args) as
+      Record<string, any>;
+    const permissions = taskArgs.permissions as Array<Record<string, any>>;
+    const actions = permissions.flatMap((statement) => list(statement.actions));
+    expect(actions).toContain("ssm:PutParameter");
+
+    const boundary = boundaryStatements();
+    const ceiling = boundary.find(({ NotAction }) => NotAction);
+    expect(ceiling).toBeDefined();
+    const admitted = list(ceiling!.NotAction);
+    for (const action of actions) {
+      expect(
+        admitted.some((pattern) => globMatches(pattern, action)),
+        `${action} is outside the workload boundary action ceiling`,
+      ).toBe(true);
+    }
+
+    // DenyPutParameterOutsideApprovalRecords is a NotResource deny: one stray
+    // resource in the same statement denies the whole call, so EVERY resource the
+    // write names has to be matched by the exception.
+    const approvalDeny = boundary.find(
+      ({ Sid }) => Sid === "DenyPutParameterOutsideApprovalRecords",
+    );
+    expect(approvalDeny).toBeDefined();
+    const exceptions = (approvalDeny!.NotResource as unknown[]).map(resolveSub);
+    const putResources = permissions
+      .filter((statement) => list(statement.actions).includes("ssm:PutParameter"))
+      .flatMap((statement) => list(statement.resources));
+    expect(putResources).toEqual([
+      "arn:aws:ssm:ap-northeast-1:123456789012:parameter/mem9-on-aws/prod/approvals/*",
+    ]);
+    for (const resource of putResources) {
+      expect(
+        exceptions.some((pattern) => globMatches(pattern, resource)),
+        `${resource} is denied by DenyPutParameterOutsideApprovalRecords`,
+      ).toBe(true);
+    }
+    // `approvals/*` is the tightest scope SSM allows here — the claim and the
+    // offer are siblings — so the immutability of a claim rests on
+    // `Overwrite: false` at the write, not on IAM. What must NOT widen is the
+    // reach beyond the approval records.
+    expect(putResources).not.toContain(
+      "arn:aws:ssm:ap-northeast-1:123456789012:parameter/mem9-on-aws/prod/*",
+    );
+  });
+
+  it("TC-SLACKAPP-154: names the scan scheduler role in both deploy-role statements that gate a Scheduler pass", async () => {
+    const { CLEANUP_SCHEDULER_ROLE_ARN_PATTERN } = await loadModule();
+    const template = cloudFormationTemplate(
+      "./cloudformation/github-actions-role.yaml",
+    );
+    const arnFor = (pattern: string) =>
+      `arn:\${AWS::Partition}:iam::\${AWS::AccountId}:role/${pattern}`;
+
+    // `PassRoleConstrained` does NOT cover this: it conditions on
+    // iam:PassedToService in [lambda, ecs-tasks] only, so a
+    // scheduler.amazonaws.com pass needs the dedicated statement. Without the
+    // widening the deploy AccessDenies on CreateSchedule's PassRole AFTER having
+    // already created the role and the group.
+    const pass = (
+      template.Resources.ScaffoldPolicy.Properties.PolicyDocument
+        .Statement as Array<Record<string, any>>
+    ).find(({ Sid }) => Sid === "PassConsolidationSchedulerRole");
+    expect(pass).toBeDefined();
+    expect((pass!.Resource as unknown[]).map(resolveSub)).toContain(
+      resolveSub({ "Fn::Sub": arnFor(CLEANUP_SCHEDULER_ROLE_ARN_PATTERN) }),
+    );
+
+    // The paired Deny has to name it too. It denies iam:PassRole on these roles
+    // for any service OTHER than Scheduler, so a role missing from the Deny is a
+    // role the deploy could hand to anything the Allow above happens to permit.
+    const deny = (
+      template.Resources.DenyPolicy.Properties.PolicyDocument
+        .Statement as Array<Record<string, any>>
+    ).find(({ Sid }) => Sid === "DenyConsolidationSchedulerRolePassToOtherServices");
+    expect(deny).toBeDefined();
+    expect((deny!.Resource as unknown[]).map(resolveSub)).toContain(
+      resolveSub({ "Fn::Sub": arnFor(CLEANUP_SCHEDULER_ROLE_ARN_PATTERN) }),
+    );
+    // Kept under the ORIGINAL Sids rather than added as new statements: both the
+    // boundary audit lib and the recorded rollout state look these up BY Sid.
+    expect(deny!.Sid).toBe("DenyConsolidationSchedulerRolePassToOtherServices");
+
+    // The pattern must actually match the name the stack synthesizes. Two globs
+    // that both look right but disagree on one hyphen is a rollout that reports
+    // success and then AccessDenies.
+    installGlobals("prod");
+    const { cleanupSchedulerRoleName } = await loadModule();
+    expect(
+      globMatches(CLEANUP_SCHEDULER_ROLE_ARN_PATTERN, cleanupSchedulerRoleName("prod")),
+    ).toBe(true);
+  });
+
   it("TC-SLACKAPP-088: adds no Lambda, no API, and no certificate", async () => {
     installGlobals("prod");
     enable();
@@ -892,5 +1366,65 @@ describe("slack approval infrastructure", () => {
     expect(
       module.slackApproval(fakeEcs(), fakeDb(), fakeIdentity(), fakeFacade()),
     ).toBeUndefined();
+  });
+});
+
+describe("scan schedule name budgets (TC-SLACKAPP-152)", () => {
+  it("keeps the scan's group prefix under Scheduler's 38-char cap and its 64-char name", async () => {
+    const { cleanupScanScheduleGroupPrefix } = await loadModule();
+    const { SCHEDULE_GROUP_NAME_PREFIX_MAX, PULUMI_NAME_SUFFIX_LEN } =
+      await import("./consolidation");
+
+    // Two limits, and the prefix cap is the tighter one — which is why it is
+    // reported first. Checking only the 64-char NAME limit is the #127 trap in
+    // reverse: `mem9-on-aws-pr-99999-cleanup-scan-` fits 64 easily and still
+    // would have been rejected by Scheduler's prefix validator if it were longer.
+    for (const stage of ["prod", "pr-1", "pr-113", "pr-99999"]) {
+      const prefix = cleanupScanScheduleGroupPrefix(stage);
+      expect(prefix.length).toBeLessThanOrEqual(SCHEDULE_GROUP_NAME_PREFIX_MAX);
+      expect(prefix.length + PULUMI_NAME_SUFFIX_LEN).toBeLessThanOrEqual(64);
+      // The deploy role's Scheduler grants are scoped to
+      // `schedule-group/mem9-on-aws-*` and `schedule/mem9-on-aws-*/*`. Those are
+      // already wide enough for this new group, which is the reason the SCHEDULE
+      // needs no deploy-role change — only the scheduler ROLE does.
+      expect(prefix.startsWith("mem9-on-aws-")).toBe(true);
+    }
+    expect(cleanupScanScheduleGroupPrefix("prod")).toBe(
+      "mem9-on-aws-prod-cleanup-scan-",
+    );
+    // Loudly at synth, never at CREATE. `boundedNamePrefix` refuses rather than
+    // truncating because two stages silently shortened to the same prefix share a
+    // schedule group — and then one stage's TargetErrorCount alarm covers both.
+    expect(() => cleanupScanScheduleGroupPrefix("a".repeat(40))).toThrow(
+      /exceeds 38 characters/u,
+    );
+  });
+
+  it("keeps the scan scheduler role name matchable by the deployed patterns", async () => {
+    const { cleanupSchedulerRoleName, CLEANUP_SCHEDULER_ROLE_ARN_PATTERN } =
+      await loadModule();
+    const { IAM_ROLE_NAME_MAX } = await import("./consolidation");
+
+    for (const stage of ["prod", "pr-1", "pr-113", "pr-99999"]) {
+      const name = cleanupSchedulerRoleName(stage);
+      // IAM's own 64-char limit, not Pulumi's 38-char name_prefix cap: this uses
+      // `name`, which is the only way a name carrying the 24-char role token fits
+      // at all.
+      expect(name.length).toBeLessThanOrEqual(IAM_ROLE_NAME_MAX);
+      // Must be matched by the pattern the deploy role and the boundary audit lib
+      // both carry, and must start with `mem9-on-aws-` for the deploy role's
+      // iam:CreateRole scope.
+      expect(globMatches(CLEANUP_SCHEDULER_ROLE_ARN_PATTERN, name)).toBe(true);
+      expect(name.startsWith("mem9-on-aws-")).toBe(true);
+      // Distinct from consolidation's role: a shared name would mean a shared
+      // trust policy, and Scheduler's aws:SourceArn must name ONE schedule group.
+      expect(name).not.toContain("Consolidation");
+    }
+    expect(cleanupSchedulerRoleName("prod")).toBe(
+      "mem9-on-aws-prod-Mem9CleanupSchedulerRole-role",
+    );
+    expect(() => cleanupSchedulerRoleName("a".repeat(60))).toThrow(
+      /exceeds 64 characters/u,
+    );
   });
 });

--- a/infra/slack-approval.ts
+++ b/infra/slack-approval.ts
@@ -65,6 +65,7 @@ import type { OauthFacadeOutputs } from "./oauth-facade";
 import type { TenantIdentityOutputs } from "./tenant-identity";
 import { taskFailureAlarm } from "./task-failure-alarm";
 import { accountId, applicationRegion, ecrImage } from "./ecr";
+import { boundedNamePrefix, IAM_ROLE_NAME_MAX, SCHEDULE_GROUP_NAME_PREFIX_MAX } from "./consolidation";
 import { resolveVpc } from "./vpc";
 
 const IMAGE_TAG = process.env.MEM9_IMAGE_TAG || "latest";
@@ -75,9 +76,64 @@ const RESPONSES_REGION = process.env.MEM9_LLM_RESPONSES_REGION || "us-west-2";
 // Same namespace as the consolidation alarm so both task failures aggregate in
 // one place; the metric name distinguishes them.
 const CLEANUP_FAILURE_METRIC = "CleanupApplyTaskFailures";
+const SCAN_TARGET_ERROR_METRIC = "TargetErrorCount";
 
 export const SLACK_APPROVAL_ENABLED_ENV = "MEM9_SLACK_APPROVAL_ENABLED";
 export const SLACK_APPROVAL_CHANNEL_ENV = "MEM9_SLACK_APPROVAL_CHANNEL";
+
+/**
+ * The weekly scan's own gate (#149), separate from `SLACK_APPROVAL_ENABLED_ENV`.
+ *
+ * Two flags rather than one because the loop has two halves with different risk:
+ * the apply half is inert until a human clicks, while the scan half runs
+ * unattended and spends a reasoning-model pass per week. An operator seeding a
+ * Slack app should be able to run the loop by hand first and turn the schedule on
+ * afterwards — the same staging `MEM9_CONSOLIDATION_SCHEDULE_ENABLED` gives
+ * consolidation, and for the same reason (infra-ci.yml documents it as "set to 1
+ * only after ... an actionable report-only run").
+ */
+export const CLEANUP_SCAN_SCHEDULE_ENABLED_ENV =
+  "MEM9_CLEANUP_SCAN_SCHEDULE_ENABLED";
+
+/**
+ * Saturday 03:00 UTC — deliberately NOT Sunday, which is consolidation's slot
+ * (`cron(0 3 ? * SUN *)`). Both tasks classify the same corpus through the same
+ * model and both take the shared database mutex on apply, so an overlap would
+ * have one of them lose the mutex and exit 3.
+ *
+ * A day EARLIER than consolidation, not later: consolidation merges and archives,
+ * which changes what a cleanup scan would classify. Scanning first means the
+ * approval list an operator sees was built from the store as it stood before the
+ * week's consolidation rewrote parts of it — and the 72h offer window then closes
+ * on Tuesday, well before the next Saturday.
+ */
+export const CLEANUP_SCAN_CRON = "cron(0 3 ? * SAT *)";
+
+/**
+ * Independent passes the scheduled scan runs, and the reason the schedule is safe
+ * to run unattended at all.
+ *
+ * `--consensus-passes 2` offers only the ids EVERY pass judged DELETE. The
+ * measurement behind it (memory-cleanup.mjs's own header): one pass reproduced
+ * only 66% of its own DELETE set on re-run. Operator-initiated, a human reading
+ * the list absorbs that nondeterminism; unattended, the quorum is the only thing
+ * that does. `consensusDecisions` requires >= 2 usable passes and the flag's
+ * `min` is 2, so this cannot be weakened to 1 without the parser rejecting it.
+ *
+ * Costs two inference runs per week, which is the price of the property.
+ */
+export const CLEANUP_SCAN_CONSENSUS_PASSES = 2;
+
+/**
+ * Where the scheduled scan writes its decision log inside the container.
+ *
+ * NOT under /app: `snippetLogDir` REFUSES a path inside the script tree, because
+ * the log holds memory snippets and must never land in a checkout. In the image
+ * /app IS that tree, so `--out /app/...` would throw before the scan started. The
+ * file is per-task and dies with the container; #150 is what gives the decision
+ * list a durable home.
+ */
+export const CLEANUP_SCAN_OUT_DIR = "/tmp/mem9-cleanup-scan";
 
 /**
  * The single container's name, which SST derives from the Task's logical name
@@ -100,6 +156,73 @@ export const APPROVED_IDS_PATH = "/tmp/mem9-approved-ids.txt";
  * many memories a single click can delete.
  */
 export const CLEANUP_CAP = 50;
+
+/**
+ * Schedule-group name prefix for the scan, under the same two limits
+ * consolidation's helper checks and for the same reasons — Scheduler's 38-char
+ * `name_prefix` cap (the tighter one, so it is reported first) and the 64-char
+ * NAME limit once Pulumi's 26-char suffix is added. `cleanup-scan-` is 13 chars
+ * against `consolidation-`'s 14, so a stage that fits there fits here — but only
+ * just, which is why the check below is a throw and not a comment.
+ *
+ * The `mem9-on-aws-` prefix is mandatory, not cosmetic: the deploy role's
+ * Scheduler grants are scoped to `schedule-group/mem9-on-aws-*` and to every
+ * schedule beneath it — the `schedule/mem9-on-aws-` form with a wildcard on both
+ * the group and the schedule name. That second literal is quoted exactly in
+ * github-actions-role.yaml and in slack-approval.test.ts rather than here, because
+ * a `*` immediately followed by a `/` would close this block comment. Both
+ * patterns are wide enough for this new group already, which is why the schedule
+ * itself needs no deploy-role change.
+ */
+export function cleanupScanScheduleGroupPrefix(stage: string): string {
+  const prefix = `mem9-on-aws-${stage}-cleanup-scan-`;
+  if (prefix.length > SCHEDULE_GROUP_NAME_PREFIX_MAX) {
+    throw new Error(
+      `schedule-group name prefix ${prefix} exceeds ` +
+        `${SCHEDULE_GROUP_NAME_PREFIX_MAX} characters`,
+    );
+  }
+  boundedNamePrefix(prefix, 64, "cleanup scan schedule");
+  return prefix;
+}
+
+/**
+ * The scan scheduler role's IAM pattern, duplicated into the DEPLOY ROLE
+ * (`PassConsolidationSchedulerRole` + `DenyConsolidationSchedulerRolePassToOther
+ * Services`, both widened for #149) and into the boundary audit lib. Exported so
+ * a unit test can assert the deployed YAML actually contains it rather than
+ * trusting that both sides were edited.
+ */
+export const CLEANUP_SCHEDULER_ROLE_ARN_PATTERN =
+  "mem9-on-a*-*Mem9CleanupSchedulerRole-*";
+
+/**
+ * A fixed `name`, for the same three intersecting constraints documented at
+ * `consolidationSchedulerRoleName`: Pulumi caps a role `name_prefix` at 38 and any
+ * prefix containing `Mem9CleanupSchedulerRole-` exceeds it; the name must contain
+ * that token for the deploy-role/boundary patterns to match; and it must start
+ * with `mem9-on-aws-` for the deploy role's `iam:CreateRole` scope.
+ *
+ * A SEPARATE role from `Mem9ConsolidationSchedulerRole`, and the reason is the
+ * trust policy rather than the permissions. Scheduler's confused-deputy guidance
+ * requires `aws:SourceArn` to be the schedule GROUP arn — not a schedule, not a
+ * name prefix — so reusing the consolidation role would mean either widening its
+ * `aws:SourceArn` to two groups (weakening a deployed control on the weekly
+ * consolidation) or putting this schedule in consolidation's group (making one
+ * group's `TargetErrorCount` alarm ambiguous across two unrelated schedules,
+ * since the alarm dimensions on ScheduleGroup). Neither is worth saving a role.
+ */
+export function cleanupSchedulerRoleName(stage: string): string {
+  // Trailing `-role` segment: the deployed patterns end `...SchedulerRole-*`, and
+  // without a following hyphen segment the glob does NOT match.
+  const name = `mem9-on-aws-${stage}-Mem9CleanupSchedulerRole-role`;
+  if (name.length > IAM_ROLE_NAME_MAX) {
+    throw new Error(
+      `cleanup scheduler role name ${name} exceeds ${IAM_ROLE_NAME_MAX} characters`,
+    );
+  }
+  return name;
+}
 
 export interface SlackApprovalOutputs {
   taskDefinitionArn: Output<string>;
@@ -271,11 +394,25 @@ export function slackApproval(
         resources: ["*"],
       },
       // The task reads the approval record to learn WHICH ids were approved. It
-      // reads only under `approvals/`, and it never writes: the claim is the
+      // reads only under `approvals/`, and it never writes the CLAIM: that is the
       // Lambda's to stamp, so a task that could rewrite it could re-approve
       // itself.
+      //
+      // `ssm:PutParameter` joins it for #149, and the scoping is what keeps the
+      // sentence above true. The scheduled SCAN is this same task definition under
+      // a command override (see the schedule below), and a scan's whole output is
+      // the `approvals/offered` record — so the task that posts the offer needs to
+      // write it. `approvals/*` is the tightest scope SSM allows here (the claim
+      // and the offer are siblings), so the immutability of a claim rests on
+      // `Overwrite: false` at the write rather than on IAM. That is where it
+      // already rested for the Lambda, which holds the identical scope.
+      //
+      // Admissible under the DEPLOYED boundary with no rollout: the ceiling admits
+      // `ssm:PutParameter` and `DenyPutParameterOutsideApprovalRecords` permits
+      // exactly `/mem9-on-aws/*/approvals/*`. Measured, not assumed —
+      // TC-SLACKAPP-153 asserts it against the boundary template.
       {
-        actions: ["ssm:GetParameters"],
+        actions: ["ssm:GetParameters", "ssm:PutParameter"],
         resources: [
           $interpolate`arn:aws:ssm:${region}:${accountId()}:parameter${prefix}/approvals/*`,
         ],
@@ -338,6 +475,181 @@ export function slackApproval(
       // the top of this file), and `stoppedReason` is the only field that names it.
       includeStoppedReason: true,
     });
+  }
+
+  // --- The weekly scan that gives the loop something to approve (#149) ---
+  //
+  // Until this existed the loop had no entry point: the apply half above is
+  // inert until a Slack click, and nothing posted the message the click comes
+  // from. The weekly consolidation schedule runs a DIFFERENT script
+  // (memory-consolidation.mjs) whose review tier goes to SNS, so no scheduled run
+  // ever produced a Slack approval.
+  //
+  // The SAME task definition under a command override, not a second Task. Two
+  // definitions would double every contract this file already pins — the container
+  // name the handler's override targets, the image, the secret wiring, the roles
+  // the boundary admits — and the scan and the apply genuinely are the same code
+  // on the same IAM, differing only in `--apply`.
+  if (process.env[CLEANUP_SCAN_SCHEDULE_ENABLED_ENV] === "1") {
+    const scanScheduleGroup = new aws.scheduler.ScheduleGroup(
+      "Mem9CleanupScanScheduleGroup",
+      { namePrefix: cleanupScanScheduleGroupPrefix($app.stage), tags },
+    );
+
+    const scanSchedulerRole = new aws.iam.Role("Mem9CleanupSchedulerRole", {
+      name: cleanupSchedulerRoleName($app.stage),
+      assumeRolePolicy: $jsonStringify({
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Principal: { Service: "scheduler.amazonaws.com" },
+            Action: "sts:AssumeRole",
+            // Both keys, and `aws:SourceArn` on the schedule GROUP. AWS's
+            // cross-service confused-deputy guidance for Scheduler is explicit
+            // that the value must be a schedule group arn and must NOT be scoped
+            // to a specific schedule or a schedule-name prefix — so `StringEquals`
+            // against the group is correct and needs no wildcard. Copied from the
+            // consolidation role, which follows the same guidance.
+            Condition: {
+              StringEquals: {
+                "aws:SourceAccount": accountId(),
+                "aws:SourceArn": scanScheduleGroup.arn,
+              },
+            },
+          },
+        ],
+      }),
+      tags,
+    });
+
+    new aws.iam.RolePolicy("Mem9CleanupSchedulerPolicy", {
+      role: scanSchedulerRole.name,
+      policy: $jsonStringify({
+        Version: "2012-10-17",
+        Statement: [
+          { Effect: "Allow", Action: "ecs:RunTask", Resource: task.taskDefinition },
+          {
+            Effect: "Allow",
+            Action: "iam:PassRole",
+            Resource: [task.nodes.taskRole.arn, task.nodes.executionRole.arn],
+            Condition: {
+              StringEquals: { "iam:PassedToService": "ecs-tasks.amazonaws.com" },
+            },
+          },
+        ],
+      }),
+    });
+
+    new aws.scheduler.Schedule("Mem9CleanupScan", {
+      namePrefix: cleanupScanScheduleGroupPrefix($app.stage),
+      description:
+        "Weekly memory cleanup scan; posts its consensus DELETE set to Slack for approval.",
+      groupName: scanScheduleGroup.name,
+      scheduleExpression: CLEANUP_SCAN_CRON,
+      scheduleExpressionTimezone: "UTC",
+      state: $app.stage === "prod" ? "ENABLED" : "DISABLED",
+      flexibleTimeWindow: { mode: "OFF" },
+      target: {
+        arn: ecsOut.cluster.nodes.cluster.arn,
+        roleArn: scanSchedulerRole.arn,
+        input: $jsonStringify({
+          containerOverrides: [
+            {
+              name: CLEANUP_CONTAINER_NAME,
+              // A FULL command, replacing the apply command rather than adding to
+              // it. ECS overrides `command` wholesale, which is the only reason one
+              // task definition can serve both halves — but it also means every
+              // argument the scan needs must appear here, including the ones the
+              // definition already sets.
+              //
+              // `--apply` is ABSENT, and its absence is the entire safety property
+              // of this schedule: `runCleanup` returns at the dry-run branch before
+              // it takes either lock, so an unattended run cannot delete anything
+              // and cannot contend with the weekly consolidation for the shared
+              // database mutex. `--ids` is absent for the same reason it must be —
+              // `readApprovedIds` treats an absent file as "no filter", which is
+              // only safe on a path that writes nothing.
+              command: [
+                "/app/scripts/memory-cleanup.mjs",
+                "--stage",
+                $app.stage,
+                "--base-url",
+                $interpolate`http://${ecsOut.serviceDnsName}:8080`,
+                // Not optional for an unattended run. See
+                // CLEANUP_SCAN_CONSENSUS_PASSES: a single pass reproduced 66% of
+                // its own DELETE set, and with no human reading the list the
+                // quorum is the only thing narrowing it.
+                "--consensus-passes",
+                String(CLEANUP_SCAN_CONSENSUS_PASSES),
+                // Outside /app, which `snippetLogDir` requires — see
+                // CLEANUP_SCAN_OUT_DIR.
+                "--out",
+                CLEANUP_SCAN_OUT_DIR,
+              ],
+              // MEM9_SLACK_APPROVAL_CHANNEL is already in the definition's
+              // `environment`, and it is what makes `buildPostApproval` return a
+              // poster at all — so the scan offers by virtue of being configured
+              // for Slack, with no extra flag. No MEM9_APPROVAL_HASH: that
+              // variable means "this run came from a click", and setting it with no
+              // `--ids` is a hard error by design (createCleanupDeps).
+            },
+          ],
+        }),
+        // One retry, matching consolidation. A scan is idempotent in the sense
+        // that matters — it writes only `approvals/offered` — but the retry is
+        // bounded because a second full classification costs a second reasoning
+        // pass, and because the refuse-to-overwrite guard makes a retry AFTER a
+        // successful post fail loudly rather than clobber the offer it just made.
+        retryPolicy: { maximumEventAgeInSeconds: 3600, maximumRetryAttempts: 1 },
+        ecsParameters: {
+          launchType: "FARGATE",
+          taskCount: 1,
+          taskDefinitionArn: task.taskDefinition,
+          networkConfiguration: {
+            assignPublicIp: task.assignPublicIp,
+            securityGroups: task.securityGroups,
+            // Passed as an Output so Pulumi resolves the nested Outputs before the
+            // API call — the `.join(",")` defect that reached two live stacks.
+            subnets: task.subnets,
+          },
+        },
+      },
+    });
+
+    // The scan's own failure signal, and it is NOT the same as the apply task's.
+    //
+    // `taskFailureAlarm` above already covers a scan that STARTS and exits
+    // non-zero — including the refuse-to-overwrite exit and a scan whose classifier
+    // is broken (exit 5) — because it matches on the task-definition arn, which is
+    // shared. What it cannot cover is an invocation that never starts a task at
+    // all: with maximumRetryAttempts 1, two failed RunTask calls (IAM drift,
+    // capacity, a task definition deleted by a teardown) are dropped silently. No
+    // task, no STOPPED event, no alarm — and the visible symptom is only that no
+    // approval message arrived, which looks exactly like a week with nothing to
+    // delete.
+    if (ecsOut.alertsTopicArn) {
+      new aws.cloudwatch.MetricAlarm("CleanupScanScheduleTargetErrorAlarm", {
+        alarmDescription:
+          "EventBridge Scheduler could not invoke the weekly memory cleanup scan, " +
+          "so no task ran and the task-exit alarm cannot fire.",
+        namespace: "AWS/Scheduler",
+        metricName: SCAN_TARGET_ERROR_METRIC,
+        // Dimensioned on THIS group, which is why the scan has a group of its own:
+        // sharing consolidation's group would make one alarm fire for either
+        // schedule and name neither.
+        dimensions: { ScheduleGroup: scanScheduleGroup.name },
+        statistic: "Sum",
+        period: 3600,
+        evaluationPeriods: 1,
+        datapointsToAlarm: 1,
+        threshold: 1,
+        comparisonOperator: "GreaterThanOrEqualToThreshold",
+        // A week with no invocation emits no datapoint; that is not an error.
+        treatMissingData: "notBreaching",
+        alarmActions: [ecsOut.alertsTopicArn],
+      });
+    }
   }
 
   // --- The three grants the façade Lambda needs, on its EXISTING role ---

--- a/infra/src/oauth-facade/handler.test.ts
+++ b/infra/src/oauth-facade/handler.test.ts
@@ -1080,8 +1080,18 @@ function slackDeps(overrides: Partial<SlackDeps> = {}): SlackDeps {
     stage: SLACK_STAGE,
     ssmPrefix: "/mem9-on-aws/test",
     now: () => Date.now(),
+    // `issuedAt` is stamped at call time, not at fixture-construction time, so
+    // these routing cases are never sitting near the 72h window's edge. The field
+    // is REQUIRED for the record to be clickable at all — `loadOffered` reads an
+    // absent one as expired (TC-SLACKAPP-136), so a fixture without it makes every
+    // case in this file assert routing against a refusal reply.
     getParameter: vi.fn(async () =>
-      JSON.stringify({ stage: SLACK_STAGE, hash: SLACK_HASH, ids: ["m-1"] }),
+      JSON.stringify({
+        stage: SLACK_STAGE,
+        hash: SLACK_HASH,
+        ids: ["m-1"],
+        issuedAt: new Date().toISOString(),
+      }),
     ),
     putParameter: vi.fn(async () => {}),
     runTask: vi.fn(async () => "arn:aws:ecs:region:account:task/cluster/abc"),
@@ -1390,6 +1400,10 @@ describe("Slack deps at the Lambda entrypoint (TC-SLACKAPP-047..049)", () => {
                       stage: SLACK_STAGE,
                       hash: SLACK_HASH,
                       ids: ["m-1"],
+                      // Inside the 72h window, or the wiring under test is never
+                      // reached: the expiry gate refuses first and the reply below
+                      // is the refusal rather than "Apply started".
+                      issuedAt: new Date().toISOString(),
                     })
                   : Name.endsWith("/subnet-ids")
                     ? "subnet-a"

--- a/infra/src/oauth-facade/slack-interactions.test.ts
+++ b/infra/src/oauth-facade/slack-interactions.test.ts
@@ -19,6 +19,7 @@ import {
   CLAIM_STALE_MS,
   claimParameterName,
   handleSlackInteraction,
+  OFFER_TTL_MS,
   type SlackDeps,
 } from "./slack-interactions.js";
 
@@ -81,6 +82,12 @@ function offered(overrides: Record<string, unknown> = {}) {
     hash: HASH,
     ids: IDS,
     generatedAt: "2026-08-05T11:59:00Z",
+    // Inside the 72h window at `NOW`, so the default fixture is a CLICKABLE
+    // offer. It has to be stated rather than omitted: an absent `issuedAt` reads
+    // as expired (#149), which is the fail-closed direction — omitting it here
+    // would silently route every test in this file into the expiry branch and
+    // assert nothing about the paths they name.
+    issuedAt: "2026-08-05T11:59:00Z",
     ...overrides,
   });
 }
@@ -558,6 +565,118 @@ describe("Slack stale-hash rejection (TC-SLACKAPP-020..025)", () => {
     expect(d.runTask).not.toHaveBeenCalled();
     expect(d.putParameter).not.toHaveBeenCalled();
     expect(JSON.stringify(res.body)).toMatch(/stage/iu);
+  });
+});
+
+// 137 is deliberately absent here: it pins this file's `OFFER_TTL_MS` against the
+// container script's duplicate copy, so it lives on the STAMPING side
+// (scripts/memory-cleanup.test.mjs) where the value is written.
+describe("Slack offer expiry (TC-SLACKAPP-134..136, 138..139)", () => {
+  /** An offered record issued `ageMs` before `NOW`. */
+  const aged = (ageMs: number) =>
+    offered({ issuedAt: new Date(NOW - ageMs).toISOString() });
+
+  it("TC-SLACKAPP-134 a click past the 72h window is refused, names the expiry, and starts nothing", async () => {
+    // The list is a snapshot of the store at scan time and the button carries only
+    // its hash, so a click days later applies verdicts taken against a corpus that
+    // has since moved. The apply's last-write-wins guard catches a memory that
+    // CHANGED; nothing catches a verdict that merely went stale.
+    const d = deps({ getParameter: vi.fn(async () => aged(OFFER_TTL_MS + 1000)) });
+    const res = await handleSlackInteraction(ev(payload()), d);
+
+    // A refusal, not a slow apply: neither the claim nor the task may happen.
+    expect(d.runTask).not.toHaveBeenCalled();
+    expect(d.putParameter).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(200);
+    const text = JSON.parse(res.body).text as string;
+    // The reply has to say EXPIRED, not just "nothing was applied": the operator's
+    // next action differs (wait for the next scan vs click the newer message), and
+    // the generic refusal sends them hunting for a message that does not exist.
+    expect(text).toMatch(/expire/iu);
+    expect(text).toMatch(/72h/u);
+    expect(text).toMatch(/nothing was applied/iu);
+    // Mutation probe: deleting the expiry branch makes this line fail, because a
+    // record whose hash matches otherwise falls straight through to the claim.
+    expect(text).not.toMatch(/apply started/iu);
+  });
+
+  it("TC-SLACKAPP-135 the window is inclusive at exactly 72h and closed one millisecond later", async () => {
+    // The boundary is asserted directly because an off-by-one between `>` and
+    // `>=` is invisible in every test that is not sitting on the millisecond —
+    // and a TTL that is silently one tick short expires a list the SCAN still
+    // refuses to overwrite, which wedges the loop with nothing able to apply.
+    const live = deps({ getParameter: vi.fn(async () => aged(OFFER_TTL_MS)) });
+    const liveRes = await handleSlackInteraction(ev(payload()), live);
+    expect(live.runTask).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(liveRes.body).text).toMatch(/apply started/iu);
+
+    const dead = deps({ getParameter: vi.fn(async () => aged(OFFER_TTL_MS + 1)) });
+    const deadRes = await handleSlackInteraction(ev(payload()), dead);
+    expect(dead.runTask).not.toHaveBeenCalled();
+    expect(JSON.parse(deadRes.body).text).toMatch(/expire/iu);
+  });
+
+  it("TC-SLACKAPP-136 a record with no or unparseable issuedAt is refused, not treated as unbounded", async () => {
+    // Fails CLOSED. A record of unknown age is exactly what the TTL exists to
+    // stop, and this is also the shape of a pre-#149 record left in SSM across the
+    // deploy that adds the check — refusing costs one re-click, while accepting
+    // would apply a list of any age.
+    //
+    // `2027` is the sharp one and the reason `offerExpiry` takes `unknown` and
+    // requires a string rather than casting: `Date.parse` COERCES, and it reads a
+    // small number as a YEAR — `Date.parse(2027)` is 2027-01-01, a date in the
+    // future, so the age is negative and the list reads permanently LIVE. Every
+    // other value here yields NaN and would be refused by a cast version too, so
+    // this is the only case that can tell the two apart.
+    for (const issuedAt of [undefined, "", "not-a-date", 1754400000, 2027, null]) {
+      const record = JSON.parse(offered()) as Record<string, unknown>;
+      if (issuedAt === undefined) delete record.issuedAt;
+      else record.issuedAt = issuedAt;
+      const d = deps({ getParameter: vi.fn(async () => JSON.stringify(record)) });
+      const res = await handleSlackInteraction(ev(payload()), d);
+
+      expect(d.runTask, `issuedAt=${JSON.stringify(issuedAt)}`).not.toHaveBeenCalled();
+      expect(d.putParameter, `issuedAt=${JSON.stringify(issuedAt)}`).not.toHaveBeenCalled();
+      const text = JSON.parse(res.body).text as string;
+      expect(text, `issuedAt=${JSON.stringify(issuedAt)}`).toMatch(/expire/iu);
+      // Never "NaNh ago" or "Invalid Date": an unknown age is said in words.
+      expect(text, `issuedAt=${JSON.stringify(issuedAt)}`).not.toMatch(/NaN|Invalid Date/u);
+    }
+  });
+
+  it("TC-SLACKAPP-138 a regenerated list is told it was regenerated, not that it expired", async () => {
+    // Ordering, and it is the operator's: the expiry check sits AFTER the hash
+    // check, so a click whose list was replaced gets "regenerated" (click the
+    // newer message) rather than "expired" (wait for the next scan). Moving the
+    // expiry gate above the hash comparison turns this green message red — an
+    // old-but-replaced list is BOTH stale and mismatched, and only one of the two
+    // answers tells the operator something they can act on.
+    const d = deps({
+      getParameter: vi.fn(async () =>
+        offered({ hash: "sha256:different", issuedAt: new Date(NOW - OFFER_TTL_MS * 2).toISOString() }),
+      ),
+    });
+    const res = await handleSlackInteraction(ev(payload()), d);
+
+    expect(d.runTask).not.toHaveBeenCalled();
+    const text = JSON.parse(res.body).text as string;
+    expect(text).toMatch(/regenerated/iu);
+    expect(text).not.toMatch(/expire/iu);
+  });
+
+  it("TC-SLACKAPP-139 the refusal is logged with the expiry cause and never the ids", async () => {
+    // The operator sees a Slack reply; whoever debugs the loop sees this line. It
+    // has to name WHY the click was refused, and must not copy the id list into
+    // CloudWatch — a wider audience than the SSM parameter the ids live in.
+    const d = deps({ getParameter: vi.fn(async () => aged(OFFER_TTL_MS * 3)) });
+    await handleSlackInteraction(ev(payload()), d);
+
+    const logged = (d.log as ReturnType<typeof vi.fn>).mock.calls
+      .map((c) => String(c[0]))
+      .join("\n");
+    expect(logged).toMatch(/expired/iu);
+    expect(logged).toContain(HASH);
+    for (const id of IDS) expect(logged).not.toContain(id);
   });
 });
 

--- a/infra/src/oauth-facade/slack-interactions.ts
+++ b/infra/src/oauth-facade/slack-interactions.ts
@@ -45,6 +45,19 @@ const MAX_TIMESTAMP_SKEW_MS = 5 * 60 * 1000;
  */
 export const CLAIM_STALE_MS = 60_000;
 
+/**
+ * How long after it was issued an offered list stays clickable (#149).
+ *
+ * DUPLICATED from `OFFER_TTL_MS` in scripts/memory-cleanup.mjs, which STAMPS the
+ * `issuedAt` this measures against, for the same reason `claimParameterName` is
+ * duplicated: the Lambda bundle and the container script share no module.
+ * TC-SLACKAPP-137 asserts the two agree, because a drift here is silent in both
+ * directions — a longer value accepts clicks the scan already considers replaceable
+ * (so the record may be gone), and a shorter one refuses clicks the scan still
+ * protects (so the list expires with nothing able to apply it).
+ */
+export const OFFER_TTL_MS = 72 * 60 * 60 * 1000;
+
 export interface SlackDeps {
   /** Slack app signing secret. Empty or absent must fail CLOSED. */
   signingSecret: string;
@@ -167,6 +180,12 @@ interface OfferedRecord {
   hash: string;
   ids: string[];
   /**
+   * When the review run made this list clickable, as an ISO string — the anchor
+   * for the `OFFER_TTL_MS` window. Optional because a record written before #149
+   * has none, and `loadOffered` treats that as EXPIRED rather than as unbounded.
+   */
+  issuedAt?: string;
+  /**
    * Where the review message was posted, stamped by the review run's second
    * `approvals/offered` write. Optional because the stamp is a best-effort
    * follow-up to the post: a run whose post succeeded but whose re-write failed
@@ -261,6 +280,48 @@ function parseAction(
   return action ? { action } : { error: "the payload carries no actions" };
 }
 
+/**
+ * Whether an offered list is past its window, and how old it is (#149).
+ *
+ * An absent or unparseable `issuedAt` is EXPIRED. That is the fail-closed
+ * direction for this side of the loop: the alternative — treating an
+ * unknown-age record as live — accepts a click against a list of unbounded age,
+ * which is exactly the thing the TTL exists to stop. It also correctly refuses
+ * a pre-#149 record left in SSM across the deploy that adds this check.
+ *
+ * `age` is a human string for the reply and `undefined` when unknown, so the
+ * message says "an unknown time ago" instead of "NaNh ago".
+ */
+function offerExpiry(
+  issuedAt: unknown,
+  now: number,
+): { expired: boolean; age?: string } {
+  // `unknown`, not `string | undefined`: the caller reads this off a parsed SSM
+  // parameter, so a NUMBER is a shape a hand-edited record can genuinely have, and
+  // `Date.parse` COERCES. An epoch-milliseconds or epoch-seconds value happens to
+  // yield NaN and would be refused either way, but a small number does not:
+  // `Date.parse(2027)` reads "2027" as a YEAR, returning a date in the FUTURE — so
+  // the age is negative and the list reads permanently live, which is the one
+  // direction this gate must never fail in. Casting at the call site would compile
+  // and take that branch; requiring a string cannot. Matches the script side's
+  // treatment of a numeric stamp as unjudgeable (TC-SLACKAPP-143), and
+  // TC-SLACKAPP-136 pins it here with that exact value.
+  const issuedAtMs = typeof issuedAt === "string" ? Date.parse(issuedAt) : NaN;
+  if (!Number.isFinite(issuedAtMs)) return { expired: true };
+  const ageMs = now - issuedAtMs;
+  // `>`, not `>=`: live for exactly OFFER_TTL_MS, matching `offerExpiry` in
+  // scripts/memory-cleanup.mjs. Asserted on the boundary itself
+  // (TC-SLACKAPP-135) — an off-by-one here passes every test that is not sitting
+  // on the millisecond.
+  return { expired: ageMs > OFFER_TTL_MS, age: formatHours(ageMs) };
+}
+
+/** `72h`, `4.5h` — a duration for one operator-facing sentence. */
+function formatHours(ms: number): string {
+  const hours = ms / (60 * 60 * 1000);
+  return `${Number.isInteger(hours) ? hours : hours.toFixed(1)}h`;
+}
+
 /** Parse a stored record, returning null for anything malformed. */
 function parseRecord(raw: string | null): Record<string, unknown> | null {
   if (!raw) return null;
@@ -304,6 +365,26 @@ async function loadOffered(
   if (record.hash !== hash) {
     return { error: "That list has been regenerated since it was posted. Nothing was applied." };
   }
+  // AFTER the hash check, so an expired click is told it expired rather than that
+  // the list was regenerated. The order is the operator's: "regenerated" means
+  // click the newer message, "expired" means wait for the next scan — and getting
+  // it backwards sends them hunting for a message that does not exist.
+  const expiry = offerExpiry(record.issuedAt, deps.now());
+  if (expiry.expired) {
+    deps.log(
+      `refused an expired approval for ${hash} ` +
+        `(issuedAt=${record.issuedAt ?? "unset"}, ttl=${OFFER_TTL_MS}ms)`,
+    );
+    // Names the expiry and what to do about it. The generic "nothing was applied"
+    // suffix is kept — every refusal in this handler ends with it, and an operator
+    // who has just clicked a destructive button reads that clause first.
+    return {
+      error:
+        `That list was issued ${expiry.age ?? "an unknown time"} ago and approvals ` +
+        `expire after ${formatHours(OFFER_TTL_MS)}, so it may no longer reflect the ` +
+        `store. Nothing was applied — the next scheduled scan will post a fresh list.`,
+    };
+  }
   // The coordinates are carried forward only when both are strings. A record
   // half-stamped (or stamped with a number, which is what a hand-edited parameter
   // or a future Slack payload change would produce) yields neither, so the apply
@@ -317,6 +398,12 @@ async function loadOffered(
       stage: record.stage,
       hash: record.hash,
       ids: record.ids.filter((id): id is string => typeof id === "string"),
+      // Carried on the RECORD but deliberately not into the claim: `buildClaim`
+      // enumerates its fields, and TC-SLACKAPP-023/023c assert the claim's exact
+      // key set because the parameter is a plain `String` whose contents are
+      // bounded on purpose. The expiry decision is already made by here, so the
+      // apply task has no use for it.
+      ...(typeof record.issuedAt === "string" ? { issuedAt: record.issuedAt } : {}),
       ...coordinates,
     },
   };

--- a/scripts/lib/workload-permissions-boundary.mjs
+++ b/scripts/lib/workload-permissions-boundary.mjs
@@ -1030,10 +1030,17 @@ export function verifyPermanentEnforcementDocuments(
     sid: "DenyConsolidationSchedulerRolePassToOtherServices",
     effect: "Deny",
     actions: ["iam:PassRole"],
-    // Both Scheduler roles under the ORIGINAL Sid. This is the frozen-state
-    // verifier for the PERMANENT enforcement documents in this repository (not the
-    // live role), so it asserts the full list — unlike `extractPassRoleScope`,
-    // which reads the live role mid-rollout and therefore checks a subset.
+    // Both Scheduler roles under the ORIGINAL Sid, asserted as the FULL list —
+    // unlike `extractPassRoleScope`, which checks a subset because it runs before
+    // and during enforcement, when the live role may legitimately lag this file.
+    //
+    // This verifier is stricter on purpose, and it does read the LIVE role:
+    // `verifyLivePolicyDocuments` in workload-permissions-boundary-aws.mjs calls it
+    // against the deployed documents after enforcement. Measured 2026-08-12: the
+    // live role still names only the consolidation pattern, so this statement is
+    // reported "malformed" until the github-actions-role.yaml widening is deployed.
+    // That makes `scripts/deploy-github-role.sh` a prerequisite of the next
+    // BOUNDARY rollout, not merely of the first deploy that creates the scan role.
     resources: schedulerRoleArnPatterns({ partition, accountId }),
     conditionOperator: "StringNotEquals",
     conditionKey: "iam:PassedToService",

--- a/scripts/lib/workload-permissions-boundary.mjs
+++ b/scripts/lib/workload-permissions-boundary.mjs
@@ -192,10 +192,30 @@ export function expectedRolePatterns(identity) {
   );
 }
 
-function consolidationSchedulerRoleArnPattern({ partition, accountId }) {
-  return (
-    `arn:${partition}:iam::${accountId}:role/` +
-    "mem9-on-a*-*Mem9ConsolidationSchedulerRole-*"
+/**
+ * Every EventBridge Scheduler role this project creates, in the order the deploy
+ * role's `PassConsolidationSchedulerRole` / `DenyConsolidationSchedulerRolePassTo
+ * OtherServices` statements list them.
+ *
+ * The order matches the template for readability only: `requireStatement` compares
+ * Resource through `sameStringSet`, which SORTS both sides, so reordering these two
+ * tokens changes nothing it enforces. Do not read this list as an ordering contract
+ * — what is enforced is the SET of ARN patterns, and the one assertion that does
+ * pin order is a `toMatchObject` in the test, whose array comparison is positional.
+ *
+ * Consolidation's role came first (#122); the cleanup scan's followed with #149.
+ * Both are Scheduler roles, and neither is coverable by `PassRoleConstrained`,
+ * whose `iam:PassedToService` condition names only lambda and ecs-tasks.
+ */
+const SCHEDULER_ROLE_TOKENS = [
+  "Mem9ConsolidationSchedulerRole-",
+  "Mem9CleanupSchedulerRole-",
+];
+
+function schedulerRoleArnPatterns({ partition, accountId }) {
+  return SCHEDULER_ROLE_TOKENS.map(
+    (roleToken) =>
+      `arn:${partition}:iam::${accountId}:role/mem9-on-a*-*${roleToken}*`,
   );
 }
 
@@ -678,8 +698,7 @@ function validatePassServices(statement) {
 export function extractPassRoleScope(policyDocuments, identity) {
   const expected = expectedRolePatterns(identity);
   const expectedSet = new Set(expected);
-  const schedulerRolePattern =
-    consolidationSchedulerRoleArnPattern(identity);
+  const knownSchedulerRoles = new Set(schedulerRoleArnPatterns(identity));
   const resources = new Set();
 
   for (const rawDocument of policyDocuments) {
@@ -709,13 +728,24 @@ export function extractPassRoleScope(policyDocuments, identity) {
         throw new Error("PassRole statement has no resource scope");
       }
       if (services.includes("scheduler.amazonaws.com")) {
+        // Every resource must be one of the KNOWN Scheduler role patterns, with no
+        // repeats — a SUBSET check, not an exact-list one. Requiring the full list
+        // would make this function's verdict depend on rollout order: it reads the
+        // LIVE deploy role, and #149's widening lands out of band, so between the
+        // two deploys the live statement legitimately names one pattern while this
+        // file names two. A subset check still rejects the thing that matters (a
+        // Scheduler pass to any role this project did not review) and still forbids
+        // pairing scheduler.amazonaws.com with a second service in one statement.
+        const distinct = new Set(statementResources);
         if (
           services.length !== 1 ||
-          statementResources.length !== 1 ||
-          statementResources[0] !== schedulerRolePattern
+          distinct.size !== statementResources.length ||
+          statementResources.some(
+            (resource) => !knownSchedulerRoles.has(resource),
+          )
         ) {
           throw new Error(
-            "Scheduler PassRole scope does not match the consolidation role",
+            "Scheduler PassRole scope does not match a known scheduler role",
           );
         }
         continue;
@@ -1000,9 +1030,11 @@ export function verifyPermanentEnforcementDocuments(
     sid: "DenyConsolidationSchedulerRolePassToOtherServices",
     effect: "Deny",
     actions: ["iam:PassRole"],
-    resources: [
-      consolidationSchedulerRoleArnPattern({ partition, accountId }),
-    ],
+    // Both Scheduler roles under the ORIGINAL Sid. This is the frozen-state
+    // verifier for the PERMANENT enforcement documents in this repository (not the
+    // live role), so it asserts the full list — unlike `extractPassRoleScope`,
+    // which reads the live role mid-rollout and therefore checks a subset.
+    resources: schedulerRoleArnPatterns({ partition, accountId }),
     conditionOperator: "StringNotEquals",
     conditionKey: "iam:PassedToService",
     conditionValue: "scheduler.amazonaws.com",

--- a/scripts/memory-cleanup.mjs
+++ b/scripts/memory-cleanup.mjs
@@ -105,6 +105,28 @@ const DEFAULT_CHAT_MODEL = "zai.glm-5";
 const UNCLASSIFIED_REASON = "classification failed after retry";
 const HOUR_MS = 3600 * 1000;
 const DEFAULT_LOCK_TTL_MS = 2 * HOUR_MS;
+/**
+ * How long an offered approval list stays clickable (#149).
+ *
+ * The list is a snapshot of the store at scan time, and the Approve button
+ * carries only its hash — so a click days later applies verdicts taken against a
+ * corpus that has since moved. The apply's last-write-wins guard catches a
+ * memory that CHANGED, but nothing catches a verdict that merely went stale.
+ *
+ * 72h, chosen against the weekly cadence rather than for roundness: an offer
+ * expires a full four days before the next scheduled scan replaces it, so the
+ * refuse-to-overwrite branch below can be unconditional for a live offer without
+ * ever blocking the schedule. Shorter risks expiring over a long weekend; longer
+ * would let two scans contend for one record.
+ *
+ * DUPLICATED as `OFFER_TTL_MS` in infra/src/oauth-facade/slack-interactions.ts,
+ * which is the ENFORCER while this file is the stamper. TC-SLACKAPP-137 asserts
+ * the two agree, for the same reason TC-SLACKAPP-131 asserts it of
+ * `claimParameterName`: the Lambda bundle and this container script share no
+ * module, and a silent drift here means either an offer that expires before the
+ * button is refused or a button that outlives the record's own claim.
+ */
+export const OFFER_TTL_MS = 72 * HOUR_MS;
 const SNIPPET_LEN = 120;
 // The two inactive states, and the only values --state accepts. They are NOT
 // interchangeable: see `inactiveMemoryAdapter` and issue #124.
@@ -885,8 +907,20 @@ async function discoverBaseUrl(opts, deps) {
  * task deletes — the one failure mode here that produces a *wrong* apply rather
  * than a failed one (TC-SLACKAPP-024).
  */
-export function buildOfferedRecord({ stage, decisions, generatedAt }) {
+export function buildOfferedRecord({ stage, decisions, generatedAt, issuedAt }) {
   const ids = decisions.filter((d) => d.verdict === "DELETE").map((d) => d.id);
+  // Required, not defaulted to `generatedAt` or to `new Date()`. Both defaults
+  // are wrong in a way that only shows up on the replay path: `loadDecisions`
+  // returns the FILE's `generatedAt` for a `--decisions` run, so anchoring the
+  // expiry to it posts a list that expired before the operator saw it (a week-old
+  // decision file is already 96h past a 72h TTL), and an internal `new Date()`
+  // would make the record untestable at the boundary the TTL turns on.
+  if (typeof issuedAt !== "string" || Number.isNaN(Date.parse(issuedAt))) {
+    throw new Error(
+      `buildOfferedRecord needs an ISO issuedAt to anchor the ` +
+        `${OFFER_TTL_MS / HOUR_MS}h offer expiry, got ${JSON.stringify(issuedAt)}`,
+    );
+  }
   const record = {
     stage,
     // Over the ids, so a click carrying an earlier list's hash no longer matches
@@ -895,6 +929,13 @@ export function buildOfferedRecord({ stage, decisions, generatedAt }) {
     hash: contentHash(ids.join("\n")),
     ids,
     generatedAt,
+    // A SEPARATE field from `generatedAt`, and the distinction is the operator's
+    // (#149): `generatedAt` is when the classifier decided, `issuedAt` is when
+    // this record became clickable. A replay reposts old decisions, so only the
+    // second one can anchor an expiry. Deliberately NOT the Slack message `ts`,
+    // which is both caller-supplied in the callback payload and absent from the
+    // record until the best-effort second write lands.
+    issuedAt,
   };
   const serialized = JSON.stringify(record);
   if (serialized.length > MAX_PARAMETER_BYTES) {
@@ -908,6 +949,50 @@ export function buildOfferedRecord({ stage, decisions, generatedAt }) {
     );
   }
   return record;
+}
+
+/**
+ * Whether an offered record is still inside its 72h window (#149).
+ *
+ * Shared by the two sides that must agree: the scan uses it to decide whether
+ * overwriting a pending offer would destroy a live human approval, and the
+ * callback Lambda's own copy uses it to refuse a late click. Exported and pure so
+ * both boundaries are testable with an injected `now` rather than a sleep.
+ *
+ * An UNPARSEABLE or absent `issuedAt` reads as EXPIRED, which is the direction
+ * that fails closed on both sides: the callback refuses the click (the operator
+ * clicks again after the next scan) and the scan is free to replace the record.
+ * Reading it as live would do the opposite of both — accept a click against a
+ * record of unknown age, and wedge the schedule forever on a record it may never
+ * overwrite. Records written before this field existed are exactly this case.
+ */
+export function offerExpiry(record, now) {
+  // A non-string is refused rather than handed to `Date.parse`, which COERCES: a
+  // hand-edited record whose stamp is the number 2027 parses as a YEAR, giving a
+  // date in the future, a negative age, and a record that never expires — which on
+  // THIS side means a scan that refuses to replace it every week from now on, the
+  // permanent wedge the fail-open branches exist to avoid.
+  const issuedAtMs =
+    typeof record?.issuedAt === "string" ? Date.parse(record.issuedAt) : NaN;
+  // `ageMs` is left ABSENT rather than set to undefined, so a caller that
+  // interpolates it cannot render "NaNh" — the same shape the facade's twin
+  // returns for an unjudgeable stamp (TC-SLACKAPP-143 asserts no log line here
+  // ever contains NaN).
+  if (!Number.isFinite(issuedAtMs)) return { expired: true };
+  const ageMs = now - issuedAtMs;
+  // `>`, not `>=`: the record is live for exactly OFFER_TTL_MS. The boundary is
+  // asserted directly (TC-SLACKAPP-135) because an off-by-one here is invisible
+  // in every test that does not sit on it.
+  return { expired: ageMs > OFFER_TTL_MS, ageMs };
+}
+
+/** `72h`, `4h` — the TTL and an age, for one operator-facing sentence. */
+export function formatHours(ms) {
+  const hours = ms / HOUR_MS;
+  // One decimal only when it changes the number: "72h" reads as a policy, while
+  // "72.0h" reads as a measurement, and the age in the same sentence is a
+  // measurement ("4.5h").
+  return `${Number.isInteger(hours) ? hours : hours.toFixed(1)}h`;
 }
 
 /**
@@ -1075,6 +1160,64 @@ async function slackCall(method, body, { botToken, fetchImpl }) {
 }
 
 /**
+ * The offer currently occupying `approvals/offered`, if overwriting it would
+ * destroy a live human approval (#149).
+ *
+ * Returns null — meaning "go ahead" — for absent, unreadable, unparseable, an
+ * offer for another stage, an offer with no ids, and an offer past its TTL. That
+ * list is deliberately generous, and in the OPPOSITE direction from
+ * `loadOffered`'s equivalent checks in the callback: there an unreadable record
+ * must never widen what is APPLIED, so it fails closed; here it must never wedge
+ * the weekly scan on a record nobody can act on, so it fails open. The asymmetry
+ * is safe because the two guard different things — the callback refuses to delete
+ * against a record it cannot verify, and no click can succeed against a record
+ * this one skipped past.
+ *
+ * A zero-id offer is skipped because it has no Slack message and therefore no
+ * button: `postApprovalRequest` writes the record and returns without posting, so
+ * there is nothing pending for a human to review.
+ */
+async function readPendingOffer({ ssm, name, stage, now, log }) {
+  const { GetParametersCommand } = await import("@aws-sdk/client-ssm");
+  let raw;
+  try {
+    const response = await ssm.send(new GetParametersCommand({ Names: [name] }));
+    raw = (response.Parameters ?? []).find((p) => p.Name === name)?.Value;
+  } catch (err) {
+    // The NAME only, never the message: an SDK error can quote the value it
+    // rejected, and this parameter's value is the id list.
+    log(
+      `WARNING ${name} could not be read (${err.name ?? "unnamed error"}), so a ` +
+        `pending approval cannot be ruled out; offering anyway`,
+    );
+    return null;
+  }
+  if (!raw) return null;
+  let record;
+  try {
+    record = JSON.parse(raw);
+  } catch {
+    log(`${name} is not valid JSON; replacing it`);
+    return null;
+  }
+  if (!record || typeof record !== "object") return null;
+  // Stage-bound like every other read of this tree: a record naming another stage
+  // is not this stage's pending approval, and the parameter is per-stage anyway —
+  // so this only fires on a hand-edited or cross-wired record.
+  if (record.stage !== stage) {
+    log(
+      `${name} names stage ${JSON.stringify(String(record.stage))}, not this ` +
+        `stage's; replacing it`,
+    );
+    return null;
+  }
+  if (!Array.isArray(record.ids) || record.ids.length === 0) return null;
+  const { expired, ageMs } = offerExpiry(record, now);
+  if (expired) return null;
+  return { stage: record.stage, hash: record.hash, ids: record.ids, ageMs };
+}
+
+/**
  * Offer this run's deletions to the operator: write the record, then post the
  * message whose button the callback Lambda validates against it (#123).
  *
@@ -1091,6 +1234,16 @@ async function slackCall(method, body, { botToken, fetchImpl }) {
  * post returns, and the apply task needs it to `chat.update` the message it was
  * approved from. A stamp failure is reported, not raised — losing the audit-trail
  * update is strictly better than refusing an approval the operator can act on.
+ *
+ * That first write is also DESTRUCTIVE, which the scheduled scan (#149) turns from
+ * a footnote into a hazard: unattended, it would silently overwrite an offer a
+ * human is still deciding on, and the operator's click would then be refused as
+ * "regenerated" with no trace of what they were reviewing. So a LIVE offer — one
+ * inside `OFFER_TTL_MS` — is refused here instead. 72h against a weekly cadence
+ * means a scheduled scan can never actually hit this branch; it exists for the
+ * off-schedule run (an operator CLI invocation, a manual re-run after a failure)
+ * where two offers genuinely could contend. An EXPIRED offer is replaced without
+ * comment, which is what keeps the schedule self-healing.
  */
 export async function postApprovalRequest({
   ssm,
@@ -1098,14 +1251,30 @@ export async function postApprovalRequest({
   stage,
   decisions,
   generatedAt,
+  issuedAt,
   channel,
   botToken,
   fetchImpl,
+  now = Date.now,
   log = () => {},
 }) {
-  const record = buildOfferedRecord({ stage, decisions, generatedAt });
+  const record = buildOfferedRecord({ stage, decisions, generatedAt, issuedAt });
   const { PutParameterCommand } = await import("@aws-sdk/client-ssm");
   const name = `${ssmPrefix}/approvals/offered`;
+  const pending = await readPendingOffer({ ssm, name, stage, now: now(), log });
+  if (pending) {
+    // A THROW, not a `return {posted: false}`: `runCleanup` maps a post failure to
+    // exit 1 (deliberately — see its offer branch), and the schedule's task-exit
+    // alarm is what tells the operator a scan declined to run. Returning quietly
+    // would make a scan that offered nothing indistinguishable from a scan that
+    // found nothing.
+    throw new Error(
+      `an approval list for ${pending.stage} is still pending after ` +
+        `${formatHours(pending.ageMs)} of its ${formatHours(OFFER_TTL_MS)} window ` +
+        `(${pending.ids.length} id(s), ${pending.hash}) — refusing to overwrite a ` +
+        `list an operator may still be reviewing; it expires on its own`,
+    );
+  }
   const write = (value) =>
     ssm.send(
       new PutParameterCommand({
@@ -1832,7 +2001,15 @@ export async function runCleanup(opts, deps) {
     // keeps the #102 operator CLI working unchanged.
     if (deps.postApproval) {
       try {
-        const offer = await deps.postApproval({ decisions, generatedAt: decisionGeneratedAt });
+        const offer = await deps.postApproval({
+          decisions,
+          generatedAt: decisionGeneratedAt,
+          // THIS run's clock, not `decisionGeneratedAt`: on a `--decisions`
+          // replay the two differ by however long the file has sat, and anchoring
+          // the 72h window to the file's stamp would post a list that is already
+          // expired (#149).
+          issuedAt: new Date(clock()).toISOString(),
+        });
         log(
           `offered ${offer.record.ids.length} id(s) to Slack as ${offer.record.hash}` +
             (offer.posted ? "" : " (nothing posted)"),
@@ -3112,12 +3289,13 @@ async function buildPostApproval(opts, region, runtime) {
   // session and an advisory lock the next run needs released, while an SSM client
   // holds local sockets that the entrypoint's `process.exit` reclaims. `release`
   // is called only on the failure path above, where nothing gets to use it.
-  return async ({ decisions, generatedAt }) =>
+  return async ({ decisions, generatedAt, issuedAt }) =>
     postApprovalRequest({
       ssm,
       ssmPrefix,
       stage: opts.stage,
       decisions,
+      issuedAt,
       generatedAt,
       channel,
       botToken,

--- a/scripts/memory-cleanup.mjs
+++ b/scripts/memory-cleanup.mjs
@@ -1163,15 +1163,23 @@ async function slackCall(method, body, { botToken, fetchImpl }) {
  * The offer currently occupying `approvals/offered`, if overwriting it would
  * destroy a live human approval (#149).
  *
- * Returns null — meaning "go ahead" — for absent, unreadable, unparseable, an
- * offer for another stage, an offer with no ids, and an offer past its TTL. That
- * list is deliberately generous, and in the OPPOSITE direction from
- * `loadOffered`'s equivalent checks in the callback: there an unreadable record
- * must never widen what is APPLIED, so it fails closed; here it must never wedge
- * the weekly scan on a record nobody can act on, so it fails open. The asymmetry
- * is safe because the two guard different things — the callback refuses to delete
- * against a record it cannot verify, and no click can succeed against a record
- * this one skipped past.
+ * Returns null — meaning "go ahead" — for absent, unparseable, an offer for
+ * another stage, an offer with no ids, and an offer past its TTL. That list is
+ * deliberately generous, and in the OPPOSITE direction from `loadOffered`'s
+ * equivalent checks in the callback: there an UNJUDGEABLE record must never widen
+ * what is APPLIED, so it fails closed; here it must never wedge the weekly scan on
+ * a record nobody can act on, so it fails open. The asymmetry is safe because the
+ * two guard different things — the callback refuses to delete against a record it
+ * cannot verify, and no click can succeed against a record this one skipped past.
+ *
+ * A FAILED READ is the one exception, and it THROWS. Every case above judges a
+ * record this function actually saw; a `GetParameters` error means it saw nothing,
+ * so "no pending offer" is not a finding but an absence of evidence. Continuing
+ * would overwrite whatever is there — including a list a human is mid-review on,
+ * whose hash then stops matching, so their click is refused as "regenerated" and
+ * the reviewed list is gone. Throwing costs one skipped week, which `runCleanup`
+ * maps to exit 1 and the schedule's task-exit alarm reports; failing open costs a
+ * destroyed approval that nothing reports at all. TC-SLACKAPP-144 pins it.
  *
  * A zero-id offer is skipped because it has no Slack message and therefore no
  * button: `postApprovalRequest` writes the record and returns without posting, so
@@ -1184,13 +1192,13 @@ async function readPendingOffer({ ssm, name, stage, now, log }) {
     const response = await ssm.send(new GetParametersCommand({ Names: [name] }));
     raw = (response.Parameters ?? []).find((p) => p.Name === name)?.Value;
   } catch (err) {
-    // The NAME only, never the message: an SDK error can quote the value it
-    // rejected, and this parameter's value is the id list.
-    log(
-      `WARNING ${name} could not be read (${err.name ?? "unnamed error"}), so a ` +
-        `pending approval cannot be ruled out; offering anyway`,
+    // The NAME and the error's TYPE only, never its message: an SDK error can quote
+    // the value it rejected, and this parameter's value is the id list.
+    throw new Error(
+      `${name} could not be read (${err.name ?? "unnamed error"}), so a pending ` +
+        `approval cannot be ruled out — refusing to overwrite what may be a list ` +
+        `an operator is still reviewing`,
     );
-    return null;
   }
   if (!raw) return null;
   let record;

--- a/scripts/memory-cleanup.test.mjs
+++ b/scripts/memory-cleanup.test.mjs
@@ -5163,11 +5163,16 @@ describe("offering the list to Slack (#123)", () => {
     }
   });
 
-  it("TC-SLACKAPP-144 offers anyway when the record cannot be READ, without echoing the SDK's message", async () => {
-    // A throwing GetParameters is not evidence of no pending offer, so this branch
-    // fails OPEN and says so. The alternative — treating a transient SSM error as
-    // "something is pending" — stops the weekly scan on an AccessDenied that may
-    // have nothing to do with approvals.
+  it("TC-SLACKAPP-144 refuses to overwrite when the record cannot be READ, without echoing the SDK's message", async () => {
+    // The one case on this side that fails CLOSED, and the boundary of
+    // TC-SLACKAPP-143's fail-open table. Every case there judges a record the scan
+    // actually saw and found unactionable; a throwing GetParameters means it saw
+    // nothing, so "no pending offer" is an absence of evidence, not a finding.
+    // Offering anyway overwrites whatever is there — including a list a human is
+    // mid-review on, whose hash then stops matching, so their click is refused as
+    // "regenerated" and the reviewed list is gone with nothing reporting it.
+    // Refusing instead costs one skipped week that exits 1 and trips the
+    // task-exit alarm, which is the strictly louder failure.
     const fakes = offerFakes();
     const underlying = fakes.ssm.send;
     fakes.ssm.send = vi.fn(async (command) => {
@@ -5180,18 +5185,44 @@ describe("offering the list to Slack (#123)", () => {
       }
       return underlying(command);
     });
-    const log = vi.fn();
 
-    const result = await offer({ fakes, log, now: DURING }).promise;
-    expect(result.posted).toBe(true);
+    const error = await offer({ fakes, now: DURING }).promise.then(
+      () => undefined,
+      (err) => err,
+    );
 
-    const logged = log.mock.calls.flat().join("\n");
-    expect(logged).toMatch(/WARNING/u);
-    expect(logged).toMatch(/pending approval cannot be ruled out/u);
-    expect(logged).toContain("ValidationException");
+    expect(error?.message).toMatch(/could not be read/u);
+    expect(error?.message).toMatch(/pending approval cannot be ruled out/u);
+    // The error CLASS survives, because "AccessDenied" and "ValidationException"
+    // send the operator to different places, and the alarm carries no detail.
+    expect(error?.message).toContain("ValidationException");
     // An SDK error can quote the value it rejected, and this parameter's value is
-    // the id list — so the NAME is logged and the message is not.
-    expect(logged).not.toContain(SNIPPET);
+    // the id list — so the name and class are raised and the message is not.
+    expect(error?.message).not.toContain(SNIPPET);
+
+    // Read-before-write again, for the same reason as TC-SLACKAPP-140: a refusal
+    // that landed after the first write would have destroyed the record it was
+    // protecting on the way to complaining about it.
+    expect(fakes.ssm.puts).toEqual([]);
+    expect(fakes.slack.fetchImpl).not.toHaveBeenCalled();
+
+    // A throw carrying no `name` still has to read as a diagnosis. Nothing in the
+    // SDK does this, but an interceptor, an agent hook or a `throw "string"` in a
+    // fake does, and "could not be read (undefined)" is the kind of line an
+    // operator reads as a bug in the guard rather than a fault in SSM.
+    const nameless = offerFakes();
+    const plain = nameless.ssm.send;
+    nameless.ssm.send = vi.fn(async (command) => {
+      if (command?.input?.Names) throw { toString: () => `${SNIPPET}-leaked` };
+      return plain(command);
+    });
+    const bare = await offer({ fakes: nameless, now: DURING }).promise.then(
+      () => undefined,
+      (err) => err,
+    );
+    expect(bare?.message).toContain("unnamed error");
+    expect(bare?.message).not.toContain(SNIPPET);
+    expect(nameless.ssm.puts).toEqual([]);
   });
 
   it("TC-SLACKAPP-145 refuses to stamp a record without an issuedAt to anchor the window", async () => {

--- a/scripts/memory-cleanup.test.mjs
+++ b/scripts/memory-cleanup.test.mjs
@@ -20,6 +20,8 @@ import {
   createCleanupDeps,
   inactiveMemoryAdapter,
   materializeApprovedIds,
+  offerExpiry,
+  OFFER_TTL_MS,
   parseArgs,
   postApprovalRequest,
   updateApprovalMessage,
@@ -3907,8 +3909,20 @@ describe("the offered approval record (#123)", () => {
         { id: "m-unstable", verdict: "UNSTABLE", reason: "passes disagreed on deletion" },
       ],
       generatedAt: "2026-08-05T00:00:00.000Z",
+      issuedAt: "2026-08-05T00:00:00.000Z",
     });
-    expect(Object.keys(record).sort()).toEqual(["generatedAt", "hash", "ids", "stage"]);
+    // `issuedAt` joins the four, and the list stays CLOSED: it is a timestamp,
+    // the same class of value as `generatedAt`, and #149's whole reason for
+    // touching this record is to bound how long it stays clickable — not to widen
+    // what it may carry. #150's merged bytes go to a separate artifact precisely
+    // because they cannot come in here.
+    expect(Object.keys(record).sort()).toEqual([
+      "generatedAt",
+      "hash",
+      "ids",
+      "issuedAt",
+      "stage",
+    ]);
     expect(record.ids).toEqual(["m-1", "m-2"]);
     expect(record.stage).toBe("prod");
     expect(JSON.stringify(record)).not.toMatch(/SENTINEL-CONTENT/u);
@@ -3919,7 +3933,11 @@ describe("the offered approval record (#123)", () => {
     // `["a","bc"]` are one hash, and a click approving one list would be accepted
     // against the other.
     expect(record.hash).toMatch(/^sha256:[0-9a-f]{64}$/u);
-    const stamp = { stage: "prod", generatedAt: "2026-08-05T00:00:00.000Z" };
+    const stamp = {
+      stage: "prod",
+      generatedAt: "2026-08-05T00:00:00.000Z",
+      issuedAt: "2026-08-05T00:00:00.000Z",
+    };
     expect(buildOfferedRecord({ ...stamp, decisions: [del("ab"), del("c")] }).hash).not.toBe(
       buildOfferedRecord({ ...stamp, decisions: [del("a"), del("bc")] }).hash,
     );
@@ -3938,7 +3956,12 @@ describe("the offered approval record (#123)", () => {
     // failing on.
     const many = Array.from({ length: 200 }, (_, i) => del(`memory-with-a-realistic-id-${i}`));
     expect(() =>
-      buildOfferedRecord({ stage: "prod", decisions: many, generatedAt: "2026-08-05T00:00:00.000Z" }),
+      buildOfferedRecord({
+        stage: "prod",
+        decisions: many,
+        generatedAt: "2026-08-05T00:00:00.000Z",
+        issuedAt: "2026-08-05T00:00:00.000Z",
+      }),
     ).toThrow(/4096|parameter limit/u);
     // Asserted on the SERIALIZED length, not the id count: a limit expressed as
     // "N ids" drifts from the real constraint the moment ids get longer, and the
@@ -3947,6 +3970,7 @@ describe("the offered approval record (#123)", () => {
       stage: "prod",
       decisions: many.slice(0, 40),
       generatedAt: "2026-08-05T00:00:00.000Z",
+      issuedAt: "2026-08-05T00:00:00.000Z",
     });
     expect(JSON.stringify(ok).length).toBeLessThanOrEqual(4096);
     expect(ok.ids).toHaveLength(40);
@@ -4035,6 +4059,36 @@ describe("materializing the approved ids in the apply task (#123)", () => {
         claimParameterName(prefix, hash),
       );
     }
+  });
+
+  it("TC-SLACKAPP-137 the offer TTL this script stamps is the one the facade enforces", async () => {
+    // Same duplication, same lack of a shared module, and the same reason this is
+    // the only thing holding the two sides together — but a worse failure than
+    // TC-SLACKAPP-131's, because it is silent in BOTH directions and neither
+    // direction errors:
+    //   facade TTL SHORTER  -> a list is refused as expired while it is still the
+    //                          newest one posted. The operator is told to wait for
+    //                          the next scheduled scan, which posts the same list,
+    //                          which is refused again. No error, no alarm, cleanup
+    //                          simply never happens again.
+    //   facade TTL LONGER   -> the scan replaces a record the facade still honours.
+    //                          The overwrite guard reads the record as dead and
+    //                          clobbers a live one, which is precisely the hazard
+    //                          #149 added it to close.
+    const { OFFER_TTL_MS: facadeTtlMs } = await import(
+      "../infra/src/oauth-facade/slack-interactions.ts"
+    );
+    expect(facadeTtlMs).toBe(OFFER_TTL_MS);
+
+    // Not just equal numbers: the STAMPER's own boundary has to fall where the
+    // ENFORCER's constant puts it. Two constants can agree while `offerExpiry`
+    // compares against something else entirely (an hour count, a half-window, a
+    // `>=`), and that mistake survives an equality assertion untouched.
+    const issuedAt = "2026-08-06T00:00:00.000Z";
+    const issuedAtMs = Date.parse(issuedAt);
+    const record = { issuedAt };
+    expect(offerExpiry(record, issuedAtMs + facadeTtlMs).expired).toBe(false);
+    expect(offerExpiry(record, issuedAtMs + facadeTtlMs + 1).expired).toBe(true);
   });
 
   it("TC-SLACKAPP-091 the ids come from the CLAIM named by the hash, not from the offered record", async () => {
@@ -4601,11 +4655,29 @@ describe("offering the list to Slack (#123)", () => {
    * before the record it is validated against is a promise the backend cannot
    * keep.
    */
-  function offerFakes(slackBodies = {}) {
+  function offerFakes(slackBodies = {}, { pending } = {}) {
     const events = [];
     const ssm = {
       puts: [],
+      // Answers BOTH commands, keyed on which input shape arrived. Before #149
+      // this fake replied `{}` to everything, which happens to read as "no
+      // pending offer" — so the refuse-to-overwrite branch would have been
+      // invisible here rather than tested. `pending` seeds the record the scan
+      // finds already in place; the reads themselves are asserted through
+      // `events`, which is what pins the read BEFORE the first write.
       send: vi.fn(async (command) => {
+        const names = command?.input?.Names;
+        if (names) {
+          events.push(["ssm-get", ...names]);
+          // The shape SSM really returns, as `fakeSsm` above models it: an absent
+          // name is echoed in `InvalidParameters` and simply MISSING from
+          // `Parameters`, never present with an empty value.
+          if (pending === undefined) return { Parameters: [], InvalidParameters: names };
+          return {
+            Parameters: names.map((name) => ({ Name: name, Value: pending })),
+            InvalidParameters: [],
+          };
+        }
         events.push(["ssm", command.input.Name]);
         ssm.puts.push(command.input);
         return {};
@@ -4650,9 +4722,11 @@ describe("offering the list to Slack (#123)", () => {
         stage: "prod",
         decisions: overrides.decisions ?? [del("m-1"), del("m-2")],
         generatedAt: "2026-08-05T03:00:00.000Z",
+        issuedAt: overrides.issuedAt ?? "2026-08-05T03:00:00.000Z",
         channel: CHANNEL,
         botToken: BOT_TOKEN,
         fetchImpl: slack.fetchImpl,
+        now: overrides.now,
         log: overrides.log ?? vi.fn(),
       }),
     };
@@ -4668,7 +4742,11 @@ describe("offering the list to Slack (#123)", () => {
     // rejects with "there is no current approval list" — a spent click and an
     // operator hunting a backend fault. The write is also what INVALIDATES last
     // week's button, so it must not be reachable only through the post.
+    // The READ comes first (#149): overwriting a record an operator is still
+    // deciding on destroys their pending approval, so the scan checks before it
+    // clobbers. Everything after it is the original #123 order.
     expect(fakes.events).toEqual([
+      ["ssm-get", OFFERED],
       ["ssm", OFFERED],
       ["slack", "chat.postMessage"],
       ["ssm", OFFERED],
@@ -4682,9 +4760,20 @@ describe("offering the list to Slack (#123)", () => {
     expect(first.Type).toBe("String");
     expect(first.Overwrite).toBe(true);
     const record = JSON.parse(first.Value);
-    expect(Object.keys(record).sort()).toEqual(["generatedAt", "hash", "ids", "stage"]);
+    expect(Object.keys(record).sort()).toEqual([
+      "generatedAt",
+      "hash",
+      "ids",
+      "issuedAt",
+      "stage",
+    ]);
     expect(record.ids).toEqual(["m-1", "m-2"]);
     expect(record.hash).toBe(contentHash("m-1\nm-2"));
+    // The value the callback measures its TTL against, so it must reach SSM on
+    // the FIRST write — the one that happens before the button exists. Stamped
+    // only on the second write it would be absent for the whole window between
+    // the post and the stamp, and an absent `issuedAt` reads as expired.
+    expect(record.issuedAt).toBe("2026-08-05T03:00:00.000Z");
     expect(result.record.hash).toBe(record.hash);
     expect(result.messageTs).toBe("1754400000.000100");
   });
@@ -4749,6 +4838,7 @@ describe("offering the list to Slack (#123)", () => {
         stage: "prod",
         decisions: small,
         generatedAt: "2026-08-05T03:00:00.000Z",
+        issuedAt: "2026-08-05T03:00:00.000Z",
       }),
       decisions: small,
       channel: CHANNEL,
@@ -4824,6 +4914,12 @@ describe("offering the list to Slack (#123)", () => {
     const flaky = offerFakes();
     let put = 0;
     flaky.ssm.send = vi.fn(async (command) => {
+      // Counts WRITES only. The pre-write read (#149) also arrives here, and
+      // counting it would make the throw land on the first write instead of the
+      // stamp — testing a different failure than the one this case names.
+      if (command?.input?.Names) {
+        return { Parameters: [], InvalidParameters: command.input.Names };
+      }
       put += 1;
       if (put === 2) throw new Error("ThrottlingException");
       flaky.ssm.puts.push(command.input);
@@ -4940,6 +5036,181 @@ describe("offering the list to Slack (#123)", () => {
 
     expect(result.exitCode).toBe(0);
     expect(postApproval.mock.calls[0][0].generatedAt).toBe("2026-07-24T00:00:00.000Z");
+  });
+
+  /**
+   * A pending record as it sits in SSM, for the overwrite guard's tests. Written
+   * out by hand rather than through `buildOfferedRecord` so that the shapes these
+   * tests care about — a missing `issuedAt`, a foreign stage — are statable at all.
+   */
+  const pendingRecord = (overrides = {}) =>
+    JSON.stringify({
+      stage: "prod",
+      hash: contentHash("m-pending"),
+      ids: ["m-pending"],
+      generatedAt: "2026-08-04T03:00:00.000Z",
+      issuedAt: "2026-08-04T03:00:00.000Z",
+      ...overrides,
+    });
+
+  // Two hours into the previous offer's window, i.e. deep inside its 72h.
+  const DURING = () => Date.parse("2026-08-04T05:00:00.000Z");
+
+  it("TC-SLACKAPP-140 refuses to overwrite an offer still inside its window, before writing anything", async () => {
+    // The hazard the schedule creates. Operator-initiated, the clobber was a
+    // footnote — the human running the scan is the same human holding the pending
+    // approval. Unattended it is a live approval destroyed at 03:00 by a scan
+    // nobody watched, and the operator's later click is refused as "regenerated"
+    // pointing at a message they never saw.
+    const fakes = offerFakes({}, { pending: pendingRecord() });
+    const log = vi.fn();
+
+    await expect(offer({ fakes, log, now: DURING }).promise).rejects.toThrow(
+      /still pending/u,
+    );
+
+    // NOTHING was written and nothing was posted. A guard that threw after the
+    // first write would have already destroyed the record it was protecting, and
+    // the message it raised would be about a record that no longer existed.
+    expect(fakes.ssm.puts).toEqual([]);
+    expect(fakes.slack.fetchImpl).not.toHaveBeenCalled();
+    expect(fakes.events).toEqual([["ssm-get", OFFERED]]);
+  });
+
+  it("TC-SLACKAPP-141 names the age, the window and the size in its refusal, and never the ids", async () => {
+    // This message is the whole diagnosis: the run exits non-zero, the alarm says
+    // only "task failed", and this line is what tells the operator the difference
+    // between "a human is mid-review, do nothing" and a real fault. So it has to
+    // carry the age (is this nearly expired?), the window (when does it clear?)
+    // and the size (is it the list I am looking at?).
+    const fakes = offerFakes({}, { pending: pendingRecord({ ids: ["m-a", "m-b"] }) });
+    const error = await offer({ fakes, now: DURING }).promise.then(
+      () => undefined,
+      (err) => err,
+    );
+
+    expect(error?.message).toMatch(/2h of its 72h window/u);
+    expect(error?.message).toMatch(/2 id\(s\)/u);
+    expect(error?.message).toContain(contentHash("m-pending"));
+    // The ids themselves stay out of it. This string reaches CloudWatch Logs and
+    // an operator's terminal, and the hash already identifies the list uniquely —
+    // TC-SLACKAPP-023's "ids and a hash only" is about what is stored, but a log
+    // line is a copy too.
+    expect(error?.message).not.toContain("m-a");
+    expect(error?.message).not.toContain("m-b");
+  });
+
+  it("TC-SLACKAPP-142 replaces an offer past its window, and one exactly at the boundary is still live", async () => {
+    // The other half: refusing forever would wedge the loop. An expired record is
+    // one no click can act on (the facade refuses it first), so replacing it costs
+    // nothing.
+    const issuedAt = "2026-08-04T03:00:00.000Z";
+    const at = (offsetMs) => () => Date.parse(issuedAt) + offsetMs;
+
+    const live = offerFakes({}, { pending: pendingRecord({ issuedAt }) });
+    await expect(
+      offer({ fakes: live, now: at(OFFER_TTL_MS) }).promise,
+    ).rejects.toThrow(/still pending/u);
+
+    // One millisecond later the same record is replaceable. Asserted as a PAIR
+    // because either bound alone passes with the comparison inverted or the window
+    // doubled.
+    const dead = offerFakes({}, { pending: pendingRecord({ issuedAt }) });
+    const result = await offer({ fakes: dead, now: at(OFFER_TTL_MS + 1) }).promise;
+    expect(result.posted).toBe(true);
+    expect(dead.ssm.puts).toHaveLength(2);
+    expect(JSON.parse(dead.ssm.puts[0].Value).ids).toEqual(["m-1", "m-2"]);
+  });
+
+  it("TC-SLACKAPP-143 treats a record it cannot judge as replaceable, in the opposite direction from the facade", async () => {
+    // The asymmetry is deliberate and it is the reason both sides are safe:
+    //   facade  — unreadable age reads EXPIRED (never apply against a record of
+    //             unknown age)
+    //   scan    — unreadable age reads REPLACEABLE (never wedge the weekly scan on
+    //             a record nobody can act on)
+    // Fail-closed on both sides deadlocks: a record with no `issuedAt` — every
+    // record written before #149 — would be un-appliable AND un-replaceable, and
+    // the loop would stop permanently with no error anywhere. The combination is
+    // safe precisely because no click can succeed against a record this scan
+    // skipped past.
+    const unjudgeable = [
+      ["no issuedAt at all", pendingRecord({ issuedAt: undefined })],
+      ["an unparseable issuedAt", pendingRecord({ issuedAt: "last tuesday" })],
+      ["a numeric issuedAt", pendingRecord({ issuedAt: 1754400000 })],
+      // The sharp one: `Date.parse` coerces, and it reads a small number as a
+      // YEAR, so `2027` is a date in the FUTURE — a negative age, a record that
+      // never expires, and a scan that refuses to replace it every week from now
+      // on. Every other numeric shape here yields NaN and is refused by a version
+      // that skips the type check too, so this is the only case that pins it.
+      ["a year-shaped issuedAt", pendingRecord({ issuedAt: 2027 })],
+      ["not JSON", "{not json"],
+      ["not an object", '"a string"'],
+      ["another stage's record", pendingRecord({ stage: "pr-123" })],
+      ["no ids left to approve", pendingRecord({ ids: [] })],
+    ];
+
+    for (const [what, pending] of unjudgeable) {
+      const fakes = offerFakes({}, { pending });
+      const log = vi.fn();
+      const result = await offer({ fakes, log, now: DURING }).promise;
+      expect(result.posted, what).toBe(true);
+      expect(fakes.slack.fetchImpl, what).toHaveBeenCalled();
+      // Whatever it says about the record, it must not render an unparsed date as
+      // arithmetic on it: "expired 4 hours ago" and "NaNh" are both worse than
+      // silence.
+      const logged = log.mock.calls.flat().join("\n");
+      expect(logged, what).not.toMatch(/NaN|Invalid Date/u);
+    }
+  });
+
+  it("TC-SLACKAPP-144 offers anyway when the record cannot be READ, without echoing the SDK's message", async () => {
+    // A throwing GetParameters is not evidence of no pending offer, so this branch
+    // fails OPEN and says so. The alternative — treating a transient SSM error as
+    // "something is pending" — stops the weekly scan on an AccessDenied that may
+    // have nothing to do with approvals.
+    const fakes = offerFakes();
+    const underlying = fakes.ssm.send;
+    fakes.ssm.send = vi.fn(async (command) => {
+      if (command?.input?.Names) {
+        const err = new Error(
+          `ValidationException: value ${SNIPPET}-leaked is not permitted`,
+        );
+        err.name = "ValidationException";
+        throw err;
+      }
+      return underlying(command);
+    });
+    const log = vi.fn();
+
+    const result = await offer({ fakes, log, now: DURING }).promise;
+    expect(result.posted).toBe(true);
+
+    const logged = log.mock.calls.flat().join("\n");
+    expect(logged).toMatch(/WARNING/u);
+    expect(logged).toMatch(/pending approval cannot be ruled out/u);
+    expect(logged).toContain("ValidationException");
+    // An SDK error can quote the value it rejected, and this parameter's value is
+    // the id list — so the NAME is logged and the message is not.
+    expect(logged).not.toContain(SNIPPET);
+  });
+
+  it("TC-SLACKAPP-145 refuses to stamp a record without an issuedAt to anchor the window", async () => {
+    // `buildOfferedRecord` will not default this, and the two defaults it could
+    // plausibly take are both wrong in ways that only appear on the replay path:
+    // `generatedAt` dates the record to the FILE's stamp (so a `--decisions` repost
+    // of a four-day-old review posts a list already expired on arrival), and
+    // `new Date()` inside the builder makes the stamp untestable and silently
+    // ignores the run's own clock.
+    for (const issuedAt of [undefined, "", "yesterday", 1754400000, null]) {
+      expect(() =>
+        buildOfferedRecord({
+          stage: "prod",
+          decisions: [del("m-1")],
+          generatedAt: "2026-08-05T03:00:00.000Z",
+          issuedAt,
+        }),
+      ).toThrow(/issuedAt/u);
+    }
   });
 });
 
@@ -5077,6 +5348,7 @@ describe("wiring the offer into the review run (#123)", () => {
         },
       ],
       generatedAt: "2026-08-05T03:00:00.000Z",
+      issuedAt: "2026-08-05T03:00:00.000Z",
     });
 
     expect(offer.posted).toBe(true);

--- a/scripts/run-slack-approval-e2e.sh
+++ b/scripts/run-slack-approval-e2e.sh
@@ -13,7 +13,9 @@
 # facade that accepted an unsigned interaction would pass every other check here.
 # It has to precede the valid click so "no record was written" is assertable at
 # all — after a successful click there is a record, and nothing can then tell the
-# two writers apart.
+# two writers apart. The expired-offer probe (#149) is second for the same reason:
+# it is a correctly signed click that must be REFUSED and must write nothing, and
+# only a run with no claim yet can prove the second half.
 #
 # The approved id is a synthetic sentinel that names no real memory. This
 # approves a DELETION against a live stage, so an id that resolved to preview
@@ -120,11 +122,29 @@ cleanup() {
 }
 trap cleanup EXIT
 
-OFFERED=$(jq -cn --arg stage "$STAGE" --arg hash "$IDS_HASH" --arg id "$APPROVED_ID" \
-  '{stage: $stage, hash: $hash, ids: [$id], generatedAt: (now | todate)}')
-echo "run-slack-approval-e2e: seeding ${OFFERED_NAME} with one synthetic id"
-aws ssm put-parameter --name "$OFFERED_NAME" --type String --value "$OFFERED" \
-  --overwrite --region "$REGION" >/dev/null
+# `issuedAt` is what the facade measures the 72h offer window against (#149), and
+# it is REQUIRED here rather than optional: an absent or unparseable stamp reads as
+# EXPIRED on the callback side, so a record seeded without one is refused and the
+# whole check below fails at "no approval record after a 200". `jq`'s `now` rather
+# than `date -u -d`, which is GNU-only — this script also runs on macOS `shasum`.
+#
+# Ages are seconds off `now` so the two cases below stay readable: `0` is a list
+# issued this instant, and `OFFER_EXPIRED_AGE` is comfortably past the window
+# rather than one second over it, so a clock skew between the runner and the Lambda
+# cannot make the expired case accidentally live.
+OFFER_EXPIRED_AGE=$((96 * 3600))
+seed_offer() {
+  local age="$1" record
+  record=$(jq -cn --arg stage "$STAGE" --arg hash "$IDS_HASH" --arg id "$APPROVED_ID" \
+    --argjson age "$age" \
+    '{stage: $stage,
+      hash: $hash,
+      ids: [$id],
+      generatedAt: (now - $age | todate),
+      issuedAt: (now - $age | todate)}')
+  aws ssm put-parameter --name "$OFFERED_NAME" --type String --value "$record" \
+    --overwrite --region "$REGION" >/dev/null
+}
 
 # Slack's own encoding: form-urlencoded with the JSON in a `payload` field. A
 # JSON body would 400 here and pass nothing but a smoke test.
@@ -183,7 +203,45 @@ if aws ssm get-parameter --name "$CLAIM_NAME" --region "$REGION" >/dev/null 2>&1
   exit 1
 fi
 
-# 2. The correctly signed click.
+# 2. The EXPIRED offer (#149). A correctly signed click against a list issued
+#    outside the 72h window must be refused, and must write no claim.
+#
+#    This runs before the live click and after the 401 for the same reason the 401
+#    comes first: "no claim was written" is only assertable while no claim exists.
+#    Reversed, the expired probe would have to prove the absence of a record the
+#    successful click had already created.
+#
+#    The refusal is an HTTP 200 with an ephemeral Slack message, not an error
+#    status — Slack renders a non-200 as its own "operation failed" and the
+#    operator never sees the reason. So the status alone cannot distinguish this
+#    from an ACCEPTED click; the body and the absent claim are what do.
+echo "run-slack-approval-e2e: seeding ${OFFERED_NAME} with a list issued $((OFFER_EXPIRED_AGE / 3600))h ago"
+seed_offer "$OFFER_EXPIRED_AGE"
+echo "run-slack-approval-e2e: POSTing a signed click against the expired list (expecting a refusal)"
+EXPIRED_STATUS=$(post "$SIGNATURE" "$RESPONSE_BODY")
+if [[ "$EXPIRED_STATUS" != "200" ]]; then
+  echo "::error::the click against an expired list was answered HTTP ${EXPIRED_STATUS}, not 200 — Slack shows the operator no reason for a non-200" >&2
+  exit 1
+fi
+# `expire` is the one word no OTHER refusal in the handler uses: "regenerated",
+# "names stage", "could not be read" and "already been applied" are all 200s with a
+# body too, so matching a generic "nothing was applied" would pass on a stale-hash
+# refusal and prove nothing about the TTL.
+EXPIRED_REPLY=$(<"$RESPONSE_BODY")
+if ! grep -qi 'expire' <<<"$EXPIRED_REPLY"; then
+  echo "::error::the click against an expired list was not refused as expired: ${EXPIRED_REPLY}" >&2
+  exit 1
+fi
+if aws ssm get-parameter --name "$CLAIM_NAME" --region "$REGION" >/dev/null 2>&1; then
+  echo "::error::an expired approval still wrote a claim — the refusal is cosmetic and an apply may have started" >&2
+  exit 1
+fi
+
+# 3. The correctly signed click against a LIVE list. Reseeded rather than reusing
+#    the record above: same ids and therefore the same hash, so what changes
+#    between the refusal and the acceptance is only `issuedAt`.
+echo "run-slack-approval-e2e: seeding ${OFFERED_NAME} with one synthetic id, issued now"
+seed_offer 0
 echo "run-slack-approval-e2e: POSTing a correctly signed interaction (expecting 200)"
 GOOD_STATUS=$(post "$SIGNATURE" "$RESPONSE_BODY")
 if [[ "$GOOD_STATUS" != "200" ]]; then
@@ -191,8 +249,9 @@ if [[ "$GOOD_STATUS" != "200" ]]; then
   exit 1
 fi
 
-# 3. The RECORD, read back by name. A 200 alone proves nothing: the handler also
-#    answers 200 for a stale hash, an unknown action, and "already applied".
+# 4. The RECORD, read back by name. A 200 alone proves nothing: the handler also
+#    answers 200 for a stale hash, an expired list, an unknown action, and
+#    "already applied".
 echo "run-slack-approval-e2e: reading the approval record back by name"
 CLAIM=""
 for attempt in 1 2 3 4 5 6; do
@@ -213,7 +272,7 @@ if [[ -z "$TASK_ARN" ]]; then
 fi
 echo "run-slack-approval-e2e: apply task ${TASK_ARN##*/} started"
 
-# 4. The apply task's own exit code. Without this the check passes on a click
+# 5. The apply task's own exit code. Without this the check passes on a click
 #    that started a task which then crashed.
 #
 # The cluster comes from SSM, NOT from slicing the task ARN. `${TASK_ARN##*:task/}`
@@ -287,4 +346,4 @@ if [[ -n "$STOP_REASON" && "$STOP_REASON" != "None" ]] \
   exit 1
 fi
 
-echo "run-slack-approval-e2e: OK — signed click accepted, record written, apply exited 0 on ${STAGE}"
+echo "run-slack-approval-e2e: OK — expired list refused, signed click accepted, record written, apply exited 0 on ${STAGE}"

--- a/scripts/run-slack-approval-e2e.test.mjs
+++ b/scripts/run-slack-approval-e2e.test.mjs
@@ -213,6 +213,7 @@ function runFixture({
   stoppedReason = "Essential container in task exited",
   facadeError = "",
   noisyStderr = "",
+  expiryBehavior = "refuse",
 } = {}) {
   const directory = mkdtempSync(join(tmpdir(), "mem9-slack-e2e-"));
   temporaryPaths.push(directory);
@@ -229,7 +230,7 @@ function runFixture({
     // forever. That is not hypothetical; it once spawned ~70k processes and
     // exhausted the systemd user slice's TasksMax.
     `#!${process.execPath}
-import { appendFileSync, existsSync } from "node:fs";
+import { appendFileSync, existsSync, writeFileSync } from "node:fs";
 const args = process.argv.slice(2);
 appendFileSync(process.env.MOCK_CALLS, JSON.stringify(["aws", ...args]) + "\\n");
 const option = (name) => {
@@ -289,7 +290,18 @@ if (command === "ssm get-parameter") {
     console.error("unexpected parameter:", name);
     process.exit(2);
   }
-} else if (command === "ssm put-parameter" || command === "ssm delete-parameter") {
+} else if (command === "ssm put-parameter") {
+  // The offered record is kept, not discarded, because the fake facade below
+  // decides the TTL question from it — exactly as the real handler does, which
+  // reads \`approvals/offered\` rather than trusting anything in the payload. A fake
+  // that answered every signed click identically could not tell an expired list
+  // from a live one, so the expiry step would pass against a handler with no
+  // expiry check at all (#149).
+  if ((option("--name") ?? "").endsWith("/approvals/offered")) {
+    writeFileSync(process.env.MOCK_OFFERED, option("--value") ?? "");
+  }
+  process.exit(0);
+} else if (command === "ssm delete-parameter") {
   process.exit(0);
 } else if (command === "ecs describe-tasks") {
   const query = option("--query") ?? "";
@@ -318,11 +330,18 @@ if (command === "ssm get-parameter") {
 
   // The fake `curl` decides which POST it is by the SIGNATURE header, exactly as
   // the real endpoint does: that is the one thing this E2E exists to exercise.
+  //
+  // It also re-implements the handler's ONE other decision the harness now depends
+  // on — the 72h offer window — by reading the seeded `approvals/offered` record,
+  // which is where the real `loadOffered` reads it from too. Modelling it rather
+  // than answering every signed click alike is what gives the expiry step teeth: a
+  // fake that always accepted would pass the same whether the script stamped
+  // `issuedAt` or not, which is the exact regression this exists to catch.
   const curl = join(bin, "curl");
   writeFileSync(
     curl,
     `#!${process.execPath}
-import { appendFileSync, writeFileSync } from "node:fs";
+import { appendFileSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 const args = process.argv.slice(2);
 appendFileSync(process.env.MOCK_CALLS, JSON.stringify(["curl", ...args]) + "\\n");
 const option = (name) => {
@@ -332,14 +351,61 @@ const option = (name) => {
 const headers = args.filter((a, i) => args[i - 1] === "-H");
 const signature = headers.find((h) => /^x-slack-signature:/i.test(h)) ?? "";
 const invalid = /deadbeef|invalid/i.test(signature);
-const status = invalid ? process.env.MOCK_BAD_STATUS : process.env.MOCK_APPROVE_STATUS;
+// OFFER_TTL_MS, duplicated a third time and deliberately not imported: the value
+// lives in a .ts Lambda source and a .mjs container script, and this fake is
+// neither. TC-SLACKAPP-137 pins the two REAL copies to each other; this one only
+// has to be the same order of magnitude as the ages the script seeds, which are
+// "now" and "96h ago".
+const OFFER_TTL_MS = 72 * 60 * 60 * 1000;
+// Absent or unparseable \`issuedAt\` is EXPIRED, matching \`offerExpiry\` in
+// infra/src/oauth-facade/slack-interactions.ts. That direction is what makes an
+// unstamped seed a FAILURE here rather than a silent pass: a fake that treated an
+// unknown age as live would accept the click and the harness would report green
+// against a facade that refuses every one of its clicks in production.
+const offered = existsSync(process.env.MOCK_OFFERED)
+  ? JSON.parse(readFileSync(process.env.MOCK_OFFERED, "utf8") || "{}")
+  : {};
+const issuedAtMs = Date.parse(offered.issuedAt ?? "");
+const expired = !Number.isFinite(issuedAtMs) || Date.now() - issuedAtMs > OFFER_TTL_MS;
+// How this fake facade answers a click against an expired list. \`refuse\` is the
+// real handler; the other three are the ways it could be broken, and each has to
+// be REACHABLE for the script's expiry step to be worth anything — \`accept\` is a
+// facade with no TTL check at all, \`cosmetic\` is one whose refusal message is
+// right but which claims the approval anyway (so an apply starts), and \`error\`
+// answers the refusal with a 5xx, which Slack renders as its own "operation
+// failed" and shows the operator no reason at all.
+const behavior = process.env.MOCK_EXPIRY_BEHAVIOR || "refuse";
+const refused = expired && behavior !== "accept";
+// Slack renders a non-200 as its own "operation failed" and shows the operator
+// nothing, so EVERY refusal the real handler makes goes through \`reply()\` — a 200
+// with an ephemeral body. The refusal is in the body, never the status.
+//
+// Hence MOCK_APPROVE_STATUS answers only the click the facade ACCEPTS, and a
+// refusal's status is independent of it: keeping the two knobs separate is what
+// lets one fixture test a broken transport on the live click without also failing
+// the expiry step two steps earlier.
+let status;
+if (invalid) status = process.env.MOCK_BAD_STATUS;
+else if (!refused) status = process.env.MOCK_APPROVE_STATUS;
+else status = behavior === "error" ? "500" : "200";
 const body = invalid
   ? "unauthorized"
-  : JSON.stringify({ response_type: "ephemeral", text: "Apply started for 1 memories." });
+  : JSON.stringify({
+      response_type: "ephemeral",
+      text: refused
+        ? "That list was issued a while ago and approvals expire after 72h. Nothing was applied."
+        : "Apply started for 1 memories.",
+    });
 const out = option("-o");
 if (out) writeFileSync(out, body);
-// A 200 on the VALID signature is what creates the claim on a real stage.
-if (!invalid && status === "200") writeFileSync(process.env.MOCK_CLICKED, "1");
+// A 200 on the VALID signature is what creates the claim on a real stage — but
+// only when the handler did not refuse. \`cosmetic\` claims despite refusing, which
+// is the whole point of it.
+const accepted = !invalid && !refused && status === "200";
+const claimedDespiteRefusing = !invalid && refused && behavior === "cosmetic";
+if (accepted || claimedDespiteRefusing) {
+  writeFileSync(process.env.MOCK_CLICKED, "1");
+}
 process.stdout.write(status);
 `,
     { mode: 0o755 },
@@ -356,6 +422,10 @@ process.stdout.write(status);
       ...process.env,
       MOCK_CALLS: calls,
       MOCK_CLICKED: join(directory, "clicked"),
+      // Where the fake `aws` records the seeded offered record and the fake `curl`
+      // reads it back, standing in for the SSM parameter both really use.
+      MOCK_OFFERED: join(directory, "offered.json"),
+      MOCK_EXPIRY_BEHAVIOR: expiryBehavior,
       MOCK_FACADE: facade,
       MOCK_SECRET: secret,
       MOCK_BAD_STATUS: badSignatureStatus,
@@ -400,20 +470,23 @@ describe("Slack approval E2E harness (TC-SLACKAPP-090)", () => {
     const { callRecords, result, output } = runFixture({ claim: claimWith() });
     expect(result.status, output).toBe(0);
 
+    // Three POSTs: the invalid signature, the expired list (TC-SLACKAPP-155), and
+    // the live click.
     const curls = callRecords.filter(([tool]) => tool === "curl");
-    expect(curls).toHaveLength(2);
+    expect(curls).toHaveLength(3);
 
     // The INVALID signature goes first, so "no record" is asserted before the
     // valid click creates one. Reversed, the 401 case would have to assert the
     // absence of a record that already exists, which nothing can do.
-    const [bad, good] = curls;
+    const [bad, , good] = curls;
     expect(bad.join(" ")).toMatch(/x-slack-signature:\s*v0=deadbeef/iu);
     expect(good.join(" ")).toMatch(/x-slack-signature:\s*v0=[0-9a-f]{64}/u);
 
-    // Same body both times. A different body would make the 401 provable by the
-    // body rather than by the signature, which is not the property under test.
+    // Same body every time. A different body would make the 401 provable by the
+    // body rather than by the signature, which is not the property under test —
+    // and would likewise make the expiry refusal provable by the stale-hash guard.
     const bodyOf = (call) => call[call.indexOf("--data-binary") + 1];
-    expect(bodyOf(bad)).toBe(bodyOf(good));
+    for (const call of curls) expect(bodyOf(call)).toBe(bodyOf(good));
     expect(bodyOf(good)).toMatch(/^payload=/u);
     expect(decodeURIComponent(bodyOf(good).slice("payload=".length))).toContain(
       "cleanup_approve",
@@ -703,6 +776,127 @@ describe("Slack approval E2E harness (TC-SLACKAPP-090)", () => {
     // silently stop testing anything while reporting green.
     const { result } = runFixture({ stage: "prod", claim: claimWith() });
     expect(result.status).toBe(1);
+  });
+
+  it("TC-SLACKAPP-155 stamps issuedAt on the seeded offer, so the facade's TTL gate can pass it", () => {
+    // The omission this case exists for was FATAL, not cosmetic. `offerExpiry` in
+    // infra/src/oauth-facade/slack-interactions.ts reads an absent `issuedAt` as
+    // EXPIRED (fail-closed: never apply against a record of unknown age), so a seed
+    // carrying only `generatedAt` is refused at the expiry gate and the run dies
+    // four steps later at "no approval record after a 200" — a message that names
+    // the claim write and sends the reader to the Lambda's SSM grants.
+    const { callRecords, result, output } = runFixture({ claim: claimWith() });
+    expect(result.status, output).toBe(0);
+
+    const seeds = callRecords.filter(
+      ([tool, service, operation, , name]) =>
+        tool === "aws" &&
+        service === "ssm" &&
+        operation === "put-parameter" &&
+        String(name).endsWith("/approvals/offered"),
+    );
+    // Two seeds: the expired probe, then the live list. Both are asserted, because
+    // a script that stamped only the live one would leave the expiry step passing
+    // for the WRONG reason — an unstamped record is refused as expired too.
+    expect(seeds).toHaveLength(2);
+    const records = seeds.map((call) => JSON.parse(call[call.indexOf("--value") + 1]));
+    for (const record of records) {
+      expect(typeof record.issuedAt).toBe("string");
+      // A real timestamp, not the string "now" or an empty field: `Date.parse` is
+      // what the facade calls, and it is the only judge that matters.
+      expect(Number.isFinite(Date.parse(record.issuedAt))).toBe(true);
+    }
+
+    // The two ages, which is what the pair of steps is FOR: one outside the 72h
+    // window and one inside it. Both derived from the same clock, so this holds
+    // regardless of when the suite runs.
+    const OFFER_TTL_MS = 72 * 60 * 60 * 1000;
+    const ages = records.map((record) => Date.now() - Date.parse(record.issuedAt));
+    expect(ages[0]).toBeGreaterThan(OFFER_TTL_MS);
+    expect(ages[1]).toBeLessThan(OFFER_TTL_MS);
+
+    // Same ids, therefore the same hash: what changes between the refusal and the
+    // acceptance is `issuedAt` alone. A differing hash would make the refusal
+    // provable by the stale-hash guard instead of the TTL — the same
+    // same-body discipline the invalid-signature POST follows.
+    expect(records[0].hash).toBe(records[1].hash);
+    expect(records[0].ids).toEqual(records[1].ids);
+  });
+
+  it("TC-SLACKAPP-155 a facade that accepts an expired list fails the run", () => {
+    // The property the expiry step actually asserts. Without a fake that can be
+    // WRONG about the TTL, the step passes against a facade with no TTL check at
+    // all, and the harness would report green on exactly the regression #149 adds
+    // the gate to prevent.
+    const { result, output } = runFixture({
+      claim: claimWith(),
+      expiryBehavior: "accept",
+    });
+    expect(result.status, output).not.toBe(0);
+    expect(output).toMatch(/not refused as expired/iu);
+  });
+
+  it("TC-SLACKAPP-155 a refusal that still claims the approval fails the run", () => {
+    // A facade whose MESSAGE is right and whose behaviour is not: it tells the
+    // operator the list expired and starts the apply anyway. The reply assertion
+    // alone cannot see this — only reading the claim back can, which is why the
+    // expiry step ends with the same by-name read the 401 step uses.
+    const { result, output } = runFixture({
+      claim: claimWith(),
+      expiryBehavior: "cosmetic",
+    });
+    expect(result.status, output).not.toBe(0);
+    expect(output).toMatch(/the refusal is cosmetic/iu);
+  });
+
+  it("TC-SLACKAPP-155 a refusal answered with a 5xx fails the run", () => {
+    // The refusal has to reach the OPERATOR, and Slack only renders a body it got
+    // with a 200 — a non-200 becomes its own "operation failed" notice with no
+    // reason in it. So a facade that refused correctly but answered 500 has an
+    // expiry gate nobody can see the output of, which is a different bug from an
+    // absent gate and is not covered by the message assertion.
+    const { result, output } = runFixture({
+      claim: claimWith(),
+      expiryBehavior: "error",
+    });
+    expect(result.status, output).not.toBe(0);
+    expect(output).toMatch(/answered HTTP 500, not 200/u);
+    expect(output).toMatch(/shows the operator no reason/iu);
+  });
+
+  it("TC-SLACKAPP-155 the expired probe runs before any claim exists", () => {
+    // Ordering, asserted rather than left to a comment. "An expired approval wrote
+    // no claim" is only provable while no claim exists, so the probe has to sit
+    // after the 401 and before the live click — and a maintainer moving it below
+    // the successful click would find it passing vacuously against the record that
+    // click created.
+    const { callRecords, result, output } = runFixture({ claim: claimWith() });
+    expect(result.status, output).toBe(0);
+    const isSeed = ([tool, service, operation, , name]) =>
+      tool === "aws" &&
+      service === "ssm" &&
+      operation === "put-parameter" &&
+      String(name).endsWith("/approvals/offered");
+    const clicks = callRecords
+      .map((call, index) => ({ call, index }))
+      .filter(({ call }) => call[0] === "curl");
+    expect(clicks).toHaveLength(3);
+    const [bad, expiredClick, live] = clicks;
+    expect(bad.call.join(" ")).toMatch(/x-slack-signature:\s*v0=deadbeef/iu);
+    // The expired click is correctly SIGNED — the refusal is the TTL's doing, not
+    // the signature's. Sharing the signature with the live click is what proves it.
+    const signatureOf = (call) => call[call.indexOf("-H") + 1];
+    expect(expiredClick.call.join(" ")).toMatch(/x-slack-signature:\s*v0=[0-9a-f]{64}/u);
+    expect(signatureOf(expiredClick.call)).toBe(signatureOf(live.call));
+
+    // And each click is preceded by the seed it is about: no seed before the 401
+    // (nothing is written until the signature is proven to be rejected), one
+    // before each of the other two.
+    const seedsBefore = (index) =>
+      callRecords.filter((call, i) => i < index && isSeed(call)).length;
+    expect(seedsBefore(bad.index)).toBe(0);
+    expect(seedsBefore(expiredClick.index)).toBe(1);
+    expect(seedsBefore(live.index)).toBe(2);
   });
 
   it("TC-SLACKAPP-090 the approved id cannot name a real memory", () => {

--- a/scripts/workload-permissions-boundary-contract.json
+++ b/scripts/workload-permissions-boundary-contract.json
@@ -13,7 +13,7 @@
     {
       "id": "infra-ci.yml",
       "path": ".github/workflows/infra-ci.yml",
-      "reviewedBlob": "3e8a8fccea16f47d91ed9189f0c8b5b4893c3872"
+      "reviewedBlob": "6b115a9b49155bca3ccecb0d824540be26240826"
     },
     {
       "id": "reconcile-previews.yml",

--- a/scripts/workload-permissions-boundary.test.mjs
+++ b/scripts/workload-permissions-boundary.test.mjs
@@ -121,6 +121,16 @@ const patterns = expectedRolePatterns({ partition, accountId });
 const consolidationSchedulerRolePattern =
   `arn:${partition}:iam::${accountId}:role/` +
   "mem9-on-a*-*Mem9ConsolidationSchedulerRole-*";
+// The #149 weekly cleanup scan's Scheduler role. A SECOND pattern under the SAME
+// deploy-role Sids, because those Sids are looked up by name by the boundary
+// audit and recorded in the deployed rollout state.
+const cleanupSchedulerRolePattern =
+  `arn:${partition}:iam::${accountId}:role/` +
+  "mem9-on-a*-*Mem9CleanupSchedulerRole-*";
+const schedulerRolePatterns = [
+  consolidationSchedulerRolePattern,
+  cleanupSchedulerRolePattern,
+];
 const denyPolicyId = DENY_DANGEROUS_POLICY_NAME;
 const denyPolicyArn = `arn:${partition}:iam::${accountId}:policy/${denyPolicyId}`;
 const independentRuntimeActions = [
@@ -1809,6 +1819,34 @@ describe("deployed PassRole scope", () => {
     ).toEqual(patterns);
   });
 
+  it("accepts BOTH scheduler roles in one statement, and either alone", () => {
+    // One statement naming both is the DEPLOYED shape after #149. Either alone is
+    // also valid, and that is not laxity: this function reads the LIVE deploy role,
+    // whose widening lands out of band via scripts/deploy-github-role.sh. Between
+    // that rollout and the stack deploy the live statement names one pattern while
+    // the repository names two, and a rollout must not fail on its own ordering.
+    for (const resources of [
+      schedulerRolePatterns,
+      [...schedulerRolePatterns].reverse(),
+      [consolidationSchedulerRolePattern],
+      [cleanupSchedulerRolePattern],
+    ]) {
+      expect(
+        extractPassRoleScope(
+          [
+            passRolePolicy([...patterns].reverse()),
+            consolidationSchedulerPassRolePolicy({ resources }),
+          ],
+          { partition, accountId },
+        ),
+        // The Scheduler statement contributes NOTHING to the returned scope — the
+        // roles it can reach are named by pattern, not discovered — so the answer
+        // is the generic set either way. A subset check that leaked these into the
+        // scope would make `discoverMatchingRoles` sweep the scheduler roles too.
+      ).toEqual(patterns);
+    }
+  });
+
   it.each([
     [
       "generic project roles",
@@ -1825,6 +1863,27 @@ describe("deployed PassRole scope", () => {
       consolidationSchedulerPassRolePolicy({
         resources: [
           `arn:${partition}:iam::${accountId}:role/other-scheduler-role-*`,
+        ],
+      }),
+    ],
+    [
+      // A subset check must still reject a KNOWN pattern smuggled in beside an
+      // unknown one — the case a naive `.some()` would pass.
+      "a known role beside an unknown one",
+      consolidationSchedulerPassRolePolicy({
+        resources: [
+          consolidationSchedulerRolePattern,
+          `arn:${partition}:iam::${accountId}:role/mem9-on-a*-*Mem9RogueSchedulerRole-*`,
+        ],
+      }),
+    ],
+    [
+      // And a repeat must not stand in for the second pattern.
+      "the same role twice",
+      consolidationSchedulerPassRolePolicy({
+        resources: [
+          cleanupSchedulerRolePattern,
+          cleanupSchedulerRolePattern,
         ],
       }),
     ],
@@ -8188,7 +8247,13 @@ describe("boundary and deploy-role templates", () => {
     ).toMatchObject({
       Effect: "Deny",
       Action: ["iam:PassRole"],
-      Resource: [consolidationSchedulerRolePattern],
+      // BOTH scheduler roles, in the order the lib's SCHEDULER_ROLE_TOKENS lists
+      // them. `toMatchObject` compares arrays positionally, so THIS assertion is
+      // what pins the order — `requireStatement` itself is set-based
+      // (`sameStringSet` sorts), so it would accept either arrangement. The point
+      // of pinning it here is drift against the deployed template's own ordering,
+      // not a claim that the runtime verifier cares.
+      Resource: schedulerRolePatterns,
       Condition: {
         StringNotEquals: {
           "iam:PassedToService": "scheduler.amazonaws.com",


### PR DESCRIPTION
Closes #149.

Nothing scheduled the cleanup scan, so no unattended run ever produced a Slack
approval. This adds that schedule, and bounds the offer it posts.

## What changed

**A weekly scan schedule** (`infra/slack-approval.ts`), Saturday 03:00, in its own
schedule group. The container override is a **dry run** — no `--apply`, no `--ids` —
so the scheduled task classifies, offers, and stops. It never takes the lockfile or
the shared DB mutex, because `runCleanup` returns from the dry-run branch before
either is acquired. `ENABLED` on prod only; every other stage is `DISABLED`.

**A 72h offer TTL, stamped on one side and enforced on the other.** The scan writes
`issuedAt` (`scripts/memory-cleanup.mjs`); the callback Lambda refuses a late click
against it (`infra/src/oauth-facade/slack-interactions.ts`) with a Slack reply that
says so, instead of approving a stale view of the store. `OFFER_TTL_MS` is duplicated
because the Lambda bundle and the container script share no module — the two copies
are pinned to each other by a test on the stamping side.

The two sides fail in **opposite directions on an unjudgeable stamp**, deliberately:
the callback treats it as EXPIRED (never apply against a record of unknown age), the
scan treats it as REPLACEABLE (never wedge the weekly scan). Failing closed on both
would deadlock permanently on any record written before this change.

**A refusal to overwrite a live offer.** The first write to `approvals/offered` is
destructive, which unattended turns from a footnote into a hazard: a 03:00 scan would
silently replace a list a human is mid-review on, and their click would then be
refused as "regenerated", pointing at a message they never saw. 72h against a weekly
cadence means a scheduled scan cannot actually hit this branch — it exists for the
off-schedule run where two offers genuinely contend. This also removes the clobbering
hazard `scripts/run-slack-approval-e2e.sh` already warned about.

A failed *read* of that parameter refuses too, and that one is the exception to the
fail-open table above: every other case judges a record the scan actually saw, while
a throwing `GetParameters` means it saw nothing — so "no pending offer" is an absence
of evidence, not a finding. It costs one skipped week at exit 1 with the task-exit
alarm firing, against a destroyed approval that nothing reports at all.

**Scheduler IAM** (`infra/cloudformation/github-actions-role.yaml`): the deploy role's
two scheduler Sids now name the cleanup scheduler role alongside the consolidation
one. `iam:PassRole` stays conditioned on `iam:PassedToService`; the existing
`PassRoleConstrained` statement does not cover Scheduler. The scheduler trust policy
uses `StringEquals` on the schedule **group** ARN — Scheduler supports no narrower
`aws:SourceArn` scoping.

MERGE stays withheld from the approval loop; replaying the reviewed decision list is
#150.

## Deploy ordering

Merging is safe with no deploy: both `MEM9_SLACK_APPROVAL_ENABLED` and
`MEM9_CLEANUP_SCAN_SCHEDULE_ENABLED` are unset, and the scan block sits inside the
former's early return, so nothing synthesizes.

The deploy-role widening must land **before** the next boundary rollout, not merely
before the first scan deploy: measured against the live role today, the full-list
frozen-state verifier already reports
`DenyConsolidationSchedulerRolePassToOtherServices is malformed`, because the deployed
policy still names only the consolidation pattern. `scripts/deploy-github-role.sh` is
the fix and is an out-of-band step.

## Testing

- Root suite 985/985, infra suite 336/336, typecheck clean.
- 26 new named cases (TC-SLACKAPP-130..155), doc'd in
  `docs/test-cases/slack-approval-loop.md`; TC-id parity between code and doc is exact
  in both directions (155/155).
- Every new guard was **mutation-probed**, not reviewed by inspection: the dedupe
  check, the PassRole subset check, both `Date.parse` coercion guards, the
  `issuedAt`-required throw, the overwrite refusal, the failed-read refusal, and the
  hash-check-before-expiry ordering each go RED against a named test when inverted.
  `2027` is a case in two of them because `Date.parse` reads it as a **year**, making
  it the only value that distinguishes the string guard from a cast.
- E2E: `scripts/run-slack-approval-e2e.sh` covers the 72h window end to end against a
  deployed façade (TC-SLACKAPP-155), runnable against a `pr-N` stage.