### PR TITLE
fix(cognito): derive stable account-scoped domain prefixes (#158)

### DIFF
--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -47,6 +47,9 @@
 #                  (github-actions-role.yaml) to be rolled out FIRST.
 #   MEM9_LLM_RESPONSES_REGION — independent fallback region for selected OpenAI
 #                  GPT models. Unset keeps the runtime/boundary default us-west-2.
+#   MEM9_COGNITO_DOMAIN_PREFIX — existing production Cognito domain prefix.
+#                  Set this before adopting derived defaults so prod keeps its
+#                  current OAuth hostname. Previews intentionally do not use it.
 #
 # Workload-boundary maintenance gate revision: 1
 
@@ -1153,6 +1156,10 @@ jobs:
         # (`mem9-<sha7>`); infra/ecs.ts reads MEM9_IMAGE_TAG.
         env:
           MEM9_IMAGE_TAG: ${{ needs.build-and-push-image.outputs.image_tag }}
+          # Preserve an existing production OAuth hostname. New repositories may
+          # leave this unset and use the account/Region/stage-derived default.
+          # Preview deploys intentionally do not receive this prod-wide value.
+          MEM9_COGNITO_DOMAIN_PREFIX: ${{ vars.MEM9_COGNITO_DOMAIN_PREFIX }}
           # Bedrock Project id → the llm-proxy sidecar's OpenAI-Project cost header
           # (infra/ecs.ts BEDROCK_PROJECT). Repo variable set out-of-band by
           # scripts/deploy-bedrock-mantle-project.sh.

--- a/README.md
+++ b/README.md
@@ -265,6 +265,13 @@ The AgentCore Gateway exposes four tools over MCP (Cognito-authenticated):
 - Set `MEM9_FACADE_AUTHORIZER_ENABLED=1` at deploy time to attach the optional
   allow-all OAuth facade compliance authorizer; it is disabled by default.
   Roll out the reviewed workload-boundary update before enabling it.
+- `MEM9_COGNITO_DOMAIN_PREFIX` overrides the Cognito hosted-UI domain prefix,
+  which is unique across **every** AWS account rather than only this one. The
+  default stays `<stage>-mem9-mcp`, so a deployment that already owns that name
+  needs nothing. A second account cannot claim it and must set its own value.
+  Treat the choice as permanent for the life of the stage: the prefix *is* the
+  OAuth token/authorize hostname, so changing it replaces the domain and moves
+  every endpoint clients have discovered.
 - `scripts/deploy-github-role.sh` always owns its account-global IAM stack in
   `us-west-2` and ignores ambient `AWS_REGION`. Application VPC discovery and
   regional bootstrap resources resolve `providers.aws.region` from

--- a/README.md
+++ b/README.md
@@ -265,13 +265,21 @@ The AgentCore Gateway exposes four tools over MCP (Cognito-authenticated):
 - Set `MEM9_FACADE_AUTHORIZER_ENABLED=1` at deploy time to attach the optional
   allow-all OAuth facade compliance authorizer; it is disabled by default.
   Roll out the reviewed workload-boundary update before enabling it.
-- `MEM9_COGNITO_DOMAIN_PREFIX` overrides the Cognito hosted-UI domain prefix,
-  which is unique across **every** AWS account rather than only this one. The
-  default stays `<stage>-mem9-mcp`, so a deployment that already owns that name
-  needs nothing. A second account cannot claim it and must set its own value.
-  Treat the choice as permanent for the life of the stage: the prefix *is* the
-  OAuth token/authorize hostname, so changing it replaces the domain and moves
-  every endpoint clients have discovered.
+- Cognito hosted-UI prefixes share a namespace across AWS accounts in each
+  Region. New stages default to a stable `mem9-<hash>` prefix derived from the
+  AWS account, application Region, and stage; the account ID is not exposed.
+  `MEM9_COGNITO_DOMAIN_PREFIX` remains an explicit override. Before adopting
+  this change for an existing stage, preserve its current prefix so the OAuth
+  hostname is not replaced:
+
+  ```bash
+  gh variable set MEM9_COGNITO_DOMAIN_PREFIX --body "<existing-prefix>"
+  ```
+
+  Infra CI passes this repository variable only to the production deploy;
+  previews use their derived stage-specific defaults. A new repository may
+  leave it unset. Treat either choice as permanent for the stage because the
+  prefix is the OAuth token/authorize hostname.
 - `scripts/deploy-github-role.sh` always owns its account-global IAM stack in
   `us-west-2` and ignores ambient `AWS_REGION`. Application VPC discovery and
   regional bootstrap resources resolve `providers.aws.region` from

--- a/docs/designs/cognito-domain-prefix.md
+++ b/docs/designs/cognito-domain-prefix.md
@@ -1,0 +1,62 @@
+# Design: Cognito domain prefix
+
+Date: 2026-08-13
+Status: Approved
+
+## Problem
+
+Amazon Cognito requires an explicit prefix for its hosted domain. Prefixes are
+shared across AWS accounts in a Region, so a stage-only name such as
+`prod-mem9-mcp` lets only the first account in that Region deploy the stage.
+
+The prefix is part of every OAuth endpoint. It must remain stable across normal
+deployments and must not expose the AWS account ID.
+
+## Decision
+
+`MEM9_COGNITO_DOMAIN_PREFIX` remains the highest-priority input. A non-blank
+override is trimmed and validated before any resource is created.
+
+Without an override, derive the prefix from a versioned SHA-256 input tuple:
+
+```text
+["mem9-cognito-domain-v1", account-id, application-region, stage]
+```
+
+The emitted prefix is `mem9-` plus the first 20 hexadecimal digest characters.
+This gives each account, Region, and stage a stable 80-bit namespace while
+keeping the account ID out of the public hostname. The version marker makes any
+future algorithm change explicit and testable.
+
+The application Region comes from the active AWS provider and the account ID
+comes from the deploy credentials. Both are Pulumi outputs resolved by the
+resource graph, not copied configuration.
+
+## Existing Production Deployment
+
+The repository variable `MEM9_COGNITO_DOMAIN_PREFIX` is seeded with the current
+production prefix before the workflow starts consuming it. Infra CI passes that
+variable only to the production deploy, preserving the existing OAuth hostname.
+
+Preview deploys intentionally do not receive the repository-wide production
+override. They use the derived account/Region/stage default so concurrent stages
+do not claim one shared prefix.
+
+New repositories may omit the variable and use the derived default for every
+stage. Operators adopting this change after a successful legacy deployment must
+set the variable to that stage's existing prefix before redeploying it.
+
+## Validation
+
+Overrides must be 1-63 lowercase letters, digits, or hyphens, without a leading
+or trailing hyphen. Values containing Cognito's reserved `aws`, `amazon`, or
+`cognito` keywords are rejected at synthesis.
+
+The generated prefix uses only the fixed `mem9-` label and hexadecimal output,
+so it satisfies those constraints by construction.
+
+## Rollback
+
+Keep the repository variable set to the existing production prefix. Reverting
+the code then restores the previous stage-only fallback without changing the
+live production domain.

--- a/docs/test-cases/cognito-domain-prefix.md
+++ b/docs/test-cases/cognito-domain-prefix.md
@@ -1,0 +1,29 @@
+# Cognito domain prefix
+
+## Derived Default
+
+| ID | Scenario | Expected result |
+| --- | --- | --- |
+| TC-COGDOMAIN-001 | Resolve the same account, application Region, and stage repeatedly without an override | The exact versioned `mem9-<20 hex>` prefix is stable |
+| TC-COGDOMAIN-002 | Change only the AWS account | The derived prefix changes without exposing the account ID |
+| TC-COGDOMAIN-003 | Change only the application Region | The derived prefix changes |
+| TC-COGDOMAIN-004 | Change only the stage | The derived prefix changes |
+| TC-COGDOMAIN-005 | Construct the Cognito stack from Pulumi account and Region outputs | `UserPoolDomain.domain` receives the resolved derived prefix |
+
+## Override
+
+| ID | Scenario | Expected result |
+| --- | --- | --- |
+| TC-COGDOMAIN-010 | Supply `MEM9_COGNITO_DOMAIN_PREFIX` explicitly or through the process environment | The trimmed override wins over the derived default |
+| TC-COGDOMAIN-011 | Leave the override absent or blank | The account/Region/stage default is used |
+| TC-COGDOMAIN-012 | Supply invalid characters, invalid length, edge hyphens, or an AWS-reserved keyword | Synthesis fails before resource creation |
+| TC-COGDOMAIN-013 | Supply valid one- and 63-character boundaries | The override is accepted |
+| TC-COGDOMAIN-014 | Construct the production stack with the environment override | `UserPoolDomain.domain` receives the exact existing prefix |
+
+## CI And Documentation
+
+| ID | Scenario | Expected result |
+| --- | --- | --- |
+| TC-COGDOMAIN-020 | Run the production deploy through Infra CI | The deploy receives `${{ vars.MEM9_COGNITO_DOMAIN_PREFIX }}` so this repository retains its existing hostname |
+| TC-COGDOMAIN-021 | Run a PR preview through Infra CI | The production repository override is absent and the stage uses its derived default |
+| TC-COGDOMAIN-022 | Read operator guidance | Existing deployments are told to preserve their current prefix before redeploying; new deployments may omit the variable |

--- a/infra/cognito.test.ts
+++ b/infra/cognito.test.ts
@@ -6,8 +6,23 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
  * client wiring and the SSM exports (client secret as SecureString, never plain).
  */
 
-function out<T>(value: T): { value: T; apply: (fn: (v: T) => unknown) => unknown } {
-  return { value, apply: (fn) => out(fn(value) as never) };
+interface TestOutput<T> {
+  value: T;
+  apply<U>(fn: (value: T) => U | TestOutput<U>): TestOutput<U>;
+}
+
+function isTestOutput<T>(value: T | TestOutput<T>): value is TestOutput<T> {
+  return typeof value === "object" && value !== null && "apply" in value;
+}
+
+function out<T>(value: T): TestOutput<T> {
+  return {
+    value,
+    apply<U>(fn: (input: T) => U | TestOutput<U>): TestOutput<U> {
+      const result = fn(value);
+      return isTestOutput(result) ? result : out(result);
+    },
+  };
 }
 
 interface Rec {
@@ -16,6 +31,11 @@ interface Rec {
 }
 let created: Rec[];
 let params: { name: string; type: string; value: unknown }[];
+let previousDomainPrefix: string | undefined;
+
+const ACCOUNT_ID = "123456789012";
+const REGION = "ap-northeast-1";
+const PROD_DERIVED_PREFIX = "mem9-eacc290a1cfb9bde8585";
 
 function installInterpolate() {
   (globalThis as Record<string, unknown>).$interpolate = (
@@ -49,11 +69,12 @@ function makeCtor(kind: string) {
   };
 }
 
-function installGlobals(stage: string) {
+function installGlobals(stage: string, accountId = ACCOUNT_ID, region = REGION) {
   (globalThis as Record<string, unknown>).$app = { name: "mem9-on-aws", stage };
   installInterpolate();
   (globalThis as Record<string, unknown>).aws = {
-    getRegionOutput: () => ({ name: out("ap-northeast-1") }),
+    getCallerIdentityOutput: () => ({ accountId: out(accountId) }),
+    getRegionOutput: () => ({ name: out(region) }),
     cognito: {
       UserPool: makeCtor("UserPool"),
       UserPoolDomain: makeCtor("UserPoolDomain"),
@@ -81,9 +102,16 @@ function installGlobals(stage: string) {
 beforeEach(() => {
   created = [];
   params = [];
+  previousDomainPrefix = process.env.MEM9_COGNITO_DOMAIN_PREFIX;
+  delete process.env.MEM9_COGNITO_DOMAIN_PREFIX;
 });
 afterEach(() => {
   for (const g of ["$app", "aws", "$interpolate"]) delete (globalThis as Record<string, unknown>)[g];
+  if (previousDomainPrefix === undefined) {
+    delete process.env.MEM9_COGNITO_DOMAIN_PREFIX;
+  } else {
+    process.env.MEM9_COGNITO_DOMAIN_PREFIX = previousDomainPrefix;
+  }
   vi.resetModules();
 });
 
@@ -158,8 +186,9 @@ describe("cognito stack", () => {
     cognito = await loadCognito();
     cognito();
     expect(byKind("UserPool")[0].args.name).toBe("pr-42-mem9-mcp");
-    // PR-stage domain gets the numeric suffix for deterministic re-deploys.
-    expect(byKind("UserPoolDomain")[0].args.domain).toBe("pr-42-mem9-mcp-42");
+    expect(
+      (byKind("UserPoolDomain")[0].args.domain as { value: string }).value,
+    ).toBe("mem9-464003a338eef415916e");
   });
 
   it("configures the pool for Hosted-UI (email schema + no forced re-verify)", async () => {
@@ -206,40 +235,71 @@ describe("cognito stack", () => {
     expect(out.revocationEndpoint).toBeDefined();
     expect(out.jwksUri).toBeDefined();
   });
+
+  it("TC-COGDOMAIN-014: preserves the configured production prefix", async () => {
+    process.env.MEM9_COGNITO_DOMAIN_PREFIX = "existing-prod-prefix";
+    installGlobals("prod");
+    const cognito = await loadCognito();
+    cognito();
+
+    expect(byKind("UserPoolDomain")[0].args.domain).toBe(
+      "existing-prod-prefix",
+    );
+  });
 });
 
-describe("cognitoDomainPrefix", () => {
+describe("Cognito domain prefix helpers", () => {
   // The module reads the SST-injected `aws` global at import time, so the stage
   // value here is irrelevant to these cases — the globals just have to exist.
-  async function loadPrefix() {
+  async function loadDomainHelpers() {
     installGlobals("prod");
     vi.resetModules();
-    return (await import("./cognito")).cognitoDomainPrefix;
+    const module = await import("./cognito");
+    return {
+      cognitoDomainOverride: module.cognitoDomainOverride,
+      cognitoDomainPrefix: module.cognitoDomainPrefix,
+    };
   }
 
-  it("defaults to the per-stage name, with the PR number on preview stages", async () => {
-    const cognitoDomainPrefix = await loadPrefix();
-    expect(cognitoDomainPrefix("prod", undefined)).toBe("prod-mem9-mcp");
-    expect(cognitoDomainPrefix("dev", undefined)).toBe("dev-mem9-mcp");
-    expect(cognitoDomainPrefix("pr-42", undefined)).toBe("pr-42-mem9-mcp-42");
+  it("TC-COGDOMAIN-001: derives a pinned stable default", async () => {
+    const { cognitoDomainPrefix } = await loadDomainHelpers();
+    const input = { accountId: ACCOUNT_ID, region: REGION, stage: "prod" };
+    expect(cognitoDomainPrefix(input)).toBe(PROD_DERIVED_PREFIX);
+    expect(cognitoDomainPrefix(input)).toBe(PROD_DERIVED_PREFIX);
+    expect(PROD_DERIVED_PREFIX).toMatch(/^mem9-[a-f0-9]{20}$/u);
   });
 
-  it("returns a configured override so a second AWS account can claim its own prefix", async () => {
-    const cognitoDomainPrefix = await loadPrefix();
-    // The default `prod-mem9-mcp` is unavailable once ANY account holds it, so a
-    // fork deploying prod must be able to choose a different global name.
-    expect(cognitoDomainPrefix("prod", "acme-mem9-mcp")).toBe("acme-mem9-mcp");
-    expect(cognitoDomainPrefix("prod", "  acme-mem9-mcp  ")).toBe("acme-mem9-mcp");
+  it("TC-COGDOMAIN-002/003/004: changes for every namespace input", async () => {
+    const { cognitoDomainPrefix } = await loadDomainHelpers();
+    const base = { accountId: ACCOUNT_ID, region: REGION, stage: "prod" };
+    expect(
+      cognitoDomainPrefix({ ...base, accountId: "test-account-two" }),
+    ).toBe("mem9-fd5620e61c7a89401f03");
+    expect(
+      cognitoDomainPrefix({ ...base, region: "us-west-2" }),
+    ).toBe("mem9-a0ae4801969aea22f95f");
+    expect(
+      cognitoDomainPrefix({ ...base, stage: "pr-42" }),
+    ).toBe("mem9-464003a338eef415916e");
   });
 
-  it("falls back to the default when the override is absent or blank", async () => {
-    const cognitoDomainPrefix = await loadPrefix();
-    expect(cognitoDomainPrefix("prod", "")).toBe("prod-mem9-mcp");
-    expect(cognitoDomainPrefix("prod", "   ")).toBe("prod-mem9-mcp");
+  it("TC-COGDOMAIN-010: returns a configured override", async () => {
+    const { cognitoDomainOverride } = await loadDomainHelpers();
+    expect(cognitoDomainOverride("acme-mem9-mcp")).toBe("acme-mem9-mcp");
+    expect(cognitoDomainOverride("  acme-mem9-mcp  ")).toBe(
+      "acme-mem9-mcp",
+    );
   });
 
-  it("rejects an override Cognito would refuse, at synth rather than mid-deploy", async () => {
-    const cognitoDomainPrefix = await loadPrefix();
+  it("TC-COGDOMAIN-011: falls back when the override is absent or blank", async () => {
+    const { cognitoDomainOverride } = await loadDomainHelpers();
+    expect(cognitoDomainOverride(undefined)).toBeUndefined();
+    expect(cognitoDomainOverride("")).toBeUndefined();
+    expect(cognitoDomainOverride("   ")).toBeUndefined();
+  });
+
+  it("TC-COGDOMAIN-012/013: validates Cognito syntax and reserved keywords", async () => {
+    const { cognitoDomainOverride } = await loadDomainHelpers();
     for (const invalid of [
       "Mem9-Prod", // uppercase
       "-mem9-prod", // leading hyphen
@@ -247,25 +307,21 @@ describe("cognitoDomainPrefix", () => {
       "mem9_prod", // underscore
       "mem9.prod", // dot
       "a".repeat(64), // 64 chars, one over the limit
+      "aws",
+      "acme-amazon-auth",
+      "my-cognito-login",
     ]) {
-      expect(() => cognitoDomainPrefix("prod", invalid)).toThrow(
+      expect(() => cognitoDomainOverride(invalid)).toThrow(
         /MEM9_COGNITO_DOMAIN_PREFIX/u,
       );
     }
-    // The boundary lengths themselves are valid.
-    expect(cognitoDomainPrefix("prod", "a")).toBe("a");
-    expect(cognitoDomainPrefix("prod", "a".repeat(63))).toBe("a".repeat(63));
+    expect(cognitoDomainOverride("a")).toBe("a");
+    expect(cognitoDomainOverride("a".repeat(63))).toBe("a".repeat(63));
   });
 
-  it("reads MEM9_COGNITO_DOMAIN_PREFIX from the environment by default", async () => {
-    const cognitoDomainPrefix = await loadPrefix();
-    const previous = process.env.MEM9_COGNITO_DOMAIN_PREFIX;
+  it("TC-COGDOMAIN-010: reads the override from the environment", async () => {
+    const { cognitoDomainOverride } = await loadDomainHelpers();
     process.env.MEM9_COGNITO_DOMAIN_PREFIX = "acme-mem9-mcp";
-    try {
-      expect(cognitoDomainPrefix("prod")).toBe("acme-mem9-mcp");
-    } finally {
-      if (previous === undefined) delete process.env.MEM9_COGNITO_DOMAIN_PREFIX;
-      else process.env.MEM9_COGNITO_DOMAIN_PREFIX = previous;
-    }
+    expect(cognitoDomainOverride()).toBe("acme-mem9-mcp");
   });
 });

--- a/infra/cognito.test.ts
+++ b/infra/cognito.test.ts
@@ -207,3 +207,65 @@ describe("cognito stack", () => {
     expect(out.jwksUri).toBeDefined();
   });
 });
+
+describe("cognitoDomainPrefix", () => {
+  // The module reads the SST-injected `aws` global at import time, so the stage
+  // value here is irrelevant to these cases — the globals just have to exist.
+  async function loadPrefix() {
+    installGlobals("prod");
+    vi.resetModules();
+    return (await import("./cognito")).cognitoDomainPrefix;
+  }
+
+  it("defaults to the per-stage name, with the PR number on preview stages", async () => {
+    const cognitoDomainPrefix = await loadPrefix();
+    expect(cognitoDomainPrefix("prod", undefined)).toBe("prod-mem9-mcp");
+    expect(cognitoDomainPrefix("dev", undefined)).toBe("dev-mem9-mcp");
+    expect(cognitoDomainPrefix("pr-42", undefined)).toBe("pr-42-mem9-mcp-42");
+  });
+
+  it("returns a configured override so a second AWS account can claim its own prefix", async () => {
+    const cognitoDomainPrefix = await loadPrefix();
+    // The default `prod-mem9-mcp` is unavailable once ANY account holds it, so a
+    // fork deploying prod must be able to choose a different global name.
+    expect(cognitoDomainPrefix("prod", "acme-mem9-mcp")).toBe("acme-mem9-mcp");
+    expect(cognitoDomainPrefix("prod", "  acme-mem9-mcp  ")).toBe("acme-mem9-mcp");
+  });
+
+  it("falls back to the default when the override is absent or blank", async () => {
+    const cognitoDomainPrefix = await loadPrefix();
+    expect(cognitoDomainPrefix("prod", "")).toBe("prod-mem9-mcp");
+    expect(cognitoDomainPrefix("prod", "   ")).toBe("prod-mem9-mcp");
+  });
+
+  it("rejects an override Cognito would refuse, at synth rather than mid-deploy", async () => {
+    const cognitoDomainPrefix = await loadPrefix();
+    for (const invalid of [
+      "Mem9-Prod", // uppercase
+      "-mem9-prod", // leading hyphen
+      "mem9-prod-", // trailing hyphen
+      "mem9_prod", // underscore
+      "mem9.prod", // dot
+      "a".repeat(64), // 64 chars, one over the limit
+    ]) {
+      expect(() => cognitoDomainPrefix("prod", invalid)).toThrow(
+        /MEM9_COGNITO_DOMAIN_PREFIX/u,
+      );
+    }
+    // The boundary lengths themselves are valid.
+    expect(cognitoDomainPrefix("prod", "a")).toBe("a");
+    expect(cognitoDomainPrefix("prod", "a".repeat(63))).toBe("a".repeat(63));
+  });
+
+  it("reads MEM9_COGNITO_DOMAIN_PREFIX from the environment by default", async () => {
+    const cognitoDomainPrefix = await loadPrefix();
+    const previous = process.env.MEM9_COGNITO_DOMAIN_PREFIX;
+    process.env.MEM9_COGNITO_DOMAIN_PREFIX = "acme-mem9-mcp";
+    try {
+      expect(cognitoDomainPrefix("prod")).toBe("acme-mem9-mcp");
+    } finally {
+      if (previous === undefined) delete process.env.MEM9_COGNITO_DOMAIN_PREFIX;
+      else process.env.MEM9_COGNITO_DOMAIN_PREFIX = previous;
+    }
+  });
+});

--- a/infra/cognito.ts
+++ b/infra/cognito.ts
@@ -15,6 +15,8 @@
  * operator.
  */
 
+import { createHash } from "node:crypto";
+
 // @ts-ignore - `aws` injected globally by SST; cognito types declared loosely.
 const awsAny = aws as unknown as Record<string, any>;
 
@@ -35,42 +37,74 @@ export interface CognitoOutputs {
 }
 
 const RESOURCE_SERVER_ID = "mem9-mcp";
+const DOMAIN_HASH_NAMESPACE = "mem9-cognito-domain-v1";
+const DOMAIN_PREFIX_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/u;
+const DOMAIN_RESERVED_KEYWORDS = ["aws", "amazon", "cognito"];
 
-// Cognito hosted-UI domain prefixes are unique across EVERY AWS account, not just
-// this one. `<stage>-mem9-mcp` therefore cannot be claimed by a second deployment
-// of this project once any account holds it — an account other than the original
-// operator's fails `prod` with "Domain already associated with another user pool"
-// (empirical 2026-08-12). MEM9_COGNITO_DOMAIN_PREFIX lets such a deployment pick
-// its own globally-unique prefix. It must stay stable for the life of the stage:
-// the prefix IS the OAuth token/authorize hostname, so changing it replaces the
-// domain and moves every endpoint clients have.
-export function cognitoDomainPrefix(
-  stage: string,
+export interface CognitoDomainPrefixInput {
+  accountId: string;
+  region: string;
+  stage: string;
+}
+
+export function cognitoDomainOverride(
   override = process.env.MEM9_COGNITO_DOMAIN_PREFIX,
-): string {
+): string | undefined {
   const configured = override?.trim();
-  if (configured) {
-    // Cognito accepts 1-63 chars of lowercase letters, digits, and hyphens, with
-    // no leading or trailing hyphen. Reject here so a typo fails at synth rather
-    // than part-way through a deploy that has already created the pool.
-    if (!/^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/u.test(configured)) {
-      throw new Error(
-        "MEM9_COGNITO_DOMAIN_PREFIX must be 1-63 characters of lowercase letters, digits, or hyphens, without a leading or trailing hyphen.",
-      );
-    }
-    return configured;
+  if (!configured) return undefined;
+
+  const hasReservedKeyword = DOMAIN_RESERVED_KEYWORDS.some((keyword) =>
+    configured.includes(keyword),
+  );
+  if (!DOMAIN_PREFIX_PATTERN.test(configured) || hasReservedKeyword) {
+    throw new Error(
+      "MEM9_COGNITO_DOMAIN_PREFIX must be 1-63 lowercase letters, digits, or hyphens, without an edge hyphen or the reserved aws, amazon, or cognito keywords.",
+    );
   }
-  // Default: the per-stage name; PR stages append the PR number for deterministic
-  // re-deploys within one account.
-  const suffix = stage.startsWith("pr-") ? `-${stage.split("-")[1]}` : "";
-  return `${stage}-mem9-mcp${suffix}`;
+  return configured;
+}
+
+// Prefixes share a namespace across AWS accounts in each Region. Derive a stable
+// default from the deployment identity without exposing the account id in the
+// public hostname. The version marker makes an algorithm change an explicit
+// migration. An existing stage must pin its current prefix through the override
+// before adopting this default.
+export function cognitoDomainPrefix({
+  accountId,
+  region,
+  stage,
+}: CognitoDomainPrefixInput): string {
+  const digest = createHash("sha256")
+    .update(
+      JSON.stringify([DOMAIN_HASH_NAMESPACE, accountId, region, stage]),
+    )
+    .digest("hex")
+    .slice(0, 20);
+  return `mem9-${digest}`;
 }
 
 export function cognito(): CognitoOutputs {
   const prefix = `/mem9-on-aws/${$app.stage}`;
   const stage = $app.stage;
   const region = awsAny.getRegionOutput().name;
+  const accountId = awsAny.getCallerIdentityOutput().accountId;
   const tags = { Project: "mem9-on-aws", Stage: stage, ManagedBy: "sst" };
+  const configuredDomainPrefix = cognitoDomainOverride();
+
+  // Validate an override synchronously so malformed operator input aborts the
+  // Pulumi program before deployment. Otherwise resolve the account and Region
+  // outputs and derive a stable default.
+  const domainPrefix =
+    configuredDomainPrefix ??
+    accountId.apply((resolvedAccountId: string) =>
+      region.apply((resolvedRegion: string) =>
+        cognitoDomainPrefix({
+          accountId: resolvedAccountId,
+          region: resolvedRegion,
+          stage,
+        }),
+      ),
+    );
 
   // Deterministic per-stage pool name (Cognito allows duplicate names, so embed
   // the stage to guarantee isolation). deleteBeforeReplace on non-prod so a
@@ -103,11 +137,11 @@ export function cognito(): CognitoOutputs {
     { deleteBeforeReplace: nonProd },
   );
 
-  // OAuth token endpoint domain. Globally unique across all AWS accounts — see
-  // cognitoDomainPrefix() for the default and the per-account override.
+  // OAuth token endpoint domain. The repository's production workflow supplies
+  // its legacy prefix as an override; new stages use the stable derived default.
   const domain = new awsAny.cognito.UserPoolDomain(
     "Mem9McpDomain",
-    { domain: cognitoDomainPrefix(stage), userPoolId: pool.id },
+    { domain: domainPrefix, userPoolId: pool.id },
     { deleteBeforeReplace: nonProd },
   );
 

--- a/infra/cognito.ts
+++ b/infra/cognito.ts
@@ -36,6 +36,36 @@ export interface CognitoOutputs {
 
 const RESOURCE_SERVER_ID = "mem9-mcp";
 
+// Cognito hosted-UI domain prefixes are unique across EVERY AWS account, not just
+// this one. `<stage>-mem9-mcp` therefore cannot be claimed by a second deployment
+// of this project once any account holds it — an account other than the original
+// operator's fails `prod` with "Domain already associated with another user pool"
+// (empirical 2026-08-12). MEM9_COGNITO_DOMAIN_PREFIX lets such a deployment pick
+// its own globally-unique prefix. It must stay stable for the life of the stage:
+// the prefix IS the OAuth token/authorize hostname, so changing it replaces the
+// domain and moves every endpoint clients have.
+export function cognitoDomainPrefix(
+  stage: string,
+  override = process.env.MEM9_COGNITO_DOMAIN_PREFIX,
+): string {
+  const configured = override?.trim();
+  if (configured) {
+    // Cognito accepts 1-63 chars of lowercase letters, digits, and hyphens, with
+    // no leading or trailing hyphen. Reject here so a typo fails at synth rather
+    // than part-way through a deploy that has already created the pool.
+    if (!/^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/u.test(configured)) {
+      throw new Error(
+        "MEM9_COGNITO_DOMAIN_PREFIX must be 1-63 characters of lowercase letters, digits, or hyphens, without a leading or trailing hyphen.",
+      );
+    }
+    return configured;
+  }
+  // Default: the per-stage name; PR stages append the PR number for deterministic
+  // re-deploys within one account.
+  const suffix = stage.startsWith("pr-") ? `-${stage.split("-")[1]}` : "";
+  return `${stage}-mem9-mcp${suffix}`;
+}
+
 export function cognito(): CognitoOutputs {
   const prefix = `/mem9-on-aws/${$app.stage}`;
   const stage = $app.stage;
@@ -73,12 +103,11 @@ export function cognito(): CognitoOutputs {
     { deleteBeforeReplace: nonProd },
   );
 
-  // OAuth token endpoint domain. Cognito domains are globally unique → embed the
-  // stage; PR stages append the PR number for deterministic re-deploys.
-  const domainSuffix = stage.startsWith("pr-") ? `-${stage.split("-")[1]}` : "";
+  // OAuth token endpoint domain. Globally unique across all AWS accounts — see
+  // cognitoDomainPrefix() for the default and the per-account override.
   const domain = new awsAny.cognito.UserPoolDomain(
     "Mem9McpDomain",
-    { domain: `${stage}-mem9-mcp${domainSuffix}`, userPoolId: pool.id },
+    { domain: cognitoDomainPrefix(stage), userPoolId: pool.id },
     { deleteBeforeReplace: nonProd },
   );
 

--- a/scripts/deployment-workflow.test.mjs
+++ b/scripts/deployment-workflow.test.mjs
@@ -393,6 +393,21 @@ describe("workflow integration", () => {
     expect(workflow.match(/pnpm -C infra exec sst deploy/g)).toHaveLength(2);
   });
 
+  it("TC-COGDOMAIN-020/021: preserves prod override without sharing it with previews", () => {
+    const workflow = parse(readFileSync(workflowPath, "utf8"));
+    const previewDeploy = workflow.jobs["deploy-preview"].steps.find(
+      ({ name }) => name === "Deploy PR stage",
+    );
+    const prodDeploy = workflow.jobs["deploy-prod"].steps.find(
+      ({ name }) => name === "Deploy prod stage",
+    );
+
+    expect(previewDeploy.env).not.toHaveProperty("MEM9_COGNITO_DOMAIN_PREFIX");
+    expect(prodDeploy.env.MEM9_COGNITO_DOMAIN_PREFIX).toBe(
+      "${{ vars.MEM9_COGNITO_DOMAIN_PREFIX }}",
+    );
+  });
+
   it("TC-CONSOL-040/041: runs a report-only preview task behind the schedule gate", () => {
     const source = readFileSync(workflowPath, "utf8");
     const workflow = parse(source);

--- a/scripts/workload-permissions-boundary-contract.json
+++ b/scripts/workload-permissions-boundary-contract.json
@@ -13,7 +13,7 @@
     {
       "id": "infra-ci.yml",
       "path": ".github/workflows/infra-ci.yml",
-      "reviewedBlob": "6b115a9b49155bca3ccecb0d824540be26240826"
+      "reviewedBlob": "b3a2a7731086ef838b6eabe54c177872f69bd8ad"
     },
     {
       "id": "reconcile-previews.yml",


### PR DESCRIPTION
Fixes #158.

## Summary

- Derive new Cognito prefix-domain defaults from the AWS account, application
  Region, and SST stage.
- Keep `MEM9_COGNITO_DOMAIN_PREFIX` as the highest-priority environment
  override, with synthesis-time validation.
- Preserve this repository's existing production OAuth hostname through a
  repository variable that Infra CI passes only to the production deploy.

## Design

Amazon Cognito prefix domains share a namespace across AWS accounts in each
Region, so a stage-only value cannot be a safe default for reusable
deployments.

The new default is `mem9-<20 hex>`, where the digest is SHA-256 over a
versioned tuple containing the account ID, Region, and stage. This is stable for
re-deployments, changes when any namespace input changes, and does not emit the
account ID in the public hostname.

An explicit `MEM9_COGNITO_DOMAIN_PREFIX` still wins. Infra CI reads the
production value from `${{ vars.MEM9_COGNITO_DOMAIN_PREFIX }}` while preview
deploys intentionally omit it and derive their own stage-specific prefixes.
The repository variable was seeded before this workflow change, so the current
production domain is not replaced.

See `docs/designs/cognito-domain-prefix.md` and
`docs/test-cases/cognito-domain-prefix.md`.

## Test Plan

- `pnpm -C infra typecheck`
- `pnpm -C infra test` (29 files, 344 tests)
- `pnpm typecheck`
- `pnpm test` (22 files, 989 tests)
- Workflow contract and security scans

## Checklist

- [x] Stable account/Region/stage-derived default
- [x] Environment override remains supported and validated
- [x] Existing production prefix stored as a repository variable
- [x] Production CI receives the override; previews do not
- [x] Design and test-case documentation added
- [x] No credentials, account IDs, or production domains committed
