### PR TITLE
fix(approval): sanitize expired offer log fields

### DIFF
--- a/docs/test-cases/slack-approval-loop.md
+++ b/docs/test-cases/slack-approval-loop.md
@@ -317,6 +317,13 @@ can succeed against a record the scan skipped past.
   and never the ids. Same argument as TC-SLACKAPP-089: the log is a wider audience
   than the parameter the ids legitimately live in, and the hash already identifies
   the list.
+- **TC-SLACKAPP-214** — an unparseable `issuedAt` containing newline, carriage
+  return, a forged refusal for another hash, and thousands of trailing characters
+  is never copied into the expired-approval log line. The refusal still logs the
+  real hash, the TTL, and a bounded derived age, while the Slack reply remains
+  byte-for-byte the existing unknown-age response. This pins the concrete audit
+  failure: one caller-controlled parameter value must not render a second plausible
+  refusal for a hash that was never clicked.
 - **TC-SLACKAPP-140** — the review run refuses to overwrite an offer still inside
   its window, **before writing anything**. Operator-initiated, the clobber was a
   footnote — the human running the scan is the human holding the pending approval.

--- a/infra/src/oauth-facade/slack-interactions.test.ts
+++ b/infra/src/oauth-facade/slack-interactions.test.ts
@@ -640,7 +640,7 @@ describe("Slack stale-hash rejection (TC-SLACKAPP-020..025)", () => {
 // 137 is deliberately absent here: it pins this file's `OFFER_TTL_MS` against the
 // container script's duplicate copy, so it lives on the STAMPING side
 // (scripts/memory-cleanup.test.mjs) where the value is written.
-describe("Slack offer expiry (TC-SLACKAPP-134..136, 138..139, 158)", () => {
+describe("Slack offer expiry (TC-SLACKAPP-134..136, 138..139, 158, 214)", () => {
   /** An offered record issued `ageMs` before `NOW`. */
   const aged = (ageMs: number) =>
     offered({ issuedAt: new Date(NOW - ageMs).toISOString() });
@@ -776,6 +776,37 @@ describe("Slack offer expiry (TC-SLACKAPP-134..136, 138..139, 158)", () => {
     expect(logged).toMatch(/expired/iu);
     expect(logged).toContain(HASH);
     for (const id of IDS) expect(logged).not.toContain(id);
+  });
+
+  it("TC-SLACKAPP-214 an untrusted issuedAt cannot forge a second refusal log line", async () => {
+    const forgedHash = "sha256:FORGED";
+    const issuedAt =
+      `not-a-date\r\nrefused an expired approval for ${forgedHash} ` +
+      `(issuedAt=forged, ttl=${OFFER_TTL_MS}ms)` +
+      "x".repeat(5000);
+    const d = deps({ getParameter: vi.fn(async () => offered({ issuedAt })) });
+    const res = await handleSlackInteraction(ev(payload()), d);
+
+    expect(d.runTask).not.toHaveBeenCalled();
+    expect(d.putParameter).not.toHaveBeenCalled();
+    const lines = (d.log as ReturnType<typeof vi.fn>).mock.calls.map((c) =>
+      String(c[0]),
+    );
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toMatch(/expired/iu);
+    expect(lines[0]).toContain(HASH);
+    expect(lines[0]).toContain(`ttl=${OFFER_TTL_MS}ms`);
+    expect(lines[0]).toContain("age=unknown");
+    expect(lines[0]).not.toContain(issuedAt);
+    expect(lines[0]).not.toContain(forgedHash);
+    expect(lines[0]).not.toMatch(/[\r\n]/u);
+    expect(lines[0].length).toBeLessThan(300);
+
+    expect(JSON.parse(res.body).text).toBe(
+      "That list was issued an unknown time ago and approvals expire after 72h, " +
+        "so it may no longer reflect the store. Nothing was applied — the next " +
+        "scheduled scan will post a fresh list.",
+    );
   });
 });
 

--- a/infra/src/oauth-facade/slack-interactions.ts
+++ b/infra/src/oauth-facade/slack-interactions.ts
@@ -409,7 +409,7 @@ async function loadOffered(
   if (expiry.expired) {
     deps.log(
       `refused an expired approval for ${hash} ` +
-        `(issuedAt=${record.issuedAt ?? "unset"}, ttl=${OFFER_TTL_MS}ms)`,
+        `(age=${expiry.age ?? "unknown"}, ttl=${OFFER_TTL_MS}ms)`,
     );
     // Names the expiry and what to do about it. The generic "nothing was applied"
     // suffix is kept — every refusal in this handler ends with it, and an operator


### PR DESCRIPTION
## Summary
- stop interpolating untrusted `issuedAt` values into expired-approval logs
- retain bounded diagnostic age, approval hash, and TTL fields
- add `TC-SLACKAPP-214` for newline, carriage-return, and over-long injection attempts

Closes #156

## Mutation Evidence
Replacing the derived `expiry.age` output with the original raw `record.issuedAt` interpolation makes only `TC-SLACKAPP-214` fail. Restoring the fix returns the suite to green.

## Test Plan
- [x] Test case documented in `docs/test-cases/slack-approval-loop.md`
- [x] Regression unit test passes
- [x] Infra suite passes (418 tests)
- [x] Root suite passes (1147 tests)
- [x] Typechecks pass
- [x] Cleanup coverage passes (242 tests; 93.27% lines, 87.25% branches)
- [x] Code simplification review passed
- [x] Independent committed-diff review passed
- [x] CI checks pass
- [x] Reviewer bot findings addressed

## E2E
The preview deployment passed the repository's Slack approval E2E. A real Slack workspace callback round trip is not reproducible in CI; the callback response is also asserted byte-identical in the regression test.