### PR TITLE
fix(cleanup): clarify scheduled offer limits

### DIFF
--- a/docs/test-cases/slack-approval-loop.md
+++ b/docs/test-cases/slack-approval-loop.md
@@ -2099,3 +2099,15 @@ done). Consensus adds no code: a run with no usable consensus offered nothing
 and did nothing wrong, so it exits 0 with the disagreement rate in its summary —
 the number the operator is meant to act on, not an exit code the scheduler would
 have to interpret.
+
+## Scheduled size-limit diagnostics (#155)
+
+- **TC-SLACKAPP-215** — both the SSM parameter-limit refusal and Slack block-limit
+  refusal distinguish an unattended scheduled scan from an operator CLI run. The
+  scheduled message names an applicable operator-run review with a smaller
+  approval limit and never names `--cap`, which the schedule cannot pass. The
+  existing CLI messages keep their exact `lower --cap` advice.
+- **TC-SLACKAPP-216** — the EventBridge Scheduler container override marks only
+  that invocation as unattended. The task definition and operator CLI remain
+  unmarked, and the override still carries neither `MEM9_APPROVAL_HASH` nor any
+  destructive flag.

--- a/infra/slack-approval.test.ts
+++ b/infra/slack-approval.test.ts
@@ -1164,7 +1164,7 @@ describe("slack approval infrastructure", () => {
     expect(actions.sort()).toEqual(["ecs:RunTask", "iam:PassRole"]);
   });
 
-  it("TC-SLACKAPP-150: overrides the command with a DRY run: no --apply, no --ids, a quorum, and an out-dir outside /app", async () => {
+  it("TC-SLACKAPP-150/216: overrides the command with a marked DRY run: no --apply, no --ids, a quorum, and an out-dir outside /app", async () => {
     installGlobals("prod");
     enable();
     enableScan();
@@ -1221,14 +1221,15 @@ describe("slack approval infrastructure", () => {
     expect(baseUrlIndex).toBeGreaterThan(0);
     expect(command[baseUrlIndex + 1]).toBe("http://mnemo.mem9-prod.local:8080");
 
-    // No environment override at all. MEM9_SLACK_APPROVAL_CHANNEL is already in
-    // the definition and is what makes `buildPostApproval` return a poster, so the
-    // scan offers by virtue of being configured for Slack. MEM9_APPROVAL_HASH must
-    // NOT appear: it means "this run came from a click", and setting it with no
-    // `--ids` is a hard error in `createCleanupDeps`.
-    expect(override.environment).toBeUndefined();
+    // Only the schedule is marked unattended, so offer-size errors can name a
+    // remedy this path can actually use. The operator CLI and task definition
+    // remain unmarked and retain their existing `--cap` advice.
+    expect(override.environment).toEqual([
+      { name: "MEM9_CLEANUP_UNATTENDED", value: "1" },
+    ]);
     const taskArgs = materialize(one("Task", "Mem9Cleanup").args) as
       Record<string, any>;
+    expect(taskArgs.environment.MEM9_CLEANUP_UNATTENDED).toBeUndefined();
     expect(Object.keys(taskArgs.environment)).not.toContain("MEM9_APPROVAL_HASH");
     expect(taskArgs.environment.MEM9_SLACK_APPROVAL_CHANNEL).toBe(CHANNEL_ID);
     expect(JSON.stringify(override)).not.toContain("MEM9_APPROVAL_HASH");

--- a/infra/slack-approval.ts
+++ b/infra/slack-approval.ts
@@ -853,6 +853,9 @@ export function slackApproval(
                 "--out",
                 CLEANUP_SCAN_OUT_DIR,
               ],
+              environment: [
+                { name: "MEM9_CLEANUP_UNATTENDED", value: "1" },
+              ],
               // MEM9_SLACK_APPROVAL_CHANNEL is already in the definition's
               // `environment`, and it is what makes `buildPostApproval` return a
               // poster at all — so the scan offers by virtue of being configured

--- a/scripts/memory-cleanup.mjs
+++ b/scripts/memory-cleanup.mjs
@@ -107,6 +107,7 @@ const SLACK_MAX_HEADER_CHARS = 150;
 const SLACK_TIMEOUT_MS = 15_000;
 /** Set by infra/slack-approval.ts; its presence is what enables the offer. */
 const MEM9_SLACK_CHANNEL_ENV = "MEM9_SLACK_APPROVAL_CHANNEL";
+const MEM9_UNATTENDED_ENV = "MEM9_CLEANUP_UNATTENDED";
 // Set by infra/slack-approval.ts to the bucket it provisions (#150). Its ABSENCE
 // is meaningful rather than an error: it is what keeps #102's operator CLI, and any
 // stage deployed before that bucket existed, writing the id-only record they always
@@ -1125,6 +1126,13 @@ export function decisionArtifactHash(serialized) {
   return contentHash(serialized);
 }
 
+function approvalSizeRemedy(unattended, cliRemedy) {
+  return unattended
+    ? `disable the cleanup scan schedule, then run an operator-initiated review ` +
+        `with a smaller approval limit before re-enabling the schedule`
+    : cliRemedy;
+}
+
 /**
  * The `{prefix}/approvals/offered` record: what the callback Lambda compares a
  * button click against, and where the apply task reads its ids from (#123).
@@ -1153,6 +1161,7 @@ export function buildOfferedRecord({
   artifactBucket,
   artifactKey,
   artifactHash,
+  unattended = false,
 }) {
   // Every id any destructive decision TOUCHES, not the DELETE-verdict ids (#150).
   // This list is the bound `applyDecisions` enforces, so a MERGE whose survivor
@@ -1263,7 +1272,10 @@ export function buildOfferedRecord({
     throw new Error(
       `the offered approval list is ${bytes} bytes, over the ` +
         `${MAX_PARAMETER_BYTES}-byte standard parameter limit for ${ids.length} ids — ` +
-        `lower --cap rather than truncating the list the operator approves`,
+        approvalSizeRemedy(
+          unattended,
+          `lower --cap rather than truncating the list the operator approves`,
+        ),
     );
   }
   return record;
@@ -1348,7 +1360,12 @@ export function formatHours(ms) {
  * 120-character slices: a snippet identifies a memory being removed, and the
  * merged text IS the change being approved.
  */
-export function buildApprovalMessage({ record, decisions, channel }) {
+export function buildApprovalMessage({
+  record,
+  decisions,
+  channel,
+  unattended = false,
+}) {
   const withheld = { RETAIN: 0, UNSTABLE: 0 };
   for (const d of decisions) {
     if (d.verdict in withheld) withheld[d.verdict] += 1;
@@ -1497,7 +1514,10 @@ export function buildApprovalMessage({ record, decisions, channel }) {
     throw new Error(
       `the review list needs ${blocks.length} Block Kit blocks, over Slack's ` +
         `${SLACK_MAX_BLOCKS}-block message limit for ${record.ids.length} ids — ` +
-        `lower --cap rather than posting a list the operator cannot see whole`,
+        approvalSizeRemedy(
+          unattended,
+          `lower --cap rather than posting a list the operator cannot see whole`,
+        ),
     );
   }
   const long = blocks.find(
@@ -1964,6 +1984,7 @@ export async function postApprovalRequest({
   fetchImpl,
   s3,
   artifactBucket,
+  unattended = false,
   now = Date.now,
   log = () => {},
 }) {
@@ -2060,6 +2081,7 @@ export async function postApprovalRequest({
     artifactBucket: artifact ? artifactBucket : undefined,
     artifactKey: artifact?.key,
     artifactHash: artifact?.hash,
+    unattended,
   });
 
   await write(record);
@@ -2071,7 +2093,12 @@ export async function postApprovalRequest({
     return { record, posted: false };
   }
 
-  const message = buildApprovalMessage({ record, decisions, channel });
+  const message = buildApprovalMessage({
+    record,
+    decisions,
+    channel,
+    unattended,
+  });
   const posted = await slackCall("chat.postMessage", message, { botToken, fetchImpl });
 
   try {
@@ -4248,6 +4275,7 @@ async function buildPostApproval(opts, region, runtime) {
       botToken,
       s3,
       artifactBucket,
+      unattended: process.env[MEM9_UNATTENDED_ENV] === "1",
       fetchImpl: runtime.fetchImpl ?? fetch,
       log: (message) =>
         console.error(`[memory-cleanup ${new Date().toISOString()}] ${message}`),

--- a/scripts/memory-cleanup.test.mjs
+++ b/scripts/memory-cleanup.test.mjs
@@ -5457,9 +5457,12 @@ describe("the apply task's in-container runtime (#123)", () => {
     "MEM9_DB_NAME",
     "MEM9_DB_PORT",
     "MEM9_DB_SECRET",
+    "MEM9_CLEANUP_UNATTENDED",
     "MEM9_LLM_MODEL",
+    "MEM9_SLACK_APPROVAL_CHANNEL",
     "MEM9_SSM_PREFIX",
     "MEM9_TENANT_ID",
+    "SLACK_BOT_TOKEN",
   ];
   afterEach(() => {
     for (const key of environmentKeys) delete process.env[key];
@@ -5580,6 +5583,61 @@ describe("the apply task's in-container runtime (#123)", () => {
     ]);
     expect(secrets.sent[0].SecretId).toBe(secretArn);
     expect(calls[0][1]).toMatchObject({ password: "from-secret" });
+    await production.close();
+  });
+
+  it("TC-SLACKAPP-215 carries the unattended marker through both offer-size refusals", async () => {
+    containerEnv({
+      MEM9_CLEANUP_UNATTENDED: "1",
+      MEM9_SLACK_APPROVAL_CHANNEL: "C0APPROVAL",
+      SLACK_BOT_TOKEN: "xoxb-fixture-token",
+    });
+    const production = await createCleanupDeps(
+      { stage: "prod", apply: false, cap: 50 },
+      {
+        ssm: fakeAwsClient(),
+        getToken: vi.fn(),
+        fromNodeProviderChain: vi.fn(),
+      },
+    );
+    const deletion = (id, reason = "session state") => ({
+      id,
+      verdict: "DELETE",
+      reason,
+      contentHash: contentHash(`content-${id}`),
+      version: 1,
+      snippet: `snippet-${id}`,
+    });
+    const offer = (decisions) =>
+      production.deps.postApproval({
+        decisions,
+        generatedAt: "2026-08-05T03:00:00.000Z",
+        issuedAt: "2026-08-05T03:00:00.000Z",
+      });
+
+    const parameterError = await offer(
+      Array.from({ length: 4000 }, (_, i) =>
+        deletion(`memory-with-a-realistic-id-${i}`),
+      ),
+    ).then(
+      () => undefined,
+      (err) => err,
+    );
+    const blockError = await offer(
+      Array.from({ length: 60 }, (_, i) =>
+        deletion(`memory-${i}`, "x".repeat(2800)),
+      ),
+    ).then(
+      () => undefined,
+      (err) => err,
+    );
+
+    for (const error of [parameterError, blockError]) {
+      expect(error?.message).toMatch(
+        /operator-initiated review with a smaller approval limit/iu,
+      );
+      expect(error?.message).not.toContain("--cap");
+    }
     await production.close();
   });
 
@@ -6331,6 +6389,56 @@ describe("offering the list to Slack (#123)", () => {
         if (element.value) expect(element.value.length).toBeLessThanOrEqual(2000);
       }
     }
+  });
+
+  it("TC-SLACKAPP-215 gives scheduled parameter and block limits an applicable remedy", () => {
+    const many = Array.from({ length: 4000 }, (_, i) =>
+      del(`memory-with-a-realistic-id-${i}`),
+    );
+    const stamp = {
+      stage: "prod",
+      decisions: many,
+      generatedAt: "2026-08-05T03:00:00.000Z",
+      issuedAt: "2026-08-05T03:00:00.000Z",
+    };
+    const messageArgs = {
+      record: {
+        stage: "prod",
+        hash: contentHash(many.map((d) => d.id).join("\n")),
+        ids: many.map((d) => d.id),
+        generatedAt: stamp.generatedAt,
+      },
+      decisions: many,
+      channel: CHANNEL,
+    };
+    const errorMessage = (action) => {
+      try {
+        action();
+      } catch (err) {
+        return err.message;
+      }
+      throw new Error("expected the size guard to refuse the review");
+    };
+
+    for (const scheduledMessage of [
+      errorMessage(() => buildOfferedRecord({ ...stamp, unattended: true })),
+      errorMessage(() =>
+        buildApprovalMessage({ ...messageArgs, unattended: true }),
+      ),
+    ]) {
+      expect(scheduledMessage).toMatch(
+        /operator-initiated review with a smaller approval limit/iu,
+      );
+      expect(scheduledMessage).toMatch(/schedule/iu);
+      expect(scheduledMessage).not.toContain("--cap");
+    }
+
+    expect(errorMessage(() => buildOfferedRecord(stamp))).toContain(
+      "lower --cap rather than truncating the list the operator approves",
+    );
+    expect(errorMessage(() => buildApprovalMessage(messageArgs))).toContain(
+      "lower --cap rather than posting a list the operator cannot see whole",
+    );
   });
 
   // #150's merge rendering, exercised through the same builder the real offer


### PR DESCRIPTION
## Summary
- mark only the EventBridge scheduled scan as unattended
- give unattended parameter/block-limit failures a schedule-applicable remedy without naming `--cap`
- preserve the operator CLI's exact existing `lower --cap` advice

Closes #155

## Stack
This PR is based on #169 so it preserves `TC-SLACKAPP-214`; its own diff is commit `28d3cb1`.

## Mutation Evidence
- dropping `unattended` before `buildOfferedRecord` makes the integrated `TC-SLACKAPP-215` parameter-limit assertion fail
- dropping it before `buildApprovalMessage` makes the integrated `TC-SLACKAPP-215` block-limit assertion fail
- changing the scheduler marker from `1` to `0` makes `TC-SLACKAPP-150/216` fail

## Test Plan
- [x] `TC-SLACKAPP-215/216` documented and mutation-proven
- [x] Root suite passes (1089 tests)
- [x] Infra suite passes (401 tests)
- [x] Root and infra typechecks pass
- [x] Cleanup coverage passes (242 tests; 93.23% lines, 87.35% branches)
- [x] Public-artifact scan and `git diff --check` pass
- [x] Code simplification review passed
- [x] Independent committed-diff review passed
- [x] CI checks pass
- [x] Reviewer bot findings addressed

## E2E
Not applicable: no UI changes and no live Slack workspace is reproducible in CI. The scheduled ECS override and both shell-level offer failures are covered by unit tests.

