### PR TITLE
fix(infra): own decision artifact bucket outside preview stages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,14 @@ AWS_PROFILE=your-aws-profile
 # Optional protected path for direct drift-repair rollback. The file must not
 # already exist; the default is a timestamped, gitignored repo-root file.
 # ECR_SCAN_BACKUP_FILE=/path/to/ecr-registry-scanning-rollback.local.json
+# Optional exact 3-33 character account-level bucket for reviewed cleanup
+# decisions. Leave unset to use mem9-audit-<aws-account-id>. Set the same value
+# before running the bucket bootstrap, workload-boundary rollout, SST deploys,
+# and E2E checks;
+# in GitHub Actions, also create the identically named repository variable.
+# Choose once: changing an owned stack's bucket is refused as a destructive
+# replacement and requires a dedicated migration.
+# MEM9_DECISION_ARTIFACT_BUCKET=example-mem9-decision-artifacts
 # Application VPC discovery follows the provider region in sst.config.ts.
 # MEM9_VPC_ID=vpc-xxxxxxxxxxxxxxxxx
 # --- llm-proxy Responses route (OpenAI gpt-5.6 terra/luna; optional) ---

--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -87,6 +87,7 @@ on:
       - "infra/cloudformation/github-actions-role.yaml"
       - "infra/cloudformation/ecr-registry-scanning.yaml"
       - "infra/cloudformation/workload-permissions-boundary.yaml"
+      - "infra/cloudformation/decision-artifact-bucket.yaml"
   push:
     branches: [main]
     paths:
@@ -103,6 +104,7 @@ on:
       - "infra/cloudformation/github-actions-role.yaml"
       - "infra/cloudformation/ecr-registry-scanning.yaml"
       - "infra/cloudformation/workload-permissions-boundary.yaml"
+      - "infra/cloudformation/decision-artifact-bucket.yaml"
 
 # Per-PR concurrency for PR events (cancel superseded runs so repeated
 # `synchronize` events don't race the same `pr-N` stage's unlock/deploy);
@@ -250,6 +252,8 @@ jobs:
           cfn-lint infra/cloudformation/ecr-registry-scanning.yaml --regions "$application_region"
           cfn-lint infra/cloudformation/github-actions-role.yaml --regions us-west-2
           cfn-lint infra/cloudformation/workload-permissions-boundary.yaml --regions us-west-2
+          # Application region: this bucket is deployed there, not us-west-2.
+          cfn-lint infra/cloudformation/decision-artifact-bucket.yaml --regions "$application_region"
 
       - name: Validate workload boundary operator scripts
         run: |

--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -50,6 +50,9 @@
 #   MEM9_COGNITO_DOMAIN_PREFIX — existing production Cognito domain prefix.
 #                  Set this before adopting derived defaults so prod keeps its
 #                  current OAuth hostname. Previews intentionally do not use it.
+#   MEM9_DECISION_ARTIFACT_BUCKET — exact account-level bucket bootstrapped by
+#                  scripts/deploy-decision-artifact-bucket.sh. Unset uses
+#                  mem9-audit-<account-id>. The boundary must use the same value.
 #
 # Workload-boundary maintenance gate revision: 1
 
@@ -88,6 +91,7 @@ on:
       - "infra/cloudformation/ecr-registry-scanning.yaml"
       - "infra/cloudformation/workload-permissions-boundary.yaml"
       - "infra/cloudformation/decision-artifact-bucket.yaml"
+      - "infra/cloudformation/decision-artifact-bucket-import.yaml"
   push:
     branches: [main]
     paths:
@@ -105,6 +109,7 @@ on:
       - "infra/cloudformation/ecr-registry-scanning.yaml"
       - "infra/cloudformation/workload-permissions-boundary.yaml"
       - "infra/cloudformation/decision-artifact-bucket.yaml"
+      - "infra/cloudformation/decision-artifact-bucket-import.yaml"
 
 # Per-PR concurrency for PR events (cancel superseded runs so repeated
 # `synchronize` events don't race the same `pr-N` stage's unlock/deploy);
@@ -124,6 +129,7 @@ concurrency:
 
 env:
   ROLE_NAME: github-actions-mem9-on-aws
+  MEM9_DECISION_ARTIFACT_BUCKET: ${{ vars.MEM9_DECISION_ARTIFACT_BUCKET }}
   # The out-of-band ECR repo namespace (infra/cloudformation/ecr-repositories.yaml).
   # build-and-push-image builds four images under it: <ns>/mnemo-server,
   # <ns>/qwen3-embed, <ns>/bootstrap, <ns>/llm-proxy. Deploy stages reference
@@ -254,6 +260,7 @@ jobs:
           cfn-lint infra/cloudformation/workload-permissions-boundary.yaml --regions us-west-2
           # Application region: this bucket is deployed there, not us-west-2.
           cfn-lint infra/cloudformation/decision-artifact-bucket.yaml --regions "$application_region"
+          cfn-lint infra/cloudformation/decision-artifact-bucket-import.yaml --regions "$application_region"
 
       - name: Validate workload boundary operator scripts
         run: |
@@ -265,6 +272,7 @@ jobs:
           # ship. 0.11.0.1 wraps upstream 0.11.0, matching what apt installed.
           python -m pip install --disable-pip-version-check 'shellcheck-py==0.11.0.1'
           shellcheck scripts/deploy-workload-permissions-boundary.sh
+          shellcheck scripts/deploy-decision-artifact-bucket.sh
           shellcheck scripts/rollout-workload-permissions-boundary.sh
           shellcheck scripts/run-consolidation-task.sh
           shellcheck scripts/run-slack-approval-e2e.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,8 +103,16 @@ them, update the file rather than silently diverging.
 ## Out-of-band bootstrap scripts
 
 `scripts/deploy-*.sh` create resources the SST app references read-only (the
-GitHub Actions IAM role, four ECR repositories, and the Bedrock Mantle Project)
-so that a `sst remove --stage pr-N` can never wipe shared/prod state. They are NOT
-part of the CI deploy — run them once per AWS account. Each reads its config from a
-gitignored `.env` (copy `.env.example` and fill in your own AWS profile). See each
-script's header comment for what it provisions and when to re-run it.
+GitHub Actions IAM role, four ECR repositories, the Bedrock Mantle Project, and
+the decision-artifact bucket) so that a `sst remove --stage pr-N` can never wipe
+shared/prod state. They are NOT part of the CI deploy — run them once per AWS
+account. Each reads its config from a gitignored `.env` (copy `.env.example` and
+fill in your own AWS profile). See each script's header comment for what it
+provisions and when to re-run it.
+
+A resource whose NAME must be fixed and account-scoped belongs here, not in the
+SST app, and the reason is stronger than teardown safety: every stage computes the
+same name, so the first stage to deploy owns it and every later stage's create
+fails as an already-exists error the provider does not adopt through. The
+decision-artifact bucket was SST-owned and hit exactly that — see
+TC-SLACKAPP-215.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,3 +116,8 @@ same name, so the first stage to deploy owns it and every later stage's create
 fails as an already-exists error the provider does not adopt through. The
 decision-artifact bucket was SST-owned and hit exactly that — see
 TC-SLACKAPP-215.
+
+`MEM9_DECISION_ARTIFACT_BUCKET` is the single optional override for that bucket.
+The owner stack, workload-boundary rollout, SST deploy, CI, and E2E must all use
+the same value; unset means `mem9-audit-<account-id>`. Never change it on only one
+surface or replace an already-owned bucket in place.

--- a/README.md
+++ b/README.md
@@ -252,8 +252,9 @@ The AgentCore Gateway exposes four tools over MCP (Cognito-authenticated):
   `bootstrap` (schema + tenant seed).
 - `scripts/` — out-of-band bootstrap scripts (GitHub Actions IAM role, workload
   permissions boundary, four ECR repositories, guarded registry scan-on-push,
-  and Bedrock Mantle Project) that the SST app references read-only. See each
-  script's header and `.env.example` for the environment it expects.
+  Bedrock Mantle Project, and the decision-artifact bucket) that the SST app
+  references read-only. See each script's header and `.env.example` for the
+  environment it expects.
 - `docs/` — `ARCHITECTURE.md` (decisions) and `mem9-facts.md` (upstream constraints).
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -288,6 +288,75 @@ The AgentCore Gateway exposes four tools over MCP (Cognito-authenticated):
   separate regional Mantle Project, such as the OpenAI Responses fallback.
 - Agent contributors: see [`AGENTS.md`](AGENTS.md) for repo conventions and hard rules.
 
+### Decision-artifact bucket bootstrap
+
+The Slack cleanup approval loop stores the reviewed decision bytes in one
+account-level S3 bucket. Every SST stage shares that bucket and is isolated by
+its `decisions/<stage>/` key prefix. The bucket must therefore be provisioned
+before enabling Slack approval; an SST stage never creates or deletes it.
+
+For the default `mem9-audit-<aws-account-id>` name:
+
+```bash
+# If .env does not already exist, copy .env.example and set AWS_PROFILE.
+scripts/deploy-decision-artifact-bucket.sh
+```
+
+To choose a different name, set one value everywhere before the first bootstrap:
+
+```bash
+# In the gitignored .env used by operator scripts:
+MEM9_DECISION_ARTIFACT_BUCKET=example-mem9-decision-artifacts
+
+scripts/deploy-decision-artifact-bucket.sh
+gh variable set MEM9_DECISION_ARTIFACT_BUCKET \
+  --body "example-mem9-decision-artifacts"
+```
+
+If the workload boundary stack is new and unattached, create it with the same
+environment:
+
+```bash
+scripts/deploy-workload-permissions-boundary.sh
+```
+
+If the boundary already exists, update it only through the guarded
+[workload permissions-boundary rollout](#workload-permissions-boundary-rollout).
+That procedure requires the deployment maintenance pause, a clean merged
+default-branch checkout, and `WORKLOAD_BOUNDARY_MAINTENANCE_ACK=true`; do not run
+the rollout as an unguarded bootstrap command.
+
+The name must be 3–33 lowercase letters, digits, or hyphens, beginning and
+ending with a letter or digit, and cannot use an S3-reserved prefix or suffix.
+The 33-character ceiling preserves the workload boundary's 6144-byte
+managed-policy quota because the exact name appears three times. The same value
+scopes the bucket stack, SST task grants, workload boundary, preview E2E, and CI
+deploys. Leave both `.env` and the repository variable unset to use the default.
+Do not change the value after the stack owns a bucket: the script refuses that
+replacement because it would split the audit trail and the boundary. A rename
+needs a dedicated data and IAM migration.
+
+On a fresh account the script creates the full stack. If the old stage-owned
+deployment left the bucket behind, the script automatically imports only that
+bucket with `decision-artifact-bucket-import.yaml`, waits for
+`stack-import-complete`, then applies the full template. This second update is
+required because CloudFormation import records properties but does not reconcile
+public-access block, encryption, lifecycle, tags, or create the TLS-only policy.
+Every path finishes by reading those controls back and requiring CloudFormation
+drift status `IN_SYNC`. Re-running the script updates and verifies the existing
+owner stack. If a full update rolls back, rerun after fixing the cause;
+`UPDATE_ROLLBACK_COMPLETE` is recoverable after the script re-verifies the
+physical bucket, while `UPDATE_ROLLBACK_FAILED` first requires
+`continue-update-rollback`.
+
+The adoption phase is rerunnable after interruption. A pending
+`REVIEW_IN_PROGRESS` stack resumes only when the fixed import change set reads
+back exactly, and `IMPORT_IN_PROGRESS` resumes only its waiter. An
+`IMPORT_ROLLBACK_COMPLETE` stack is recreated only after the script confirms its
+stack shell owns no resources. `IMPORT_ROLLBACK_FAILED`, an unrecognized change
+set, or any rollback stack that still owns a resource is left untouched for
+explicit CloudFormation recovery.
+
 ### Optional hosted OAuth callback URLs
 
 Native MCP clients continue to use RFC 8252 loopback callbacks without any
@@ -1144,12 +1213,15 @@ deliberate: GitHub exposes an unset secret as an empty string, so the failure it
 replaces is a Slack app that answers 401 to every click after a completely green
 deploy.
 
-Two prerequisites are not part of an application deploy. The workload
-permissions boundary must already admit the approval-record write
+Two infrastructure prerequisites are not part of an application deploy. The
+decision-artifact bucket must be bootstrapped as described above, and the
+workload permissions boundary must already admit the approval-record write
 (`ssm:PutParameter` scoped to `parameter/mem9-on-aws/*/approvals/*`) — until that
 rollout runs, the claim is denied at runtime and the click reports that the
-approval could not be recorded. Use a **private** channel: anyone who can click
-can approve a deletion, and the message shows every offered id and snippet.
+approval could not be recorded. If the bucket name is overridden, roll out the
+boundary with the same `MEM9_DECISION_ARTIFACT_BUCKET` value before deploying
+any stage. Use a **private** channel: anyone who can click can approve a deletion,
+and the message shows every offered id and snippet.
 
 **Nothing scheduled posts the review list yet.** The weekly Scheduler target is
 `memory-consolidation.mjs`, which never executes a DELETE, and this stack's

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -748,6 +748,7 @@ to the GitHub Actions deploy role.
 | Database               | Aurora PostgreSQL Serverless v2, direct writer endpoint; PITR retention prod=14 days, non-prod=1 day | `infra/db.ts`                                                                                                 |
 | Database credential    | Secrets Manager task-definition secret                                                               | `infra/db.ts`, `docker/mnemo-server/entrypoint.sh`                                                            |
 | Workload IAM ceiling   | Retained operator-owned permissions boundary; guarded live migration                                 | `infra/cloudformation/workload-permissions-boundary.yaml`, `scripts/rollout-workload-permissions-boundary.sh` |
+| Decision audit         | One retained, account-level S3 bucket shared by stages through stage-scoped key prefixes             | `infra/cloudformation/decision-artifact-bucket.yaml`, `scripts/deploy-decision-artifact-bucket.sh`             |
 | Embedding              | Local qwen3 sidecar, 1024 dimensions                                                                 | `docker/qwen3-embed/`                                                                                         |
 | Smart-ingest LLM       | Local proxy to Bedrock Mantle                                                                        | `docker/llm-proxy/`                                                                                           |
 | Mantle attribution     | `OpenAI-Project` added by `llm-proxy` when a project is configured                                   | `docker/llm-proxy/server.mjs`                                                                                 |
@@ -765,6 +766,15 @@ to the GitHub Actions deploy role.
   independent defaults. Existing live deployments cannot be moved in place.
 - Account-global IAM ownership stacks remain in `us-west-2`. The selected
   OpenAI GPT route uses its independent Responses region, default `us-west-2`.
+- The reviewed-decision artifact bucket is owned by one out-of-band
+  CloudFormation stack in the application region. SST stages reference it and
+  never own it. `MEM9_DECISION_ARTIFACT_BUCKET` may select an exact name before
+  bootstrap; unset uses `mem9-audit-<account-id>`. The bucket stack, workload
+  boundary, SST synthesis, CI, and E2E must receive the same value. Existing
+  bucket adoption imports only the bucket, then performs a normal full-template
+  update and requires live control read-back plus `IN_SYNC` drift status. Every
+  runtime and E2E S3 request also supplies the current account as
+  `ExpectedBucketOwner`.
 - Aurora PostgreSQL plus pgvector is the database engine.
 - Aurora automated backup retention is 14 days in production and 1 day in every
   non-production stage; PITR restores to a separate cluster.

--- a/docs/test-cases/slack-approval-loop.md
+++ b/docs/test-cases/slack-approval-loop.md
@@ -865,6 +865,18 @@ these cover its shape. Every property here is a *deploy-time* property whose
 failure lands at runtime — an AccessDenied after a scan has spent two reasoning
 passes, or after an approval click has been spent.
 
+The bucket is **out-of-band** — `infra/cloudformation/decision-artifact-bucket.yaml`,
+deployed once per account by `scripts/deploy-decision-artifact-bucket.sh` — so the
+cases below read the operator-owned template rather than this app's synthesized
+resources. It was originally SST-owned, and that could not work: the boundary pins
+the exact bucket ARN, so the name must be fixed, and it is account-scoped, so every
+stage computes the same one while S3 bucket names are globally unique. The first
+stage to deploy owned it and every later stage's `CreateBucket` failed
+`BucketAlreadyOwnedByYou` — the provider surfaces that error rather than adopting a
+same-owner bucket — while `retainOnDelete` meant a torn-down preview kept the
+bucket and left prod's first deploy permanently failing. TC-SLACKAPP-215 is what
+keeps it from coming back.
+
 - **TC-SLACKAPP-161** — the bucket is named with the **account id** and no
   wildcard. This is a security property, not a naming style: S3 bucket names are a
   **global** namespace, so a wildcard in the bucket segment of the boundary's ARN
@@ -885,17 +897,22 @@ passes, or after an approval click has been spent.
   a combination that denies every artifact write **and** read after deploy.
   Whichever way a future edit breaks the pair, one of the two now fails.
 - **TC-SLACKAPP-163** — the artifact is encrypted with SSE-KMS (`alias/aws/s3`) and
-  **bucket keys on**, asserted at the same bucket the name came from: a sub-resource
-  addressed elsewhere leaves this bucket on the provider default, SSE-S3, which is
-  encrypted with a key the boundary's encryption-context denies say nothing about.
-  The bucket-key flag is pinned from *both* sides — here and in 162 — because the
+  **bucket keys on**. In CloudFormation these are inline properties of the one
+  bucket, so "asserted at the same bucket" is now structural rather than a separate
+  check: unlike the Pulumi sub-resources they replaced, they cannot be addressed at
+  a different bucket and leave this one on the provider default (SSE-S3, encrypted
+  with a key the boundary's encryption-context denies say nothing about). The
+  bucket-key flag is still pinned from *both* sides — here and in 162 — because the
   mismatch is invisible until deploy.
 - **TC-SLACKAPP-164** — the object expires on the **same 72h bound as the
   approval**, not an independently chosen retention: past that the approval cannot
   be clicked, so the artifact could not be replayed by anything and holding memory
-  ids longer serves no purpose. `abortIncompleteMultipartUpload` is pinned
-  separately — failed multipart writes are not covered by the expiration rule and
-  would accumulate invisibly.
+  ids longer serves no purpose. Asserted twice: against the literal 3, and against
+  `DECISION_ARTIFACT_TTL_DAYS`. The second is load-bearing now that the rule lives
+  in CloudFormation while the constant stays in TypeScript — nothing but that line
+  keeps two files in two languages in step. `AbortIncompleteMultipartUpload` is
+  pinned separately — failed multipart writes are not covered by the expiration rule
+  and would accumulate invisibly.
 - **TC-SLACKAPP-165** — all four public-access blocks and a bucket policy that
   **denies** non-TLS requests. Four and not three: two cover ACLs and two cover
   bucket policies, and three-of-four leaves a way to make the object public. The
@@ -904,11 +921,57 @@ passes, or after an approval click has been spent.
   policies that are supposed to be the only way in. Both ARN forms are named,
   because bucket-level operations do not match the `/*` form and a policy naming
   only objects leaves `ListBucket` reachable over plain HTTP.
-- **TC-SLACKAPP-166** — the bucket is **retained** on stage teardown and
-  `forceDestroy` stays off. The name is account-scoped, so every stage — including
-  each PR's preview stage — resolves to the same bucket; a preview teardown that
-  deleted it would take prod's audit trail of what was deleted with it, and
-  `forceDestroy` would empty the bucket even where the bucket survives.
+- **TC-SLACKAPP-166** — the bucket is **retained**, via both `DeletionPolicy` and
+  `UpdateReplacePolicy`. Two policies and not one, because they cover different
+  events: a stack `DELETE`, and a property change that *replaces* the bucket. The
+  name is account-scoped, so every stage — including each PR's preview stage —
+  resolves to the same bucket, and losing it takes prod's audit trail of what was
+  deleted with it.
+- **TC-SLACKAPP-217** — the bucket **policy** is retained too, and the template has
+  **no `Outputs`**. Both halves are one fact: retaining the bucket without its policy
+  means a stack `DELETE` keeps the audit trail and deletes the only thing requiring
+  TLS to reach it (TC-165), so the surviving bucket is weaker than the reviewed one.
+  The same attribute is also what keeps the recovery path open, and both constraints
+  came back as rejections from a real `CreateChangeSet`, not from reading the docs:
+  an `IMPORT` change set must name **every** resource in the template ("Resources
+  [DecisionArtifactBucketPolicy] is missing from ResourceToImport list"), each of
+  those resources must carry `DeletionPolicy`, and "you cannot modify or add
+  [Outputs]" — for a stack that does not exist yet, *any* output is an add. So an
+  export block here would break adopting a bucket that a stage-owned deploy already
+  created, which is the one recovery this template exists for. Nothing consumes an
+  export: both the SST app and the E2E harness derive the name from the account id.
+  The assertion loops over every resource, so adding a third without a
+  `DeletionPolicy` fails here rather than at recovery time, when the bucket already
+  exists and the operator has no other way in. Note the docs describe import as
+  going "into an existing stack"; that describes a flow, not a constraint — a
+  probe confirmed `--change-set-type IMPORT` is accepted for a stack that does not
+  exist yet. Both resources also carry `UpdateReplacePolicy: Retain`, which closes
+  the same loss through a different door: `BucketName` is createOnly on the bucket
+  and `Bucket` is createOnly on the policy (per their live resource schemas), so
+  retargeting either **replaces** it and the replacement's cleanup deletes the
+  original. `cfn-lint` reports the missing half as `W3011`, but only as a warning
+  and only for templates the lint step actually names — see TC-SLACKAPP-218.
+- **TC-SLACKAPP-218** — `infra-ci.yml` **gates and lints** this template. The
+  workflow excludes `infra/cloudformation/**` and then re-includes specific
+  templates, so a template is gated only if it appears *after* the exclusion —
+  order decides it, not presence. This one was missing from both the
+  `pull_request` and `push` filters and from the `cfn-lint` step, so a PR touching
+  only the template triggered no run at all, while the five security properties
+  that moved out of `infra/slack-approval.ts` lived there unwatched. That gap is
+  what let a missing `UpdateReplacePolicy` reach review: the CloudFormation API
+  accepts the template, the unit tests did not read the attribute, and the only
+  tool that flags it was not pointed at the file. The case asserts the path's
+  position relative to the exclusion in both triggers *and* the `cfn-lint`
+  invocation, pinned to the application region — this bucket is deployed there,
+  not in `us-west-2` with the account-global IAM stacks.
+- **TC-SLACKAPP-215** — this stack declares **no bucket resource at all**, asserted
+  by resource *type* rather than by logical name so a rename cannot slip past. The
+  regression it guards is not hypothetical — it shipped, and it is a permanent prod
+  outage rather than a degraded one: re-adding any of the five resources restores the
+  `BucketAlreadyOwnedByYou` collision described above, with no way back short of
+  deleting the audit trail. This is the case to read first if a future change is
+  tempted to move the bucket back into the app for the convenience of a resource
+  handle.
 - **TC-SLACKAPP-167** — the **stage** goes in the key, not the bucket name. Once
   the bucket became account-scoped, the key prefix is the only thing carrying
   cross-stage separation — without it two stages write the same object and a
@@ -2015,6 +2078,19 @@ fail the run.
   incidental: a different assertion about a different thing, reachable only because the
   same injected error also hit a read that classifies properly. Asserted on the message
   rather than the exit code for that reason.
+
+- **TC-SLACKAPP-216** — an absent artifact bucket **fails** the run and names
+  `scripts/deploy-decision-artifact-bucket.sh`. The bucket is provisioned out-of-band,
+  which decoupled two facts that used to travel together: a stage holding
+  `slack/signing-secret` no longer implies the bucket exists, so this is the state a
+  fresh account is in until the bootstrap has been run once. Deliberately **not** one of
+  this harness's graceful skips — the approval loop is deployed on the stage by the time
+  this check runs, so the artifact half is genuinely broken and a skip would report a
+  green run for a loop that cannot execute a `MERGE`. Without the preflight the first
+  `put_artifact` fails with a bare `NoSuchBucket` into a discarded stdout and the run
+  surfaces later as a hash mismatch, sending the reader to the wrong file entirely.
+  Asserted to refuse *before* seeding, too: an abort that had already written
+  `approvals/offered` would leave a record the next run's click could consume.
 
 - **TC-SLACKAPP-212** — an exit between building the two artifact bodies and the full
   `cleanup` trap still deletes them. The bodies are `mktemp`ed well before that trap is

--- a/docs/test-cases/slack-approval-loop.md
+++ b/docs/test-cases/slack-approval-loop.md
@@ -1877,6 +1877,9 @@ fail the run.
     A failed `FilterLogEvents` call is a query failure, never zero matches; after
     the marker poll expires, an empty-pattern count distinguishes a populated
     stream missing the replay marker from a stream whose logs have not arrived.
+    The AWS CLI query uses JSON output: text output applies `length(events)` once
+    per page and can return `1` then `0`, while JSON aggregates pages before the
+    query and returns one count.
   - **The signing secret reaches the HMAC through the ENVIRONMENT**, not an argv:
     `openssl dgst -hmac "$SECRET"` is the obvious way to write this in bash and
     would put the secret in a world-readable command line. Pinned by a static

--- a/docs/test-cases/slack-approval-loop.md
+++ b/docs/test-cases/slack-approval-loop.md
@@ -1873,7 +1873,10 @@ fail the run.
     config fails the run by name (TC-SLACKAPP-209) rather than scanning nothing.
     Only the replayed **count** is matched, not the log line whole: that line names
     the audit bucket, whose name embeds the account id, and preview CI logs are
-    public.
+    public. The marker is polled for two minutes to allow CloudWatch delivery.
+    A failed `FilterLogEvents` call is a query failure, never zero matches; after
+    the marker poll expires, an empty-pattern count distinguishes a populated
+    stream missing the replay marker from a stream whose logs have not arrived.
   - **The signing secret reaches the HMAC through the ENVIRONMENT**, not an argv:
     `openssl dgst -hmac "$SECRET"` is the obvious way to write this in bash and
     would put the secret in a world-readable command line. Pinned by a static
@@ -2068,9 +2071,16 @@ fail the run.
     reviewed`), and for a 5xx (`answered HTTP 500, not 200`). Three distinguishable
     messages, because the operator's next move differs: a façade bug, a claim-order
     bug, and a reply the operator cannot see.
-  - **Zero replay lines fails the run**, naming the cause the count implies — the task
-    exited 0 by **re-classifying** instead of replaying, so the approved `MERGE` was
-    not what ran.
+  - **Zero replay lines fails the run after a two-minute poll.** A second,
+    empty-pattern count decides what can actually be inferred: a populated stream
+    missing the marker means the task exited 0 by **re-classifying** instead of
+    replaying, while a stream with zero total events reports delayed log delivery
+    or wrong stream configuration and does not claim which application path ran.
+  - **A failed CloudWatch Logs query fails distinctly.** The harness suppresses the
+    raw AWS error so account-scoped identifiers cannot enter public CI output, but
+    preserves the nonzero status and reports that the replay assertion could not
+    inspect the stream. It never turns `AccessDenied`, throttling, or a missing log
+    group into a zero-event diagnosis.
   - **The log query uses the task definition's own group and stream prefix.** Asserted
     on the fake's recorded `logs filter-log-events` invocations: a hash-suffixed group
     name and a `{prefix}/{container}/{task-id}` stream, neither of which a hand-

--- a/docs/test-cases/slack-approval-loop.md
+++ b/docs/test-cases/slack-approval-loop.md
@@ -927,30 +927,17 @@ keeps it from coming back.
   name is account-scoped, so every stage — including each PR's preview stage —
   resolves to the same bucket, and losing it takes prod's audit trail of what was
   deleted with it.
-- **TC-SLACKAPP-217** — the bucket **policy** is retained too, and the template has
-  **no `Outputs`**. Both halves are one fact: retaining the bucket without its policy
+- **TC-SLACKAPP-217** — the bucket **policy** is retained too, and the full
+  template has **no `Outputs`**. Retaining the bucket without its policy
   means a stack `DELETE` keeps the audit trail and deletes the only thing requiring
   TLS to reach it (TC-165), so the surviving bucket is weaker than the reviewed one.
-  The same attribute is also what keeps the recovery path open, and both constraints
-  came back as rejections from a real `CreateChangeSet`, not from reading the docs:
-  an `IMPORT` change set must name **every** resource in the template ("Resources
-  [DecisionArtifactBucketPolicy] is missing from ResourceToImport list"), each of
-  those resources must carry `DeletionPolicy`, and "you cannot modify or add
-  [Outputs]" — for a stack that does not exist yet, *any* output is an add. So an
-  export block here would break adopting a bucket that a stage-owned deploy already
-  created, which is the one recovery this template exists for. Nothing consumes an
-  export: both the SST app and the E2E harness derive the name from the account id.
-  The assertion loops over every resource, so adding a third without a
-  `DeletionPolicy` fails here rather than at recovery time, when the bucket already
-  exists and the operator has no other way in. Note the docs describe import as
-  going "into an existing stack"; that describes a flow, not a constraint — a
-  probe confirmed `--change-set-type IMPORT` is accepted for a stack that does not
-  exist yet. Both resources also carry `UpdateReplacePolicy: Retain`, which closes
-  the same loss through a different door: `BucketName` is createOnly on the bucket
-  and `Bucket` is createOnly on the policy (per their live resource schemas), so
-  retargeting either **replaces** it and the replacement's cleanup deletes the
-  original. `cfn-lint` reports the missing half as `W3011`, but only as a warning
-  and only for templates the lint step actually names — see TC-SLACKAPP-218.
+  Both resources also carry `UpdateReplacePolicy: Retain`, which closes the same
+  loss through a different door: `BucketName` is createOnly on the bucket and
+  `Bucket` is createOnly on the policy. The absent output keeps the external
+  bucket setting as the one source of truth for every consumer instead of
+  introducing a stack export that only some deployments might follow.
+  Existing-bucket recovery is separately pinned by TC-SLACKAPP-220: import uses a
+  bucket-only template, never this final template.
 - **TC-SLACKAPP-218** — `infra-ci.yml` **gates and lints** this template. The
   workflow excludes `infra/cloudformation/**` and then re-includes specific
   templates, so a template is gated only if it appears *after* the exclusion —
@@ -964,6 +951,55 @@ keeps it from coming back.
   position relative to the exclusion in both triggers *and* the `cfn-lint`
   invocation, pinned to the application region — this bucket is deployed there,
   not in `us-west-2` with the account-global IAM stacks.
+- **TC-SLACKAPP-219** — `MEM9_DECISION_ARTIFACT_BUCKET` is one optional,
+  externally supplied bucket name for **every** consumer: the out-of-band bucket
+  stack, the SST task environment and identity policy, the workload-boundary
+  object ARN and both KMS encryption-context pins, CI, and the live E2E harness.
+  Unset, all consumers retain the account-derived `mem9-audit-<account-id>`
+  default. Set, they use the exact validated override with no account-derived
+  suffix. Invalid names and names over 33 characters fail before synthesis or an
+  AWS mutation; the ceiling preserves the 6144-byte boundary quota because the
+  exact name renders three times. The boundary keeps an exact bucket ARN rather
+  than widening the bucket segment. SST also injects the current 12-digit account
+  as `MEM9_DECISION_ARTIFACT_BUCKET_OWNER`; runtime Get/Put and E2E Head/Put/Delete
+  pass it as `ExpectedBucketOwner`, so an override cannot silently target a
+  same-named bucket in another account.
+- **TC-SLACKAPP-220** — adopting a bucket left by the old stage-owned deployment
+  uses a separate **import-only** template containing exactly the bucket, its
+  name parameter, and both retention policies. The import change set names only
+  that existing bucket. After `stack-import-complete`, a normal update applies the
+  full template, adding the TLS-only policy and reconciling public-access block,
+  SSE-KMS bucket keys, lifecycle, and tags. Importing the final template directly
+  is forbidden: the policy may not exist, and CloudFormation import records
+  properties without reconciling the live bucket.
+- **TC-SLACKAPP-221** — stack discovery, bucket discovery, import, create, update,
+  waits, and every verification read are **fail closed**. Only an explicit
+  CloudFormation "stack does not exist" response selects bootstrap, and only an
+  explicit S3 not-found response selects create rather than import. AccessDenied,
+  throttling, malformed output, or a wrong-region bucket causes no subsequent
+  mutation. Interrupted adoption has three narrow recovery paths:
+  `REVIEW_IN_PROGRESS` resumes only the fixed-name change set after its
+  description, parameter, and single bucket `Import` action read back exactly;
+  `IMPORT_IN_PROGRESS` only resumes its waiter; and
+  `IMPORT_ROLLBACK_COMPLETE` is deleted and recreated only when the stack shell
+  owns zero resources. `UPDATE_ROLLBACK_COMPLETE` retries the full update after
+  re-verifying the physical bucket. `IMPORT_ROLLBACK_FAILED`,
+  `UPDATE_ROLLBACK_FAILED`, any unknown state, and any rollback stack that still
+  owns a resource require explicit operator recovery.
+- **TC-SLACKAPP-222** — every successful create/import/update finishes with live
+  read-back of the exact bucket identity, region, four public-access blocks,
+  SSE-KMS plus bucket keys, the 3-day lifecycle and 1-day multipart abort, the
+  TLS-only bucket policy, and CloudFormation ownership of both the bucket and
+  policy resources. The script then runs stack drift detection and accepts only
+  `DETECTION_COMPLETE` plus `IN_SYNC`. A no-op update is not proof that direct
+  resource drift is absent.
+- **TC-SLACKAPP-223** — artifact reads and writes require a 12-digit
+  `MEM9_DECISION_ARTIFACT_BUCKET_OWNER` and pass it to S3 as
+  `ExpectedBucketOwner`. Both offer creation and approved cleanup refuse before
+  issuing an S3 request when the owner is absent or malformed. This keeps a
+  correctly formatted override from redirecting reviewed decision bytes to a
+  bucket owned by another account, even if identity policy configuration is
+  later widened accidentally.
 - **TC-SLACKAPP-215** — this stack declares **no bucket resource at all**, asserted
   by resource *type* rather than by logical name so a rename cannot slip past. The
   regression it guards is not hypothetical — it shipped, and it is a permanent prod
@@ -1610,14 +1646,14 @@ and therefore the withholding.
      exactly when a guard earns its place: the alternative is a preview review
      applied to prod.
 - **TC-SLACKAPP-191** — the replay thunk is wired **exactly when the claim names an
-  artifact**, and the direction matters. `MEM9_DECISION_ARTIFACT_BUCKET` is the
-  *scan* task's variable — the apply task does not carry it — so the coordinates can
-  only come from the claim. Keying on anything else would mean a hash covering a
-  reviewed list gets checked by the weaker id-list rule whenever the apply task
-  happens to be configured differently from the scan that offered it. A **thunk**,
-  so nothing is fetched during dep construction: the artifact is read inside
-  `runCleanup`, after service discovery, and a stage whose mnemo service is down
-  fails on discovery and never touches the object.
+  artifact**, and the direction matters. The offer and apply commands share one
+  task definition, but its current `MEM9_DECISION_ARTIFACT_BUCKET` may differ from
+  the value that produced an earlier approval. The reviewed claim is therefore the
+  only source for replay coordinates. Keying on current task configuration would
+  detach the clicked hash from its reviewed object after a configuration change. A
+  **thunk**, so nothing is fetched during dep construction: the artifact is read
+  inside `runCleanup`, after service discovery, and a stage whose mnemo service is
+  down fails on discovery and never touches the object.
 - **TC-SLACKAPP-192** — the reviewed verdicts are applied and the classifier is
   **never called**. Not merely disagreed with: a run that classified and then
   discarded the result would burn Bedrock tokens on every click and be one careless

--- a/infra/cloudformation/decision-artifact-bucket-import.yaml
+++ b/infra/cloudformation/decision-artifact-bucket-import.yaml
@@ -1,0 +1,29 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  Import-only bridge for adopting the retained decision-artifact bucket left by
+  the former stage-owned deployment. After import, the deployment script updates
+  the stack with decision-artifact-bucket.yaml to reconcile all controls and add
+  the TLS-only bucket policy.
+
+Parameters:
+  DecisionArtifactBucketName:
+    Type: String
+    MinLength: 3
+    MaxLength: 33
+    AllowedPattern: "^[a-z0-9][a-z0-9-]*[a-z0-9]$"
+    ConstraintDescription: >
+      Use 3-33 lowercase letters, digits, and hyphens, beginning and ending
+      with a letter or digit. The 33-character ceiling preserves IAM boundary
+      policy quota headroom because the name is rendered three times.
+    Description: >
+      Exact account-level bucket shared by every SST stage. The deployment
+      script defaults this to mem9-audit-<account-id> and accepts
+      MEM9_DECISION_ARTIFACT_BUCKET as an override.
+
+Resources:
+  DecisionArtifactBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      BucketName: !Ref DecisionArtifactBucketName

--- a/infra/cloudformation/decision-artifact-bucket.yaml
+++ b/infra/cloudformation/decision-artifact-bucket.yaml
@@ -5,26 +5,35 @@ Description: >
   stage, and read back by the cleanup apply task to prove the clicked hash still
   matches the reviewed bytes.
 
-  NOT SST-managed, and the reason is a name collision rather than only teardown
-  safety. The name is account-scoped (`mem9-audit-<account-id>`) because the
-  workload permissions boundary pins that exact ARN, so every stage computes the
-  SAME name; S3 bucket names are globally unique. Owned by the SST app, whichever
-  stage deployed first would hold it and every LATER stage's CreateBucket would
-  fail `BucketAlreadyOwnedByYou` — the AWS provider surfaces that error rather
-  than adopting the existing bucket, and `retainOnDelete` means a torn-down
-  preview keeps the bucket and poisons prod. Owning it here makes it exist once,
-  before any stage, for all of them.
+  NOT SST-managed. The workload boundary pins one exact account-level name
+  (default `mem9-audit-<account-id>`, or an external override), so every stage
+  uses the same globally unique S3 bucket. Per-stage ownership makes the first
+  deployment own it and every later create fail; retained previews can then
+  block production. This stack owns it once for every stage.
 
   Bootstrap ONCE per AWS account, in the application region, via
   scripts/deploy-decision-artifact-bucket.sh.
 
 Parameters:
+  DecisionArtifactBucketName:
+    Type: String
+    MinLength: 3
+    MaxLength: 33
+    AllowedPattern: "^[a-z0-9][a-z0-9-]*[a-z0-9]$"
+    ConstraintDescription: >
+      Use 3-33 lowercase letters, digits, and hyphens, beginning and ending
+      with a letter or digit. The 33-character ceiling preserves IAM boundary
+      policy quota headroom because the name is rendered three times.
+    Description: >
+      Exact account-level bucket shared by every SST stage. The deployment
+      script defaults this to mem9-audit-<account-id> and accepts
+      MEM9_DECISION_ARTIFACT_BUCKET as an override.
   ProjectName:
     Type: String
     Default: mem9-on-aws
     Description: >
-      SST app name. Tag value only — the bucket NAME is derived from the account
-      id, because that is what the boundary pins.
+      SST app name. Tag value only; DecisionArtifactBucketName controls the
+      separately configured exact bucket name.
 
 Resources:
   DecisionArtifactBucket:
@@ -44,10 +53,10 @@ Resources:
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Properties:
-      # Byte-identical to `decisionArtifactBucketName()` in infra/slack-approval.ts
-      # and to the three ARNs in workload-permissions-boundary.yaml. A drift here
-      # is an AccessDenied at artifact-write time — after the click is spent.
-      BucketName: !Sub mem9-audit-${AWS::AccountId}
+      # The bootstrap, SST app, E2E harness, and workload boundary all consume the
+      # same externally configured value. A drift is an AccessDenied at
+      # artifact-write time — after the click is spent.
+      BucketName: !Ref DecisionArtifactBucketName
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true
@@ -101,9 +110,8 @@ Resources:
     # covers the same loss through a different door: `Bucket` is this resource's
     # only createOnly property, so retargeting it REPLACES the policy, and the
     # replacement's cleanup would strip TLS from the bucket being left behind.
-    # DeletionPolicy is also what makes the bucket importable: an IMPORT change
-    # set must name EVERY resource in the template, and CloudFormation rejects one
-    # whose resources lack it.
+    # Existing-bucket adoption deliberately omits this resource from the
+    # import-only template; the subsequent normal update creates it.
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Properties:
@@ -122,11 +130,7 @@ Resources:
               Bool:
                 aws:SecureTransport: "false"
 
-# Deliberately NO Outputs. Nothing needs the name fed to it — the SST app and the
-# E2E harness both DERIVE `mem9-audit-<account-id>` from the caller's account id
-# rather than reading it back, which is the stricter check. And an Outputs block
-# would not be free: CloudFormation rejects an IMPORT change set that "cannot
-# modify or add [Outputs]", and for a stack that does not exist yet, ANY output is
-# an add. Adding one here would break the adoption path the deploy script prints
-# for a bucket a stage-owned deploy already created — the one recovery this
-# template exists to make possible.
+# Deliberately NO Outputs. The external setting is the source of truth for the
+# owner stack, boundary, SST, CI, and E2E; exporting a second value would invite
+# consumers to configure only one side. Existing-bucket adoption uses the
+# bucket-only import template, then updates to this complete declaration.

--- a/infra/cloudformation/decision-artifact-bucket.yaml
+++ b/infra/cloudformation/decision-artifact-bucket.yaml
@@ -1,0 +1,132 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  OUT-OF-BAND reviewed-decision artifact bucket for mem9-on-aws (#123/#150).
+  Holds the audit trail of what a Slack approval authorized deleting, keyed by
+  stage, and read back by the cleanup apply task to prove the clicked hash still
+  matches the reviewed bytes.
+
+  NOT SST-managed, and the reason is a name collision rather than only teardown
+  safety. The name is account-scoped (`mem9-audit-<account-id>`) because the
+  workload permissions boundary pins that exact ARN, so every stage computes the
+  SAME name; S3 bucket names are globally unique. Owned by the SST app, whichever
+  stage deployed first would hold it and every LATER stage's CreateBucket would
+  fail `BucketAlreadyOwnedByYou` — the AWS provider surfaces that error rather
+  than adopting the existing bucket, and `retainOnDelete` means a torn-down
+  preview keeps the bucket and poisons prod. Owning it here makes it exist once,
+  before any stage, for all of them.
+
+  Bootstrap ONCE per AWS account, in the application region, via
+  scripts/deploy-decision-artifact-bucket.sh.
+
+Parameters:
+  ProjectName:
+    Type: String
+    Default: mem9-on-aws
+    Description: >
+      SST app name. Tag value only — the bucket NAME is derived from the account
+      id, because that is what the boundary pins.
+
+Resources:
+  DecisionArtifactBucket:
+    Type: AWS::S3::Bucket
+    # Retain on both: the bucket is the audit trail of executed deletions, and it
+    # is shared by every stage. `DeletionPolicy` covers a stack DELETE and
+    # `UpdateReplacePolicy` a property change that REPLACES — the Pulumi original
+    # needed only `retainOnDelete` because Pulumi models replacement as a
+    # delete-after-create it also skips.
+    #
+    # There is no counterpart to the old `forceDestroy: false` because raw
+    # CloudFormation has none to set: it will not empty a bucket, and a non-empty
+    # bucket simply fails to delete. (`AutoDeleteObjects` is a CDK custom resource,
+    # not a CFN property.) So that half of the guarantee is now structural. Retain
+    # is still required, or a DELETE would try — and succeed, once the 72h
+    # lifecycle rule had emptied the bucket for it.
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      # Byte-identical to `decisionArtifactBucketName()` in infra/slack-approval.ts
+      # and to the three ARNs in workload-permissions-boundary.yaml. A drift here
+      # is an AccessDenied at artifact-write time — after the click is spent.
+      BucketName: !Sub mem9-audit-${AWS::AccountId}
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          # SSE-KMS with the AWS-managed S3 key: a customer-managed key would need
+          # its own key policy plus a boundary exception per principal.
+          #
+          # Bucket keys ON, which cuts KMS request cost by up to 99% — and which
+          # CHANGES the encryption context S3 presents: without them the context is
+          # the object ARN, with them it is the BUCKET ARN. So this line and the
+          # boundary's two `aws:s3:arn` pins are one decision, not two. Flipping it
+          # to false without repinning the boundary denies every artifact write and
+          # read, and only after deploy.
+          - BucketKeyEnabled: true
+            ServerSideEncryptionByDefault:
+              SSEAlgorithm: aws:kms
+              KMSMasterKeyID: alias/aws/s3
+      LifecycleConfiguration:
+        Rules:
+          # Expire on the same 72h bound as the approval that would replay the
+          # artifact (DECISION_ARTIFACT_TTL_DAYS = 3 in infra/slack-approval.ts):
+          # past that the object is unreachable by design. Keep the two in step.
+          - Id: expire-decision-artifacts
+            Status: Enabled
+            # Every stage's key prefix — the key, not the bucket, carries the stage.
+            Prefix: ""
+            ExpirationInDays: 3
+            # The parts of a write that failed midway are NOT covered by the
+            # expiration rule and would otherwise accumulate silently.
+            AbortIncompleteMultipartUpload:
+              DaysAfterInitiation: 1
+      Tags:
+        - Key: Project
+          Value: !Ref ProjectName
+        - Key: ManagedBy
+          Value: cloudformation
+
+  # S3 has no bucket-level "require TLS" setting; `aws:SecureTransport` in a
+  # bucket policy is the mechanism. This is the ONE statement — it constrains the
+  # transport and grants nothing, so it does not widen who can reach the artifact.
+  # The two reader/writer principals are admitted by their IDENTITY policies.
+  DecisionArtifactBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    # Retain with the bucket it constrains, on both policies for the same reason
+    # the bucket carries both. Without DeletionPolicy a stack DELETE keeps the
+    # audit bucket (above) but calls DeleteBucketPolicy, and the retained bucket
+    # silently loses the only thing that requires TLS to reach it. UpdateReplace
+    # covers the same loss through a different door: `Bucket` is this resource's
+    # only createOnly property, so retargeting it REPLACES the policy, and the
+    # replacement's cleanup would strip TLS from the bucket being left behind.
+    # DeletionPolicy is also what makes the bucket importable: an IMPORT change
+    # set must name EVERY resource in the template, and CloudFormation rejects one
+    # whose resources lack it.
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      Bucket: !Ref DecisionArtifactBucket
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: DenyInsecureTransport
+            Effect: Deny
+            Principal: "*"
+            Action: "s3:*"
+            Resource:
+              - !GetAtt DecisionArtifactBucket.Arn
+              - !Sub ${DecisionArtifactBucket.Arn}/*
+            Condition:
+              Bool:
+                aws:SecureTransport: "false"
+
+# Deliberately NO Outputs. Nothing needs the name fed to it — the SST app and the
+# E2E harness both DERIVE `mem9-audit-<account-id>` from the caller's account id
+# rather than reading it back, which is the stricter check. And an Outputs block
+# would not be free: CloudFormation rejects an IMPORT change set that "cannot
+# modify or add [Outputs]", and for a stack that does not exist yet, ANY output is
+# an add. Adding one here would break the adoption path the deploy script prints
+# for a bucket a stage-owned deploy already created — the one recovery this
+# template exists to make possible.

--- a/infra/cloudformation/workload-permissions-boundary.yaml
+++ b/infra/cloudformation/workload-permissions-boundary.yaml
@@ -4,6 +4,15 @@ Description: >
   workload roles. Deploy out of band before the guarded role migration.
 
 Parameters:
+  DecisionArtifactBucketName:
+    Type: String
+    MinLength: 3
+    MaxLength: 33
+    AllowedPattern: "^[a-z0-9][a-z0-9-]*[a-z0-9]$"
+    ConstraintDescription: >
+      Use 3-33 lowercase letters, digits, and hyphens, beginning and ending
+      with a letter or digit.
+    Description: Exact operator-owned bucket containing reviewed decisions.
   ApplicationRegion:
     Type: String
     AllowedPattern: "^[a-z]{2}(-[a-z0-9]+)+-[0-9]+$"
@@ -146,7 +155,7 @@ Resources:
               # the OBJECT glob, for S3's own resource scope; the two KMS
               # encryption-context pins below use the BUCKET arn instead, and the
               # difference is deploy-breaking rather than cosmetic.
-              - !Sub arn:${AWS::Partition}:s3:::mem9-audit-${AWS::AccountId}/*
+              - !Sub arn:${AWS::Partition}:s3:::${DecisionArtifactBucketName}/*
           # The statement above scopes the write to the PROJECT prefix, i.e. every
           # stage's whole SSM tree. That is too wide for a write, and this ceiling
           # is the only control on it: identity policies are PR-authored, and the
@@ -191,7 +200,7 @@ Resources:
                 # explicitDeny and every artifact read would have failed after
                 # deploy. Pinning both forms costs 6215 bytes, past the hard quota.
                 # Load-bearing — removed, the artifact read is explicitDeny.
-                "kms:EncryptionContext:aws:s3:arn": !Sub arn:${AWS::Partition}:s3:::mem9-audit-${AWS::AccountId}
+                "kms:EncryptionContext:aws:s3:arn": !Sub arn:${AWS::Partition}:s3:::${DecisionArtifactBucketName}
           - Sid: KmsVia
             Effect: Deny
             Action: kms:Decrypt
@@ -281,7 +290,7 @@ Resources:
             Resource: "*"
             Condition:
               StringNotLikeIfExists:
-                "kms:EncryptionContext:aws:s3:arn": !Sub arn:${AWS::Partition}:s3:::mem9-audit-${AWS::AccountId}
+                "kms:EncryptionContext:aws:s3:arn": !Sub arn:${AWS::Partition}:s3:::${DecisionArtifactBucketName}
           - Sid: LongBearer
             Effect: Deny
             Action: bedrock-mantle:CallWithBearerToken

--- a/infra/slack-approval.test.ts
+++ b/infra/slack-approval.test.ts
@@ -206,28 +206,26 @@ function installGlobals(stage: string) {
         }
       },
     },
-    // #150's decision artifact. `id` returns the RESOLVED bucket name rather than
-    // the logical name, because the four hardening resources address the bucket
-    // through `bucket: artifactBucket.id` — so a test can prove each one points at
-    // the same bucket the boundary permits, instead of merely existing.
+    // #150's decision artifact — kept although `slackApproval()` no longer
+    // constructs ANY of these (the bucket moved out-of-band to
+    // infra/cloudformation/decision-artifact-bucket.yaml). They are retained
+    // deliberately, and this is the only place that records why: TC-SLACKAPP-215
+    // asserts none of these five kinds is declared, and without the stubs a
+    // re-added `new aws.s3.BucketV2(...)` would die with a TypeError on an
+    // undefined constructor instead of turning 215 red with its explanation of the
+    // `BucketAlreadyOwnedByYou` collision. The stubs ARE the mechanism that makes
+    // that failure readable, so deleting them as dead code would cost the diagnosis.
     s3: {
       BucketV2: class {
         id: Output<string>;
         arn: Output<string>;
         bucket: Output<string>;
-        constructor(
-          logicalName: string,
-          args: Record<string, unknown>,
-          opts?: Record<string, unknown>,
-        ) {
+        constructor(logicalName: string, args: Record<string, unknown>) {
           const name = String(materialize(args.bucket));
           this.id = out(name);
           this.bucket = out(name);
           this.arn = out(`arn:aws:s3:::${name}`);
-          // Record the resource OPTIONS too: retainOnDelete is the difference
-          // between a preview stage's teardown keeping the audit trail and
-          // deleting it, and it lives in opts rather than args.
-          record("BucketV2", logicalName, { ...args, __opts: opts });
+          record("BucketV2", logicalName, args);
         }
       },
       BucketPublicAccessBlock: class {
@@ -436,7 +434,12 @@ function cloudFormationTemplate(path: string) {
         resolve: (value: string) => ({ "Fn::GetAtt": value.split(".") }),
       },
     ],
-  }) as { Resources: Record<string, { Properties: Record<string, any> }> };
+    // `Outputs` is optional and typed deliberately: TC-217 asserts its ABSENCE,
+    // which only type-checks if the shape admits it could be present.
+  }) as {
+    Resources: Record<string, { Properties: Record<string, any> }>;
+    Outputs?: Record<string, unknown>;
+  };
 }
 
 /** Statements of the boundary that this stack's roles must survive. */
@@ -445,6 +448,27 @@ function boundaryStatements(): Array<Record<string, any>> {
     "./cloudformation/workload-permissions-boundary.yaml",
   ).Resources.WorkloadPermissionsBoundary.Properties.PolicyDocument
     .Statement as Array<Record<string, any>>;
+}
+
+/**
+ * The OUT-OF-BAND artifact bucket template. The bucket is not part of this stack
+ * (see TC-SLACKAPP-215 for why a fixed account-scoped name cannot be), so the
+ * settings that protect the audit trail are asserted against the template the
+ * operator deploys.
+ */
+function artifactBucketTemplate() {
+  return cloudFormationTemplate("./cloudformation/decision-artifact-bucket.yaml");
+}
+
+/** Properties of the one `AWS::S3::Bucket` in that template. */
+function artifactBucketProperties(): Record<string, any> {
+  const buckets = Object.values(artifactBucketTemplate().Resources).filter(
+    (resource: any) => resource.Type === "AWS::S3::Bucket",
+  );
+  // Exactly one: a second bucket in this template would mean the settings below
+  // were asserted against an arbitrary one of them.
+  expect(buckets).toHaveLength(1);
+  return (buckets[0] as { Properties: Record<string, any> }).Properties;
 }
 
 /**
@@ -1423,12 +1447,12 @@ describe("slack approval infrastructure", () => {
   });
 
   it("TC-SLACKAPP-161: names the artifact bucket with the ACCOUNT ID and no wildcard", async () => {
-    installGlobals("prod");
-    enable();
-    await loadAndRun();
-
-    const bucket = one("BucketV2", "Mem9DecisionArtifacts");
-    const name = String(materialize((bucket.args as any).bucket));
+    // Asserted against the OUT-OF-BAND template, not this stack: the bucket is
+    // provisioned by infra/cloudformation/decision-artifact-bucket.yaml because a
+    // fixed, account-scoped name cannot be owned by a per-stage app (see
+    // TC-SLACKAPP-215). The derived name this stack passes to the task is checked
+    // in TC-SLACKAPP-181.
+    const name = resolveSub(artifactBucketProperties().BucketName);
     // The security property, not a style choice. S3 bucket names are a GLOBAL
     // namespace, so a wildcard in the bucket segment of the boundary's ARN also
     // matches a bucket an attacker creates FIRST in their own account —
@@ -1447,13 +1471,7 @@ describe("slack approval infrastructure", () => {
   });
 
   it("TC-SLACKAPP-162: matches the bucket the DEPLOYED boundary permits, byte for byte", async () => {
-    installGlobals("prod");
-    enable();
-    await loadAndRun();
-
-    const name = String(
-      materialize((one("BucketV2", "Mem9DecisionArtifacts").args as any).bucket),
-    );
+    const name = resolveSub(artifactBucketProperties().BucketName);
     // The whole point of the exact name is that two files must agree. Read the
     // operator-owned template rather than trusting that both sides were edited:
     // a drift here is an AccessDenied at artifact-write time, AFTER the approval
@@ -1467,17 +1485,7 @@ describe("slack approval infrastructure", () => {
     // Both KMS context values too: the write needs GenerateDataKey under the
     // `GenKey` deny, and the read needs Decrypt under `KmsContext`. A bucket name
     // that matched only one of the three would break exactly one direction.
-    //
-    // These pin the BARE BUCKET ARN, not the object glob, and that asymmetry with
-    // the resource scope above is the whole point of this assertion. S3 presents
-    // the bucket ARN as `aws:s3:arn` when bucket keys are enabled (S3 user guide,
-    // "Using SSE-KMS -> Encryption context"), and `bucket/*` does not match
-    // `bucket`. The first version of this test asserted `/*` on all three sites
-    // and passed while TC-163 pinned `bucketKeyEnabled: true` — two green tests
-    // describing a combination that denies every artifact write and read after
-    // deploy. Whichever way a future edit breaks the pair, one of these two tests
-    // now fails.
-    const contextValues = boundary
+    const contextArn = boundary
       .filter(({ Sid }) => Sid === "KmsContext" || Sid === "GenKey")
       .map((statement) =>
         resolveSub(
@@ -1486,42 +1494,41 @@ describe("slack approval infrastructure", () => {
           ],
         ),
       );
-    expect(contextValues).toHaveLength(2);
-    for (const value of contextValues) {
-      expect(value).toBe(`arn:aws:s3:::${name}`);
-      expect(value).not.toMatch(/\/\*$/u);
-    }
-  });
-
-  it("TC-SLACKAPP-163: encrypts the artifact with SSE-KMS and bucket keys on", async () => {
+    expect(contextArn).toEqual([
+      `arn:aws:s3:::${name}`,
+      `arn:aws:s3:::${name}`,
+    ]);
+    // And the name this STACK derives, which is what the task actually receives.
+    // The bucket moved out of this app; the two must still agree byte for byte.
     installGlobals("prod");
     enable();
     await loadAndRun();
+    const taskArgs = materialize(one("Task", "Mem9Cleanup").args) as
+      Record<string, any>;
+    expect(taskArgs.environment.MEM9_DECISION_ARTIFACT_BUCKET).toBe(name);
+  });
 
-    const bucketName = String(
-      materialize((one("BucketV2", "Mem9DecisionArtifacts").args as any).bucket),
-    );
-    const encryption = one(
-      "BucketServerSideEncryptionConfigurationV2",
-      "Mem9DecisionArtifactsEncryption",
-    ).args as any;
-    // Addressed at the SAME bucket. A sub-resource pointed elsewhere leaves this
-    // bucket on the provider default, which is SSE-S3 — encrypted, but with a key
-    // the boundary's encryption-context denies say nothing about.
-    expect(String(materialize(encryption.bucket))).toBe(bucketName);
-    const rule = encryption.rules[0];
-    expect(rule.applyServerSideEncryptionByDefault.sseAlgorithm).toBe("aws:kms");
-    expect(rule.applyServerSideEncryptionByDefault.kmsMasterKeyId).toBe(
+  it("TC-SLACKAPP-163: encrypts the artifact with SSE-KMS and bucket keys on", () => {
+    const properties = artifactBucketProperties();
+    const name = resolveSub(properties.BucketName);
+    // All four hardening settings are INLINE properties of the one CFN bucket, so
+    // unlike the Pulumi sub-resources they cannot be addressed at a different
+    // bucket — the "same bucket" assertion the previous revision needed is now
+    // structural.
+    const [rule] =
+      properties.BucketEncryption.ServerSideEncryptionConfiguration;
+    expect(rule.ServerSideEncryptionByDefault.SSEAlgorithm).toBe("aws:kms");
+    expect(rule.ServerSideEncryptionByDefault.KMSMasterKeyID).toBe(
       "alias/aws/s3",
     );
     // Bucket keys change WHICH ARN S3 presents as `aws:s3:arn`: the bucket ARN
     // with them on, the object ARN with them off (S3 user guide, "Using SSE-KMS ->
     // Encryption context"). So this flag and the boundary's two context pins must
     // agree, and TC-162 asserts the bucket-ARN half. Asserted from both sides
-    // because the mismatch is invisible until deploy: the earlier revision of this
+    // because the mismatch is invisible until deploy: an earlier revision of this
     // suite had bucket keys on here and `/*` there, both tests green, and every
     // artifact write and read would have failed with a KMS AccessDenied.
-    expect(rule.bucketKeyEnabled).toBe(true);
+    expect(rule.BucketKeyEnabled).toBe(true);
     // Pin the coupling directly, so flipping the flag alone turns THIS test red
     // rather than only the other one.
     const contextArn = boundaryStatements()
@@ -1534,94 +1541,155 @@ describe("slack approval infrastructure", () => {
         ),
       );
     expect(contextArn).toEqual([
-      `arn:aws:s3:::${bucketName}`,
-      `arn:aws:s3:::${bucketName}`,
+      `arn:aws:s3:::${name}`,
+      `arn:aws:s3:::${name}`,
     ]);
   });
 
   it("TC-SLACKAPP-164: expires the artifact on the same 72h bound as the approval", async () => {
-    installGlobals("prod");
-    enable();
-    await loadAndRun();
-
     const { DECISION_ARTIFACT_TTL_DAYS } = await loadModule();
-    const bucketName = String(
-      materialize((one("BucketV2", "Mem9DecisionArtifacts").args as any).bucket),
-    );
-    const lifecycle = one(
-      "BucketLifecycleConfigurationV2",
-      "Mem9DecisionArtifactsLifecycle",
-    ).args as any;
-    expect(String(materialize(lifecycle.bucket))).toBe(bucketName);
-    const rule = lifecycle.rules[0];
-    expect(rule.status).toBe("Enabled");
+    const [rule] =
+      artifactBucketProperties().LifecycleConfiguration.Rules;
+    expect(rule.Status).toBe("Enabled");
     // 3 days, matching #123's 72h offer TTL rather than an independently chosen
     // retention: past that the approval cannot be clicked, so the artifact could
     // not be replayed by anything and holding memory ids longer serves no purpose.
-    expect(rule.expiration.days).toBe(3);
-    expect(DECISION_ARTIFACT_TTL_DAYS).toBe(3);
+    expect(rule.ExpirationInDays).toBe(3);
+    // The constant and the template are now in DIFFERENT files and different
+    // languages, so nothing but this line keeps them in step — the rule moved to
+    // CloudFormation while `putDecisionArtifact`'s callers still reason about the
+    // TTL from the constant. Editing one alone turns this red.
+    expect(rule.ExpirationInDays).toBe(DECISION_ARTIFACT_TTL_DAYS);
     // Failed multipart writes are NOT covered by the expiration rule and would
     // accumulate invisibly.
-    expect(rule.abortIncompleteMultipartUpload.daysAfterInitiation).toBe(1);
+    expect(rule.AbortIncompleteMultipartUpload.DaysAfterInitiation).toBe(1);
   });
 
-  it("TC-SLACKAPP-165: blocks public access and denies non-TLS requests", async () => {
-    installGlobals("prod");
-    enable();
-    await loadAndRun();
-
-    const bucketName = String(
-      materialize((one("BucketV2", "Mem9DecisionArtifacts").args as any).bucket),
-    );
-    const block = one(
-      "BucketPublicAccessBlock",
-      "Mem9DecisionArtifactsPublicAccess",
-    ).args as any;
-    expect(String(materialize(block.bucket))).toBe(bucketName);
+  it("TC-SLACKAPP-165: blocks public access and denies non-TLS requests", () => {
+    const template = artifactBucketTemplate();
+    const properties = artifactBucketProperties();
+    const block = properties.PublicAccessBlockConfiguration;
     // All four, because they gate different paths: two cover ACLs and two cover
     // bucket policies, and three-of-four leaves a way to make the object public.
-    expect(block.blockPublicAcls).toBe(true);
-    expect(block.blockPublicPolicy).toBe(true);
-    expect(block.ignorePublicAcls).toBe(true);
-    expect(block.restrictPublicBuckets).toBe(true);
+    expect(block.BlockPublicAcls).toBe(true);
+    expect(block.BlockPublicPolicy).toBe(true);
+    expect(block.IgnorePublicAcls).toBe(true);
+    expect(block.RestrictPublicBuckets).toBe(true);
 
-    const policy = JSON.parse(
-      String(
-        materialize(
-          (one("BucketPolicy", "Mem9DecisionArtifactsPolicy").args as any).policy,
-        ),
-      ),
-    );
+    const policy = Object.values(template.Resources).find(
+      (resource: any) => resource.Type === "AWS::S3::BucketPolicy",
+    ) as any;
+    expect(policy).toBeDefined();
     // Exactly one statement, and it must DENY. A bucket policy that granted
     // anything would widen who can reach the artifact beyond the two identity
     // policies that are supposed to be the only way in.
-    expect(policy.Statement).toHaveLength(1);
-    const [statement] = policy.Statement;
+    expect(policy.Properties.PolicyDocument.Statement).toHaveLength(1);
+    const [statement] = policy.Properties.PolicyDocument.Statement;
     expect(statement.Effect).toBe("Deny");
     expect(statement.Condition).toEqual({
       Bool: { "aws:SecureTransport": "false" },
     });
-    // Both ARN forms: bucket-level operations do not match the `/*` form, so a
-    // policy naming only the objects leaves ListBucket reachable over plain HTTP.
+    // Both ARN forms, in order, and both naming THIS bucket. Bucket-level
+    // operations do not match the `/*` form, so a policy naming only the objects
+    // leaves ListBucket reachable over plain HTTP. The two forms use different
+    // intrinsics because CFN has no `!GetAtt`-with-suffix — hence comparing the
+    // parsed intrinsics rather than a rendered string. `bucketRef` is read from the
+    // policy's own target so the entries cannot drift to a DIFFERENT bucket's ARN:
+    // an earlier revision classified the forms with a regex that accepted any
+    // logical id, and a mutant pointing the object entry at `SomeOtherBucket` kept
+    // the whole suite green.
+    const bucketRef = policy.Properties.Bucket.Ref;
     expect(statement.Resource).toEqual([
-      `arn:aws:s3:::${bucketName}`,
-      `arn:aws:s3:::${bucketName}/*`,
+      { "Fn::GetAtt": [bucketRef, "Arn"] },
+      { "Fn::Sub": `\${${bucketRef}.Arn}/*` },
     ]);
   });
 
-  it("TC-SLACKAPP-166: retains the artifact bucket when a stage is torn down", async () => {
+  it("TC-SLACKAPP-166: retains the artifact bucket when a stage is torn down", () => {
+    const bucket = Object.values(artifactBucketTemplate().Resources).find(
+      (resource: any) => resource.Type === "AWS::S3::Bucket",
+    ) as any;
+    // The bucket's name is account-scoped, so EVERY stage — including each PR's
+    // preview stage — resolves to the same bucket. Deleting it would take prod's
+    // audit trail of what was deleted with it. Both policies, because they cover
+    // different events: a stack DELETE and a property change that REPLACES.
+    expect(bucket.DeletionPolicy).toBe("Retain");
+    expect(bucket.UpdateReplacePolicy).toBe("Retain");
+  });
+
+  it("TC-SLACKAPP-217: retains the bucket POLICY too, and stays importable", () => {
+    const template = artifactBucketTemplate();
+    const policy = Object.values(template.Resources).find(
+      (resource: any) => resource.Type === "AWS::S3::BucketPolicy",
+    ) as any;
+    // Retaining the bucket without its policy is worse than it looks: the stack
+    // DELETE keeps the audit bucket and deletes the ONLY thing requiring TLS to
+    // reach it (TC-165), so the retained bucket quietly ends up weaker than the
+    // one that was reviewed.
+    expect(policy.DeletionPolicy).toBe("Retain");
+
+    // `UpdateReplacePolicy` closes the same loss through a different door: `Bucket`
+    // is this resource's only createOnly property (per its live resource schema), so
+    // retargeting it REPLACES the policy, and the replacement's cleanup would strip
+    // TLS from the bucket left behind. Asserted here rather than left to cfn-lint's
+    // W3011 — which does catch it, but only warns, and only once this template is
+    // inside the lint step at all (TC-SLACKAPP-218).
+    expect(policy.UpdateReplacePolicy).toBe("Retain");
+
+    // The same attribute is also what keeps the recovery path open, which is why
+    // this is asserted here rather than left to the bucket's own case. Both facts
+    // below were rejections from a real CreateChangeSet, not inferences:
+    //   - "The following resources to import [DecisionArtifactBucketPolicy] must
+    //      have DeletionPolicy attribute specified in the template."
+    //   - "As part of the import operation, you cannot modify or add [Outputs]" —
+    //      and for a stack that does not exist yet, ANY output is an add.
+    // So an Outputs block here would break adopting a bucket that a stage-owned
+    // deploy already created, which is the one recovery this template exists for.
+    // Nothing consumes an export: both the SST app and the E2E harness DERIVE
+    // `mem9-audit-<account-id>` from the caller's account id.
+    expect(template.Outputs).toBeUndefined();
+
+    // Every resource in the template must carry DeletionPolicy for the import to
+    // validate, so assert over the whole set — adding a third resource without one
+    // turns this red here instead of at recovery time, when the bucket already
+    // exists and the operator has no other way in.
+    for (const [logicalId, resource] of Object.entries<any>(template.Resources)) {
+      expect(resource.DeletionPolicy, logicalId).toBe("Retain");
+    }
+  });
+
+  it("TC-SLACKAPP-215: declares NO bucket resource in this stack", async () => {
     installGlobals("prod");
     enable();
     await loadAndRun();
 
-    const bucket = one("BucketV2", "Mem9DecisionArtifacts").args as any;
-    // The bucket's name is account-scoped, so EVERY stage — including each PR's
-    // preview stage — resolves to the same bucket. A preview teardown that
-    // deleted it would take prod's audit trail of what was deleted with it.
-    expect(bucket.__opts?.retainOnDelete).toBe(true);
-    // And `forceDestroy` must stay off, which is the second half of the same
-    // guarantee: it would empty the bucket even where the bucket survives.
-    expect(bucket.forceDestroy).toBe(false);
+    // The regression this guards is a permanent, self-inflicted prod outage, and
+    // it is not hypothetical — it shipped. A fixed account-scoped name plus a
+    // per-stage owner means whichever stage deploys FIRST owns the bucket and
+    // every later stage's CreateBucket fails `BucketAlreadyOwnedByYou`; the AWS
+    // provider surfaces that error rather than adopting a same-owner bucket, and
+    // `retainOnDelete` meant a torn-down preview kept the bucket and left prod's
+    // first deploy failing with no way back short of deleting the audit trail.
+    // Re-adding ANY of the five resources here reintroduces it, so assert their
+    // absence by TYPE rather than by name — a rename would slip past a name check.
+    //
+    // The list covers `aws.s3.*`, which is what the deleted code used. A bucket
+    // re-added through a DIFFERENT namespace does not slip past silently, but it
+    // fails less usefully: probed with `new sst.aws.Bucket(...)`, this case goes
+    // red on `TypeError: sst.aws.Bucket is not a constructor` — caught, but
+    // without the explanation above. Adding a stub for that component would trade
+    // the TypeError for this assertion; it is deliberately not stubbed, since an
+    // unstubbed constructor cannot silently succeed.
+    for (const type of [
+      "BucketV2",
+      "Bucket",
+      "BucketPublicAccessBlock",
+      "BucketServerSideEncryptionConfigurationV2",
+      "BucketLifecycleConfigurationV2",
+      "BucketPolicy",
+    ]) {
+      expect(all(type)).toHaveLength(0);
+    }
   });
 
   it("TC-SLACKAPP-167: puts the STAGE in the key, not the bucket name", async () => {
@@ -1657,9 +1725,10 @@ describe("slack approval infrastructure", () => {
 
     const taskArgs = materialize(one("Task", "Mem9Cleanup").args) as
       Record<string, any>;
-    const bucketName = String(
-      materialize((one("BucketV2", "Mem9DecisionArtifacts").args as any).bucket),
-    );
+    // Read from the out-of-band template, which is now the only declaration of
+    // the bucket: this stack derives the name and the operator provisions it, so
+    // this assertion spans the two files that must agree.
+    const bucketName = resolveSub(artifactBucketProperties().BucketName);
     // The container script gates the artifact on this variable's PRESENCE
     // (TC-SLACKAPP-179/180), so the two files must agree on the name and on the
     // value. A drift in the name leaves the scan silently writing the id-only

--- a/infra/slack-approval.test.ts
+++ b/infra/slack-approval.test.ts
@@ -476,6 +476,14 @@ function artifactBucketProperties(): Record<string, any> {
  * pattern can be compared against a rendered ARN.
  */
 function resolveSub(value: unknown): string {
+  if (
+    value &&
+    typeof value === "object" &&
+    "Ref" in (value as object) &&
+    (value as { Ref: string }).Ref === "DecisionArtifactBucketName"
+  ) {
+    return "mem9-audit-123456789012";
+  }
   const raw =
     value && typeof value === "object" && "Fn::Sub" in (value as object)
       ? String((value as { "Fn::Sub": string })["Fn::Sub"])
@@ -483,6 +491,7 @@ function resolveSub(value: unknown): string {
   return raw
     .replaceAll("${AWS::Partition}", "aws")
     .replaceAll("${AWS::AccountId}", "123456789012")
+    .replaceAll("${DecisionArtifactBucketName}", "mem9-audit-123456789012")
     .replaceAll("${ApplicationRegion}", "ap-northeast-1");
 }
 
@@ -507,6 +516,7 @@ const ENV_KEYS = [
   "MEM9_BEDROCK_PROJECT_OPENAI",
   "MEM9_CLEANUP_CAP",
   "MEM9_CLEANUP_SCAN_SCHEDULE_ENABLED",
+  "MEM9_DECISION_ARTIFACT_BUCKET",
 ];
 
 function enable() {
@@ -1506,7 +1516,83 @@ describe("slack approval infrastructure", () => {
     const taskArgs = materialize(one("Task", "Mem9Cleanup").args) as
       Record<string, any>;
     expect(taskArgs.environment.MEM9_DECISION_ARTIFACT_BUCKET).toBe(name);
+    expect(taskArgs.environment.MEM9_DECISION_ARTIFACT_BUCKET_OWNER).toBe(
+      "123456789012",
+    );
   });
+
+  it("TC-SLACKAPP-219: applies one validated bucket override to the task and boundary", async () => {
+    const override = "example-mem9-decision-artifacts";
+    process.env.MEM9_DECISION_ARTIFACT_BUCKET = override;
+    installGlobals("prod");
+    enable();
+    await loadAndRun();
+
+    const taskArgs = materialize(one("Task", "Mem9Cleanup").args) as
+      Record<string, any>;
+    expect(taskArgs.environment.MEM9_DECISION_ARTIFACT_BUCKET).toBe(override);
+    expect(taskArgs.environment.MEM9_DECISION_ARTIFACT_BUCKET_OWNER).toBe(
+      "123456789012",
+    );
+    expect(
+      taskArgs.permissions
+        .filter((statement: any) =>
+          list(statement.actions).includes("s3:PutObject"),
+        )
+        .flatMap((statement: any) => list(statement.resources)),
+    ).toEqual([`arn:aws:s3:::${override}/decisions/prod/*`]);
+    expect(
+      taskArgs.permissions
+        .find((statement: any) =>
+          list(statement.actions).includes("kms:GenerateDataKey"),
+        )
+        .conditions.find(
+          (condition: any) =>
+            condition.variable === "kms:EncryptionContext:aws:s3:arn",
+        ).values,
+    ).toEqual([`arn:aws:s3:::${override}`]);
+
+    const boundary = boundaryStatements();
+    expect(
+      JSON.stringify(
+        listRaw(boundary.find(({ Sid }) => Sid === "Resources")!.NotResource),
+      ),
+    ).toContain("${DecisionArtifactBucketName}");
+  });
+
+  it.each([
+    "UPPERCASE",
+    "ab",
+    "192.0.2.1",
+    "bad..name",
+    "bad_name",
+    "xn--reserved",
+    "sthree-reserved",
+    "amzn-s3-demo-reserved",
+    "reserved-s3alias",
+    "reserved--ol-s3",
+    "reserved--x-s3",
+    "reserved--table-s3",
+    "reserved-an",
+    "a".repeat(34),
+  ])(
+    "TC-SLACKAPP-219: rejects invalid bucket override %s before synthesis",
+    async (override) => {
+      process.env.MEM9_DECISION_ARTIFACT_BUCKET = override;
+      installGlobals("prod");
+      enable();
+      const module = await loadModule();
+      expect(() =>
+        module.slackApproval(
+          fakeEcs(),
+          fakeDb(),
+          fakeIdentity(),
+          fakeFacade(),
+        ),
+      ).toThrow(/invalid.*bucket name/iu);
+      expect(resources).toEqual([]);
+    },
+  );
 
   it("TC-SLACKAPP-163: encrypts the artifact with SSE-KMS and bucket keys on", () => {
     const properties = artifactBucketProperties();
@@ -1617,7 +1703,7 @@ describe("slack approval infrastructure", () => {
     expect(bucket.UpdateReplacePolicy).toBe("Retain");
   });
 
-  it("TC-SLACKAPP-217: retains the bucket POLICY too, and stays importable", () => {
+  it("TC-SLACKAPP-217: retains the bucket policy and exposes no second config source", () => {
     const template = artifactBucketTemplate();
     const policy = Object.values(template.Resources).find(
       (resource: any) => resource.Type === "AWS::S3::BucketPolicy",
@@ -1636,23 +1722,13 @@ describe("slack approval infrastructure", () => {
     // inside the lint step at all (TC-SLACKAPP-218).
     expect(policy.UpdateReplacePolicy).toBe("Retain");
 
-    // The same attribute is also what keeps the recovery path open, which is why
-    // this is asserted here rather than left to the bucket's own case. Both facts
-    // below were rejections from a real CreateChangeSet, not inferences:
-    //   - "The following resources to import [DecisionArtifactBucketPolicy] must
-    //      have DeletionPolicy attribute specified in the template."
-    //   - "As part of the import operation, you cannot modify or add [Outputs]" —
-    //      and for a stack that does not exist yet, ANY output is an add.
-    // So an Outputs block here would break adopting a bucket that a stage-owned
-    // deploy already created, which is the one recovery this template exists for.
-    // Nothing consumes an export: both the SST app and the E2E harness DERIVE
-    // `mem9-audit-<account-id>` from the caller's account id.
+    // The external variable is the one source of truth for the owner stack,
+    // boundary, SST, CI, and E2E. A stack output would create a second source
+    // that only some consumers follow. Adoption uses the separate bucket-only
+    // import template and then a normal update to this complete declaration.
     expect(template.Outputs).toBeUndefined();
 
-    // Every resource in the template must carry DeletionPolicy for the import to
-    // validate, so assert over the whole set — adding a third resource without one
-    // turns this red here instead of at recovery time, when the bucket already
-    // exists and the operator has no other way in.
+    // Every retained control must survive stack deletion with the audit data.
     for (const [logicalId, resource] of Object.entries<any>(template.Resources)) {
       expect(resource.DeletionPolicy, logicalId).toBe("Retain");
     }
@@ -1734,6 +1810,9 @@ describe("slack approval infrastructure", () => {
     // value. A drift in the name leaves the scan silently writing the id-only
     // record — the pre-#150 shape — with no error anywhere.
     expect(taskArgs.environment.MEM9_DECISION_ARTIFACT_BUCKET).toBe(bucketName);
+    expect(taskArgs.environment.MEM9_DECISION_ARTIFACT_BUCKET_OWNER).toBe(
+      "123456789012",
+    );
     // `environment`, not `ssm`: a bucket name is not a secret, and the apply half's
     // role holds `ssm:GetParameters` under `approvals/*` only — a secret-style
     // reference would put the artifact's location behind a grant it does not have.

--- a/infra/slack-approval.ts
+++ b/infra/slack-approval.ts
@@ -425,112 +425,26 @@ export function slackApproval(
   param("SlackApprovalChannel", "slack/approval-channel", channel);
 
   // ── The reviewed decision artifact (#150) ────────────────────────────────
-  // A raw `aws.s3.BucketV2` rather than `sst.aws.Bucket`: the SST component adds
-  // a bucket POLICY and public-access plumbing aimed at web-servable buckets,
-  // and this bucket must be reachable by exactly two principals through their
-  // identity policies. It is also why the four hardening resources below are
-  // explicit — with the raw provider they are not defaults.
+  // The BUCKET ITSELF IS NOT DECLARED HERE — it is provisioned out-of-band by
+  // infra/cloudformation/decision-artifact-bucket.yaml
+  // (scripts/deploy-decision-artifact-bucket.sh), together with its public-access
+  // block, SSE-KMS + bucket-keys rule, 72h lifecycle rule, and TLS-only policy.
+  // This function only DERIVES the name to hand to the task and to scope grants.
   //
-  // `bucket` (a fixed name) rather than `bucketPrefix`: the boundary pins the
-  // exact name, so Pulumi's random suffix would put the live bucket outside the
-  // permitted ARN. That makes the name a cross-stage singleton, which is safe
-  // here only because the KEY carries the stage.
+  // Why it cannot live here: the boundary pins the exact bucket ARN, so the name
+  // must be fixed rather than prefixed, and it is account-scoped — every stage
+  // computes `mem9-audit-<account-id>`, while S3 bucket names are globally
+  // unique. Owned by this app, whichever stage deployed first would own the
+  // bucket and every LATER stage's CreateBucket would fail
+  // `BucketAlreadyOwnedByYou`; the AWS provider surfaces that error rather than
+  // adopting a same-owner bucket. `retainOnDelete` made it worse, not better: a
+  // torn-down preview kept the bucket and left prod's first deploy permanently
+  // failing. Provisioned out-of-band it exists once, before any stage, for all of
+  // them — which is also why the preview E2E needs no bucket setup of its own.
+  //
+  // Consumers below take this STRING, never a bucket resource handle, so nothing
+  // in this stack depends on who owns the bucket.
   const artifactBucketName = decisionArtifactBucketName(accountId());
-  const artifactBucket = new aws.s3.BucketV2("Mem9DecisionArtifacts", {
-    bucket: artifactBucketName,
-    // The bucket outlives any single stage (its name is account-scoped, so every
-    // stage shares it) and holds the audit trail of what was deleted. A preview
-    // stage's teardown must not take it with them.
-    forceDestroy: false,
-    tags,
-  }, { retainOnDelete: true });
-
-  // Block public access at the bucket level as well as the account level. The
-  // account-level setting is not visible from this stack and cannot be asserted
-  // here, so this is the copy that a test can prove is present.
-  new aws.s3.BucketPublicAccessBlock("Mem9DecisionArtifactsPublicAccess", {
-    bucket: artifactBucket.id,
-    blockPublicAcls: true,
-    blockPublicPolicy: true,
-    ignorePublicAcls: true,
-    restrictPublicBuckets: true,
-  });
-
-  // SSE-KMS with the AWS-managed S3 key. A customer-managed key would need its
-  // own key policy plus a boundary exception per principal; `alias/aws/s3` needs
-  // neither, and the boundary already confines `kms:GenerateDataKey` to this
-  // bucket's own encryption context (the `GenKey` deny).
-  //
-  // Bucket keys ON, which cuts KMS request cost by up to 99% — and which CHANGES
-  // the encryption context S3 presents. Per the S3 user guide ("Using SSE-KMS ->
-  // Encryption context"): without bucket keys the context is the object ARN; with
-  // them it is the BUCKET ARN. So this line and the boundary's two `aws:s3:arn`
-  // pins are one decision, not two. The boundary pins the bare bucket ARN for
-  // exactly this reason; `arn:aws:s3:::bucket/*` does NOT match
-  // `arn:aws:s3:::bucket`, and an earlier revision of this file paired bucket keys
-  // with the object glob — that combination simulates explicitDeny on both
-  // GenerateDataKey and Decrypt, i.e. every artifact write and read fails, and
-  // only after deploy. Flipping this to false without repinning the boundary
-  // breaks it the other way round.
-  new aws.s3.BucketServerSideEncryptionConfigurationV2(
-    "Mem9DecisionArtifactsEncryption",
-    {
-      bucket: artifactBucket.id,
-      rules: [
-        {
-          applyServerSideEncryptionByDefault: {
-            sseAlgorithm: "aws:kms",
-            kmsMasterKeyId: "alias/aws/s3",
-          },
-          bucketKeyEnabled: true,
-        },
-      ],
-    },
-  );
-
-  // Expire the artifact on the same 72h bound as the approval that would replay
-  // it (see DECISION_ARTIFACT_TTL_DAYS). `abortIncompleteMultipartUpload` covers
-  // the parts of a write that failed midway — those are not covered by the
-  // expiration rule and would otherwise accumulate silently and unbilled-for.
-  new aws.s3.BucketLifecycleConfigurationV2("Mem9DecisionArtifactsLifecycle", {
-    bucket: artifactBucket.id,
-    rules: [
-      {
-        id: "expire-decision-artifacts",
-        status: "Enabled",
-        // An empty prefix filter, stated explicitly: the rule covers every stage's
-        // key prefix, and a `filter` omitted entirely is a provider-version-
-        // dependent diff rather than a clearer intent.
-        filter: { prefix: "" },
-        expiration: { days: DECISION_ARTIFACT_TTL_DAYS },
-        abortIncompleteMultipartUpload: { daysAfterInitiation: 1 },
-      },
-    ],
-  });
-
-  // Deny any request that is not TLS. S3 has no bucket-level "require TLS"
-  // setting; `aws:SecureTransport` in a bucket policy is the mechanism. This is
-  // the ONE bucket policy statement — it constrains the transport, and grants
-  // nothing, so it does not widen who can reach the artifact.
-  new aws.s3.BucketPolicy("Mem9DecisionArtifactsPolicy", {
-    bucket: artifactBucket.id,
-    policy: $interpolate`{
-      "Version": "2012-10-17",
-      "Statement": [
-        {
-          "Sid": "DenyInsecureTransport",
-          "Effect": "Deny",
-          "Principal": "*",
-          "Action": "s3:*",
-          "Resource": [
-            "arn:aws:s3:::${artifactBucketName}",
-            "arn:aws:s3:::${artifactBucketName}/*"
-          ],
-          "Condition": { "Bool": { "aws:SecureTransport": "false" } }
-        }
-      ]
-    }`,
-  });
 
   const task = new sst.aws.Task(CLEANUP_CONTAINER_NAME, {
     cluster: ecsOut.cluster,

--- a/infra/slack-approval.ts
+++ b/infra/slack-approval.ts
@@ -80,6 +80,10 @@ const SCAN_TARGET_ERROR_METRIC = "TargetErrorCount";
 
 export const SLACK_APPROVAL_ENABLED_ENV = "MEM9_SLACK_APPROVAL_ENABLED";
 export const SLACK_APPROVAL_CHANNEL_ENV = "MEM9_SLACK_APPROVAL_CHANNEL";
+export const DECISION_ARTIFACT_BUCKET_ENV =
+  "MEM9_DECISION_ARTIFACT_BUCKET";
+export const DECISION_ARTIFACT_BUCKET_OWNER_ENV =
+  "MEM9_DECISION_ARTIFACT_BUCKET_OWNER";
 
 /**
  * The weekly scan's own gate (#149), separate from `SLACK_APPROVAL_ENABLED_ENV`.
@@ -158,8 +162,7 @@ export const APPROVED_IDS_PATH = "/tmp/mem9-approved-ids.txt";
 export const CLEANUP_CAP = 50;
 
 /**
- * The decision artifact's bucket name, and the reason it carries the ACCOUNT ID
- * rather than the stage.
+ * The decision artifact's exact account-level bucket name.
  *
  * S3 bucket names are a single GLOBAL namespace — not per-account, not
  * per-region — so a boundary pattern with a wildcard in the bucket segment
@@ -167,9 +170,10 @@ export const CLEANUP_CAP = 50;
  * against `arn:aws:s3:::mem9-on-aws-*-decisions/*`, `iam:simulate-custom-policy`
  * returned `allowed` for `s3:PutObject` on `mem9-on-aws-evil-decisions`, a name
  * anyone can create first. For an object that holds the reviewed deletion list,
- * that is an exfiltration target. The account id is the disambiguating suffix a
- * global namespace needs, so the boundary pins an EXACT bucket name and the stage
- * moves into the key prefix instead (see `decisionArtifactKey`).
+ * that is an exfiltration target. By default the account id is the disambiguating
+ * suffix a global namespace needs. An operator may instead provide one exact
+ * external name. Either way the boundary pins the exact bucket and the stage
+ * moves into the key prefix (see `decisionArtifactKey`).
  *
  * The textbook alternative — keeping the wildcard and adding an
  * `aws:ResourceAccount` condition — renders the boundary at 6280 bytes. 6144 is
@@ -182,15 +186,26 @@ export const CLEANUP_CAP = 50;
  * clears by 31. Nothing pins an S3 prefix for this project — the deploy role's
  * `S3State` is `Resource: "*"` — so the shorter name costs no access.
  *
- * Must stay byte-identical to the `Resources` NotResource entry (as the object
- * glob) and to the two KMS encryption-context values (as the BUCKET arn, since
- * bucket keys are on) in
- * infra/cloudformation/workload-permissions-boundary.yaml. A drift here is an
- * AccessDenied at artifact-write time — after the click has been spent.
+ * `MEM9_DECISION_ARTIFACT_BUCKET` is consumed by the owner stack, boundary
+ * rollout, CI, and E2E too. A drift is an AccessDenied at artifact-write time —
+ * after the click has been spent.
  */
 export function decisionArtifactBucketName(
   account: Output<string> | string,
-): Output<string> {
+): Output<string> | string {
+  const configured = process.env[DECISION_ARTIFACT_BUCKET_ENV];
+  if (configured) {
+    if (
+      !/^[a-z0-9][a-z0-9-]{1,31}[a-z0-9]$/u.test(configured) ||
+      /^(?:xn--|sthree-|amzn-s3-demo-)/u.test(configured) ||
+      /(?:-s3alias|--ol-s3|--x-s3|--table-s3|-an)$/u.test(configured)
+    ) {
+      throw new Error(
+        `${DECISION_ARTIFACT_BUCKET_ENV} is an invalid decision-artifact bucket name`,
+      );
+    }
+    return configured;
+  }
   // 12-digit account id + the 11-char literal = 23 chars, inside S3's 63-char
   // bucket-name limit with room to spare, and lowercase/hyphen-only as S3
   // requires. $interpolate, never a template literal: an Output stringified into
@@ -390,6 +405,10 @@ export function slackApproval(
     SlackBotToken: "the Slack bot token",
     SlackSigningSecret: "the Slack signing secret",
   });
+  // Resolve and validate external configuration before constructing any
+  // resource, so a malformed bucket name cannot leave a partial graph.
+  const artifactBucketOwner = accountId();
+  const artifactBucketName = decisionArtifactBucketName(artifactBucketOwner);
   const botToken = new sst.Secret("SlackBotToken").value;
   const signingSecret = new sst.Secret("SlackSigningSecret").value;
 
@@ -429,13 +448,13 @@ export function slackApproval(
   // infra/cloudformation/decision-artifact-bucket.yaml
   // (scripts/deploy-decision-artifact-bucket.sh), together with its public-access
   // block, SSE-KMS + bucket-keys rule, 72h lifecycle rule, and TLS-only policy.
-  // This function only DERIVES the name to hand to the task and to scope grants.
+  // This function resolves the configured name to hand to the task and grants.
   //
   // Why it cannot live here: the boundary pins the exact bucket ARN, so the name
-  // must be fixed rather than prefixed, and it is account-scoped — every stage
-  // computes `mem9-audit-<account-id>`, while S3 bucket names are globally
-  // unique. Owned by this app, whichever stage deployed first would own the
-  // bucket and every LATER stage's CreateBucket would fail
+  // must be fixed rather than prefixed. Every stage receives the same external
+  // override or the same account-derived default, while S3 bucket names are
+  // globally unique. Owned by this app, whichever stage deployed first would own
+  // the bucket and every LATER stage's CreateBucket would fail
   // `BucketAlreadyOwnedByYou`; the AWS provider surfaces that error rather than
   // adopting a same-owner bucket. `retainOnDelete` made it worse, not better: a
   // torn-down preview kept the bucket and left prod's first deploy permanently
@@ -444,8 +463,6 @@ export function slackApproval(
   //
   // Consumers below take this STRING, never a bucket resource handle, so nothing
   // in this stack depends on who owns the bucket.
-  const artifactBucketName = decisionArtifactBucketName(accountId());
-
   const task = new sst.aws.Task(CLEANUP_CONTAINER_NAME, {
     cluster: ecsOut.cluster,
     architecture: "arm64",
@@ -488,6 +505,10 @@ export function slackApproval(
       // deployed before this bucket existed keeps writing the id-only record until
       // it is redeployed, instead of failing on a bucket its role cannot reach.
       MEM9_DECISION_ARTIFACT_BUCKET: artifactBucketName,
+      // Every S3 Get/Put includes ExpectedBucketOwner. The exact bucket ARN in
+      // IAM prevents widening, while this account binding also blocks a
+      // cross-account bucket selected through external configuration.
+      MEM9_DECISION_ARTIFACT_BUCKET_OWNER: artifactBucketOwner,
       // No MEM9_ALERTS_TOPIC_ARN and no sns:Publish: scripts/memory-cleanup.mjs
       // contains no SNS code (memory-consolidation.mjs does, which is what makes
       // the omission look like an oversight). Passing the variable and granting

--- a/scripts/deploy-decision-artifact-bucket.sh
+++ b/scripts/deploy-decision-artifact-bucket.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# deploy-decision-artifact-bucket.sh — Create or update the OUT-OF-BAND reviewed-
+# decision artifact bucket (`mem9-audit-<account-id>`) for the Slack approval
+# loop (#123/#150).
+#
+# Scope: **the artifact bucket only**. The SST/Pulumi app does NOT manage it; it
+# derives the same name and reads/writes objects under a stage-scoped key.
+#
+# Why out-of-band, and this one is a hard requirement rather than only teardown
+# hygiene: the boundary pins the exact bucket ARN, so the name must be fixed, and
+# it is account-scoped — every stage computes `mem9-audit-<account-id>`. S3 bucket
+# names are globally unique. If the SST app owned it, whichever stage deployed
+# first would own it and every later stage's CreateBucket would fail
+# `BucketAlreadyOwnedByYou` (the provider surfaces that error, it does not adopt
+# the bucket), while `retainOnDelete` left a torn-down preview's bucket behind to
+# poison prod. Provisioned here it exists once, before any stage, for all of them.
+#
+# Bootstrap ONCE per AWS account, in the application region, and RE-RUN only if
+# decision-artifact-bucket.yaml changes.
+#
+# Region: the SST application region (sst.config.ts). Ambient AWS_REGION is
+# ignored, so a shell pointed elsewhere cannot create the bucket in the wrong
+# region — where the stages would still compute this name and still collide.
+#
+# Config: set AWS_PROFILE (and any overrides) in a gitignored .env at the repo
+# root — copy .env.example.
+#
+# Usage:
+#   scripts/deploy-decision-artifact-bucket.sh            # auto create/update (reads .env)
+#   scripts/deploy-decision-artifact-bucket.sh --create   # force create-stack
+#   scripts/deploy-decision-artifact-bucket.sh --update   # force update-stack
+#
+# Nothing needs to be fed to CI afterwards: both the SST app and
+# scripts/run-slack-approval-e2e.sh derive the name from the caller's own account
+# id rather than reading it back.
+
+set -euo pipefail
+
+# Load repo-root .env (gitignored) for AWS_PROFILE etc., if present.
+_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+[ -f "$_repo_root/.env" ] && set -a && . "$_repo_root/.env" && set +a
+
+STACK_NAME="${STACK_NAME:-decision-artifact-bucket-mem9-on-aws}"
+TEMPLATE_FILE="infra/cloudformation/decision-artifact-bucket.yaml"
+REGION="$(node "$_repo_root/scripts/resolve-application-region.mjs")"
+
+MODE=""
+for arg in "$@"; do
+  case "$arg" in
+    --create) MODE="create" ;;
+    --update) MODE="update" ;;
+    -h|--help)
+      sed -n '2,/^$/p' "$0" | sed 's/^# \?//'
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ ! -f "$TEMPLATE_FILE" ]]; then
+  echo "Error: template not found at $TEMPLATE_FILE (run from repo root)" >&2
+  exit 2
+fi
+
+echo "Stack:    $STACK_NAME"
+echo "Region:   $REGION"
+echo "Template: $TEMPLATE_FILE"
+
+# Auto-detect create vs update when the caller did not pass --create / --update.
+if [[ -z "$MODE" ]]; then
+  if aws cloudformation describe-stacks \
+      --stack-name "$STACK_NAME" \
+      --region "$REGION" \
+      >/dev/null 2>&1; then
+    MODE="update"
+  else
+    MODE="create"
+  fi
+fi
+
+# Derived, never read back from a stack output — the same way the SST app and the
+# E2E harness compute it, which is the stricter check. Hoisted above the preflight
+# because the summary at the end needs it too, and the template deliberately has no
+# Outputs block to read (an Outputs block would break the IMPORT adoption path
+# printed below).
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+BUCKET_NAME="mem9-audit-${ACCOUNT_ID}"
+
+# A bucket that already exists OUTSIDE this stack cannot be adopted by a
+# create-stack — CloudFormation fails with "already exists" and rolls back. That
+# is the state a stage-owned deploy would have left behind, so name the remedy
+# here rather than leaving the operator to read a raw CFN failure.
+if [[ "$MODE" == "create" ]]; then
+  # --region for the same reason the header claims ambient AWS_REGION is ignored:
+  # the preflight must ask about the bucket in the region this stack targets.
+  if aws s3api head-bucket --bucket "$BUCKET_NAME" --region "$REGION" >/dev/null 2>&1; then
+    echo "Error: bucket $BUCKET_NAME already exists but this stack does not own it." >&2
+    echo "  A stage-owned deploy created it. Adopt it with an IMPORT change set --" >&2
+    echo "  which does work for a stack that does not exist yet, but must name EVERY" >&2
+    echo "  resource in the template (both, here) or CFN rejects the change set:" >&2
+    echo "    aws cloudformation create-change-set --stack-name $STACK_NAME \\" >&2
+    echo "      --change-set-name adopt-artifact-bucket \\" >&2
+    echo "      --change-set-type IMPORT --region $REGION \\" >&2
+    echo "      --template-body file://$TEMPLATE_FILE \\" >&2
+    echo "      --resources-to-import \\" >&2
+    echo "      '[{\"ResourceType\":\"AWS::S3::Bucket\",\"LogicalResourceId\":\"DecisionArtifactBucket\",\"ResourceIdentifier\":{\"BucketName\":\"$BUCKET_NAME\"}},{\"ResourceType\":\"AWS::S3::BucketPolicy\",\"LogicalResourceId\":\"DecisionArtifactBucketPolicy\",\"ResourceIdentifier\":{\"Bucket\":\"$BUCKET_NAME\"}}]'" >&2
+    echo "  Then: aws cloudformation execute-change-set --stack-name $STACK_NAME \\" >&2
+    echo "          --change-set-name adopt-artifact-bucket --region $REGION" >&2
+    exit 1
+  fi
+fi
+
+case "$MODE" in
+  create)
+    echo "Creating stack..."
+    aws cloudformation create-stack \
+      --stack-name "$STACK_NAME" \
+      --template-body "file://$TEMPLATE_FILE" \
+      --region "$REGION" \
+      --tags Key=Project,Value=mem9-on-aws Key=ManagedBy,Value=cli
+    aws cloudformation wait stack-create-complete \
+      --stack-name "$STACK_NAME" \
+      --region "$REGION"
+    ;;
+  update)
+    echo "Updating stack..."
+    # update-stack exits non-zero with "No updates are to be performed" when the
+    # template is unchanged — swallow that so re-running for idempotency is safe.
+    set +e
+    UPDATE_OUTPUT=$(aws cloudformation update-stack \
+      --stack-name "$STACK_NAME" \
+      --template-body "file://$TEMPLATE_FILE" \
+      --region "$REGION" 2>&1)
+    UPDATE_EXIT=$?
+    set -e
+    if [[ $UPDATE_EXIT -ne 0 ]]; then
+      if echo "$UPDATE_OUTPUT" | grep -q "No updates are to be performed"; then
+        echo "No changes to apply."
+      else
+        echo "$UPDATE_OUTPUT" >&2
+        exit $UPDATE_EXIT
+      fi
+    else
+      aws cloudformation wait stack-update-complete \
+        --stack-name "$STACK_NAME" \
+        --region "$REGION"
+    fi
+    ;;
+esac
+
+echo
+echo "BucketName: $BUCKET_NAME"
+echo
+echo "No CI variable to set — the SST app and the E2E harness both derive this"
+echo "name from the caller's account id. The next deploy of any stage will find"
+echo "the bucket already present."

--- a/scripts/deploy-decision-artifact-bucket.sh
+++ b/scripts/deploy-decision-artifact-bucket.sh
@@ -1,54 +1,47 @@
 #!/usr/bin/env bash
-# deploy-decision-artifact-bucket.sh — Create or update the OUT-OF-BAND reviewed-
-# decision artifact bucket (`mem9-audit-<account-id>`) for the Slack approval
-# loop (#123/#150).
+# deploy-decision-artifact-bucket.sh — Own the account-level reviewed-decision
+# artifact bucket outside SST/Pulumi.
 #
-# Scope: **the artifact bucket only**. The SST/Pulumi app does NOT manage it; it
-# derives the same name and reads/writes objects under a stage-scoped key.
+# Every SST stage shares this bucket and uses a stage-scoped object prefix.
+# Keeping one CloudFormation owner avoids same-name CreateBucket failures and
+# prevents preview teardown from owning shared audit data.
 #
-# Why out-of-band, and this one is a hard requirement rather than only teardown
-# hygiene: the boundary pins the exact bucket ARN, so the name must be fixed, and
-# it is account-scoped — every stage computes `mem9-audit-<account-id>`. S3 bucket
-# names are globally unique. If the SST app owned it, whichever stage deployed
-# first would own it and every later stage's CreateBucket would fail
-# `BucketAlreadyOwnedByYou` (the provider surfaces that error, it does not adopt
-# the bucket), while `retainOnDelete` left a torn-down preview's bucket behind to
-# poison prod. Provisioned here it exists once, before any stage, for all of them.
+# Configuration (repo-root, gitignored .env or ambient environment):
+#   AWS_PROFILE
+#   MEM9_DECISION_ARTIFACT_BUCKET  optional exact bucket name; defaults to
+#                                  mem9-audit-<caller-account-id>
+#   STACK_NAME                    optional CloudFormation stack name
 #
-# Bootstrap ONCE per AWS account, in the application region, and RE-RUN only if
-# decision-artifact-bucket.yaml changes.
-#
-# Region: the SST application region (sst.config.ts). Ambient AWS_REGION is
-# ignored, so a shell pointed elsewhere cannot create the bucket in the wrong
-# region — where the stages would still compute this name and still collide.
-#
-# Config: set AWS_PROFILE (and any overrides) in a gitignored .env at the repo
-# root — copy .env.example.
+# Existing buckets are adopted automatically in two phases:
+#   1. IMPORT the bucket alone with decision-artifact-bucket-import.yaml.
+#   2. UPDATE to decision-artifact-bucket.yaml to reconcile hardening and create
+#      the TLS-only policy.
 #
 # Usage:
-#   scripts/deploy-decision-artifact-bucket.sh            # auto create/update (reads .env)
-#   scripts/deploy-decision-artifact-bucket.sh --create   # force create-stack
-#   scripts/deploy-decision-artifact-bucket.sh --update   # force update-stack
-#
-# Nothing needs to be fed to CI afterwards: both the SST app and
-# scripts/run-slack-approval-e2e.sh derive the name from the caller's own account
-# id rather than reading it back.
+#   scripts/deploy-decision-artifact-bucket.sh
+#   scripts/deploy-decision-artifact-bucket.sh --create
+#   scripts/deploy-decision-artifact-bucket.sh --update
 
 set -euo pipefail
 
-# Load repo-root .env (gitignored) for AWS_PROFILE etc., if present.
-_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-[ -f "$_repo_root/.env" ] && set -a && . "$_repo_root/.env" && set +a
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=/dev/null
+if [[ -f "$repo_root/.env" ]]; then
+  set -a
+  . "$repo_root/.env"
+  set +a
+fi
 
-STACK_NAME="${STACK_NAME:-decision-artifact-bucket-mem9-on-aws}"
-TEMPLATE_FILE="infra/cloudformation/decision-artifact-bucket.yaml"
-REGION="$(node "$_repo_root/scripts/resolve-application-region.mjs")"
+stack_name="${STACK_NAME:-decision-artifact-bucket-mem9-on-aws}"
+full_template="$repo_root/infra/cloudformation/decision-artifact-bucket.yaml"
+import_template="$repo_root/infra/cloudformation/decision-artifact-bucket-import.yaml"
+region="$(node "$repo_root/scripts/resolve-application-region.mjs")"
+mode=""
 
-MODE=""
 for arg in "$@"; do
   case "$arg" in
-    --create) MODE="create" ;;
-    --update) MODE="update" ;;
+    --create) mode="create" ;;
+    --update) mode="update" ;;
     -h|--help)
       sed -n '2,/^$/p' "$0" | sed 's/^# \?//'
       exit 0
@@ -60,100 +53,626 @@ for arg in "$@"; do
   esac
 done
 
-if [[ ! -f "$TEMPLATE_FILE" ]]; then
-  echo "Error: template not found at $TEMPLATE_FILE (run from repo root)" >&2
+if [[ ! -f "$full_template" || ! -f "$import_template" ]]; then
+  echo "Decision-artifact CloudFormation template is missing." >&2
   exit 2
 fi
 
-echo "Stack:    $STACK_NAME"
-echo "Region:   $REGION"
-echo "Template: $TEMPLATE_FILE"
+valid_bucket_name() {
+  local name="$1"
+  [[ "$name" =~ ^[a-z0-9][a-z0-9-]{1,31}[a-z0-9]$ ]] &&
+    [[ "$name" != xn--* ]] &&
+    [[ "$name" != sthree-* ]] &&
+    [[ "$name" != amzn-s3-demo-* ]] &&
+    [[ "$name" != *-s3alias ]] &&
+    [[ "$name" != *--ol-s3 ]] &&
+    [[ "$name" != *--x-s3 ]] &&
+    [[ "$name" != *--table-s3 ]] &&
+    [[ "$name" != *-an ]]
+}
 
-# Auto-detect create vs update when the caller did not pass --create / --update.
-if [[ -z "$MODE" ]]; then
-  if aws cloudformation describe-stacks \
-      --stack-name "$STACK_NAME" \
-      --region "$REGION" \
-      >/dev/null 2>&1; then
-    MODE="update"
-  else
-    MODE="create"
+# Validate an explicit override before the first AWS call. Besides producing a
+# clearer error, this keeps an invalid external value from selecting an account.
+bucket_name="${MEM9_DECISION_ARTIFACT_BUCKET:-}"
+if [[ -n "$bucket_name" ]] && ! valid_bucket_name "$bucket_name"; then
+  echo "MEM9_DECISION_ARTIFACT_BUCKET is an invalid decision-artifact bucket name." >&2
+  exit 2
+fi
+
+account_id="$(aws sts get-caller-identity --query Account --output text)"
+if [[ ! "$account_id" =~ ^[0-9]{12}$ ]]; then
+  echo "AWS caller identity did not return a 12-digit account id." >&2
+  exit 1
+fi
+bucket_name="${bucket_name:-mem9-audit-${account_id}}"
+if ! valid_bucket_name "$bucket_name"; then
+  echo "Resolved decision-artifact bucket name is invalid." >&2
+  exit 2
+fi
+
+parameters=(
+  "ParameterKey=DecisionArtifactBucketName,ParameterValue=$bucket_name"
+)
+import_change_set_name="adopt-decision-artifact-bucket"
+import_change_set_description="mem9 decision-artifact bucket adoption"
+
+read_stack_resources() {
+  aws cloudformation describe-stack-resources \
+    --stack-name "$stack_name" \
+    --region "$region"
+}
+
+require_empty_stack_shell() {
+  local resources
+  if ! resources="$(read_stack_resources)"; then
+    echo "Reading decision-artifact stack resources failed." >&2
+    return 1
+  fi
+  if ! jq -e '
+      .StackResources
+      | type == "array" and length == 0
+    ' <<<"$resources" >/dev/null; then
+    echo "Decision-artifact recovery stack unexpectedly owns resources." >&2
+    return 1
+  fi
+}
+
+require_stack_bucket() {
+  local resources
+  if ! resources="$(read_stack_resources)"; then
+    echo "Reading existing decision-artifact stack resources failed." >&2
+    return 1
+  fi
+  if ! jq -e --arg bucket "$bucket_name" '
+      [
+        .StackResources[]?
+        | select(
+            .LogicalResourceId == "DecisionArtifactBucket"
+            and .ResourceType == "AWS::S3::Bucket"
+            and .PhysicalResourceId == $bucket
+          )
+      ]
+      | length == 1
+    ' <<<"$resources" >/dev/null; then
+    echo "Existing decision-artifact stack owns a different bucket; refusing replacement." >&2
+    return 1
+  fi
+}
+
+execute_verified_import_change_set() {
+  local change_set
+  if ! aws cloudformation wait change-set-create-complete \
+      --stack-name "$stack_name" \
+      --change-set-name "$import_change_set_name" \
+      --region "$region"; then
+    echo "Bucket import change set did not become ready." >&2
+    return 1
+  fi
+  if ! change_set="$(aws cloudformation describe-change-set \
+      --stack-name "$stack_name" \
+      --change-set-name "$import_change_set_name" \
+      --region "$region")"; then
+    echo "Reading the bucket import change set failed." >&2
+    return 1
+  fi
+  if ! jq -e \
+      --arg bucket "$bucket_name" \
+      --arg description "$import_change_set_description" '
+      .Description == $description
+      and .Status == "CREATE_COMPLETE"
+      and .ExecutionStatus == "AVAILABLE"
+      and (
+        .Parameters == [{
+          ParameterKey: "DecisionArtifactBucketName",
+          ParameterValue: $bucket
+        }]
+      )
+      and (
+        [
+          .Changes[]?
+          | select(
+              .Type == "Resource"
+              and .ResourceChange.Action == "Import"
+              and .ResourceChange.LogicalResourceId == "DecisionArtifactBucket"
+              and .ResourceChange.ResourceType == "AWS::S3::Bucket"
+            )
+        ]
+        | length == 1
+      )
+      and (.Changes | length == 1)
+    ' <<<"$change_set" >/dev/null; then
+    echo "Bucket import change set read-back mismatch; refusing execution." >&2
+    return 1
+  fi
+  if ! aws cloudformation execute-change-set \
+      --stack-name "$stack_name" \
+      --change-set-name "$import_change_set_name" \
+      --region "$region"; then
+    echo "Executing the bucket import change set failed." >&2
+    return 1
+  fi
+  if ! aws cloudformation wait stack-import-complete \
+      --stack-name "$stack_name" \
+      --region "$region"; then
+    echo "Bucket import did not complete." >&2
+    return 1
+  fi
+}
+
+if ! aws cloudformation validate-template \
+    --template-body "file://$full_template" \
+    --region "$region" >/dev/null; then
+  echo "Decision-artifact full template validation failed." >&2
+  exit 1
+fi
+if ! aws cloudformation validate-template \
+    --template-body "file://$import_template" \
+    --region "$region" >/dev/null; then
+  echo "Decision-artifact import template validation failed." >&2
+  exit 1
+fi
+
+set +e
+describe_output="$(aws cloudformation describe-stacks \
+  --stack-name "$stack_name" \
+  --region "$region" 2>&1)"
+describe_exit=$?
+set -e
+stack_exists=false
+recovering_stack=false
+resume_import_change_set=false
+resume_import_wait=false
+if [[ $describe_exit -eq 0 ]]; then
+  stack_exists=true
+elif grep -qiE 'does not exist|not exist' <<<"$describe_output"; then
+  stack_exists=false
+else
+  echo "Could not determine whether the decision-artifact stack exists: $describe_output" >&2
+  exit 1
+fi
+
+if [[ "$stack_exists" == "true" ]]; then
+  if ! stack_status="$(jq -er '
+      .Stacks
+      | select(type == "array" and length == 1)
+      | .[0].StackStatus
+      | select(type == "string")
+    ' <<<"$describe_output")"; then
+    echo "Decision-artifact stack status is malformed." >&2
+    exit 1
+  fi
+  case "$stack_status" in
+    REVIEW_IN_PROGRESS)
+      recovering_stack=true
+      resume_import_change_set=true
+      ;;
+    IMPORT_IN_PROGRESS)
+      recovering_stack=true
+      resume_import_wait=true
+      ;;
+    IMPORT_ROLLBACK_COMPLETE)
+      recovering_stack=true
+      ;;
+    CREATE_COMPLETE|IMPORT_COMPLETE|UPDATE_COMPLETE|UPDATE_ROLLBACK_COMPLETE) ;;
+    IMPORT_ROLLBACK_FAILED)
+      echo "Decision-artifact import rollback failed; recover it in CloudFormation before retrying." >&2
+      exit 1
+      ;;
+    UPDATE_ROLLBACK_FAILED)
+      echo "Decision-artifact stack rollback failed; run CloudFormation continue-update-rollback before retrying." >&2
+      exit 1
+      ;;
+    *)
+      echo "Decision-artifact stack is not in an accepted complete state: $stack_status" >&2
+      exit 1
+      ;;
+  esac
+  existing_bucket_name="$(jq -r '
+    [
+      .Stacks[0].Parameters[]?
+      | select(.ParameterKey == "DecisionArtifactBucketName")
+      | .ParameterValue
+    ]
+    | if length == 0 then "" elif length == 1 then .[0] else error("duplicate") end
+  ' <<<"$describe_output")" || {
+    echo "Decision-artifact stack parameters are malformed." >&2
+    exit 1
+  }
+  if [[ "$recovering_stack" == "true" &&
+        -n "$existing_bucket_name" &&
+        "$existing_bucket_name" != "$bucket_name" ]]; then
+    echo "Recovery stack names a different decision-artifact bucket; refusing mutation." >&2
+    exit 1
+  fi
+  if [[ "$recovering_stack" != "true" &&
+        -n "$existing_bucket_name" &&
+        "$existing_bucket_name" != "$bucket_name" ]]; then
+    echo "Existing decision-artifact stack owns a different bucket; refusing replacement." >&2
+    exit 1
+  fi
+  case "$stack_status" in
+    REVIEW_IN_PROGRESS|IMPORT_ROLLBACK_COMPLETE)
+      require_empty_stack_shell || exit 1
+      ;;
+    IMPORT_IN_PROGRESS)
+      ;;
+    *)
+      require_stack_bucket || exit 1
+      ;;
+  esac
+  if [[ "$stack_status" == "IMPORT_ROLLBACK_COMPLETE" ]]; then
+    echo "Removing the verified empty import-rollback stack shell..."
+    if ! aws cloudformation delete-stack \
+        --stack-name "$stack_name" \
+        --region "$region"; then
+      echo "Deleting the empty import-rollback stack shell failed." >&2
+      exit 1
+    fi
+    if ! aws cloudformation wait stack-delete-complete \
+        --stack-name "$stack_name" \
+        --region "$region"; then
+      echo "Empty import-rollback stack shell did not delete." >&2
+      exit 1
+    fi
+    stack_exists=false
   fi
 fi
 
-# Derived, never read back from a stack output — the same way the SST app and the
-# E2E harness compute it, which is the stricter check. Hoisted above the preflight
-# because the summary at the end needs it too, and the template deliberately has no
-# Outputs block to read (an Outputs block would break the IMPORT adoption path
-# printed below).
-ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
-BUCKET_NAME="mem9-audit-${ACCOUNT_ID}"
+if [[ "$mode" == "create" &&
+      "$stack_exists" == "true" &&
+      "$recovering_stack" != "true" ]]; then
+  echo "Decision-artifact stack already exists; --create refused." >&2
+  exit 1
+fi
+if [[ "$mode" == "update" &&
+      "$stack_exists" != "true" &&
+      "$recovering_stack" != "true" ]]; then
+  echo "Decision-artifact stack does not exist; --update refused." >&2
+  exit 1
+fi
 
-# A bucket that already exists OUTSIDE this stack cannot be adopted by a
-# create-stack — CloudFormation fails with "already exists" and rolls back. That
-# is the state a stage-owned deploy would have left behind, so name the remedy
-# here rather than leaving the operator to read a raw CFN failure.
-if [[ "$MODE" == "create" ]]; then
-  # --region for the same reason the header claims ambient AWS_REGION is ignored:
-  # the preflight must ask about the bucket in the region this stack targets.
-  if aws s3api head-bucket --bucket "$BUCKET_NAME" --region "$REGION" >/dev/null 2>&1; then
-    echo "Error: bucket $BUCKET_NAME already exists but this stack does not own it." >&2
-    echo "  A stage-owned deploy created it. Adopt it with an IMPORT change set --" >&2
-    echo "  which does work for a stack that does not exist yet, but must name EVERY" >&2
-    echo "  resource in the template (both, here) or CFN rejects the change set:" >&2
-    echo "    aws cloudformation create-change-set --stack-name $STACK_NAME \\" >&2
-    echo "      --change-set-name adopt-artifact-bucket \\" >&2
-    echo "      --change-set-type IMPORT --region $REGION \\" >&2
-    echo "      --template-body file://$TEMPLATE_FILE \\" >&2
-    echo "      --resources-to-import \\" >&2
-    echo "      '[{\"ResourceType\":\"AWS::S3::Bucket\",\"LogicalResourceId\":\"DecisionArtifactBucket\",\"ResourceIdentifier\":{\"BucketName\":\"$BUCKET_NAME\"}},{\"ResourceType\":\"AWS::S3::BucketPolicy\",\"LogicalResourceId\":\"DecisionArtifactBucketPolicy\",\"ResourceIdentifier\":{\"Bucket\":\"$BUCKET_NAME\"}}]'" >&2
-    echo "  Then: aws cloudformation execute-change-set --stack-name $STACK_NAME \\" >&2
-    echo "          --change-set-name adopt-artifact-bucket --region $REGION" >&2
+bucket_exists=false
+if [[ "$stack_exists" != "true" ||
+      "$resume_import_change_set" == "true" ]]; then
+  set +e
+  bucket_probe="$(aws s3api head-bucket \
+    --bucket "$bucket_name" \
+    --expected-bucket-owner "$account_id" \
+    --region "$region" 2>&1)"
+  bucket_probe_exit=$?
+  set -e
+  if [[ $bucket_probe_exit -eq 0 ]]; then
+    bucket_exists=true
+  elif grep -qiE '\(404\)|NoSuchBucket|Not Found' <<<"$bucket_probe"; then
+    bucket_exists=false
+  else
+    echo "Could not safely determine whether bucket $bucket_name exists: $bucket_probe" >&2
     exit 1
   fi
 fi
 
-case "$MODE" in
-  create)
-    echo "Creating stack..."
-    aws cloudformation create-stack \
-      --stack-name "$STACK_NAME" \
-      --template-body "file://$TEMPLATE_FILE" \
-      --region "$REGION" \
-      --tags Key=Project,Value=mem9-on-aws Key=ManagedBy,Value=cli
-    aws cloudformation wait stack-create-complete \
-      --stack-name "$STACK_NAME" \
-      --region "$REGION"
-    ;;
-  update)
-    echo "Updating stack..."
-    # update-stack exits non-zero with "No updates are to be performed" when the
-    # template is unchanged — swallow that so re-running for idempotency is safe.
-    set +e
-    UPDATE_OUTPUT=$(aws cloudformation update-stack \
-      --stack-name "$STACK_NAME" \
-      --template-body "file://$TEMPLATE_FILE" \
-      --region "$REGION" 2>&1)
-    UPDATE_EXIT=$?
-    set -e
-    if [[ $UPDATE_EXIT -ne 0 ]]; then
-      if echo "$UPDATE_OUTPUT" | grep -q "No updates are to be performed"; then
-        echo "No changes to apply."
-      else
-        echo "$UPDATE_OUTPUT" >&2
-        exit $UPDATE_EXIT
-      fi
-    else
-      aws cloudformation wait stack-update-complete \
-        --stack-name "$STACK_NAME" \
-        --region "$REGION"
-    fi
-    ;;
-esac
+echo "Stack:      $stack_name"
+echo "Region:     $region"
+echo "BucketName: $bucket_name"
 
-echo
-echo "BucketName: $BUCKET_NAME"
-echo
-echo "No CI variable to set — the SST app and the E2E harness both derive this"
-echo "name from the caller's account id. The next deploy of any stage will find"
-echo "the bucket already present."
+import_completed=false
+if [[ "$resume_import_wait" == "true" ]]; then
+  echo "Waiting for the in-progress bucket import..."
+  if ! aws cloudformation wait stack-import-complete \
+      --stack-name "$stack_name" \
+      --region "$region"; then
+    echo "Bucket import did not complete." >&2
+    exit 1
+  fi
+  import_completed=true
+elif [[ "$resume_import_change_set" == "true" ]]; then
+  if [[ "$bucket_exists" != "true" ]]; then
+    echo "Recovery change set targets a bucket that no longer exists." >&2
+    exit 1
+  fi
+  echo "Resuming the pending bucket import change set..."
+  execute_verified_import_change_set || exit 1
+  import_completed=true
+elif [[ "$stack_exists" != "true" && "$bucket_exists" == "true" ]]; then
+  resources_to_import="$(jq -cn --arg bucket "$bucket_name" '[
+    {
+      ResourceType: "AWS::S3::Bucket",
+      LogicalResourceId: "DecisionArtifactBucket",
+      ResourceIdentifier: { BucketName: $bucket }
+    }
+  ]')"
+  echo "Importing existing bucket with the import-only template..."
+  if ! aws cloudformation create-change-set \
+      --stack-name "$stack_name" \
+      --change-set-name "$import_change_set_name" \
+      --description "$import_change_set_description" \
+      --change-set-type IMPORT \
+      --template-body "file://$import_template" \
+      --parameters "${parameters[@]}" \
+      --resources-to-import "$resources_to_import" \
+      --region "$region" >/dev/null; then
+    echo "Creating the bucket import change set failed." >&2
+    exit 1
+  fi
+  execute_verified_import_change_set || exit 1
+  import_completed=true
+elif [[ "$stack_exists" != "true" ]]; then
+  echo "Creating the decision-artifact stack..."
+  if ! aws cloudformation create-stack \
+      --stack-name "$stack_name" \
+      --template-body "file://$full_template" \
+      --parameters "${parameters[@]}" \
+      --region "$region" \
+      --tags Key=Project,Value=mem9-on-aws Key=ManagedBy,Value=cli >/dev/null; then
+    echo "Decision-artifact stack creation failed." >&2
+    exit 1
+  fi
+  if ! aws cloudformation wait stack-create-complete \
+      --stack-name "$stack_name" \
+      --region "$region"; then
+    echo "Decision-artifact stack creation did not complete." >&2
+    exit 1
+  fi
+  stack_exists=created
+fi
+
+if [[ "$import_completed" == "true" ]]; then
+  require_stack_bucket || exit 1
+  stack_exists=true
+fi
+
+# An import records the live properties but does not reconcile them. The normal
+# update is therefore mandatory after adoption, even if the bucket looked close
+# to the desired declaration before import.
+if [[ "$stack_exists" == "true" ]]; then
+  echo "Applying the complete decision-artifact template..."
+  set +e
+  update_output="$(aws cloudformation update-stack \
+    --stack-name "$stack_name" \
+    --template-body "file://$full_template" \
+    --parameters "${parameters[@]}" \
+    --region "$region" 2>&1)"
+  update_exit=$?
+  set -e
+  if [[ $update_exit -eq 0 ]]; then
+    if ! aws cloudformation wait stack-update-complete \
+        --stack-name "$stack_name" \
+        --region "$region"; then
+      echo "Decision-artifact stack update did not complete." >&2
+      exit 1
+    fi
+  elif grep -q "No updates are to be performed" <<<"$update_output"; then
+    echo "No template update was required; live verification still runs."
+  else
+    echo "Decision-artifact stack update failed: $update_output" >&2
+    exit 1
+  fi
+fi
+
+if ! final_stack="$(aws cloudformation describe-stacks \
+    --stack-name "$stack_name" \
+    --region "$region")"; then
+  echo "Reading the final decision-artifact stack failed." >&2
+  exit 1
+fi
+if ! jq -e --arg bucket "$bucket_name" '
+    .Stacks
+    | select(type == "array" and length == 1)
+    | .[0]
+      | select(
+        .StackStatus == "CREATE_COMPLETE"
+        or .StackStatus == "IMPORT_COMPLETE"
+        or .StackStatus == "UPDATE_COMPLETE"
+        or .StackStatus == "UPDATE_ROLLBACK_COMPLETE"
+      )
+    | [
+        .Parameters[]?
+        | select(.ParameterKey == "DecisionArtifactBucketName")
+        | .ParameterValue
+      ]
+    | length == 1 and .[0] == $bucket
+  ' <<<"$final_stack" >/dev/null; then
+  echo "Decision-artifact stack read-back mismatch." >&2
+  exit 1
+fi
+
+if ! stack_resources="$(aws cloudformation describe-stack-resources \
+    --stack-name "$stack_name" \
+    --region "$region")"; then
+  echo "Reading decision-artifact stack resources failed." >&2
+  exit 1
+fi
+if ! jq -e --arg bucket "$bucket_name" '
+    .StackResources
+    | select(type == "array")
+    | . as $resources
+    | (
+        [
+          $resources[]
+          | select(
+              .LogicalResourceId == "DecisionArtifactBucket"
+              and .ResourceType == "AWS::S3::Bucket"
+              and .PhysicalResourceId == $bucket
+            )
+        ]
+        | length == 1
+      )
+      and (
+        [
+          $resources[]
+          | select(
+              .LogicalResourceId == "DecisionArtifactBucketPolicy"
+              and .ResourceType == "AWS::S3::BucketPolicy"
+            )
+        ]
+        | length == 1
+      )
+  ' <<<"$stack_resources" >/dev/null; then
+  echo "Decision-artifact bucket or policy ownership read-back mismatch." >&2
+  exit 1
+fi
+
+s3_args=(
+  --bucket "$bucket_name"
+  --expected-bucket-owner "$account_id"
+  --region "$region"
+)
+
+if ! location_json="$(aws s3api get-bucket-location "${s3_args[@]}")"; then
+  echo "Reading decision-artifact bucket location failed." >&2
+  exit 1
+fi
+location="$(jq -r '
+  .LocationConstraint
+  | if . == null or . == "None" then "us-east-1"
+    elif . == "EU" then "eu-west-1"
+    else .
+    end
+' <<<"$location_json")" || {
+  echo "Decision-artifact bucket location response is malformed." >&2
+  exit 1
+}
+if [[ "$location" != "$region" ]]; then
+  echo "Decision-artifact bucket is in $location, expected $region." >&2
+  exit 1
+fi
+
+if ! public_access="$(aws s3api get-public-access-block "${s3_args[@]}")"; then
+  echo "Reading decision-artifact public-access block failed." >&2
+  exit 1
+fi
+if ! jq -e '
+    .PublicAccessBlockConfiguration == {
+      BlockPublicAcls: true,
+      BlockPublicPolicy: true,
+      IgnorePublicAcls: true,
+      RestrictPublicBuckets: true
+    }
+  ' <<<"$public_access" >/dev/null; then
+  echo "Decision-artifact public-access block read-back mismatch." >&2
+  exit 1
+fi
+
+if ! encryption="$(aws s3api get-bucket-encryption "${s3_args[@]}")"; then
+  echo "Reading decision-artifact bucket encryption failed." >&2
+  exit 1
+fi
+if ! jq -e '
+    .ServerSideEncryptionConfiguration.Rules
+    | select(type == "array" and length == 1)
+    | .[0]
+    | .BucketKeyEnabled == true
+      and .ApplyServerSideEncryptionByDefault.SSEAlgorithm == "aws:kms"
+      and (
+        .ApplyServerSideEncryptionByDefault.KMSMasterKeyID == "alias/aws/s3"
+        or .ApplyServerSideEncryptionByDefault.KMSMasterKeyID == "aws/s3"
+        or (
+          .ApplyServerSideEncryptionByDefault.KMSMasterKeyID
+          | endswith(":alias/aws/s3")
+        )
+      )
+  ' <<<"$encryption" >/dev/null; then
+  echo "Decision-artifact bucket encryption read-back mismatch." >&2
+  exit 1
+fi
+
+if ! lifecycle="$(aws s3api get-bucket-lifecycle-configuration \
+    "${s3_args[@]}")"; then
+  echo "Reading decision-artifact lifecycle failed." >&2
+  exit 1
+fi
+if ! jq -e '
+    .Rules
+    | select(type == "array" and length == 1)
+    | .[0]
+    | .ID == "expire-decision-artifacts"
+      and .Status == "Enabled"
+      and ((.Filter.Prefix // .Prefix // "") == "")
+      and .Expiration.Days == 3
+      and .AbortIncompleteMultipartUpload.DaysAfterInitiation == 1
+  ' <<<"$lifecycle" >/dev/null; then
+  echo "Decision-artifact lifecycle read-back mismatch." >&2
+  exit 1
+fi
+
+if ! policy="$(aws s3api get-bucket-policy "${s3_args[@]}")"; then
+  echo "Reading decision-artifact bucket policy failed." >&2
+  exit 1
+fi
+if ! jq -e --arg bucket_arn "arn:aws:s3:::$bucket_name" '
+    .Policy
+    | fromjson
+    | select(.Version == "2012-10-17")
+    | .Statement
+    | select(type == "array" and length == 1)
+    | .[0]
+    | .Sid == "DenyInsecureTransport"
+      and .Effect == "Deny"
+      and (.Principal == "*" or .Principal == {AWS: "*"})
+      and (.Action == "s3:*" or .Action == ["s3:*"])
+      and (
+        (if (.Resource | type) == "array" then .Resource else [.Resource] end)
+        | sort == ([$bucket_arn, ($bucket_arn + "/*")] | sort)
+      )
+      and .Condition.Bool["aws:SecureTransport"] == "false"
+  ' <<<"$policy" >/dev/null; then
+  echo "Decision-artifact bucket policy read-back mismatch." >&2
+  exit 1
+fi
+
+if ! tags="$(aws s3api get-bucket-tagging "${s3_args[@]}")"; then
+  echo "Reading decision-artifact bucket tags failed." >&2
+  exit 1
+fi
+if ! jq -e '
+    .TagSet
+    | map(select(
+        (.Key == "ManagedBy" and .Value == "cloudformation")
+        or (.Key == "Project" and .Value == "mem9-on-aws")
+      ))
+    | length == 2
+  ' <<<"$tags" >/dev/null; then
+  echo "Decision-artifact bucket tags read-back mismatch." >&2
+  exit 1
+fi
+
+if ! drift_detection_id="$(aws cloudformation detect-stack-drift \
+    --stack-name "$stack_name" \
+    --region "$region" \
+    --query StackDriftDetectionId \
+    --output text)" ||
+    [[ -z "$drift_detection_id" || "$drift_detection_id" == "None" ]]; then
+  echo "Starting decision-artifact stack drift detection failed." >&2
+  exit 1
+fi
+drift_status=""
+for _ in {1..60}; do
+  if ! drift_status="$(aws cloudformation describe-stack-drift-detection-status \
+      --stack-drift-detection-id "$drift_detection_id" \
+      --region "$region")"; then
+    echo "Reading decision-artifact stack drift status failed." >&2
+    exit 1
+  fi
+  detection_status="$(jq -r '.DetectionStatus // empty' <<<"$drift_status")"
+  case "$detection_status" in
+    DETECTION_COMPLETE) break ;;
+    DETECTION_IN_PROGRESS) sleep 5 ;;
+    DETECTION_FAILED)
+      echo "Decision-artifact stack drift detection failed." >&2
+      exit 1
+      ;;
+    *)
+      echo "Decision-artifact stack drift status is malformed." >&2
+      exit 1
+      ;;
+  esac
+done
+if ! jq -e '
+    .DetectionStatus == "DETECTION_COMPLETE"
+    and .StackDriftStatus == "IN_SYNC"
+  ' <<<"$drift_status" >/dev/null; then
+  echo "Decision-artifact stack drift verification failed." >&2
+  exit 1
+fi
+
+echo "Decision-artifact bucket is CloudFormation-owned, hardened, and IN_SYNC."

--- a/scripts/deploy-decision-artifact-bucket.test.mjs
+++ b/scripts/deploy-decision-artifact-bucket.test.mjs
@@ -1,0 +1,697 @@
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const script = resolve(root, "scripts/deploy-decision-artifact-bucket.sh");
+const fullTemplate = resolve(
+  root,
+  "infra/cloudformation/decision-artifact-bucket.yaml",
+);
+const importTemplate = resolve(
+  root,
+  "infra/cloudformation/decision-artifact-bucket-import.yaml",
+);
+const temporaryPaths = [];
+
+function parseCloudFormation(path) {
+  return parse(readFileSync(path, "utf8"), {
+    customTags: [
+      { tag: "!Ref", resolve: (value) => ({ Ref: value }) },
+      { tag: "!Sub", resolve: (value) => ({ "Fn::Sub": value }) },
+      {
+        tag: "!GetAtt",
+        resolve: (value) => ({ "Fn::GetAtt": value.split(".") }),
+      },
+    ],
+  });
+}
+
+afterEach(() => {
+  for (const path of temporaryPaths.splice(0)) {
+    rmSync(path, { force: true, recursive: true });
+  }
+});
+
+function runFixture({
+  bucket = "absent",
+  bucketName = "",
+  changeSetMismatch = false,
+  drift = "IN_SYNC",
+  recoveryHasResource = false,
+  stack = "absent",
+  stackBucketName = "",
+  stackHasBucketParameter = true,
+  stackPolicyOwned = true,
+  stackStatus = "UPDATE_COMPLETE",
+  updateNoop = false,
+  verificationFailure = "",
+} = {}) {
+  const directory = mkdtempSync(join(tmpdir(), "mem9-artifact-bucket-"));
+  temporaryPaths.push(directory);
+  const aws = join(directory, "aws");
+  const calls = join(directory, "calls.jsonl");
+
+  writeFileSync(
+    aws,
+    `#!${process.execPath}
+import { appendFileSync, existsSync, rmSync, writeFileSync } from "node:fs";
+
+const args = process.argv.slice(2);
+appendFileSync(process.env.MOCK_CALLS, JSON.stringify(args) + "\\n");
+const command = args.slice(0, 2).join(" ");
+const option = (name) => {
+  const index = args.indexOf(name);
+  return index === -1 ? "" : args[index + 1];
+};
+const stackNowExists = () =>
+  !existsSync(process.env.MOCK_STACK_DELETED) &&
+  (
+    process.env.MOCK_STACK === "present" ||
+    existsSync(process.env.MOCK_STACK_CREATED) ||
+    existsSync(process.env.MOCK_FULL_STACK_CREATED)
+  );
+if (command === process.env.MOCK_VERIFICATION_FAILURE) {
+  console.error("AccessDenied: simulated verification failure");
+  process.exit(254);
+}
+
+switch (command) {
+  case "sts get-caller-identity":
+    console.log("123456789012");
+    break;
+  case "cloudformation validate-template":
+    console.log("{}");
+    break;
+  case "cloudformation describe-stacks":
+    if (process.env.MOCK_STACK === "denied") {
+      console.error("AccessDenied: denied");
+      process.exit(254);
+    }
+    if (!stackNowExists()) {
+      console.error("ValidationError: Stack with id decision-artifact-bucket-mem9-on-aws does not exist");
+      process.exit(255);
+    }
+    console.log(JSON.stringify({
+      Stacks: [{
+        StackStatus: existsSync(process.env.MOCK_UPDATED)
+          ? "UPDATE_COMPLETE"
+          : existsSync(process.env.MOCK_IMPORTED)
+            ? "IMPORT_COMPLETE"
+            : existsSync(process.env.MOCK_FULL_STACK_CREATED)
+              ? "CREATE_COMPLETE"
+          : process.env.MOCK_STACK_STATUS,
+        Parameters:
+          process.env.MOCK_STACK_HAS_BUCKET_PARAMETER === "false"
+            ? []
+            : [{
+                ParameterKey: "DecisionArtifactBucketName",
+                ParameterValue:
+                  process.env.MOCK_STACK_BUCKET_NAME ||
+                  process.env.MEM9_DECISION_ARTIFACT_BUCKET ||
+                  "mem9-audit-123456789012",
+              }],
+      }],
+    }));
+    break;
+  case "s3api head-bucket":
+    if (process.env.MOCK_BUCKET === "denied") {
+      console.error("An error occurred (403) when calling the HeadBucket operation: Forbidden");
+      process.exit(254);
+    }
+    if (process.env.MOCK_BUCKET === "wrong-region") {
+      console.error("An error occurred (301) when calling the HeadBucket operation: Moved Permanently");
+      process.exit(254);
+    }
+    if (process.env.MOCK_BUCKET === "absent") {
+      console.error("An error occurred (404) when calling the HeadBucket operation: Not Found");
+      process.exit(254);
+    }
+    break;
+  case "cloudformation create-change-set":
+    rmSync(process.env.MOCK_STACK_DELETED, { force: true });
+    writeFileSync(process.env.MOCK_STACK_CREATED, "1");
+    break;
+  case "cloudformation create-stack":
+    rmSync(process.env.MOCK_STACK_DELETED, { force: true });
+    writeFileSync(process.env.MOCK_FULL_STACK_CREATED, "1");
+    break;
+  case "cloudformation describe-change-set":
+    console.log(JSON.stringify({
+      Description:
+        process.env.MOCK_CHANGE_SET_MISMATCH === "true"
+          ? "unrecognized import"
+          : "mem9 decision-artifact bucket adoption",
+      Status: "CREATE_COMPLETE",
+      ExecutionStatus: "AVAILABLE",
+      Parameters: [{
+        ParameterKey: "DecisionArtifactBucketName",
+        ParameterValue:
+          process.env.MOCK_STACK_BUCKET_NAME ||
+          process.env.MEM9_DECISION_ARTIFACT_BUCKET ||
+          "mem9-audit-123456789012",
+      }],
+      Changes: [{
+        Type: "Resource",
+        ResourceChange: {
+          Action: "Import",
+          LogicalResourceId: "DecisionArtifactBucket",
+          ResourceType: "AWS::S3::Bucket",
+        },
+      }],
+    }));
+    break;
+  case "cloudformation execute-change-set":
+    writeFileSync(process.env.MOCK_IMPORTED, "1");
+    break;
+  case "cloudformation delete-stack":
+    writeFileSync(process.env.MOCK_STACK_DELETED, "1");
+    break;
+  case "cloudformation update-stack":
+    if (process.env.MOCK_UPDATE_NOOP === "true") {
+      console.error("ValidationError: No updates are to be performed.");
+      process.exit(255);
+    }
+    writeFileSync(process.env.MOCK_UPDATED, "1");
+    break;
+  case "cloudformation detect-stack-drift":
+    if (command === "cloudformation detect-stack-drift") {
+      console.log("drift-detection-id");
+    }
+    break;
+  case "cloudformation wait":
+    if (args[2] === "stack-import-complete") {
+      writeFileSync(process.env.MOCK_IMPORTED, "1");
+    }
+    break;
+  case "cloudformation describe-stack-resources":
+    {
+      const initialRecovery =
+        ["REVIEW_IN_PROGRESS", "IMPORT_IN_PROGRESS", "IMPORT_ROLLBACK_COMPLETE"]
+          .includes(process.env.MOCK_STACK_STATUS) &&
+        !existsSync(process.env.MOCK_IMPORTED) &&
+        !existsSync(process.env.MOCK_UPDATED) &&
+        !existsSync(process.env.MOCK_FULL_STACK_CREATED);
+      if (
+        initialRecovery &&
+        process.env.MOCK_RECOVERY_HAS_RESOURCE !== "true"
+      ) {
+        console.log(JSON.stringify({ StackResources: [] }));
+        break;
+      }
+      const policyOwned =
+        existsSync(process.env.MOCK_UPDATED) ||
+        existsSync(process.env.MOCK_FULL_STACK_CREATED) ||
+        (
+          !existsSync(process.env.MOCK_IMPORTED) &&
+          process.env.MOCK_STACK_POLICY_OWNED === "true"
+        );
+      console.log(JSON.stringify({
+        StackResources: [
+          {
+            LogicalResourceId: "DecisionArtifactBucket",
+            PhysicalResourceId:
+              process.env.MOCK_STACK_BUCKET_NAME ||
+              process.env.MEM9_DECISION_ARTIFACT_BUCKET ||
+              "mem9-audit-123456789012",
+            ResourceStatus: "UPDATE_COMPLETE",
+            ResourceType: "AWS::S3::Bucket",
+          },
+          ...(policyOwned
+            ? [{
+                LogicalResourceId: "DecisionArtifactBucketPolicy",
+                PhysicalResourceId:
+                  process.env.MOCK_STACK_BUCKET_NAME ||
+                  process.env.MEM9_DECISION_ARTIFACT_BUCKET ||
+                  "mem9-audit-123456789012",
+                ResourceStatus: "UPDATE_COMPLETE",
+                ResourceType: "AWS::S3::BucketPolicy",
+              }]
+            : []),
+        ],
+      }));
+      break;
+    }
+  case "s3api get-bucket-location":
+    console.log(JSON.stringify({ LocationConstraint: "ap-northeast-1" }));
+    break;
+  case "s3api get-public-access-block":
+    console.log(JSON.stringify({
+      PublicAccessBlockConfiguration: {
+        BlockPublicAcls: true,
+        BlockPublicPolicy: true,
+        IgnorePublicAcls: true,
+        RestrictPublicBuckets: true,
+      },
+    }));
+    break;
+  case "s3api get-bucket-encryption":
+    console.log(JSON.stringify({
+      ServerSideEncryptionConfiguration: {
+        Rules: [{
+          ApplyServerSideEncryptionByDefault: {
+            SSEAlgorithm: "aws:kms",
+            KMSMasterKeyID: "alias/aws/s3",
+          },
+          BucketKeyEnabled: true,
+        }],
+      },
+    }));
+    break;
+  case "s3api get-bucket-lifecycle-configuration":
+    console.log(JSON.stringify({
+      Rules: [{
+        ID: "expire-decision-artifacts",
+        Status: "Enabled",
+        Filter: { Prefix: "" },
+        Expiration: { Days: 3 },
+        AbortIncompleteMultipartUpload: { DaysAfterInitiation: 1 },
+      }],
+    }));
+    break;
+  case "s3api get-bucket-policy":
+    console.log(JSON.stringify({
+      Policy: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [{
+          Sid: "DenyInsecureTransport",
+          Effect: "Deny",
+          Principal: "*",
+          Action: "s3:*",
+          Resource: [
+            \`arn:aws:s3:::\${option("--bucket")}\`,
+            \`arn:aws:s3:::\${option("--bucket")}/*\`,
+          ],
+          Condition: { Bool: { "aws:SecureTransport": "false" } },
+        }],
+      }),
+    }));
+    break;
+  case "s3api get-bucket-tagging":
+    console.log(JSON.stringify({
+      TagSet: [
+        { Key: "ManagedBy", Value: "cloudformation" },
+        { Key: "Project", Value: "mem9-on-aws" },
+      ],
+    }));
+    break;
+  case "cloudformation describe-stack-drift-detection-status":
+    console.log(JSON.stringify({
+      DetectionStatus: "DETECTION_COMPLETE",
+      StackDriftStatus: process.env.MOCK_DRIFT,
+    }));
+    break;
+  default:
+    console.error("unexpected aws command:", command, args.join(" "));
+    process.exit(2);
+}
+`,
+  );
+  chmodSync(aws, 0o755);
+
+  const result = spawnSync("bash", [script], {
+    cwd: root,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      AWS_PROFILE: "",
+      MEM9_DECISION_ARTIFACT_BUCKET: bucketName,
+      MOCK_BUCKET: bucket,
+      MOCK_CALLS: calls,
+      MOCK_CHANGE_SET_MISMATCH: String(changeSetMismatch),
+      MOCK_DRIFT: drift,
+      MOCK_FULL_STACK_CREATED: join(directory, "full-stack-created"),
+      MOCK_IMPORTED: join(directory, "imported"),
+      MOCK_RECOVERY_HAS_RESOURCE: String(recoveryHasResource),
+      MOCK_STACK: stack,
+      MOCK_STACK_BUCKET_NAME: stackBucketName,
+      MOCK_STACK_DELETED: join(directory, "stack-deleted"),
+      MOCK_STACK_HAS_BUCKET_PARAMETER: String(stackHasBucketParameter),
+      MOCK_STACK_POLICY_OWNED: String(stackPolicyOwned),
+      MOCK_STACK_STATUS: stackStatus,
+      MOCK_UPDATE_NOOP: String(updateNoop),
+      MOCK_STACK_CREATED: join(directory, "stack-created"),
+      MOCK_UPDATED: join(directory, "updated"),
+      MOCK_VERIFICATION_FAILURE: verificationFailure,
+      PATH: `${directory}:${process.env.PATH}`,
+    },
+  });
+  const callRecords = (existsSync(calls) ? readFileSync(calls, "utf8") : "")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+  return {
+    calls: callRecords,
+    output: `${result.stdout}${result.stderr}`,
+    result,
+  };
+}
+
+const hasMutation = (calls) =>
+  calls.some(
+    ([service, operation]) =>
+      service === "cloudformation" &&
+      [
+        "create-change-set",
+        "create-stack",
+        "execute-change-set",
+        "update-stack",
+      ].includes(operation),
+  );
+
+describe("decision-artifact bucket bootstrap", () => {
+  it("TC-SLACKAPP-220 keeps import limited to the retained bucket", () => {
+    const template = parseCloudFormation(importTemplate);
+    expect(Object.keys(template.Resources)).toEqual(["DecisionArtifactBucket"]);
+    expect(template.Resources.DecisionArtifactBucket).toMatchObject({
+      Type: "AWS::S3::Bucket",
+      DeletionPolicy: "Retain",
+      UpdateReplacePolicy: "Retain",
+      Properties: {
+        BucketName: { Ref: "DecisionArtifactBucketName" },
+      },
+    });
+    expect(template.Outputs).toBeUndefined();
+    expect(
+      parseCloudFormation(fullTemplate).Parameters.DecisionArtifactBucketName,
+    ).toEqual(template.Parameters.DecisionArtifactBucketName);
+  });
+
+  it("TC-SLACKAPP-220 imports an existing bucket before applying the full template", () => {
+    const { calls, output, result } = runFixture({ bucket: "present" });
+    expect(result.status, output).toBe(0);
+    const importCall = calls.find(
+      ([service, operation]) =>
+        service === "cloudformation" && operation === "create-change-set",
+    );
+    expect(importCall).toBeDefined();
+    expect(importCall.join(" ")).toContain(
+      "infra/cloudformation/decision-artifact-bucket-import.yaml",
+    );
+    const resources = JSON.parse(
+      importCall[importCall.indexOf("--resources-to-import") + 1],
+    );
+    expect(resources).toEqual([
+      {
+        ResourceType: "AWS::S3::Bucket",
+        LogicalResourceId: "DecisionArtifactBucket",
+        ResourceIdentifier: { BucketName: "mem9-audit-123456789012" },
+      },
+    ]);
+    const imported = calls.findIndex(
+      (call) =>
+        call[0] === "cloudformation" &&
+        call[1] === "wait" &&
+        call[2] === "stack-import-complete",
+    );
+    const updated = calls.findIndex(
+      ([service, operation]) =>
+        service === "cloudformation" && operation === "update-stack",
+    );
+    expect(imported).toBeGreaterThanOrEqual(0);
+    expect(updated).toBeGreaterThan(imported);
+    expect(calls[updated].join(" ")).toContain(
+      "infra/cloudformation/decision-artifact-bucket.yaml",
+    );
+  });
+
+  it("TC-SLACKAPP-219 passes a validated override through create and verification", () => {
+    const override = "example-mem9-decision-artifacts";
+    const { calls, output, result } = runFixture({ bucketName: override });
+    expect(result.status, output).toBe(0);
+    const create = calls.find(
+      ([service, operation]) =>
+        service === "cloudformation" && operation === "create-stack",
+    );
+    expect(create.join(" ")).toContain(
+      `ParameterKey=DecisionArtifactBucketName,ParameterValue=${override}`,
+    );
+    for (const call of calls.filter(([service]) => service === "s3api")) {
+      expect(call[call.indexOf("--bucket") + 1]).toBe(override);
+    }
+  });
+
+  it.each([
+    "UPPERCASE",
+    "ab",
+    "192.0.2.1",
+    "bad..name",
+    "bad_name",
+    "xn--reserved",
+    "sthree-reserved",
+    "amzn-s3-demo-reserved",
+    "reserved-s3alias",
+    "reserved--ol-s3",
+    "reserved--x-s3",
+    "reserved--table-s3",
+    "reserved-an",
+    "a".repeat(34),
+  ])(
+    "TC-SLACKAPP-219 rejects invalid override %s before AWS",
+    (bucketName) => {
+      const { calls, output, result } = runFixture({ bucketName });
+      expect(result.status).toBe(2);
+      expect(output).toMatch(/invalid.*bucket name/iu);
+      expect(calls).toEqual([]);
+    },
+  );
+
+  it.each([
+    ["stack discovery", { stack: "denied" }],
+    ["bucket discovery", { bucket: "denied" }],
+    ["wrong-region bucket", { bucket: "wrong-region" }],
+  ])("TC-SLACKAPP-221 fails closed on %s", (_name, options) => {
+    const { calls, output, result } = runFixture(options);
+    expect(result.status, output).not.toBe(0);
+    expect(hasMutation(calls)).toBe(false);
+  });
+
+  it("TC-SLACKAPP-221 resumes its verified REVIEW_IN_PROGRESS import", () => {
+    const { calls, output, result } = runFixture({
+      bucket: "present",
+      stack: "present",
+      stackStatus: "REVIEW_IN_PROGRESS",
+    });
+    expect(result.status, output).toBe(0);
+    expect(
+      calls.some(
+        ([service, operation]) =>
+          service === "cloudformation" && operation === "create-change-set",
+      ),
+    ).toBe(false);
+    const described = calls.findIndex(
+      ([service, operation]) =>
+        service === "cloudformation" && operation === "describe-change-set",
+    );
+    const executed = calls.findIndex(
+      ([service, operation]) =>
+        service === "cloudformation" && operation === "execute-change-set",
+    );
+    expect(described).toBeGreaterThanOrEqual(0);
+    expect(executed).toBeGreaterThan(described);
+  });
+
+  it("TC-SLACKAPP-221 refuses an unrecognized REVIEW_IN_PROGRESS change set", () => {
+    const { calls, output, result } = runFixture({
+      bucket: "present",
+      changeSetMismatch: true,
+      stack: "present",
+      stackStatus: "REVIEW_IN_PROGRESS",
+    });
+    expect(result.status, output).not.toBe(0);
+    expect(output).toMatch(/change set read-back mismatch/iu);
+    expect(
+      calls.some(
+        ([service, operation]) =>
+          service === "cloudformation" && operation === "execute-change-set",
+      ),
+    ).toBe(false);
+  });
+
+  it("TC-SLACKAPP-221 resumes waiting for an IMPORT_IN_PROGRESS stack", () => {
+    const { calls, output, result } = runFixture({
+      bucket: "present",
+      stack: "present",
+      stackStatus: "IMPORT_IN_PROGRESS",
+    });
+    expect(result.status, output).toBe(0);
+    const importWait = calls.findIndex(
+      (call) =>
+        call[0] === "cloudformation" &&
+        call[1] === "wait" &&
+        call[2] === "stack-import-complete",
+    );
+    const updated = calls.findIndex(
+      ([service, operation]) =>
+        service === "cloudformation" && operation === "update-stack",
+    );
+    expect(importWait).toBeGreaterThanOrEqual(0);
+    expect(updated).toBeGreaterThan(importWait);
+  });
+
+  it("TC-SLACKAPP-221 recreates a verified empty IMPORT_ROLLBACK_COMPLETE shell", () => {
+    const { calls, output, result } = runFixture({
+      bucket: "present",
+      stack: "present",
+      stackStatus: "IMPORT_ROLLBACK_COMPLETE",
+    });
+    expect(result.status, output).toBe(0);
+    const deleted = calls.findIndex(
+      ([service, operation]) =>
+        service === "cloudformation" && operation === "delete-stack",
+    );
+    const recreated = calls.findIndex(
+      ([service, operation]) =>
+        service === "cloudformation" && operation === "create-change-set",
+    );
+    expect(deleted).toBeGreaterThanOrEqual(0);
+    expect(recreated).toBeGreaterThan(deleted);
+  });
+
+  it("TC-SLACKAPP-221 never deletes an import-rollback stack with resources", () => {
+    const { calls, output, result } = runFixture({
+      bucket: "present",
+      recoveryHasResource: true,
+      stack: "present",
+      stackStatus: "IMPORT_ROLLBACK_COMPLETE",
+    });
+    expect(result.status, output).not.toBe(0);
+    expect(output).toMatch(/unexpectedly owns resources/iu);
+    expect(
+      calls.some(
+        ([service, operation]) =>
+          service === "cloudformation" && operation === "delete-stack",
+      ),
+    ).toBe(false);
+  });
+
+  it("TC-SLACKAPP-222 rejects CloudFormation drift after live read-back", () => {
+    const { calls, output, result } = runFixture({ drift: "DRIFTED" });
+    expect(result.status, output).not.toBe(0);
+    expect(output).toMatch(/drift/iu);
+    expect(
+      calls.some(
+        ([service, operation]) =>
+          service === "cloudformation" && operation === "detect-stack-drift",
+      ),
+    ).toBe(true);
+    for (const operation of [
+      "get-public-access-block",
+      "get-bucket-encryption",
+      "get-bucket-lifecycle-configuration",
+      "get-bucket-policy",
+    ]) {
+      expect(
+        calls.some(
+          ([service, candidate]) =>
+            service === "s3api" && candidate === operation,
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it("TC-SLACKAPP-222 requires CloudFormation to own the TLS bucket policy", () => {
+    const { calls, output, result } = runFixture({
+      stack: "present",
+      stackPolicyOwned: false,
+      updateNoop: true,
+    });
+    expect(result.status, output).not.toBe(0);
+    expect(output).toMatch(/policy ownership/iu);
+    expect(
+      calls.some(
+        ([service, operation]) =>
+          service === "cloudformation" && operation === "detect-stack-drift",
+      ),
+    ).toBe(false);
+  });
+
+  it("TC-SLACKAPP-221 fails closed when a verification read errors", () => {
+    const { calls, output, result } = runFixture({
+      verificationFailure: "s3api get-bucket-encryption",
+    });
+    expect(result.status, output).not.toBe(0);
+    expect(output).toMatch(/encryption failed/iu);
+    expect(
+      calls.some(
+        ([service, operation]) =>
+          service === "cloudformation" && operation === "detect-stack-drift",
+      ),
+    ).toBe(false);
+  });
+
+  it("TC-SLACKAPP-219 refuses to replace an existing stack's bucket", () => {
+    const { calls, output, result } = runFixture({
+      bucketName: "example-mem9-decision-artifacts",
+      stack: "present",
+      stackBucketName: "existing-mem9-decision-artifacts",
+    });
+    expect(result.status, output).not.toBe(0);
+    expect(output).toMatch(/different bucket.*refusing replacement/iu);
+    expect(hasMutation(calls)).toBe(false);
+  });
+
+  it("TC-SLACKAPP-219 refuses replacement when a legacy stack has no name parameter", () => {
+    const { calls, output, result } = runFixture({
+      bucketName: "example-mem9-decision-artifacts",
+      stack: "present",
+      stackBucketName: "mem9-audit-123456789012",
+      stackHasBucketParameter: false,
+    });
+    expect(result.status, output).not.toBe(0);
+    expect(output).toMatch(/different bucket.*refusing replacement/iu);
+    expect(hasMutation(calls)).toBe(false);
+  });
+
+  it("TC-SLACKAPP-221 retries a verified bucket from UPDATE_ROLLBACK_COMPLETE", () => {
+    const { calls, output, result } = runFixture({
+      stack: "present",
+      stackStatus: "UPDATE_ROLLBACK_COMPLETE",
+    });
+    expect(result.status, output).toBe(0);
+    expect(
+      calls.some(
+        ([service, operation]) =>
+          service === "cloudformation" && operation === "update-stack",
+      ),
+    ).toBe(true);
+  });
+
+  it("TC-SLACKAPP-221 accepts a verified no-op retry from UPDATE_ROLLBACK_COMPLETE", () => {
+    const { calls, output, result } = runFixture({
+      stack: "present",
+      stackStatus: "UPDATE_ROLLBACK_COMPLETE",
+      updateNoop: true,
+    });
+    expect(result.status, output).toBe(0);
+    expect(output).toContain("No template update was required");
+    expect(
+      calls.some(
+        ([service, operation]) =>
+          service === "cloudformation" && operation === "detect-stack-drift",
+      ),
+    ).toBe(true);
+  });
+
+  it("TC-SLACKAPP-221 refuses UPDATE_ROLLBACK_FAILED without mutation", () => {
+    const { calls, output, result } = runFixture({
+      stack: "present",
+      stackStatus: "UPDATE_ROLLBACK_FAILED",
+    });
+    expect(result.status, output).not.toBe(0);
+    expect(output).toMatch(/continue-update-rollback/iu);
+    expect(hasMutation(calls)).toBe(false);
+  });
+});

--- a/scripts/deploy-workload-permissions-boundary.sh
+++ b/scripts/deploy-workload-permissions-boundary.sh
@@ -81,6 +81,25 @@ if [[ ! "$node_major" =~ ^[0-9]+$ || "$node_major" -lt 24 ]]; then
   exit 2
 fi
 
+valid_bucket_name() {
+  local name="$1"
+  [[ "$name" =~ ^[a-z0-9][a-z0-9-]{1,31}[a-z0-9]$ ]] &&
+    [[ "$name" != xn--* ]] &&
+    [[ "$name" != sthree-* ]] &&
+    [[ "$name" != amzn-s3-demo-* ]] &&
+    [[ "$name" != *-s3alias ]] &&
+    [[ "$name" != *--ol-s3 ]] &&
+    [[ "$name" != *--x-s3 ]] &&
+    [[ "$name" != *--table-s3 ]] &&
+    [[ "$name" != *-an ]]
+}
+decision_artifact_bucket_name="${MEM9_DECISION_ARTIFACT_BUCKET:-}"
+if [[ -n "$decision_artifact_bucket_name" ]] &&
+    ! valid_bucket_name "$decision_artifact_bucket_name"; then
+  echo "MEM9_DECISION_ARTIFACT_BUCKET is an invalid decision-artifact bucket name; no mutation attempted." >&2
+  exit 2
+fi
+
 identity_json="$(aws sts get-caller-identity --output json 2>/dev/null || true)"
 account_id="$(jq -r '.Account // empty' <<<"$identity_json")"
 partition="$(jq -r '.Arn // empty' <<<"$identity_json" | sed -n 's/^arn:\([^:]*\):.*/\1/p')"
@@ -88,6 +107,7 @@ if [[ ! "$account_id" =~ ^[0-9]{12}$ || ! "$partition" =~ ^[a-z0-9-]+$ ]]; then
   echo "AWS caller identity is malformed; no boundary mutation attempted." >&2
   exit 1
 fi
+decision_artifact_bucket_name="${decision_artifact_bucket_name:-mem9-audit-${account_id}}"
 if [[ "$partition" == "aws-cn" ]]; then
   url_suffix="amazonaws.com.cn"
 else
@@ -235,6 +255,7 @@ verify_boundary_policy() {
   if ! WORKLOAD_BOUNDARY_ACCOUNT_ID="$account_id" \
     WORKLOAD_BOUNDARY_APPLICATION_REGION="$application_region" \
     WORKLOAD_BOUNDARY_BEDROCK_PROJECT_ARN="$bedrock_project_arn" \
+    WORKLOAD_BOUNDARY_DECISION_ARTIFACT_BUCKET="$decision_artifact_bucket_name" \
     WORKLOAD_BOUNDARY_OPENAI_BEDROCK_PROJECT_ARN="$openai_bedrock_project_arn" \
     WORKLOAD_BOUNDARY_PARTITION="$partition" \
     WORKLOAD_BOUNDARY_POLICY_REVISION="$policy_revision" \
@@ -505,6 +526,7 @@ if [[ $describe_exit -eq 0 ]]; then
     --parameters \
       "ParameterKey=ApplicationRegion,ParameterValue=$application_region" \
       "ParameterKey=BedrockProjectArn,ParameterValue=$bedrock_project_arn" \
+      "ParameterKey=DecisionArtifactBucketName,ParameterValue=$decision_artifact_bucket_name" \
       "ParameterKey=OpenAiBedrockProjectArn,ParameterValue=$openai_bedrock_project_arn" \
       "ParameterKey=PolicyRevision,ParameterValue=$policy_revision" \
     --capabilities CAPABILITY_NAMED_IAM \
@@ -533,6 +555,7 @@ elif grep -qi "does not exist" <<<"$describe_output"; then
     --parameters \
       "ParameterKey=ApplicationRegion,ParameterValue=$application_region" \
       "ParameterKey=BedrockProjectArn,ParameterValue=$bedrock_project_arn" \
+      "ParameterKey=DecisionArtifactBucketName,ParameterValue=$decision_artifact_bucket_name" \
       "ParameterKey=OpenAiBedrockProjectArn,ParameterValue=$openai_bedrock_project_arn" \
       "ParameterKey=PolicyRevision,ParameterValue=r1" \
     --capabilities CAPABILITY_NAMED_IAM \

--- a/scripts/deployment-workflow.test.mjs
+++ b/scripts/deployment-workflow.test.mjs
@@ -252,7 +252,10 @@ describe("workflow integration", () => {
 
   it("TC-SLACKAPP-218: gates and lints the decision-artifact bucket template", () => {
     const workflow = parse(readFileSync(workflowPath, "utf8"));
-    const template = "infra/cloudformation/decision-artifact-bucket.yaml";
+    const templates = [
+      "infra/cloudformation/decision-artifact-bucket.yaml",
+      "infra/cloudformation/decision-artifact-bucket-import.yaml",
+    ];
 
     // `!infra/cloudformation/**` excludes the whole directory, so a template is
     // only gated if it is RE-INCLUDED after the exclusion — order decides it, not
@@ -261,9 +264,11 @@ describe("workflow integration", () => {
     // infra/slack-approval.ts into that file drift with nothing watching.
     for (const trigger of ["pull_request", "push"]) {
       const paths = workflow.on[trigger].paths;
-      expect(paths.indexOf(template)).toBeGreaterThan(
-        paths.indexOf("!infra/cloudformation/**"),
-      );
+      for (const template of templates) {
+        expect(paths.indexOf(template)).toBeGreaterThan(
+          paths.indexOf("!infra/cloudformation/**"),
+        );
+      }
     }
 
     // Being gated only re-runs the suite; it does not lint. cfn-lint is what
@@ -272,7 +277,24 @@ describe("workflow integration", () => {
     const lint = workflow.jobs.typecheck.steps.find(
       ({ name }) => name === "Validate ECR registry scanning template",
     );
-    expect(lint.run).toContain(`cfn-lint ${template} --regions "$application_region"`);
+    for (const template of templates) {
+      expect(lint.run).toContain(
+        `cfn-lint ${template} --regions "$application_region"`,
+      );
+    }
+    const operatorValidation = workflow.jobs.typecheck.steps.find(
+      ({ name }) => name === "Validate workload boundary operator scripts",
+    );
+    expect(operatorValidation.run).toContain(
+      "shellcheck scripts/deploy-decision-artifact-bucket.sh",
+    );
+  });
+
+  it("TC-SLACKAPP-219: passes the decision-artifact bucket override to every AWS job", () => {
+    const workflow = parse(readFileSync(workflowPath, "utf8"));
+    expect(workflow.env.MEM9_DECISION_ARTIFACT_BUCKET).toBe(
+      "${{ vars.MEM9_DECISION_ARTIFACT_BUCKET }}",
+    );
   });
 
   it("runs the PostgreSQL durable-ingest integration suite in CI", () => {

--- a/scripts/deployment-workflow.test.mjs
+++ b/scripts/deployment-workflow.test.mjs
@@ -421,6 +421,15 @@ describe("workflow integration", () => {
     const healthSmoke = readFileSync(healthSmokePath, "utf8");
     expect(healthSmoke).toContain("--tty=false");
     expect(healthSmoke).toContain("validate-emf-event.mjs --docker-stream");
+    expect(healthSmoke).toContain(
+      'server_logs=$(docker logs "$SERVER_CONTAINER" 2>&1)',
+    );
+    expect(healthSmoke).not.toMatch(
+      /docker logs "\$SERVER_CONTAINER" 2>&1 \|\s*grep -Eq "migration applied/,
+    );
+    expect(healthSmoke).not.toContain(
+      `printf '%s\\n' "$server_logs" | grep -Fq "$DB_PASSWORD"`,
+    );
   });
 
   it("uses one enabled rollout after baking the repeatable migration into startup", () => {

--- a/scripts/deployment-workflow.test.mjs
+++ b/scripts/deployment-workflow.test.mjs
@@ -250,6 +250,31 @@ describe("workflow integration", () => {
     }
   });
 
+  it("TC-SLACKAPP-218: gates and lints the decision-artifact bucket template", () => {
+    const workflow = parse(readFileSync(workflowPath, "utf8"));
+    const template = "infra/cloudformation/decision-artifact-bucket.yaml";
+
+    // `!infra/cloudformation/**` excludes the whole directory, so a template is
+    // only gated if it is RE-INCLUDED after the exclusion — order decides it, not
+    // presence. Without this, a PR touching only the bucket template triggers no
+    // infra-ci run at all, and the five security properties that moved out of
+    // infra/slack-approval.ts into that file drift with nothing watching.
+    for (const trigger of ["pull_request", "push"]) {
+      const paths = workflow.on[trigger].paths;
+      expect(paths.indexOf(template)).toBeGreaterThan(
+        paths.indexOf("!infra/cloudformation/**"),
+      );
+    }
+
+    // Being gated only re-runs the suite; it does not lint. cfn-lint is what
+    // catches resource-level semantics the CFN API accepts and the unit tests do
+    // not read — a missing retention policy passed both until cfn-lint saw it.
+    const lint = workflow.jobs.typecheck.steps.find(
+      ({ name }) => name === "Validate ECR registry scanning template",
+    );
+    expect(lint.run).toContain(`cfn-lint ${template} --regions "$application_region"`);
+  });
+
   it("runs the PostgreSQL durable-ingest integration suite in CI", () => {
     const workflow = readFileSync(workflowPath, "utf8");
     expect(workflow).toContain("bash scripts/run-ingest-queue-integration.sh");

--- a/scripts/lib/workload-permissions-boundary.mjs
+++ b/scripts/lib/workload-permissions-boundary.mjs
@@ -159,7 +159,7 @@ const GLOBAL_RUNTIME_ACTIONS = [
 ];
 // Singleton Action/NotAction/Resource/NotResource entries are rendered as SCALARS
 // rather than one-element arrays, which reclaims 22 bytes across the document
-// against a 6144 quota that #150 leaves 25 bytes under. Safe because the verifier
+// against a 6144 quota that #150 leaves 31 bytes under. Safe because the verifier
 // compares these four keys through list(), so a scalar and a one-element array are
 // the same set — and simulated identical on all 12 authorization cases. NOT safe
 // inside Condition, where canonicalJson() compares the two as different values.
@@ -316,6 +316,7 @@ function boundaryContract({
   accountId,
   applicationRegion,
   bedrockProjectArn,
+  decisionArtifactBucketName = `mem9-audit-${accountId}`,
   openAiBedrockProjectArn = "",
   policyRevision = "r1",
 }) {
@@ -346,6 +347,17 @@ function boundaryContract({
   if (!/^r[0-9]{1,20}$/u.test(policyRevision)) {
     throw new Error("invalid boundary policy revision");
   }
+  if (
+    !/^[a-z0-9][a-z0-9-]{1,31}[a-z0-9]$/u.test(
+      decisionArtifactBucketName ?? "",
+    ) ||
+    /^(?:xn--|sthree-|amzn-s3-demo-)/u.test(decisionArtifactBucketName) ||
+    /(?:-s3alias|--ol-s3|--x-s3|--table-s3|-an)$/u.test(
+      decisionArtifactBucketName,
+    )
+  ) {
+    throw new Error("invalid decision-artifact bucket name");
+  }
   // Two ARNs, not one, and the difference is load-bearing. S3's own resource
   // scope needs the OBJECT glob; the SSE-KMS encryption context needs the BUCKET
   // ARN, because the bucket enables S3 Bucket Keys. Documented AWS behavior, S3
@@ -358,7 +370,8 @@ function boundaryContract({
   // keys on, GenerateDataKey and Decrypt both simulate explicitDeny and every
   // artifact write and read dies after deploy. Pinning both forms is not an
   // option: 6215 bytes, past the hard quota.
-  const decisionArtifactBucketArn = `arn:${partition}:s3:::mem9-audit-${accountId}`;
+  const decisionArtifactBucketArn =
+    `arn:${partition}:s3:::${decisionArtifactBucketName}`;
   const decisionArtifactArn = `${decisionArtifactBucketArn}/*`;
 
   return {
@@ -418,7 +431,7 @@ function boundaryContract({
     //
     // The name is `mem9-audit-` rather than `mem9-on-aws-audit-` because the ARN
     // renders three times: seven characters of prefix cost 21 bytes, and at the
-    // revision this document actually deploys with there are only 10 to spare
+    // revision this document actually deploys with there are only 31 to spare
     // (see the size gate). Nothing pins an S3 prefix for this project — the
     // deploy role's S3State is Resource: "*" — so the shorter name costs no
     // access, and it is free only while the bucket does not yet exist.

--- a/scripts/memory-cleanup.mjs
+++ b/scripts/memory-cleanup.mjs
@@ -113,6 +113,8 @@ const MEM9_SLACK_CHANNEL_ENV = "MEM9_SLACK_APPROVAL_CHANNEL";
 // did. So the offer degrades to no artifact instead of refusing to run — and the
 // apply refuses to replay when there is none, which is where the safety lives.
 const MEM9_DECISION_BUCKET_ENV = "MEM9_DECISION_ARTIFACT_BUCKET";
+const MEM9_DECISION_BUCKET_OWNER_ENV =
+  "MEM9_DECISION_ARTIFACT_BUCKET_OWNER";
 const REQUEST_TIMEOUT_MS = 30_000; // REST calls; the LLM call sets its own
 const LLM_TIMEOUT_MS = 120_000;
 // Reasoning models consume output tokens on hidden reasoning BEFORE emitting
@@ -1710,11 +1712,13 @@ async function readPendingOffer({ ssm, name, stage, now, log }) {
 export async function putDecisionArtifact({
   s3,
   bucket,
+  expectedBucketOwner,
   stage,
   generatedAt,
   decisions,
   log = () => {},
 }) {
+  requireDecisionArtifactBucketOwner(expectedBucketOwner);
   const { PutObjectCommand } = await import("@aws-sdk/client-s3");
   const body = serializeDecisionArtifact({ stage, generatedAt, decisions });
   // `Buffer.byteLength`, not `String.length`: the latter counts UTF-16 code units
@@ -1756,6 +1760,7 @@ export async function putDecisionArtifact({
   await s3.send(
     new PutObjectCommand({
       Bucket: bucket,
+      ExpectedBucketOwner: expectedBucketOwner,
       Key: key,
       Body: body,
       ContentType: "application/json",
@@ -1807,16 +1812,22 @@ export async function putDecisionArtifact({
 export async function loadDecisionArtifact({
   s3,
   bucket,
+  expectedBucketOwner,
   key,
   hash,
   stage,
   log = () => {},
 }) {
+  requireDecisionArtifactBucketOwner(expectedBucketOwner);
   const { GetObjectCommand } = await import("@aws-sdk/client-s3");
   let body;
   try {
     const response = await s3.send(
-      new GetObjectCommand({ Bucket: bucket, Key: key }),
+      new GetObjectCommand({
+        Bucket: bucket,
+        ExpectedBucketOwner: expectedBucketOwner,
+        Key: key,
+      }),
     );
     // `transformToString` rather than a stream pipe: the body is bounded at
     // MAX_ARTIFACT_BYTES by the writer, and the SDK's helper is the only form that
@@ -1964,6 +1975,7 @@ export async function postApprovalRequest({
   fetchImpl,
   s3,
   artifactBucket,
+  artifactBucketOwner,
   now = Date.now,
   log = () => {},
 }) {
@@ -2026,6 +2038,7 @@ export async function postApprovalRequest({
       ? await putDecisionArtifact({
           s3,
           bucket: artifactBucket,
+          expectedBucketOwner: artifactBucketOwner,
           stage,
           generatedAt,
           decisions,
@@ -2389,6 +2402,16 @@ function artifactCoordinates(record) {
     );
   }
   return { bucket, key };
+}
+
+function requireDecisionArtifactBucketOwner(value) {
+  if (!/^[0-9]{12}$/u.test(value ?? "")) {
+    throw new Error(
+      `${MEM9_DECISION_BUCKET_OWNER_ENV} must be a 12-digit AWS account id ` +
+        `when a decision artifact is read or written`,
+    );
+  }
+  return value;
 }
 
 /**
@@ -4225,6 +4248,11 @@ async function buildPostApproval(opts, region, runtime) {
   // tree would put the artifact's location behind the same `approvals/*`-scoped
   // grant the apply task is confined to — a second failure mode for no benefit.
   const artifactBucket = process.env[MEM9_DECISION_BUCKET_ENV];
+  const artifactBucketOwner = artifactBucket
+    ? requireDecisionArtifactBucketOwner(
+        process.env[MEM9_DECISION_BUCKET_OWNER_ENV],
+      )
+    : undefined;
   const { s3 } = artifactBucket
     ? await s3Client(region, runtime)
     : { s3: undefined };
@@ -4248,6 +4276,7 @@ async function buildPostApproval(opts, region, runtime) {
       botToken,
       s3,
       artifactBucket,
+      artifactBucketOwner,
       fetchImpl: runtime.fetchImpl ?? fetch,
       log: (message) =>
         console.error(`[memory-cleanup ${new Date().toISOString()}] ${message}`),
@@ -4384,14 +4413,16 @@ export async function createCleanupDeps(opts, runtime = {}) {
     // configuration (#150). A claim with coordinates gets a replay; a pre-#150 claim
     // gets the #123 behaviour it was written for.
     //
-    // The client is built from the REGION, not from the offer's bucket variable —
-    // `MEM9_DECISION_ARTIFACT_BUCKET` is the scan task's configuration and the apply
-    // task does not carry it. So there is no "artifact named but unreachable" case to
-    // branch on here: the coordinates come from the claim, the client always exists,
-    // and an artifact this task genuinely cannot read fails inside
-    // `loadDecisionArtifact` as an AccessDenied refusal (TC-SLACKAPP-190) rather than
-    // as a fallback to re-classification.
+    // The client is built from the REGION, while replay coordinates come from the
+    // reviewed claim rather than the task definition's current bucket setting. That
+    // setting can change between offer and apply. There is no "artifact named but
+    // unreachable" branch here: the client always exists, and an artifact this task
+    // genuinely cannot read fails inside `loadDecisionArtifact` as an AccessDenied
+    // refusal (TC-SLACKAPP-190), never as a fallback to re-classification.
     if (claim.artifact) {
+      const expectedBucketOwner = requireDecisionArtifactBucketOwner(
+        process.env[MEM9_DECISION_BUCKET_OWNER_ENV],
+      );
       const { s3 } = await s3Client(region, runtime);
       // A THUNK, not the fetched list. `loadDecisions` calls it inside `runCleanup`,
       // after `discoverBaseUrl` — so a stage whose mnemo service is unreachable
@@ -4402,6 +4433,7 @@ export async function createCleanupDeps(opts, runtime = {}) {
         loadDecisionArtifact({
           s3,
           bucket: claim.artifact.bucket,
+          expectedBucketOwner,
           key: claim.artifact.key,
           hash: approvalHash,
           stage: opts.stage,

--- a/scripts/memory-cleanup.test.mjs
+++ b/scripts/memory-cleanup.test.mjs
@@ -56,6 +56,7 @@ afterEach(() => {
 });
 
 const TENANT = "tenant-key-0123456789abcdef";
+const EXPECTED_BUCKET_OWNER = "123456789012";
 
 // dirname(dirname(scripts/memory-cleanup.mjs)) — the same bound `snippetLogDir`
 // computes, derived the same way rather than hardcoded, and shared by both tests
@@ -4484,6 +4485,7 @@ describe("the reviewed decision artifact (#150)", () => {
     const result = await putDecisionArtifact({
       s3,
       bucket: "mem9-audit-123456789012",
+      expectedBucketOwner: EXPECTED_BUCKET_OWNER,
       stage: "prod",
       generatedAt: GENERATED_AT,
       decisions,
@@ -4498,6 +4500,7 @@ describe("the reviewed decision artifact (#150)", () => {
     expect(s3.send).toHaveBeenCalledTimes(1);
     const [put] = s3.puts;
     expect(put.Bucket).toBe("mem9-audit-123456789012");
+    expect(put.ExpectedBucketOwner).toBe(EXPECTED_BUCKET_OWNER);
     const body = serializeDecisionArtifact({ stage: "prod", generatedAt: GENERATED_AT, decisions });
     expect(put.Body).toBe(body);
     expect(put.ContentType).toBe("application/json");
@@ -4536,6 +4539,7 @@ describe("the reviewed decision artifact (#150)", () => {
       putDecisionArtifact({
         s3,
         bucket: "mem9-audit-123456789012",
+        expectedBucketOwner: EXPECTED_BUCKET_OWNER,
         stage: "prod",
         generatedAt: GENERATED_AT,
         decisions,
@@ -4559,6 +4563,7 @@ describe("the reviewed decision artifact (#150)", () => {
     const other = await putDecisionArtifact({
       s3,
       bucket: "mem9-audit-123456789012",
+      expectedBucketOwner: EXPECTED_BUCKET_OWNER,
       stage: "pr-42",
       generatedAt: GENERATED_AT,
       decisions: [del("m-1"), merge("m-2")],
@@ -4566,6 +4571,20 @@ describe("the reviewed decision artifact (#150)", () => {
     });
     expect(other.key).not.toBe(first.key);
     expect(other.key).toContain("decisions/pr-42/");
+  });
+
+  it("TC-SLACKAPP-223 refuses an artifact write without an expected bucket owner", async () => {
+    const s3 = fakeS3();
+    await expect(
+      putDecisionArtifact({
+        s3,
+        bucket: "example-mem9-decision-artifacts",
+        stage: "prod",
+        generatedAt: GENERATED_AT,
+        decisions: [del("m-1")],
+      }),
+    ).rejects.toThrow(/12-digit AWS account id/iu);
+    expect(s3.send).not.toHaveBeenCalled();
   });
 
   it("TC-SLACKAPP-174 refuses an artifact over the single-PutObject bound rather than truncating or splitting", async () => {
@@ -4577,6 +4596,7 @@ describe("the reviewed decision artifact (#150)", () => {
     const err = await putDecisionArtifact({
       s3,
       bucket: "mem9-audit-123456789012",
+      expectedBucketOwner: EXPECTED_BUCKET_OWNER,
       stage: "prod",
       generatedAt: GENERATED_AT,
       decisions: huge,
@@ -4632,6 +4652,7 @@ describe("the reviewed decision artifact (#150)", () => {
       putDecisionArtifact({
         s3,
         bucket: "mem9-audit-123456789012",
+        expectedBucketOwner: EXPECTED_BUCKET_OWNER,
         stage: "prod",
         generatedAt: GENERATED_AT,
         decisions: cjk,
@@ -4651,6 +4672,7 @@ describe("the reviewed decision artifact (#150)", () => {
     const result = await putDecisionArtifact({
       s3,
       bucket: "mem9-audit-123456789012",
+      expectedBucketOwner: EXPECTED_BUCKET_OWNER,
       stage: "prod",
       generatedAt: GENERATED_AT,
       decisions,
@@ -5327,12 +5349,24 @@ describe("materializing the approved ids in the apply task (#123)", () => {
       }),
     });
     const load = (s3, overrides = {}) =>
-      loadDecisionArtifact({ s3, bucket, key, hash, stage: "prod", ...overrides });
+      loadDecisionArtifact({
+        s3,
+        bucket,
+        expectedBucketOwner: EXPECTED_BUCKET_OWNER,
+        key,
+        hash,
+        stage: "prod",
+        ...overrides,
+      });
 
     // The happy path FIRST, or every refusal below could be passing because the
     // reader refuses unconditionally.
     const log = vi.fn();
-    const ok = await load(s3Returning(body), { log });
+    const readable = s3Returning(body);
+    const ok = await load(readable, { log });
+    expect(readable.send.mock.calls[0][0].input.ExpectedBucketOwner).toBe(
+      EXPECTED_BUCKET_OWNER,
+    );
     // Against the SERIALIZED projection, not the input: the writer deliberately
     // drops `reason` (it is operator prose, not a replay input), so comparing to
     // `decisions` would assert a field the artifact does not and should not carry.
@@ -5457,6 +5491,7 @@ describe("the apply task's in-container runtime (#123)", () => {
     "MEM9_DB_NAME",
     "MEM9_DB_PORT",
     "MEM9_DB_SECRET",
+    "MEM9_DECISION_ARTIFACT_BUCKET_OWNER",
     "MEM9_LLM_MODEL",
     "MEM9_SSM_PREFIX",
     "MEM9_TENANT_ID",
@@ -5478,6 +5513,7 @@ describe("the apply task's in-container runtime (#123)", () => {
         username: "mem9",
         password: "fixture-password",
       }),
+      MEM9_DECISION_ARTIFACT_BUCKET_OWNER: EXPECTED_BUCKET_OWNER,
       MEM9_SSM_PREFIX: "/mem9-on-aws/prod",
       MEM9_TENANT_ID: TENANT,
       ...extra,
@@ -5666,11 +5702,10 @@ describe("the apply task's in-container runtime (#123)", () => {
 
   it("TC-SLACKAPP-191 wires a replay thunk exactly when the claim names an artifact", async () => {
     // The branch is on the RECORD, not on this task's configuration, and the
-    // direction matters. `MEM9_DECISION_ARTIFACT_BUCKET` is the SCAN task's variable
-    // — the apply task does not carry it — so the coordinates can only come from the
-    // claim. Keying on anything else would mean a hash covering a reviewed list gets
-    // checked by the weaker id-list rule whenever the apply task happens to be
-    // configured differently from the scan that offered it.
+    // direction matters. The coordinates can only come from the claim. Keying on
+    // the task's configured bucket instead would mean a hash covering a reviewed
+    // list gets checked against a different location whenever configuration changed
+    // between offer and apply.
     const ids = ["m-1"];
     const artifactHash = `sha256:${"e".repeat(64)}`;
     const key = decisionArtifactKey("prod", artifactHash);
@@ -5713,6 +5748,39 @@ describe("the apply task's in-container runtime (#123)", () => {
       ),
     ).toMatch(/refusing to apply/u);
     await withArtifact.close();
+
+    containerEnv({
+      MEM9_APPROVAL_HASH: artifactHash,
+      MEM9_DECISION_ARTIFACT_BUCKET_OWNER: "",
+    });
+    await expect(
+      createCleanupDeps(
+        {
+          stage: "prod",
+          apply: true,
+          cap: 50,
+          idsFile: join(dir, "missing-owner.txt"),
+        },
+        {
+          Client: fakeClientClass([]),
+          ssm: fakeAwsClient({
+            [claimParameterName("/mem9-on-aws/prod", artifactHash)]:
+              JSON.stringify({
+                stage: "prod",
+                hash: artifactHash,
+                ids,
+                claimedAt: "2026-08-05T00:05:00.000Z",
+                artifactBucket: "example-mem9-decision-artifacts",
+                artifactKey: key,
+              }),
+          }),
+          secrets: fakeAwsClient(),
+          s3: { send: vi.fn() },
+          getToken: vi.fn(),
+          fromNodeProviderChain: vi.fn(),
+        },
+      ),
+    ).rejects.toThrow(/12-digit AWS account id/iu);
 
     // A pre-#150 claim gets no thunk, so `loadDecisions` takes the #123 path the
     // record was written for rather than fetching a coordinate it does not have.
@@ -6202,6 +6270,9 @@ describe("offering the list to Slack (#123)", () => {
         // the operator CLI still takes.
         s3: overrides.artifactBucket ? s3 : undefined,
         artifactBucket: overrides.artifactBucket,
+        artifactBucketOwner: overrides.artifactBucket
+          ? EXPECTED_BUCKET_OWNER
+          : undefined,
         fetchImpl: slack.fetchImpl,
         now: overrides.now,
         log: overrides.log ?? vi.fn(),
@@ -7269,6 +7340,7 @@ describe("offering the list to Slack (#123)", () => {
               }),
             },
             bucket: ARTIFACT.artifactBucket,
+            expectedBucketOwner: EXPECTED_BUCKET_OWNER,
             key: fakes.s3.puts[0].Key,
             hash: offered.record.hash,
             stage: "prod",
@@ -7353,6 +7425,7 @@ describe("offering the list to Slack (#123)", () => {
       const err = await loadDecisionArtifact({
         s3: { send: async () => ({ Body: { transformToString: async () => body } }) },
         bucket: ARTIFACT.artifactBucket,
+        expectedBucketOwner: EXPECTED_BUCKET_OWNER,
         key: fakes.s3.puts[0].Key,
         hash: hash ?? decisionArtifactHash(body),
         stage: "prod",
@@ -7377,6 +7450,7 @@ describe("offering the list to Slack (#123)", () => {
     const oversized = await putDecisionArtifact({
       s3: { send: vi.fn() },
       bucket: ARTIFACT.artifactBucket,
+      expectedBucketOwner: EXPECTED_BUCKET_OWNER,
       stage: "prod",
       generatedAt,
       decisions: Array.from({ length: 40 }, (_, i) => ({
@@ -7410,6 +7484,7 @@ describe("wiring the offer into the review run (#123)", () => {
     "MEM9_DB_PORT",
     "MEM9_DB_SECRET",
     "MEM9_DECISION_ARTIFACT_BUCKET",
+    "MEM9_DECISION_ARTIFACT_BUCKET_OWNER",
     "MEM9_SLACK_APPROVAL_CHANNEL",
     "MEM9_SSM_PREFIX",
     "MEM9_TENANT_ID",
@@ -7559,6 +7634,7 @@ describe("wiring the offer into the review run (#123)", () => {
       MEM9_SLACK_APPROVAL_CHANNEL: "C0APPROVAL",
       SLACK_BOT_TOKEN: "xoxb-injected",
       MEM9_DECISION_ARTIFACT_BUCKET: "mem9-audit-123456789012",
+      MEM9_DECISION_ARTIFACT_BUCKET_OWNER: EXPECTED_BUCKET_OWNER,
     });
     const ssm = ssmFake();
     const s3 = { sent: [], send: vi.fn(async (c) => (s3.sent.push(c.input), {})) };
@@ -7595,11 +7671,32 @@ describe("wiring the offer into the review run (#123)", () => {
     // AccessDenied at runtime, after the scan has done its whole audit.
     expect(s3.sent).toHaveLength(1);
     expect(s3.sent[0].Bucket).toBe("mem9-audit-123456789012");
+    expect(s3.sent[0].ExpectedBucketOwner).toBe(EXPECTED_BUCKET_OWNER);
     expect(s3.sent[0].Key).toMatch(/^decisions\/prod\/sha256-[0-9a-f]{64}\.json$/u);
     const record = JSON.parse(ssm.sent.find((input) => input.Name).Value);
     expect(record.artifactBucket).toBe("mem9-audit-123456789012");
     expect(record.artifactKey).toBe(s3.sent[0].Key);
     await production.close();
+  });
+
+  it("TC-SLACKAPP-223 refuses an artifact offer without an expected bucket owner", async () => {
+    reviewEnv({
+      MEM9_SLACK_APPROVAL_CHANNEL: "C0APPROVAL",
+      SLACK_BOT_TOKEN: "xoxb-injected",
+      MEM9_DECISION_ARTIFACT_BUCKET: "example-mem9-decision-artifacts",
+    });
+    await expect(
+      createCleanupDeps(
+        { stage: "prod", apply: false, cap: 50 },
+        {
+          ssm: ssmFake(),
+          s3: { send: vi.fn() },
+          getToken: vi.fn(),
+          fromNodeProviderChain: vi.fn(),
+          fetchImpl: vi.fn(),
+        },
+      ),
+    ).rejects.toThrow(/12-digit AWS account id/iu);
   });
 
   it("TC-SLACKAPP-180 offers without an artifact when no bucket is configured, without constructing an S3 client", async () => {

--- a/scripts/rollout-workload-permissions-boundary.sh
+++ b/scripts/rollout-workload-permissions-boundary.sh
@@ -59,6 +59,19 @@ if [[ ! "$effective_application_region" =~ ^[a-z]{2}(-gov)?-[a-z0-9-]+-[0-9]+$ ]
   exit 2
 fi
 export WORKLOAD_BOUNDARY_APPLICATION_REGION="$effective_application_region"
+if [[ -n "${MEM9_DECISION_ARTIFACT_BUCKET:-}" ]] &&
+    { [[ ! "$MEM9_DECISION_ARTIFACT_BUCKET" =~ ^[a-z0-9][a-z0-9-]{1,31}[a-z0-9]$ ]] ||
+      [[ "$MEM9_DECISION_ARTIFACT_BUCKET" == xn--* ]] ||
+      [[ "$MEM9_DECISION_ARTIFACT_BUCKET" == sthree-* ]] ||
+      [[ "$MEM9_DECISION_ARTIFACT_BUCKET" == amzn-s3-demo-* ]] ||
+      [[ "$MEM9_DECISION_ARTIFACT_BUCKET" == *-s3alias ]] ||
+      [[ "$MEM9_DECISION_ARTIFACT_BUCKET" == *--ol-s3 ]] ||
+      [[ "$MEM9_DECISION_ARTIFACT_BUCKET" == *--x-s3 ]] ||
+      [[ "$MEM9_DECISION_ARTIFACT_BUCKET" == *--table-s3 ]] ||
+      [[ "$MEM9_DECISION_ARTIFACT_BUCKET" == *-an ]]; }; then
+  echo "MEM9_DECISION_ARTIFACT_BUCKET is an invalid decision-artifact bucket name; no mutation was attempted." >&2
+  exit 2
+fi
 
 if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
   sed -n '2,/^$/p' "$0" | sed 's/^# \?//'
@@ -336,6 +349,7 @@ write_resume_assignment() {
       AWS_CONFIG_FILE \
       AWS_SHARED_CREDENTIALS_FILE \
       AWS_CA_BUNDLE \
+      MEM9_DECISION_ARTIFACT_BUCKET \
       MEM9_LLM_RESPONSES_REGION \
       WORKLOAD_BOUNDARY_APPLICATION_REGION \
       WORKLOAD_BOUNDARY_OPENAI_PROJECT_REGION \

--- a/scripts/run-mnemo-health-smoke.sh
+++ b/scripts/run-mnemo-health-smoke.sh
@@ -176,10 +176,10 @@ if [ "$server_healthy" != true ]; then
   exit 1
 fi
 
-if ! docker logs "$SERVER_CONTAINER" 2>&1 |
-    grep -Eq "migration applied after [1-9][0-9]* retries"; then
+server_logs=$(docker logs "$SERVER_CONTAINER" 2>&1)
+if ! grep -Eq "migration applied after [1-9][0-9]* retries" <<<"$server_logs"; then
   echo "mnemo-health-smoke: startup migration did not recover after PostgreSQL became reachable" >&2
-  docker logs "$SERVER_CONTAINER" >&2
+  printf '%s\n' "$server_logs" >&2
   exit 1
 fi
 
@@ -223,8 +223,7 @@ if [ "$migration_complete" != "t" ]; then
   docker logs "$SERVER_CONTAINER" >&2
   exit 1
 fi
-server_logs=$(docker logs "$SERVER_CONTAINER" 2>&1)
-if printf '%s\n' "$server_logs" | grep -Fq "$DB_PASSWORD"; then
+if grep -Fq "$DB_PASSWORD" <<<"$server_logs"; then
   echo "mnemo-health-smoke: database password appeared in server logs" >&2
   exit 1
 fi

--- a/scripts/run-slack-approval-e2e.sh
+++ b/scripts/run-slack-approval-e2e.sh
@@ -120,20 +120,37 @@ if [[ -z "$SIGNING_SECRET" || "$SIGNING_SECRET" == "None" ]]; then
   exit 0
 fi
 
-# The bucket is derived, not read from SSM: `slackApproval()` publishes the
-# cluster, the task-def arn, the SG and the subnets under `cleanup/`, but the
-# artifact bucket is an ENVIRONMENT entry on the task definition and never a
-# parameter. Deriving it from the caller's own account id is also the stricter
-# check — it asserts the name this repo computes rather than the name the stage
-# happens to have been configured with, so a drift between
-# `decisionArtifactBucketName` and the deployed bucket fails here instead of
-# silently exercising whatever bucket the stage names.
+# The bucket is an environment entry on the task definition, not SSM. Use the
+# same external override as SST, the owner stack, and the workload boundary.
+# Unset keeps the account-derived default.
+valid_bucket_name() {
+  local name="$1"
+  [[ "$name" =~ ^[a-z0-9][a-z0-9-]{1,31}[a-z0-9]$ ]] &&
+    [[ "$name" != xn--* ]] &&
+    [[ "$name" != sthree-* ]] &&
+    [[ "$name" != amzn-s3-demo-* ]] &&
+    [[ "$name" != *-s3alias ]] &&
+    [[ "$name" != *--ol-s3 ]] &&
+    [[ "$name" != *--x-s3 ]] &&
+    [[ "$name" != *--table-s3 ]] &&
+    [[ "$name" != *-an ]]
+}
+
+ARTIFACT_BUCKET="${MEM9_DECISION_ARTIFACT_BUCKET:-}"
+if [[ -n "$ARTIFACT_BUCKET" ]]; then
+  if ! valid_bucket_name "$ARTIFACT_BUCKET"; then
+    echo "::error::MEM9_DECISION_ARTIFACT_BUCKET is an invalid decision-artifact bucket name" >&2
+    exit 2
+  fi
+fi
 ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 if ! [[ "$ACCOUNT_ID" =~ ^[0-9]{12}$ ]]; then
   echo "::error::could not read a 12-digit account id from sts:GetCallerIdentity" >&2
   exit 1
 fi
-ARTIFACT_BUCKET="mem9-audit-${ACCOUNT_ID}"
+if [[ -z "$ARTIFACT_BUCKET" ]]; then
+  ARTIFACT_BUCKET="mem9-audit-${ACCOUNT_ID}"
+fi
 
 # The bucket is provisioned OUT-OF-BAND, so its existence is no longer implied by
 # the stage having the Slack secrets — those two used to travel together when
@@ -143,7 +160,8 @@ ARTIFACT_BUCKET="mem9-audit-${ACCOUNT_ID}"
 # task failing later for a reason that looks like a hash mismatch. Hard failure,
 # not a skip: the stage HAS the approval loop deployed at this point, so the
 # artifact half genuinely is broken and a skip would hide it.
-if ! aws s3api head-bucket --bucket "$ARTIFACT_BUCKET" --region "$REGION" >/dev/null 2>&1; then
+if ! aws s3api head-bucket --bucket "$ARTIFACT_BUCKET" \
+    --expected-bucket-owner "$ACCOUNT_ID" --region "$REGION" >/dev/null 2>&1; then
   echo "::error::artifact bucket ${ARTIFACT_BUCKET} does not exist — bootstrap it once per account with scripts/deploy-decision-artifact-bucket.sh" >&2
   exit 1
 fi
@@ -281,6 +299,7 @@ cleanup() {
   for key in "$ARTIFACT_KEY" "$TAMPERED_KEY"; do
     [[ -n "$key" ]] || continue
     aws s3api delete-object --bucket "$ARTIFACT_BUCKET" --key "$key" \
+      --expected-bucket-owner "$ACCOUNT_ID" \
       --region "$REGION" >/dev/null 2>&1 || true
   done
   rm -f "$ARTIFACT_BODY" "$TAMPERED_BODY"
@@ -300,7 +319,8 @@ trap cleanup EXIT
 put_artifact() {
   local key="$1" body="$2"
   aws s3api put-object --bucket "$ARTIFACT_BUCKET" --key "$key" --body "$body" \
-    --content-type application/json --region "$REGION" >/dev/null
+    --content-type application/json --expected-bucket-owner "$ACCOUNT_ID" \
+    --region "$REGION" >/dev/null
 }
 echo "run-slack-approval-e2e: uploading the reviewed decision artifact and its tampered twin"
 put_artifact "$ARTIFACT_KEY" "$ARTIFACT_BODY"

--- a/scripts/run-slack-approval-e2e.sh
+++ b/scripts/run-slack-approval-e2e.sh
@@ -689,8 +689,10 @@ LOG_STREAM="${LOG_PREFIX}/${CONTAINER_NAME}/${TASK_ARN##*/}"
 # hashed to the approved value, so its presence IS "the reviewed list was replayed".
 echo "run-slack-approval-e2e: checking ${LOG_STREAM} for the artifact-replay line"
 
-# AWS CLI paginates `filter-log-events` by default. That matters because the API
-# may return an empty page with a next token even when a later page has events.
+# AWS CLI paginates `filter-log-events` by default. JSON output is load-bearing:
+# the CLI combines all pages before applying the query, while text output applies
+# `length(events)` to EACH page and prints values such as `1\n0`. The API may
+# return an empty page with a next token even when another page has the marker.
 # Keep stderr out of public CI logs (an AWS error can contain account-scoped
 # identifiers), but never turn a failed query into a zero count.
 cloudwatch_event_count() {
@@ -705,7 +707,7 @@ cloudwatch_event_count() {
     --start-time "$((TIMESTAMP * 1000))" \
     --region "$REGION" \
     --query 'length(events)' \
-    --output text 2>/dev/null) || {
+    --output json 2>/dev/null) || {
       local status=$?
       echo "::error::the CloudWatch Logs ${query_name} query failed (exit ${status}); the replay assertion could not inspect the apply task stream" >&2
       return "$status"

--- a/scripts/run-slack-approval-e2e.sh
+++ b/scripts/run-slack-approval-e2e.sh
@@ -135,6 +135,19 @@ if ! [[ "$ACCOUNT_ID" =~ ^[0-9]{12}$ ]]; then
 fi
 ARTIFACT_BUCKET="mem9-audit-${ACCOUNT_ID}"
 
+# The bucket is provisioned OUT-OF-BAND, so its existence is no longer implied by
+# the stage having the Slack secrets — those two used to travel together when
+# `slackApproval()` declared the bucket. Check it here so a missing bootstrap
+# reports the script to run, rather than surfacing as a bare `NoSuchBucket` from
+# the first `put_artifact` (whose output is discarded) or, worse, as the apply
+# task failing later for a reason that looks like a hash mismatch. Hard failure,
+# not a skip: the stage HAS the approval loop deployed at this point, so the
+# artifact half genuinely is broken and a skip would hide it.
+if ! aws s3api head-bucket --bucket "$ARTIFACT_BUCKET" --region "$REGION" >/dev/null 2>&1; then
+  echo "::error::artifact bucket ${ARTIFACT_BUCKET} does not exist — bootstrap it once per account with scripts/deploy-decision-artifact-bucket.sh" >&2
+  exit 1
+fi
+
 # The reviewed list, its tampered twin, and the ids the offer will name — all
 # built by the SAME functions the scan uses, imported from the script under test.
 # Rehashing a hand-written JSON literal here would prove only that this file and

--- a/scripts/run-slack-approval-e2e.sh
+++ b/scripts/run-slack-approval-e2e.sh
@@ -688,25 +688,62 @@ LOG_STREAM="${LOG_PREFIX}/${CONTAINER_NAME}/${TASK_ARN##*/}"
 # assertion — `loadDecisionArtifact` emits this line only after the fetched bytes
 # hashed to the approved value, so its presence IS "the reviewed list was replayed".
 echo "run-slack-approval-e2e: checking ${LOG_STREAM} for the artifact-replay line"
-REPLAYED=0
-for attempt in 1 2 3 4 5 6; do
-  MATCHES=$(aws logs filter-log-events \
+
+# AWS CLI paginates `filter-log-events` by default. That matters because the API
+# may return an empty page with a next token even when a later page has events.
+# Keep stderr out of public CI logs (an AWS error can contain account-scoped
+# identifiers), but never turn a failed query into a zero count.
+cloudwatch_event_count() {
+  local filter_pattern="$1"
+  local query_name="$2"
+  local count
+
+  count=$(aws logs filter-log-events \
     --log-group-name "$LOG_GROUP" \
     --log-stream-names "$LOG_STREAM" \
-    --filter-pattern '"reviewed decision(s) from s3://"' \
+    --filter-pattern "$filter_pattern" \
     --start-time "$((TIMESTAMP * 1000))" \
     --region "$REGION" \
     --query 'length(events)' \
-    --output text 2>/dev/null || true)
-  if [[ "$MATCHES" =~ ^[0-9]+$ ]] && ((MATCHES > 0)); then
+    --output text 2>/dev/null) || {
+      local status=$?
+      echo "::error::the CloudWatch Logs ${query_name} query failed (exit ${status}); the replay assertion could not inspect the apply task stream" >&2
+      return "$status"
+    }
+
+  if [[ ! "$count" =~ ^[0-9]+$ ]]; then
+    echo "::error::the CloudWatch Logs ${query_name} query returned a non-numeric event count; the replay assertion could not inspect the apply task stream" >&2
+    return 1
+  fi
+  printf '%s' "$count"
+}
+
+REPLAYED=0
+REPLAY_POLL_ATTEMPTS=13
+REPLAY_POLL_INTERVAL_SECONDS=10
+for ((attempt = 1; attempt <= REPLAY_POLL_ATTEMPTS; attempt += 1)); do
+  if ! MATCHES=$(cloudwatch_event_count \
+    '"reviewed decision(s) from s3://"' "artifact-replay marker"); then
+    exit 1
+  fi
+  if ((MATCHES > 0)); then
     REPLAYED=$MATCHES
     break
   fi
-  echo "run-slack-approval-e2e: replay line not visible yet (attempt ${attempt}/6)"
-  sleep 10
+  echo "run-slack-approval-e2e: replay line not visible yet (attempt ${attempt}/${REPLAY_POLL_ATTEMPTS})"
+  if ((attempt < REPLAY_POLL_ATTEMPTS)); then
+    sleep "$REPLAY_POLL_INTERVAL_SECONDS"
+  fi
 done
 if ((REPLAYED == 0)); then
-  echo "::error::the apply task never logged an artifact replay — it exited 0 by re-classifying instead of applying the reviewed list, so the approved MERGE was not what ran" >&2
+  if ! TOTAL_EVENTS=$(cloudwatch_event_count "" "total-event diagnostic"); then
+    exit 1
+  fi
+  if ((TOTAL_EVENTS == 0)); then
+    echo "::error::the apply task log stream still had zero events after 120 seconds; CloudWatch log delivery may be delayed or the stream configuration may be wrong, so the artifact replay could not be proven" >&2
+  else
+    echo "::error::the apply task log stream contained ${TOTAL_EVENTS} event(s) but never logged an artifact replay — it exited 0 by re-classifying instead of applying the reviewed list, so the approved MERGE was not what ran" >&2
+  fi
   exit 1
 fi
 

--- a/scripts/run-slack-approval-e2e.test.mjs
+++ b/scripts/run-slack-approval-e2e.test.mjs
@@ -224,6 +224,8 @@ function runFixture({
   logGroup = "/sst/cluster/mem9-pr-123-a1b2c3/Mem9Cleanup-d4e5f6",
   logPrefix = "mem9",
   replayLines = "1",
+  logLines = "1",
+  logQueryError = "",
   failingJqFilter = "",
   claimReadError = "",
 } = {}) {
@@ -414,10 +416,24 @@ if (command === "ssm get-parameter") {
   // The pattern is asserted, not ignored: a script that queried for the wrong
   // phrase would find nothing on a healthy stage and report a re-classification
   // that never happened.
-  const matched = (option("--filter-pattern") ?? "").includes(
+  if (process.env.MOCK_LOG_QUERY_ERROR) {
+    console.error(
+      \`An error occurred (\${process.env.MOCK_LOG_QUERY_ERROR}) when calling the \` +
+        "FilterLogEvents operation: simulated failure",
+    );
+    process.exit(255);
+  }
+  const pattern = option("--filter-pattern") ?? "";
+  const matched = pattern.includes(
     "reviewed decision(s) from s3://",
   );
-  console.log(matched ? (process.env.MOCK_REPLAY_LINES ?? "0") : "0");
+  console.log(
+    matched
+      ? (process.env.MOCK_REPLAY_LINES ?? "0")
+      : pattern === ""
+        ? (process.env.MOCK_LOG_LINES ?? "0")
+        : "0",
+  );
 } else if (command === "ecs describe-tasks") {
   const query = option("--query") ?? "";
   // The cluster is asserted, not ignored: the script must pass the name it read
@@ -639,6 +655,8 @@ process.exit(real.status ?? 1);
       MOCK_LOG_GROUP: logGroup,
       MOCK_LOG_PREFIX: logPrefix,
       MOCK_REPLAY_LINES: replayLines,
+      MOCK_LOG_LINES: logLines,
+      MOCK_LOG_QUERY_ERROR: logQueryError,
       MOCK_FACADE: facade,
       MOCK_SECRET: secret,
       MOCK_BAD_STATUS: badSignatureStatus,
@@ -1370,6 +1388,36 @@ describe("Slack approval E2E harness (TC-SLACKAPP-090)", () => {
     expect(result.status, output).not.toBe(0);
     expect(output).toMatch(/never logged an artifact replay/iu);
     expect(output).toMatch(/re-classifying/iu);
+  });
+
+  it("TC-SLACKAPP-209 reports delayed or missing log delivery when the stream has no events", () => {
+    const { callRecords, result, output } = runFixture({
+      claim: claimWith(),
+      replayLines: "0",
+      logLines: "0",
+    });
+    expect(result.status, output).not.toBe(0);
+    expect(output).toMatch(/log stream still had zero events after 120 seconds/iu);
+    expect(output).toMatch(/log delivery may be delayed/iu);
+    expect(output).not.toMatch(/re-classifying/iu);
+
+    const filters = callRecords.filter(
+      ([tool, service, operation]) =>
+        tool === "aws" && service === "logs" && operation === "filter-log-events",
+    );
+    expect(filters).toHaveLength(14);
+    expect(filters.at(-1)?.[filters.at(-1).indexOf("--filter-pattern") + 1]).toBe("");
+  });
+
+  it("TC-SLACKAPP-209 reports a CloudWatch query failure instead of treating it as zero matches", () => {
+    const { result, output } = runFixture({
+      claim: claimWith(),
+      logQueryError: "AccessDeniedException",
+    });
+    expect(result.status, output).not.toBe(0);
+    expect(output).toMatch(/CloudWatch Logs artifact-replay marker query failed/iu);
+    expect(output).toMatch(/replay assertion could not inspect/iu);
+    expect(output).not.toMatch(/never logged an artifact replay/iu);
   });
 
   it("TC-SLACKAPP-209 the log group and stream come from the task definition, never a computed path", () => {

--- a/scripts/run-slack-approval-e2e.test.mjs
+++ b/scripts/run-slack-approval-e2e.test.mjs
@@ -217,6 +217,7 @@ function runFixture({
   expiryBehavior = "refuse",
   tamperBehavior = "refuse",
   accountId = "123456789012",
+  artifactBucket = "",
   artifactBucketMissing = "",
   taskDef = "arn:aws:ecs:ap-northeast-1:123456789012:task-definition/mem9-cleanup:7",
   containerName = "Mem9Cleanup",
@@ -354,11 +355,9 @@ if (command === "ssm get-parameter") {
 } else if (command === "ssm delete-parameter") {
   process.exit(0);
 } else if (command === "sts get-caller-identity") {
-  // The artifact bucket is NOT an SSM parameter — it is an environment entry on
-  // the task definition — so the harness derives \`mem9-audit-<account>\` from the
-  // caller's own identity. A malformed value here is a fixture knob because the
-  // script has to refuse it: an empty or non-numeric account would build a bucket
-  // name that S3 rejects, and the resulting upload failure would read as a
+  // With no external override, the harness derives the default
+  // \`mem9-audit-<account>\` from the caller identity. A malformed value here is
+  // a fixture knob because the resulting bucket name would otherwise read as a
   // permissions problem.
   console.log(process.env.MOCK_ACCOUNT_ID ?? "");
 } else if (command === "s3api head-bucket") {
@@ -654,6 +653,7 @@ process.exit(real.status ?? 1);
       PATH: `${bin}${delimiter}${process.env.PATH}`,
       STAGE: stage,
       AWS_REGION: "ap-northeast-1",
+      MEM9_DECISION_ARTIFACT_BUCKET: artifactBucket,
     },
   });
   // The log file only exists once a fake has been invoked, and the whole point of
@@ -1224,10 +1224,8 @@ describe("Slack approval E2E harness (TC-SLACKAPP-090)", () => {
       expect(artifact.decisions.some((d) => d.verdict === "DELETE")).toBe(true);
     }
 
-    // The record points at the reviewed object, in the bucket derived from the
-    // CALLER's account — the artifact bucket is a task-definition environment entry,
-    // never an SSM parameter, so deriving it is also the stricter check: it asserts
-    // the name this repo computes rather than whatever the stage was configured with.
+    // With no override, the record points at the account-derived default bucket.
+    // The override path is asserted separately by TC-SLACKAPP-219.
     const seeds = callRecords.filter(
       ([tool, service, operation, , name]) =>
         tool === "aws" &&
@@ -1442,6 +1440,63 @@ describe("Slack approval E2E harness (TC-SLACKAPP-090)", () => {
       expect(callRecords.filter(([tool]) => tool === "curl")).toHaveLength(0);
     }
   });
+
+  it("TC-SLACKAPP-219 binds the validated external bucket override to the caller account", () => {
+    const artifactBucket = "example-mem9-decision-artifacts";
+    const { callRecords, result, output } = runFixture({
+      artifactBucket,
+      claim: claimWith(),
+    });
+    expect(result.status, output).toBe(0);
+    expect(
+      callRecords.some(
+        ([tool, service, operation]) =>
+          tool === "aws" &&
+          service === "sts" &&
+          operation === "get-caller-identity",
+      ),
+    ).toBe(true);
+    for (const call of callRecords.filter(
+      ([tool, service]) => tool === "aws" && service === "s3api",
+    )) {
+      expect(call[call.indexOf("--bucket") + 1]).toBe(artifactBucket);
+      expect(call[call.indexOf("--expected-bucket-owner") + 1]).toBe(
+        "123456789012",
+      );
+    }
+  });
+
+  it.each([
+    "UPPERCASE",
+    "ab",
+    "192.0.2.1",
+    "bad..name",
+    "bad_name",
+    "xn--reserved",
+    "sthree-reserved",
+    "amzn-s3-demo-reserved",
+    "reserved-s3alias",
+    "reserved--ol-s3",
+    "reserved--x-s3",
+    "reserved--table-s3",
+    "reserved-an",
+    "a".repeat(34),
+  ])(
+    "TC-SLACKAPP-219 rejects invalid external bucket override %s before S3",
+    (artifactBucket) => {
+      const { callRecords, result, output } = runFixture({
+        artifactBucket,
+        claim: claimWith(),
+      });
+      expect(result.status, output).not.toBe(0);
+      expect(output).toMatch(/invalid.*bucket name/iu);
+      expect(
+        callRecords.some(
+          ([tool, service]) => tool === "aws" && service === "s3api",
+        ),
+      ).toBe(false);
+    },
+  );
 
   it("TC-SLACKAPP-216 an absent artifact bucket names the bootstrap script, and is not a skip", () => {
     // The bucket moved OUT-OF-BAND, which decoupled two facts that used to travel

--- a/scripts/run-slack-approval-e2e.test.mjs
+++ b/scripts/run-slack-approval-e2e.test.mjs
@@ -217,6 +217,7 @@ function runFixture({
   expiryBehavior = "refuse",
   tamperBehavior = "refuse",
   accountId = "123456789012",
+  artifactBucketMissing = "",
   taskDef = "arn:aws:ecs:ap-northeast-1:123456789012:task-definition/mem9-cleanup:7",
   containerName = "Mem9Cleanup",
   logGroup = "/sst/cluster/mem9-pr-123-a1b2c3/Mem9Cleanup-d4e5f6",
@@ -360,6 +361,13 @@ if (command === "ssm get-parameter") {
   // name that S3 rejects, and the resulting upload failure would read as a
   // permissions problem.
   console.log(process.env.MOCK_ACCOUNT_ID ?? "");
+} else if (command === "s3api head-bucket") {
+  // The artifact bucket is provisioned OUT-OF-BAND, so the script checks it exists
+  // before seeding. A fixture knob because the interesting case is the ABSENT
+  // bucket: that used to be impossible to reach — the bucket travelled with the
+  // Slack secrets the skip gate already tested — and is now the state a fresh
+  // account is in until the bootstrap script has been run once.
+  process.exit(process.env.MOCK_ARTIFACT_BUCKET_MISSING === "1" ? 255 : 0);
 } else if (command === "s3api put-object") {
   // The artifact objects. Recorded rather than stored, and the BODY is read from
   // the path the script passed: the assertions are about what the script
@@ -626,6 +634,7 @@ process.exit(real.status ?? 1);
       MOCK_EXPIRY_BEHAVIOR: expiryBehavior,
       MOCK_TAMPER_BEHAVIOR: tamperBehavior,
       MOCK_ACCOUNT_ID: accountId,
+      MOCK_ARTIFACT_BUCKET_MISSING: artifactBucketMissing,
       MOCK_TASK_DEF: taskDef,
       MOCK_CONTAINER_NAME: containerName,
       MOCK_LOG_GROUP: logGroup,
@@ -1432,6 +1441,42 @@ describe("Slack approval E2E harness (TC-SLACKAPP-090)", () => {
       ).toHaveLength(0);
       expect(callRecords.filter(([tool]) => tool === "curl")).toHaveLength(0);
     }
+  });
+
+  it("TC-SLACKAPP-216 an absent artifact bucket names the bootstrap script, and is not a skip", () => {
+    // The bucket moved OUT-OF-BAND, which decoupled two facts that used to travel
+    // together: the stage having `slack/signing-secret` no longer implies the bucket
+    // exists, so this state is reachable on any account whose bootstrap has not been
+    // run. Without the preflight the first `put_artifact` fails with a bare
+    // `NoSuchBucket` into a discarded stdout, and the run reads as a hash mismatch.
+    const { callRecords, result, output } = runFixture({
+      artifactBucketMissing: "1",
+      claim: claimWith(),
+    });
+    // A FAILURE, not one of this harness's graceful skips: the approval loop IS
+    // deployed on the stage by this point, so the artifact half is genuinely broken
+    // and a skip would report a green run for a loop that cannot execute a MERGE.
+    expect(result.status, output).not.toBe(0);
+    expect(output).toMatch(/does not exist/iu);
+    // The remedy has to name the script, since the reader's next question is what to
+    // run — and the bucket is not something a stage deploy will create for them.
+    expect(output).toMatch(/deploy-decision-artifact-bucket\.sh/u);
+    // And it refuses BEFORE seeding anything: no upload, no offered record, no POST.
+    // An abort that had already written the offered parameter would leave a record
+    // the next run's click could consume.
+    expect(
+      callRecords.filter(
+        ([tool, service, operation]) =>
+          tool === "aws" && service === "s3api" && operation === "put-object",
+      ),
+    ).toHaveLength(0);
+    expect(
+      callRecords.filter(
+        ([tool, service, operation]) =>
+          tool === "aws" && service === "ssm" && operation === "put-parameter",
+      ),
+    ).toHaveLength(0);
+    expect(callRecords.filter(([tool]) => tool === "curl")).toHaveLength(0);
   });
 
   it("TC-SLACKAPP-212 an exit between building the artifacts and the full trap still deletes them", () => {

--- a/scripts/run-slack-approval-e2e.test.mjs
+++ b/scripts/run-slack-approval-e2e.test.mjs
@@ -427,12 +427,16 @@ if (command === "ssm get-parameter") {
   const matched = pattern.includes(
     "reviewed decision(s) from s3://",
   );
-  console.log(
-    matched
-      ? (process.env.MOCK_REPLAY_LINES ?? "0")
-      : pattern === ""
-        ? (process.env.MOCK_LOG_LINES ?? "0")
-        : "0",
+  const count = matched
+    ? (process.env.MOCK_REPLAY_LINES ?? "0")
+    : pattern === ""
+      ? (process.env.MOCK_LOG_LINES ?? "0")
+      : "0";
+  // AWS CLI applies a JMESPath query to each page separately for text output.
+  // Reproduce the live \`1\\n0\` shape so changing the script back from JSON
+  // makes every healthy replay fixture fail as non-numeric.
+  process.stdout.write(
+    option("--output") === "text" ? \`\${count}\\n0\\n\` : \`\${count}\\n\`,
   );
 } else if (command === "ecs describe-tasks") {
   const query = option("--query") ?? "";
@@ -1444,6 +1448,9 @@ describe("Slack approval E2E harness (TC-SLACKAPP-090)", () => {
       // The EXACT stream of THIS task, `<prefix>/<container>/<task id>` — not a
       // group-wide scan, which a previous run's replay line would satisfy.
       expect(call).toContain("mem9/Mem9Cleanup/task-abc");
+      // Text output applies `length(events)` once per page and yields values such
+      // as `1\n0`; JSON combines all pages before applying the query.
+      expect(call[call.indexOf("--output") + 1]).toBe("json");
     }
 
     // And the matched line is never echoed. It names `s3://mem9-audit-<account>/...`,

--- a/scripts/verify-workload-permissions-boundary.mjs
+++ b/scripts/verify-workload-permissions-boundary.mjs
@@ -16,6 +16,8 @@ try {
           accountId: process.env.WORKLOAD_BOUNDARY_ACCOUNT_ID,
           applicationRegion: process.env.WORKLOAD_BOUNDARY_APPLICATION_REGION,
           bedrockProjectArn: process.env.WORKLOAD_BOUNDARY_BEDROCK_PROJECT_ARN,
+          decisionArtifactBucketName:
+            process.env.WORKLOAD_BOUNDARY_DECISION_ARTIFACT_BUCKET,
           openAiBedrockProjectArn:
             process.env.WORKLOAD_BOUNDARY_OPENAI_BEDROCK_PROJECT_ARN || "",
           partition: process.env.WORKLOAD_BOUNDARY_PARTITION,

--- a/scripts/workload-permissions-boundary-contract.json
+++ b/scripts/workload-permissions-boundary-contract.json
@@ -13,7 +13,7 @@
     {
       "id": "infra-ci.yml",
       "path": ".github/workflows/infra-ci.yml",
-      "reviewedBlob": "c2b2681fda878ca5ca00a9a7c2080734b3a0c502"
+      "reviewedBlob": "513bf48ba03258c999549754974c2679fe42e532"
     },
     {
       "id": "reconcile-previews.yml",

--- a/scripts/workload-permissions-boundary-contract.json
+++ b/scripts/workload-permissions-boundary-contract.json
@@ -13,7 +13,7 @@
     {
       "id": "infra-ci.yml",
       "path": ".github/workflows/infra-ci.yml",
-      "reviewedBlob": "74d3c7bcf317a2225212f50e8bfee4140da83190"
+      "reviewedBlob": "c2b2681fda878ca5ca00a9a7c2080734b3a0c502"
     },
     {
       "id": "reconcile-previews.yml",

--- a/scripts/workload-permissions-boundary.test.mjs
+++ b/scripts/workload-permissions-boundary.test.mjs
@@ -1,6 +1,6 @@
 import { spawn, spawnSync } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -545,6 +545,9 @@ function resolveTemplateValue(
   }
   if (typeof value !== "string") return value;
   if (value === "BedrockProjectArn") return boundaryContract.bedrockProjectArn;
+  if (value === "DecisionArtifactBucketName") {
+    return "mem9-audit-123456789012";
+  }
   // Only reachable from the !If true branch above; unconfigured, the whole node
   // collapses to NO_VALUE before this can be consulted.
   if (value === "OpenAiBedrockProjectArn") return openAiBedrockProjectArn;
@@ -553,6 +556,7 @@ function resolveTemplateValue(
     .replaceAll("${AWS::AccountId}", accountId)
     .replaceAll("${AWS::URLSuffix}", "amazonaws.com")
     .replaceAll("${ApplicationRegion}", boundaryContract.applicationRegion)
+    .replaceAll("${DecisionArtifactBucketName}", "mem9-audit-123456789012")
     .replaceAll("${PolicyRevision}", policyRevision)
     .replaceAll("${ProjectName}", "mem9-on-aws")
     .replaceAll("${GitHubRepo}", "mem9-on-aws");
@@ -646,6 +650,8 @@ async function runBoundaryDeployMock({
   boundarySimulationBadProbe = "",
   boundarySimulationMalformedProbe = "",
   defaultVersionDriftsAfterSimulation = false,
+  decisionArtifactBucketName = "",
+  decisionArtifactBucketEnv = decisionArtifactBucketName,
   guarded = false,
   matching = false,
   postMutationDrift = false,
@@ -672,8 +678,12 @@ async function runBoundaryDeployMock({
   const quarantinePath = join(directory, "quarantine.json");
   const simulationPath = join(directory, "simulation.json");
   const simulationCompletePath = join(directory, "simulation-complete");
-  const expectedBoundaryPolicy =
-    expectedBoundaryPolicyDocument(boundaryContract);
+  const expectedBoundaryPolicy = expectedBoundaryPolicyDocument({
+    ...boundaryContract,
+    ...(decisionArtifactBucketName
+      ? { decisionArtifactBucketName }
+      : {}),
+  });
   await writeFile(
     expectedPath,
     JSON.stringify(expectedBoundaryPolicy),
@@ -1142,6 +1152,7 @@ esac
           MOCK_STACK_EXISTS: String(stackExists),
           MOCK_STACK_STATUS: stackStatus,
           MOCK_UPDATED: updatedPath,
+          MEM9_DECISION_ARTIFACT_BUCKET: decisionArtifactBucketEnv,
           PATH: `${directory}:${dirname(process.execPath)}:${process.env.PATH}`,
           ...(boundaryOpenAiRegion === undefined
             ? {}
@@ -1158,7 +1169,10 @@ esac
       },
     );
     return {
-      calls: readFileSync(callsPath, "utf8").trim().split("\n"),
+      calls: (existsSync(callsPath) ? readFileSync(callsPath, "utf8") : "")
+        .trim()
+        .split("\n")
+        .filter(Boolean),
       result,
     };
   } finally {
@@ -1176,6 +1190,7 @@ async function runRolloutGateMock({
   dirtyWorktree = false,
   dotenvAck,
   dotenvApplicationRegion,
+  dotenvDecisionArtifactBucket,
   dotenvOpenAiProjectRegion,
   dotenvResponsesRegion,
   dotenvProfile,
@@ -1214,6 +1229,7 @@ async function runRolloutGateMock({
   if (
     dotenvAck !== undefined ||
     dotenvApplicationRegion !== undefined ||
+    dotenvDecisionArtifactBucket !== undefined ||
     dotenvOpenAiProjectRegion !== undefined ||
     dotenvResponsesRegion !== undefined ||
     dotenvProfile !== undefined ||
@@ -1236,6 +1252,11 @@ async function runRolloutGateMock({
           ? []
           : [
               `WORKLOAD_BOUNDARY_APPLICATION_REGION=${dotenvApplicationRegion}`,
+            ]),
+        ...(dotenvDecisionArtifactBucket === undefined
+          ? []
+          : [
+              `MEM9_DECISION_ARTIFACT_BUCKET=${dotenvDecisionArtifactBucket}`,
             ]),
         ...(dotenvOpenAiProjectRegion === undefined
           ? []
@@ -1477,13 +1498,18 @@ printf '%s\\n' "$((now + MOCK_CLOCK_STEP_MS * 1000000))" > "$MOCK_CLOCK"
     WORKLOAD_BOUNDARY_GH_TIMEOUT: timeout,
     WORKLOAD_BOUNDARY_MAINTENANCE_ACK: "true",
     WORKLOAD_BOUNDARY_SKIP_DOTENV:
-      dotenvAck === undefined && dotenvProfile === undefined ? "true" : "false",
+      dotenvAck === undefined &&
+      dotenvDecisionArtifactBucket === undefined &&
+      dotenvProfile === undefined
+        ? "true"
+        : "false",
     ...(repositoryOverride === undefined
       ? {}
       : { GITHUB_REPOSITORY: repositoryOverride }),
   };
   for (const name of [
     "AWS_PROFILE",
+    "MEM9_DECISION_ARTIFACT_BUCKET",
     "MEM9_LLM_RESPONSES_REGION",
     "MEM9_TEMPLATE_BUCKET",
     "MEM9_VPC_ID",
@@ -6998,6 +7024,7 @@ describe("operator entry point", () => {
     const { calls, result, resumeState } = await runRolloutGateMock({
       dotenvAck: "true",
       dotenvApplicationRegion: "eu-west-1",
+      dotenvDecisionArtifactBucket: "example-mem9-decision-artifacts",
       dotenvOpenAiProjectRegion: "us-east-1",
       dotenvResponsesRegion: "us-east-1",
       dotenvProfile: "custom-operator",
@@ -7013,6 +7040,9 @@ describe("operator entry point", () => {
     expect(resumeState).toContain(
       "WORKLOAD_BOUNDARY_APPLICATION_REGION=eu-west-1",
     );
+    expect(resumeState).toContain(
+      "MEM9_DECISION_ARTIFACT_BUCKET=example-mem9-decision-artifacts",
+    );
     expect(resumeState).not.toMatch(/^PROJECT_REGION=/mu);
     expect(resumeState).toContain(
       "WORKLOAD_BOUNDARY_OPENAI_PROJECT_REGION=us-east-1",
@@ -7027,6 +7057,17 @@ describe("operator entry point", () => {
     expect(ROLLOUT_RESUME_COMMAND).toContain(
       "WORKLOAD_BOUNDARY_SKIP_DOTENV=false",
     );
+  });
+
+  it("TC-SLACKAPP-219 rejects an S3-reserved bucket before rollout gates", async () => {
+    const { calls, result, resumeState } = await runRolloutGateMock({
+      dotenvDecisionArtifactBucket: "sthree-reserved",
+    });
+    expect(result.status).toBe(2);
+    expect(result.stderr).toMatch(/invalid.*bucket name/iu);
+    expect(calls).not.toContain("variable get");
+    expect(calls).not.toContain("node invoked");
+    expect(resumeState).toBe("");
   });
 
   it("does not treat the independent Project region as an application selector", async () => {
@@ -7177,6 +7218,35 @@ describe("operator entry point", () => {
     expect(
       calls.filter((call) => call.startsWith("iam get-role-policy")),
     ).toHaveLength(2);
+  });
+
+  it("TC-SLACKAPP-219 passes the exact bucket override to the boundary stack", async () => {
+    const decisionArtifactBucketName = "example-mem9-decision-artifacts";
+    const { calls, result } = await runBoundaryDeployMock({
+      decisionArtifactBucketName,
+      guarded: true,
+    });
+    expect(result.status).toBe(0);
+    const update = calls.find((call) =>
+      call.startsWith("cloudformation update-stack"),
+    );
+    expect(update).toContain(
+      `ParameterKey=DecisionArtifactBucketName,ParameterValue=${decisionArtifactBucketName}`,
+    );
+  });
+
+  it("TC-SLACKAPP-219 rejects an S3-reserved bucket name before boundary mutation", async () => {
+    const { calls, result } = await runBoundaryDeployMock({
+      decisionArtifactBucketEnv: "sthree-reserved",
+      guarded: true,
+    });
+    expect(result.status).toBe(2);
+    expect(result.stderr).toMatch(/invalid.*bucket name/iu);
+    expect(
+      calls.some((call) =>
+        /cloudformation (create-stack|update-stack)/u.test(call),
+      ),
+    ).toBe(false);
   });
 
   it("refuses a guarded update when quarantine disappears after simulation", async () => {
@@ -8143,6 +8213,25 @@ describe("boundary and deploy-role templates", () => {
     ).toContain("s3.ap-northeast-1.amazonaws.com");
   });
 
+  it("TC-SLACKAPP-219 renders an exact custom decision-artifact bucket", () => {
+    const bucket = "example-mem9-decision-artifacts";
+    const document = expectedBoundaryPolicyDocument({
+      ...boundaryContract,
+      decisionArtifactBucketName: bucket,
+    });
+    const bySid = (sid) => document.Statement.find((entry) => entry.Sid === sid);
+    expect(asList(bySid("Resources").NotResource)).toContain(
+      `arn:aws:s3:::${bucket}/*`,
+    );
+    for (const sid of ["KmsContext", "GenKey"]) {
+      expect(
+        bySid(sid).Condition.StringNotLikeIfExists[
+          "kms:EncryptionContext:aws:s3:arn"
+        ],
+      ).toBe(`arn:aws:s3:::${bucket}`);
+    }
+  });
+
   // AWS requires this outright: "In IAM, the `Sid` value must be unique within a
   // JSON policy" (IAM User Guide, reference_policies_elements_sid). A collision is
   // therefore a malformed policy, not a style problem, and CloudFormation would
@@ -8310,6 +8399,34 @@ describe("boundary and deploy-role templates", () => {
     // mutation the inequality above cannot see: rendering the 2-character fixture
     // revision here instead of the deployed one is 19 bytes cheaper and passes.
     expect(6_144 - size).toBe(BOUNDARY_SIZE_RESERVE);
+  });
+
+  it("TC-SLACKAPP-219 reserves enough policy bytes for a 33-character bucket", () => {
+    const document = expectedBoundaryPolicyDocument({
+      ...boundaryContract,
+      decisionArtifactBucketName: "a".repeat(33),
+      openAiBedrockProjectArn: OPENAI_PROJECT_ARN,
+      policyRevision: worstCasePolicyRevision(),
+    });
+    expect(JSON.stringify(document).length).toBeLessThanOrEqual(6_144);
+    for (const invalidName of [
+      "a".repeat(34),
+      "xn--reserved",
+      "sthree-reserved",
+      "amzn-s3-demo-reserved",
+      "reserved-s3alias",
+      "reserved--ol-s3",
+      "reserved--x-s3",
+      "reserved--table-s3",
+      "reserved-an",
+    ]) {
+      expect(() =>
+        expectedBoundaryPolicyDocument({
+          ...boundaryContract,
+          decisionArtifactBucketName: invalidName,
+        }),
+      ).toThrow(/invalid decision-artifact bucket name/iu);
+    }
   });
 
   // The gate above is only as honest as the revision it renders, and the fixture


### PR DESCRIPTION
## Summary
- own the shared decision-artifact bucket in one out-of-band CloudFormation stack instead of every SST stage
- adopt a retained legacy bucket through a bucket-only import, then reconcile the full hardened template and verify live controls plus drift
- support one validated `MEM9_DECISION_ARTIFACT_BUCKET` override across CI, SST, boundary rollout, E2E, and operator scripts
- bind runtime and E2E S3 operations to the caller account with `ExpectedBucketOwner`
- document bootstrap, existing-stack rollout, rollback recovery, and the 33-character IAM quota constraint

This removes the shared-name collision that blocked preview deployment reruns such as #169 and #170. It does not close those PRs.

## Deployment
No AWS mutation was performed while developing this change. Bootstrap the bucket once in the application region with `scripts/deploy-decision-artifact-bucket.sh`. When overriding the name, use the same value for the bucket stack, guarded workload-boundary rollout, SST deploy, CI variable, and E2E.

Interrupted imports resume only after exact read-back. Empty `IMPORT_ROLLBACK_COMPLETE` stack shells may be recreated; rollback stacks that still own resources fail closed for operator recovery.

## Test Plan
- [x] root suite: 25 files, 1147 tests
- [x] Slack approval E2E harness: 50 tests
- [x] infra suite: 30 files, 417 tests
- [x] root and infra typechecks
- [x] ShellCheck for changed deployment scripts
- [x] `cfn-lint` for the bucket, import, and boundary templates
- [x] public-artifact scan and `git diff --check`
- [x] independent review; P1 import-resume finding fixed and re-reviewed with no remaining findings
