### PR TITLE
fix(cleanup): name the real size driver in both offer refusals (#155)

### DIFF
--- a/docs/test-cases/slack-approval-loop.md
+++ b/docs/test-cases/slack-approval-loop.md
@@ -236,10 +236,16 @@ concurrent applies of the same ids.
   `--cap 50` and `--cap 10`. So the old "lower `--cap`" clause was *false* on the
   operator CLI, not merely inert on the scheduled scan, and it was the whole
   diagnosis at the one moment it is the only one available. The replacement names
-  what actually drives the bytes (every id a destructive decision touches) and
-  gives the same remedy the artifact refusal already gives for the same class of
-  input — `narrow the scan` — so the two ceilings speak with one voice. Asserted
-  against **any** flag, not just `--cap`: a later `--consensus-passes` or
+  what actually drives the bytes (every id a destructive decision touches) and points
+  at a lever that EXISTS on both paths: the decision list survives the throw, and a
+  hand-run `--apply --ids` over a reviewed subset is the documented way through —
+  which is also what `runCleanup`'s exit-1 line already names. Deliberately **not**
+  "narrow the scan", the wording the adjacent artifact refusal uses: there is no scan
+  bound to turn down (`scanActiveMemories` exhausts every page and `--limit` is
+  list-only), so that would have replaced one inert clause with another. The same
+  reason the diagnosis says "offered set" rather than "consensus set": these builders
+  also serve the single-pass operator dry run, where there is no quorum to blame.
+  Asserted against **any** flag, not just `--cap`: a later `--consensus-passes` or
   `--protected-topics` clause would reintroduce the defect under a new name on the
   path that can pass neither. Also asserted through the real offer, where this
   refusal fires **before** the write, so a scan that cannot offer leaves last

--- a/docs/test-cases/slack-approval-loop.md
+++ b/docs/test-cases/slack-approval-loop.md
@@ -1204,11 +1204,17 @@ ordering between the two writes is the part that is easy to get backwards.
   and no flag at all (#155): TC-SLACKAPP-224's defect on the Slack surface, fixed
   the same way and asserted the same way. The block count scales with the decisions
   under review, one line each, while the cap bounds an apply's mutations and never
-  reaches this builder either. Driven from a hand-built record, as TC-SLACKAPP-107
-  is, and for a reason worth recording: a decision set large enough to need 50+
-  blocks cannot arrive through `buildOfferedRecord`, which refuses it at 4096 bytes
-  first — so this refusal is only reachable with a record built outside that guard,
-  and that is the input it is tested on.
+  reaches this builder either. Driven through the **real offer**, because the two
+  ceilings measure different things and assuming otherwise was wrong once: the SSM
+  record carries ids only, while the message renders each decision's **reason** as
+  well — so a wordy classifier fits 4096 bytes comfortably and still overflows Slack.
+  Measured: 48 ids with ~2900-character reasons is a record far under the parameter
+  limit and more than 50 blocks. The case asserts that premise (the record passes the
+  first guard) before asserting the second refusal, so it cannot silently become a
+  second copy of TC-SLACKAPP-224. Through the offer it fails **after** the write —
+  the record has already invalidated last week's button and nothing was posted, the
+  ordering TC-SLACKAPP-205 pins for the merge case and the opposite of
+  TC-SLACKAPP-224's.
 - **TC-SLACKAPP-108** — `{ok: false, error}` at HTTP **200** is a failure. Every
   Slack Web API method answers 200 for application errors, so a `response.ok`
   check alone reports a message that was never delivered and the weekly loop looks

--- a/docs/test-cases/slack-approval-loop.md
+++ b/docs/test-cases/slack-approval-loop.md
@@ -207,7 +207,8 @@ concurrent applies of the same ids.
   length, not an id count: a limit expressed as "N ids" drifts from the real
   constraint as soon as ids get longer, and bytes are what SSM rejects. The
   advanced tier's 8 KB is deliberately not the answer — it incurs a charge and
-  cannot be reverted to standard without data loss, so `--cap` is the knob.
+  cannot be reverted to standard without data loss, so the offered set has to fit
+  here, and what has to shrink is the scan (TC-SLACKAPP-224), not the cap.
 - **TC-SLACKAPP-024b** — the size guard measures the artifact coordinates **inside**
   the limit it enforces. The two coordinates add ~151 bytes, so a caller that
   assigned them onto an already-validated record opened a window where the guard
@@ -228,6 +229,22 @@ concurrent applies of the same ids.
   fixture is sized by search against the **real** record rather than a hand-built
   approximation, and the window's existence (under the limit in code units, over it
   in bytes) is asserted before the refusal is.
+- **TC-SLACKAPP-224** — the parameter-limit refusal names the **scanned set**, and
+  no flag at all (#155). `--cap` never reaches this throw: it is not a parameter of
+  `buildOfferedRecord`, it is read only inside `applyDecisions` at apply time, and
+  the guard fires before an apply exists — measured, the byte-identical error at
+  `--cap 50` and `--cap 10`. So the old "lower `--cap`" clause was *false* on the
+  operator CLI, not merely inert on the scheduled scan, and it was the whole
+  diagnosis at the one moment it is the only one available. The replacement names
+  what actually drives the bytes (every id a destructive decision touches) and
+  gives the same remedy the artifact refusal already gives for the same class of
+  input — `narrow the scan` — so the two ceilings speak with one voice. Asserted
+  against **any** flag, not just `--cap`: a later `--consensus-passes` or
+  `--protected-topics` clause would reintroduce the defect under a new name on the
+  path that can pass neither. Also asserted through the real offer, where this
+  refusal fires **before** the write, so a scan that cannot offer leaves last
+  week's button as it found it rather than invalidating it and then refusing to
+  replace it.
 - **TC-SLACKAPP-025** — the record is stage-bound, and a hash whose record names
   another stage is refused. Same reasoning as #102's decision-file stage guard: a
   preview approval must never apply to prod.
@@ -1183,6 +1200,15 @@ ordering between the two writes is the part that is easy to get backwards.
   limit at ~46 ids, **below** #102's default `--cap 50`: the id lines are packed
   into as few sections as the character limit allows, and the test asserts every
   limit on the built message rather than only the block count.
+- **TC-SLACKAPP-225** — the block-limit refusal names the **reviewed decisions**,
+  and no flag at all (#155): TC-SLACKAPP-224's defect on the Slack surface, fixed
+  the same way and asserted the same way. The block count scales with the decisions
+  under review, one line each, while the cap bounds an apply's mutations and never
+  reaches this builder either. Driven from a hand-built record, as TC-SLACKAPP-107
+  is, and for a reason worth recording: a decision set large enough to need 50+
+  blocks cannot arrive through `buildOfferedRecord`, which refuses it at 4096 bytes
+  first — so this refusal is only reachable with a record built outside that guard,
+  and that is the input it is tested on.
 - **TC-SLACKAPP-108** — `{ok: false, error}` at HTTP **200** is a failure. Every
   Slack Web API method answers 200 for application errors, so a `response.ok`
   check alone reports a message that was never delivered and the weekly loop looks

--- a/scripts/memory-cleanup.mjs
+++ b/scripts/memory-cleanup.mjs
@@ -1263,20 +1263,28 @@ export function buildOfferedRecord({
     // expressed as "N ids" drifts from the real constraint as soon as ids get
     // longer, and bytes are what SSM rejects.
     //
-    // The remedy names the SCANNED corpus, deliberately not `--cap` (#155), for
-    // the same reason MAX_ARTIFACT_BYTES does: this record holds every id a
-    // destructive decision touches, so it scales with what the scan found, while
-    // `cap` is read only inside `applyDecisions` and is not even a parameter of
-    // this builder. Measured, the identical error at `--cap 50` and `--cap 10` —
-    // the throw precedes the apply the cap would bound. So "lower --cap" was
-    // false on the operator CLI, and inert as well on the scheduled scan, which
-    // passes no flags and has no operator at the keyboard to pass one.
+    // Deliberately not `--cap` (#155): this record holds every id a destructive
+    // decision touches, so it scales with what the scan found, while `cap` is read
+    // only inside `applyDecisions` and is not even a parameter of this builder.
+    // Measured, the identical error at `--cap 50` and `--cap 10` — the throw precedes
+    // the apply the cap would bound. So "lower --cap" was false on the operator CLI,
+    // and inert as well on the scheduled scan, which passes no flags and has no
+    // operator at the keyboard to pass one.
+    //
+    // What the remedy names instead is something that EXISTS on both paths. Not
+    // "narrow the scan": there is no scan bound to turn down — `scanActiveMemories`
+    // exhausts every page and `--limit` is list-only — so that would be a second
+    // inert clause. The decision list on disk is the real lever: it survives this
+    // throw, and a hand-run `--apply --ids` over a reviewed subset is the documented
+    // way through, which is also what `runCleanup`'s exit-1 line already points at.
+    // "offered set", not "consensus set": these builders serve the single-pass
+    // operator dry run too, where there is no quorum to blame.
     throw new Error(
       `the offered approval list is ${bytes} bytes, over the ` +
         `${MAX_PARAMETER_BYTES}-byte standard parameter limit for ${ids.length} ids — ` +
-        `the record holds every id a destructive decision TOUCHES, so this is a ` +
-        `consensus set too large to offer in one record; narrow the scan rather ` +
-        `than truncating the list the operator approves`,
+        `the record holds every id a destructive decision TOUCHES, so this is an ` +
+        `offered set too large for one record; review it in batches from the kept ` +
+        `decision list rather than truncating the list the operator approves`,
     );
   }
   return record;
@@ -1507,16 +1515,18 @@ export function buildApprovalMessage({ record, decisions, channel }) {
   ];
 
   if (blocks.length > SLACK_MAX_BLOCKS) {
-    // Same remedy as `buildOfferedRecord`'s parameter-limit refusal and for the
-    // same reason (#155): the block count scales with the decisions under review,
-    // one line each, while `cap` bounds an apply's mutations and never reaches
-    // this builder either.
+    // Same remedy as `buildOfferedRecord`'s parameter-limit refusal and for the same
+    // reasons (#155): the block count scales with the decisions under review, one
+    // line each, while `cap` bounds an apply's mutations and never reaches this
+    // builder either. Note this ceiling is reachable with a record that PASSED the
+    // 4096-byte one — the record carries ids, this renders reasons — so the two are
+    // genuinely different limits and not one guard twice (TC-SLACKAPP-225).
     throw new Error(
       `the review list needs ${blocks.length} Block Kit blocks, over Slack's ` +
         `${SLACK_MAX_BLOCKS}-block message limit for ${record.ids.length} ids — ` +
-        `the message renders one line per reviewed decision, so this is a ` +
-        `consensus set too large to show whole; narrow the scan rather than ` +
-        `posting a list the operator cannot see whole`,
+        `the message renders one line per reviewed decision, so this is an offered ` +
+        `set too large to show whole; review it in batches from the kept decision ` +
+        `list rather than posting a list the operator cannot see whole`,
     );
   }
   const long = blocks.find(

--- a/scripts/memory-cleanup.mjs
+++ b/scripts/memory-cleanup.mjs
@@ -1261,11 +1261,22 @@ export function buildOfferedRecord({
   if (bytes > MAX_PARAMETER_BYTES) {
     // Measured on the SERIALIZED value rather than the id count: a limit
     // expressed as "N ids" drifts from the real constraint as soon as ids get
-    // longer, and bytes are what SSM rejects. `--cap` is the knob to lower.
+    // longer, and bytes are what SSM rejects.
+    //
+    // The remedy names the SCANNED corpus, deliberately not `--cap` (#155), for
+    // the same reason MAX_ARTIFACT_BYTES does: this record holds every id a
+    // destructive decision touches, so it scales with what the scan found, while
+    // `cap` is read only inside `applyDecisions` and is not even a parameter of
+    // this builder. Measured, the identical error at `--cap 50` and `--cap 10` —
+    // the throw precedes the apply the cap would bound. So "lower --cap" was
+    // false on the operator CLI, and inert as well on the scheduled scan, which
+    // passes no flags and has no operator at the keyboard to pass one.
     throw new Error(
       `the offered approval list is ${bytes} bytes, over the ` +
         `${MAX_PARAMETER_BYTES}-byte standard parameter limit for ${ids.length} ids — ` +
-        `lower --cap rather than truncating the list the operator approves`,
+        `the record holds every id a destructive decision TOUCHES, so this is a ` +
+        `consensus set too large to offer in one record; narrow the scan rather ` +
+        `than truncating the list the operator approves`,
     );
   }
   return record;
@@ -1496,10 +1507,16 @@ export function buildApprovalMessage({ record, decisions, channel }) {
   ];
 
   if (blocks.length > SLACK_MAX_BLOCKS) {
+    // Same remedy as `buildOfferedRecord`'s parameter-limit refusal and for the
+    // same reason (#155): the block count scales with the decisions under review,
+    // one line each, while `cap` bounds an apply's mutations and never reaches
+    // this builder either.
     throw new Error(
       `the review list needs ${blocks.length} Block Kit blocks, over Slack's ` +
         `${SLACK_MAX_BLOCKS}-block message limit for ${record.ids.length} ids — ` +
-        `lower --cap rather than posting a list the operator cannot see whole`,
+        `the message renders one line per reviewed decision, so this is a ` +
+        `consensus set too large to show whole; narrow the scan rather than ` +
+        `posting a list the operator cannot see whole`,
     );
   }
   const long = blocks.find(

--- a/scripts/memory-cleanup.test.mjs
+++ b/scripts/memory-cleanup.test.mjs
@@ -6542,11 +6542,16 @@ describe("offering the list to Slack (#123)", () => {
       thrown = err;
     }
     expect(thrown?.message).toMatch(/over the 4096-byte standard parameter limit/u);
-    // Names what actually drives the bytes, and the same remedy the artifact
-    // refusal already gives for the same class of input (MAX_ARTIFACT_BYTES),
-    // rather than a third voice for one more size ceiling.
+    // Names what actually drives the bytes, and a remedy that EXISTS on both paths.
+    // Deliberately not "narrow the scan": there is no scan bound to turn down
+    // (`scanActiveMemories` exhausts every page and `--limit` is list-only), so that
+    // would be a second inert clause. The decision list survives this throw and a
+    // hand-run `--apply --ids` over a subset is the documented way through.
     expect(thrown.message).toMatch(/every id a destructive decision TOUCHES/u);
-    expect(thrown.message).toMatch(/narrow the scan/u);
+    expect(thrown.message).toMatch(/review it in batches from the kept decision list/u);
+    // "offered set", never "consensus set": the same builders serve the single-pass
+    // operator dry run, where there is no quorum to blame for the size.
+    expect(thrown.message).not.toMatch(/consensus set/u);
     // No FLAG at all, not merely no `--cap`: the scheduled scan is the path that
     // cannot act on one, so a later `--consensus-passes` or `--protected-topics`
     // clause would reintroduce this defect under a new name.
@@ -6557,7 +6562,9 @@ describe("offering the list to Slack (#123)", () => {
     // was written, so a scan that cannot offer leaves last week's button as it
     // found it instead of invalidating it and then refusing to replace it.
     const fakes = offerFakes();
-    await expect(offer({ fakes, decisions: many }).promise).rejects.toThrow(/narrow the scan/u);
+    await expect(offer({ fakes, decisions: many }).promise).rejects.toThrow(
+      /review it in batches from the kept decision list/u,
+    );
     expect(fakes.ssm.puts).toHaveLength(0);
     expect(fakes.slack.fetchImpl).not.toHaveBeenCalled();
   });
@@ -6591,7 +6598,8 @@ describe("offering the list to Slack (#123)", () => {
     }
     expect(thrown?.message).toMatch(/over Slack's 50-block message limit/u);
     expect(thrown.message).toMatch(/one line per reviewed decision/u);
-    expect(thrown.message).toMatch(/narrow the scan/u);
+    expect(thrown.message).toMatch(/review it in batches from the kept decision list/u);
+    expect(thrown.message).not.toMatch(/consensus set/u);
     expect(thrown.message).not.toMatch(/--[a-z]/u);
 
     // And from the real offer, where it fails AFTER the write — the record is what
@@ -6601,7 +6609,7 @@ describe("offering the list to Slack (#123)", () => {
     // parameter-limit refusal in TC-SLACKAPP-224.
     const fakes = offerFakes();
     await expect(offer({ fakes, decisions: wordy }).promise).rejects.toThrow(
-      /narrow the scan/u,
+      /review it in batches from the kept decision list/u,
     );
     expect(fakes.ssm.puts).toHaveLength(1);
     expect(fakes.slack.fetchImpl).not.toHaveBeenCalled();

--- a/scripts/memory-cleanup.test.mjs
+++ b/scripts/memory-cleanup.test.mjs
@@ -4066,9 +4066,9 @@ describe("the offered approval record (#123)", () => {
     //
     // 4096 is the STANDARD tier's content limit; the advanced tier's 8 KB is not
     // an option here, since an advanced parameter incurs a charge and cannot be
-    // reverted. `--cap 50` keeps a real record at ~2 KB, so hitting this needs a
-    // cap far above the default — which is exactly the operator mistake worth
-    // failing on.
+    // reverted. What reaches the limit is the SCANNED corpus, not the cap: a
+    // ~120-id consensus set breaches it at any `--cap` value, because the cap is
+    // spent at apply time and this guard runs before that (TC-SLACKAPP-224).
     const many = Array.from({ length: 200 }, (_, i) => del(`memory-with-a-realistic-id-${i}`));
     expect(() =>
       buildOfferedRecord({
@@ -6508,8 +6508,8 @@ describe("offering the list to Slack (#123)", () => {
     expect(thrown.message).toMatch(/surv/u);
     // The remedy is deliberately NOT "lower --cap": the cap bounds how many
     // decisions a run applies and cannot shrink a single merge, so that advice
-    // would be inert on precisely the input that triggers this. The block-limit
-    // refusal above it still says --cap, and correctly.
+    // would be inert on precisely the input that triggers this. The two size
+    // refusals around it now say the same (TC-SLACKAPP-224, TC-SLACKAPP-225).
     expect(thrown.message).not.toMatch(/--cap/u);
 
     // Reachable from the real offer, and it fails there the same way a Slack error
@@ -6525,6 +6525,69 @@ describe("offering the list to Slack (#123)", () => {
     // And the refusal names no memory content, unlike the message it declined to
     // build. The id is fine (the record carries ids); the merged bytes are not.
     expect(thrown.message).not.toContain(long);
+  });
+
+  it("TC-SLACKAPP-224 the parameter-limit refusal names the scanned set, not a flag (#155)", async () => {
+    // `--cap` never reaches this throw. `buildOfferedRecord` is not given a cap —
+    // `cap` is read only inside `applyDecisions`, at apply time — and the guard
+    // fires before any apply exists to spend one, so the SAME error came back
+    // byte-for-byte at `--cap 50` and `--cap 10` (measured on #155). The old
+    // "lower --cap" clause was therefore false on the operator CLI, not merely
+    // inert on the scheduled scan, whose container override passes no flags at all.
+    const many = Array.from({ length: 200 }, (_, i) => del(`memory-with-a-realistic-id-${i}`));
+    let thrown;
+    try {
+      offeredWith(many);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown?.message).toMatch(/over the 4096-byte standard parameter limit/u);
+    // Names what actually drives the bytes, and the same remedy the artifact
+    // refusal already gives for the same class of input (MAX_ARTIFACT_BYTES),
+    // rather than a third voice for one more size ceiling.
+    expect(thrown.message).toMatch(/every id a destructive decision TOUCHES/u);
+    expect(thrown.message).toMatch(/narrow the scan/u);
+    // No FLAG at all, not merely no `--cap`: the scheduled scan is the path that
+    // cannot act on one, so a later `--consensus-passes` or `--protected-topics`
+    // clause would reintroduce this defect under a new name.
+    expect(thrown.message).not.toMatch(/--[a-z]/u);
+
+    // Reachable from the real offer, where it fails BEFORE the write — unlike the
+    // block-limit refusal, which fires with the record already in place. Nothing
+    // was written, so a scan that cannot offer leaves last week's button as it
+    // found it instead of invalidating it and then refusing to replace it.
+    const fakes = offerFakes();
+    await expect(offer({ fakes, decisions: many }).promise).rejects.toThrow(/narrow the scan/u);
+    expect(fakes.ssm.puts).toHaveLength(0);
+    expect(fakes.slack.fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("TC-SLACKAPP-225 the block-limit refusal names the reviewed decisions, not a flag (#155)", () => {
+    // The same defect as TC-SLACKAPP-224 on the Slack surface: the block count
+    // scales with the decisions being reviewed, one line each, while `--cap` bounds
+    // an apply's mutations and is never read by this builder either.
+    //
+    // Driven from a hand-built record, as TC-SLACKAPP-107 is: a decision set large
+    // enough to need 50+ blocks cannot arrive through `buildOfferedRecord`, which
+    // would have refused it at 4096 bytes first. So this refusal is only reachable
+    // with a record built outside that guard, and that is the input it is tested on.
+    const many = Array.from({ length: 4000 }, (_, i) => del(`memory-${i}`));
+    const record = {
+      stage: "prod",
+      hash: contentHash(many.map((d) => d.id).join("\n")),
+      ids: many.map((d) => d.id),
+      generatedAt: "2026-08-05T03:00:00.000Z",
+    };
+    let thrown;
+    try {
+      buildApprovalMessage({ record, decisions: many, channel: CHANNEL });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown?.message).toMatch(/over Slack's 50-block message limit/u);
+    expect(thrown.message).toMatch(/one line per reviewed decision/u);
+    expect(thrown.message).toMatch(/narrow the scan/u);
+    expect(thrown.message).not.toMatch(/--[a-z]/u);
   });
 
   it("TC-SLACKAPP-206 a merge-free offer keeps the pre-#150 wording exactly", () => {

--- a/scripts/memory-cleanup.test.mjs
+++ b/scripts/memory-cleanup.test.mjs
@@ -6562,25 +6562,30 @@ describe("offering the list to Slack (#123)", () => {
     expect(fakes.slack.fetchImpl).not.toHaveBeenCalled();
   });
 
-  it("TC-SLACKAPP-225 the block-limit refusal names the reviewed decisions, not a flag (#155)", () => {
+  it("TC-SLACKAPP-225 the block-limit refusal names the reviewed decisions, not a flag (#155)", async () => {
     // The same defect as TC-SLACKAPP-224 on the Slack surface: the block count
     // scales with the decisions being reviewed, one line each, while `--cap` bounds
     // an apply's mutations and is never read by this builder either.
     //
-    // Driven from a hand-built record, as TC-SLACKAPP-107 is: a decision set large
-    // enough to need 50+ blocks cannot arrive through `buildOfferedRecord`, which
-    // would have refused it at 4096 bytes first. So this refusal is only reachable
-    // with a record built outside that guard, and that is the input it is tested on.
-    const many = Array.from({ length: 4000 }, (_, i) => del(`memory-${i}`));
-    const record = {
-      stage: "prod",
-      hash: contentHash(many.map((d) => d.id).join("\n")),
-      ids: many.map((d) => d.id),
-      generatedAt: "2026-08-05T03:00:00.000Z",
-    };
+    // Driven through the REAL offer, because this refusal is reachable there — which
+    // is not obvious and was got wrong once. The two surfaces measure different
+    // things: the record carries ids ONLY, while the message renders a line per
+    // decision INCLUDING its reason. So a wordy classifier fits the 4096-byte record
+    // comfortably and still overflows Slack: 48 ids with ~2900-character reasons is a
+    // record well under the limit and more than 50 blocks.
+    const wordy = Array.from({ length: 48 }, (_, i) => ({
+      ...del(`m-${i}`),
+      reason: "x".repeat(2900),
+    }));
+    const record = offeredWith(wordy);
+    // The premise, asserted rather than asserted-about: the record passed the guard
+    // that TC-SLACKAPP-224 covers, so what follows is the SECOND ceiling and not the
+    // first one in disguise.
+    expect(Buffer.byteLength(JSON.stringify(record), "utf8")).toBeLessThanOrEqual(4096);
+
     let thrown;
     try {
-      buildApprovalMessage({ record, decisions: many, channel: CHANNEL });
+      buildApprovalMessage({ record, decisions: wordy, channel: CHANNEL });
     } catch (err) {
       thrown = err;
     }
@@ -6588,6 +6593,18 @@ describe("offering the list to Slack (#123)", () => {
     expect(thrown.message).toMatch(/one line per reviewed decision/u);
     expect(thrown.message).toMatch(/narrow the scan/u);
     expect(thrown.message).not.toMatch(/--[a-z]/u);
+
+    // And from the real offer, where it fails AFTER the write — the record is what
+    // invalidates last week's button, so a scan that cannot render the message has
+    // already replaced the previous offer and posted nothing. Same ordering
+    // TC-SLACKAPP-205 pins for the merge case, and the opposite of the
+    // parameter-limit refusal in TC-SLACKAPP-224.
+    const fakes = offerFakes();
+    await expect(offer({ fakes, decisions: wordy }).promise).rejects.toThrow(
+      /narrow the scan/u,
+    );
+    expect(fakes.ssm.puts).toHaveLength(1);
+    expect(fakes.slack.fetchImpl).not.toHaveBeenCalled();
   });
 
   it("TC-SLACKAPP-206 a merge-free offer keeps the pre-#150 wording exactly", () => {


### PR DESCRIPTION
## Summary

- Both offer-size refusals (`buildOfferedRecord`'s 4096-byte SSM parameter limit and
  `buildApprovalMessage`'s 50-block Slack limit) stop telling the reader to
  `lower --cap`, and name what actually drives the size instead.
- The remedy names a lever that exists on both paths: the kept decision list and the
  hand-run `--apply --ids` over a reviewed subset that `runCleanup`'s exit-1 line
  already points at.
- Two regression tests plus three stale comments that carried the same false model.

## Which remedy, and why (the issue asks the implementer to pick and say)

Neither of the two candidates in the issue body, and no per-path wording.

`--cap` is not a parameter of `buildOfferedRecord`; `cap` is read only inside
`applyDecisions`, at apply time, and both guards throw before an apply exists. The
correction on #155 measured the byte-identical error at `--cap 50` and `--cap 10`.
So the clause was **false on the operator CLI**, not merely inert on the scheduled
scan — which strikes option 2 (wiring a cap into the schedule's environment cannot
change the outcome) and removes the premise for option 1's path-dependent wording:
if the advice is wrong on both paths, the message does not need to know which path
it is on. That drops the `MEM9_CLEANUP_UNATTENDED` marker, the container-override
`environment` entry, and the parameter threading through three functions that an
earlier attempt on this branch carried, and leaves the diff on the message content
the issue calls the deliverable.

What replaced it is the driver plus a remedy that exists:

- parameter limit — `the record holds every id a destructive decision TOUCHES, so
  this is an offered set too large for one record; review it in batches from the kept
  decision list rather than truncating the list the operator approves`
- block limit — `the message renders one line per reviewed decision, so this is an
  offered set too large to show whole; review it in batches from the kept decision
  list rather than posting a list the operator cannot see whole`

Deliberately **not** `narrow the scan`, which is the wording the adjacent artifact
refusal uses: there is no scan bound to turn down — `scanActiveMemories` exhausts
every page and `--limit` is `mode: ["list"]` — so a scheduled retry would rescan the
same corpus and fail identically. That would have replaced one inert clause with
another, which is the defect this issue is about. The decision list, by contrast,
survives the throw on both paths and is what a hand-run `--apply --ids` reads.

"offered set" rather than "consensus set" because these builders also serve the
default operator dry run, where `loadDecisions` makes a single pass and there is no
quorum to blame. Asserted.

The artifact refusal still says `narrow the scan` and has the same weakness. It is a
third call site this issue did not scope, so it is left alone rather than widening
the change — flagged here instead of quietly fixed or quietly ignored.

The throw's own reasoning about measuring **bytes** rather than an id count is
untouched, per the issue: only the remedy clause was false.

## Mutation evidence

Each guard's message was reverted in isolation and the suite re-run; the file was
md5-verified back to its pre-mutation state after each round.

| Mutation | Test that turns RED |
|---|---|
| restore `lower --cap rather than truncating the list the operator approves` | `TC-SLACKAPP-224` (225 stays green) |
| restore `lower --cap rather than posting a list the operator cannot see whole` | `TC-SLACKAPP-225` (224 stays green) |

Both new tests assert the absence of **any** flag (`/--[a-z]/`), not just `--cap`:
a later `--consensus-passes` or `--protected-topics` clause would reintroduce this
defect under a new name on the path that can pass neither.

`TC-SLACKAPP-224` also drives the parameter-limit refusal through the real
`postApprovalRequest`, pinning that it fires **before** the write — so a scan that
cannot offer leaves last week's button as it found it, rather than invalidating it
and then refusing to replace it.

`TC-SLACKAPP-225` drives the block-limit refusal through the real offer too. An
earlier revision claimed that ceiling was unreachable that way, and a Codex review
disproved it by execution: the record carries ids **only** while the message renders
each decision's reason, so 48 ids with ~2900-character reasons is a 462-byte record
and 51 blocks. The case now uses that shape and asserts the record passes the
4096-byte guard first, so it cannot decay into a second copy of `TC-SLACKAPP-224`.
Through the offer it fails **after** the write, the opposite ordering from 224.

## Scope notes

- The restore path's `raise --cap or split the ids file` is untouched: it is
  CLI-only and correct, per the issue's Out of Scope.
- No infra change, so nothing to verify in `Deploy PR Preview` for this fix
  (option 2, which would have needed it, is struck).
- `TC-SLACKAPP-107`'s doc entry still compares the block ceiling to "#102's default
  `--cap 50`". Left as written: it is a historical rationale for section packing,
  not remedy advice.

## Test Plan

- [x] Test cases documented (`docs/test-cases/slack-approval-loop.md`, TC-SLACKAPP-224/225)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Unit tests pass (`npm test` — 25 files, 1149 tests)
- [x] Mutation-verified (table above)
- [x] Public-artifact scan clean over the pushed range
- [x] Code simplification review passed
- [x] PR review passed
- [ ] CI checks pass
- [x] E2E: **not applicable** — no UI and no infra change;
      `scripts/run-slack-approval-e2e.sh` needs no update, stated explicitly rather
      than silently skipped.

Closes #155


---

## Review round-trip

Reviewed with the local `codex` CLI (Bedrock), three passes:

1. **[P1]** the block-limit "unreachable through the real offer" claim was false —
   disproved by execution. Fixed: the case now uses the reachable shape and drives
   the real path.
2. **[P2]** `narrow the scan` named no lever the reader has (`--limit` is list-only,
   `scanActiveMemories` exhausts every page). Fixed: both messages point at the kept
   decision list and the hand-run `--apply --ids`.
3. **[P2]** "consensus set" is wrong on a single-pass operator dry run. Fixed: both
   say "offered set", asserted.

Third pass: no remaining P1/P2, merge-ready.

`Amazon Q Developer`'s three "critical" findings on this PR cite symbols that do not
exist in `scripts/memory-cleanup.mjs` on this branch or on `main` (`Math.abs`,
`memUsage`, `largeItems`, `heapUsed` — zero occurrences each); replied inline with
the counts and made no changes.
