### PR TITLE
fix(cleanup): log the skipped offer step when no channel is configured (#157)

### DIFF
--- a/docs/test-cases/slack-approval-loop.md
+++ b/docs/test-cases/slack-approval-loop.md
@@ -1256,6 +1256,20 @@ ordering between the two writes is the part that is easy to get backwards.
   would have every hand-run dry run attempt an approval-record write the
   operator's identity may not hold, and would post a clickable Approve button for
   a list they ran locally just to look at.
+- **TC-SLACKAPP-226** — the skipped offer step is **logged**, naming the unset
+  variable (#157). TC-SLACKAPP-114's design is correct and unchanged; what was
+  missing is the line saying it happened. Without it a scheduled scan that lost
+  `MEM9_SLACK_APPROVAL_CHANNEL` did its whole audit, offered nothing, exited 0, and
+  left logs indistinguishable from a healthy week with nothing to clean — the same
+  outcome the adjacent "configured channel with no reachable token **throws**"
+  decision was written to avoid, reached by a different route. Deliberately still
+  **not** a throw: an absent channel is the operator-CLI configuration and must keep
+  working. Synth refuses a prod scan with no channel, so what this diagnoses is
+  drift (an entry edited out of the task definition after deploy) or a hand-run
+  container — neither of which any other check sees, which is also why the fix is
+  one log line and not a startup validation. The case asserts the exit code is still
+  0, that nothing was written or posted, and the converse — a run WITH a poster does
+  not emit the line, so the branch cannot be satisfied by logging unconditionally.
 - **TC-SLACKAPP-115** — the bot token is read from `{prefix}/slack/bot-token`
   **decrypted**, via `GetParameters`. It is a SecureString, so without decryption
   the value returns as ciphertext and every post 401s with `invalid_auth`; and the

--- a/scripts/memory-cleanup.mjs
+++ b/scripts/memory-cleanup.mjs
@@ -2994,6 +2994,19 @@ export async function runCleanup(opts, deps) {
         );
         return result({ exitCode: 1, decisions, decisionPath });
       }
+    } else {
+      // One line, and deliberately NOT a throw (#157). An absent poster is the
+      // legitimate #102 operator-CLI configuration, so failing closed here would
+      // break the very path `buildPostApproval`'s undefined return exists to serve.
+      // What the line buys is a distinction the logs could not otherwise make: this
+      // run had no Slack surface by design, versus this run should have offered and
+      // did not. Synth refuses a prod scan with no channel, so the reachable causes
+      // are drift — an entry edited out of the task definition after deploy — and a
+      // hand-run container, neither of which any other check sees.
+      log(
+        `skipping the Slack offer: ${MEM9_SLACK_CHANNEL_ENV} is not set, so this ` +
+          `run reviewed the list without offering it`,
+      );
     }
     return result({ exitCode: 0, decisions, decisionPath });
   }

--- a/scripts/memory-cleanup.test.mjs
+++ b/scripts/memory-cleanup.test.mjs
@@ -6766,6 +6766,53 @@ describe("offering the list to Slack (#123)", () => {
     expect(postApproval).not.toHaveBeenCalled();
   });
 
+  it("TC-SLACKAPP-226 names the unset channel variable when the offer step is skipped (#157)", async () => {
+    // An absent `postApproval` dep is CORRECT — `buildPostApproval` returns
+    // undefined for an unset channel so #102's operator CLI neither writes an
+    // approval record the operator may not be able to write nor posts a button for
+    // a list they ran locally just to look at. What was missing is the line saying
+    // so: without it a scheduled scan that lost its channel variable did its whole
+    // audit, offered nothing, exited 0, and produced logs identical to a healthy
+    // week's. Synth already refuses a prod scan with no channel, so what this line
+    // diagnoses is drift — an entry edited out of the task definition after deploy,
+    // or a hand-run container — which is exactly the case no other check sees.
+    const server = fakeServer([memory("del-1", "session noise")]);
+    const llm = fakeLlm([[{ id: "del-1", verdict: "DELETE", reason: "session-state" }]]);
+    const deps = baseDeps(server, llm, tempDir());
+    expect(deps.postApproval).toBeUndefined();
+    const skipped = await runCleanup(baseOpts(), deps);
+
+    const logged = deps.log.mock.calls.flat().join("\n");
+    // The variable spelled as the LITERAL the task definition carries, not imported
+    // from the module: a test reading the module's own constant would follow a
+    // rename and keep passing while every existing deployment's logs named a
+    // variable the code no longer reads.
+    expect(logged).toContain("MEM9_SLACK_APPROVAL_CHANNEL");
+    expect(logged).toMatch(/skipping the Slack offer/u);
+    // Still a no-op, not a throw: the operator CLI runs this path every time, so a
+    // fix that drifted into failing closed would break the configuration the dep's
+    // absence exists to serve. The decision list is still written — that is the
+    // deliverable of a dry run — but nothing was deleted, rewritten, or posted.
+    expect(skipped.exitCode).toBe(0);
+    expect(existsSync(skipped.decisionPath)).toBe(true);
+    expect(server.calls.filter((c) => c.method !== "GET")).toEqual([]);
+    expect(server.calls.some((c) => c.path.includes("chat.postMessage"))).toBe(false);
+
+    // The converse, so the branch cannot be satisfied by logging unconditionally: a
+    // run WITH a poster reports what it offered and never says it skipped.
+    const offering = fakeServer([memory("del-1", "session noise")]);
+    const offeringDeps = {
+      ...baseDeps(offering, fakeLlm([[{ id: "del-1", verdict: "DELETE", reason: "session-state" }]]), tempDir()),
+      postApproval: vi.fn(async () => ({ posted: true, record: { hash: "sha256:x", ids: ["del-1"] } })),
+    };
+    const offered = await runCleanup(baseOpts(), offeringDeps);
+    const offeredLog = offeringDeps.log.mock.calls.flat().join("\n");
+    expect(offered.exitCode).toBe(0);
+    expect(offeredLog).toMatch(/offered 1 id\(s\) to Slack/u);
+    expect(offeredLog).not.toMatch(/skipping the Slack offer/u);
+    expect(offeredLog).not.toContain("MEM9_SLACK_APPROVAL_CHANNEL");
+  });
+
   it("TC-SLACKAPP-113 fails the run when the offer fails, naming the decision list it kept", async () => {
     // A scheduled review run whose post failed has done its audit and offered
     // nothing. Exit 0 would make that indistinguishable from a healthy week, and


### PR DESCRIPTION
## Summary

- One log line at the offer call site in `runCleanup`'s dry-run branch, naming
  `MEM9_SLACK_APPROVAL_CHANNEL` when the `postApproval` dep is absent.
- No throw, no synth-time or startup validation, no change to `buildPostApproval`.

## Why a line and nothing more

`buildPostApproval` returning `undefined` for an unset channel is correct and
unchanged — its JSDoc's argument stands: a dep that existed unconditionally would
make every hand-run dry run attempt an approval-record write the operator's identity
may not hold, and post a clickable Approve button for a list they ran locally just
to look at. The gap was that the absent dep was a silent no-op, so a scheduled scan
that lost the variable completed its whole audit, offered nothing, exited 0, and
left logs indistinguishable from a healthy week with nothing to clean. That is the
same outcome the adjacent "configured channel with no reachable token **throws**"
decision was written to avoid, reached by a different route.

Per the reachability note on the issue, this is diagnostic-under-drift rather than
protection of the normal deploy path: synth already refuses a prod scan with no
channel configured, so the reachable causes are a task definition edited out of band
after deploy and a hand-run container. That is exactly why the fix is not built up
into a startup or synth validation — it would duplicate a check that already exists
where it belongs, and neither existing check sees drift.

The line:

```
skipping the Slack offer: MEM9_SLACK_APPROVAL_CHANNEL is not set, so this run
reviewed the list without offering it
```

## Mutation evidence

`TC-SLACKAPP-226` kills both mutations; the file was md5-verified back to its
pre-mutation state after each round.

| Mutation | Result |
|---|---|
| delete the `log(...)` call | RED — `expected 'decision list written to …' to contain 'MEM9_SLACK_APPROVAL_CHANNEL'` |
| move the call out of the `else` so it logs unconditionally | RED — `expected … not to match /skipping the Slack offer/` |

The case also pins the properties that keep the fix from drifting into a failure:
exit code still 0, the decision list still written, no non-GET request to the store,
nothing posted, and the variable name asserted as the **literal** the task
definition carries rather than read from the module's own constant.

## Scope notes

- `MEM9_SLACK_APPROVAL_CHANNEL` unset remains a supported configuration (#102).
- The configured-channel-with-no-token path still throws, untouched.
- Alarming on a scan that offers zero ids is #154, not this PR.

## Test Plan

- [x] Test cases documented (`docs/test-cases/slack-approval-loop.md`, TC-SLACKAPP-226)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Unit tests pass (`npm test` — 25 files, 1148 tests)
- [x] Mutation-verified (table above)
- [x] Public-artifact scan clean over the pushed range
- [x] Code simplification review passed
- [x] PR review passed
- [ ] CI checks pass
- [x] E2E: **not applicable** — no UI and no infra change;
      `scripts/run-slack-approval-e2e.sh` needs no update, stated explicitly rather
      than silently skipped.

Closes #157