### PR TITLE
feat(cleanup): alarm on a scan that offers zero ids for two weeks (#154)

### DIFF
--- a/docs/designs/quiet-scan-alarm.md
+++ b/docs/designs/quiet-scan-alarm.md
@@ -41,6 +41,19 @@ scan run ──► offered record  (approvals/offered, unchanged)
                     └─ LogMetricFilter → ScanRan ────────► alarm: FILL(...,0) < 1
 ```
 
+### Only the schedule contributes
+
+`MEM9_CLEANUP_SCHEDULED=1` is set on the EventBridge Scheduler container override
+and nowhere else — not on the task definition, so neither the apply half nor the
+operator CLI carries it. It gates the week record and the metric line, and nothing
+else: an off-schedule dry run still writes and posts its offer exactly as before.
+
+Without the gate, an operator's hand-run would be indistinguishable from a
+scheduled one in the data, in both directions: a hand-run that offered nothing
+could supply the **second** quiet week and page for a classifier that is fine, and
+*any* hand-run would publish `ScanRan` and hold the liveness alarm green for
+another seven days while the Scheduler was dead.
+
 ### Per-week record, not a counter
 
 Key: `{prefix}/approvals/scan-outcome-<iso-week>`, value

--- a/docs/designs/quiet-scan-alarm.md
+++ b/docs/designs/quiet-scan-alarm.md
@@ -1,0 +1,139 @@
+# Alarming on a scan that offers zero ids (#154)
+
+A scheduled cleanup scan whose consensus DELETE set is empty writes the offered
+record, posts nothing, exits 0, and nothing reports it. That is correct for a
+genuinely quiet week and indistinguishable from a classifier that degraded far
+enough to collapse the consensus without tripping `classifierBroken` — which
+needs **every** batch to fail. The measured basis: one pass reproduced only 66%
+of its own DELETE set on re-run, so a *partial* degradation can empty the
+intersection while every batch still "succeeds".
+
+## The constraint that shapes everything below
+
+A CloudWatch alarm's evaluation window is capped at 604,800 s (`Period` ×
+`EvaluationPeriods`, [PutMetricAlarm][putmetricalarm]). The scan is weekly
+(`CLEANUP_SCAN_CRON`), so two consecutive scans are 14 days apart and **one
+alarm can observe at most one scan**. ">= 2 consecutive zero-offer weeks" is
+therefore not expressible in a single alarm by any combination of `period`,
+`evaluationPeriods`, `datapointsToAlarm`, or metric math; latching flips on the
+first quiet week, and a composite alarm combines instantaneous child states
+(`ALARM(A) AND ALARM(A)` is `A`) with no accumulator.
+
+So the 14-day memory has to be persisted somewhere. This design puts the
+smallest possible amount of it in SSM and keeps the alarm dumb.
+
+[putmetricalarm]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_PutMetricAlarm.html
+
+## Shape
+
+```
+scan run ──► offered record  (approvals/offered, unchanged)
+        ├──► week record     (approvals/scan-outcome-<iso-week>, new)
+        ├──► reads the last 4 week records ──► quietWeeks (pure function)
+        └──► one JSON log line {event, stage, isoWeek, offered, quietWeeks, scanRan:1}
+                    │
+                    ├─ LogMetricFilter → QuietScanWeeks ─► alarm: >= 2
+                    └─ LogMetricFilter → ScanRan ────────► alarm: FILL(...,0) < 1
+```
+
+### Per-week record, not a counter
+
+Key: `{prefix}/approvals/scan-outcome-<iso-week>`, value
+`{"stage","isoWeek","offered","at"}`. One key per ISO week means a same-week
+retry is an idempotent rewrite rather than a read-modify-write, so there is no
+double-increment race to defend, and a corrupted or deleted key costs one week
+of history instead of the series. It also needs **no new IAM**: the scan task
+role already holds `ssm:GetParameters` + `ssm:PutParameter` on
+`{prefix}/approvals/*`, and the workload permissions boundary — which renders
+near IAM's non-adjustable 6144-character ceiling — is untouched.
+
+These records are the alarm's only memory. Deleting them as "stale" silently
+resets the streak; they are not pruned by this change (~52 small parameters per
+year per stage, far inside the SSM quota).
+
+### The streak is derived, never incremented
+
+`quietWeekStreak` is a pure function over the last N (4) week records, newest
+first, recomputed from scratch every run: count contiguous **present**
+zero-offer records ending at the current week. An **absent** record does not
+extend the streak — the semantics are asserted rather than left implicit,
+because the natural mistake (skip the gap and keep counting) turns a missing
+week into a silent false negative.
+
+One `isoWeek` function serves both the writer and the reader. A W52/W53
+disagreement between two implementations would produce a *permanent* false
+negative — the alarm would never fire again — so the ISO week-numbering year is
+derived the ISO-8601 way (from the Thursday of the week) and the year-boundary
+cases are asserted directly.
+
+### A read failure is loud and never rounds down
+
+The scan computes the number its own alarm reads, so the failure mode to design
+against is a read that silently yields a *lower* count. Absence and error are
+distinguished: an absent parameter comes back in `InvalidParameters` and
+legitimately breaks the streak, while a thrown read — or a record whose value
+will not parse, which is corruption rather than legitimate absence — emits its
+own log line, publishes **no** streak value at all, and exits non-zero so the
+existing task-exit alarm fires. A failed *write* of this week's record is
+reported the same way, for the same reason: next week would read this week as
+absent. A zero-id scan still exits 0 — a quiet week is not a failure, and
+exiting non-zero there would page every quiet week.
+
+### Bookkeeping runs last and never throws
+
+The week record and the streak are handled **after** the offered record is
+written and, when non-empty, after the message is posted; `recordScanOutcome`
+returns its failures instead of throwing. Both properties exist to keep one
+ordering true: an alarm's input must never be able to stop an operator's review
+list from being offered. Running earlier would let a failed parameter write
+block the post, and throwing would surface a telemetry fault through
+`runCleanup`'s offer-failure branch as "failed to offer the review list to
+Slack".
+
+### Why a JSON line in addition to the existing lines
+
+The existing `offered N id(s) …` and `no deletions to offer; posted nothing to
+Slack` lines survive verbatim; other consumers parse that format. A metric
+filter cannot use the `{ $.field = ... }` form on them, because
+`[memory-cleanup <iso>] <message>` is not JSON. The new line is emitted
+unprefixed, on its own, carrying both metrics the two alarms need — which is
+also why neither alarm costs the task any IAM: a log-filter metric needs no
+`cloudwatch:PutMetricData`, and the scan role must not acquire one.
+
+### Two alarms, and why the second one exists
+
+| Alarm | Metric | Shape |
+|---|---|---|
+| streak | `QuietScanWeeks` (`$.quietWeeks`) | `>= 2`, `period=604800`, `evaluationPeriods=1` (exactly at the cap, therefore legal), `treatMissingData: notBreaching` |
+| liveness | `ScanRan` (`$.scanRan`) | `FILL(scan_ran, 0) < 1`, `period=604800`, `evaluationPeriods=1`, armed only where the schedule is `ENABLED` |
+
+The streak alarm alone fails open: if the scan never runs — schedule flipped to
+`DISABLED`, broken task definition, scheduler misconfiguration — no metric is
+published and `notBreaching` keeps it green forever. That is the same
+"silence reads as health" defect one layer up, and the ECS task-exit alarm
+cannot see a task that never started. `FILL` turns a missing datapoint into a
+concrete breaching value, which `treatMissingData` cannot do
+(`DurableIngestTelemetryLivenessAlarm` in `infra/observability.ts` is the
+precedent). It arms only on stages whose schedule state is `ENABLED` — today
+`prod` — or every other stage would page continuously.
+
+**No volume guard, deliberately.** A volume guard protects a *rate's*
+denominator; `quietWeeks` is a count of consecutive discrete runs with exactly
+one run per period by construction, so the "high zero rate on low volume"
+failure the ingest precedent guards against cannot arise. A guard here would
+*suppress* genuine signal. The omission is documented at the alarm declaration
+so it is not "restored" by analogy.
+
+## Rejected
+
+- **A single alarm with a 14-day window** — over the hard cap.
+- **A counter parameter** — read-modify-write on a path with retries.
+- **An independent scheduled evaluator** reading metrics instead of the scan
+  deriving its own count. It would decouple watcher from watched, but costs a
+  new principal, `cloudwatch:GetMetricData`, and a second scheduled resource,
+  to buy independence against SSM read failure — a failure mode that barely
+  overlaps the classifier degradation this targets, and one the loud read-error
+  path already covers. Revisit only if the coupling bites.
+- **Separating "consensus collapsed" from "nothing to delete"** at the
+  classifier level. Still the same observable event here; splitting it is a
+  larger change to `consensusDecisions` than this needs.

--- a/docs/designs/quiet-scan-alarm.md
+++ b/docs/designs/quiet-scan-alarm.md
@@ -10,17 +10,22 @@ intersection while every batch still "succeeds".
 
 ## The constraint that shapes everything below
 
-A CloudWatch alarm's evaluation window is capped at 604,800 s (`Period` ×
-`EvaluationPeriods`, [PutMetricAlarm][putmetricalarm]). The scan is weekly
-(`CLEANUP_SCAN_CRON`), so two consecutive scans are 14 days apart and **one
-alarm can observe at most one scan**. ">= 2 consecutive zero-offer weeks" is
-therefore not expressible in a single alarm by any combination of `period`,
+A CloudWatch alarm's total evaluation window is capped at 604,800 s — seven days
+— for `Period` × `EvaluationPeriods` ([PutMetricAlarm][putmetricalarm]). The scan
+is weekly (`CLEANUP_SCAN_CRON`), so consecutive runs are seven days apart, and a
+window that is *guaranteed* to contain two of them has to be longer than seven
+days. `period=604800, evaluationPeriods=2` is 1,209,600 s and is rejected;
+`period=86400, evaluationPeriods=7, datapointsToAlarm=2` is a seven-day window
+that holds one weekly run, so the second breaching datapoint never exists. So no
+single alarm can be relied on to see both runs, and ">= 2 consecutive zero-offer
+weeks" is not expressible in one by any combination of `period`,
 `evaluationPeriods`, `datapointsToAlarm`, or metric math; latching flips on the
 first quiet week, and a composite alarm combines instantaneous child states
 (`ALARM(A) AND ALARM(A)` is `A`) with no accumulator.
 
-So the 14-day memory has to be persisted somewhere. This design puts the
-smallest possible amount of it in SSM and keeps the alarm dumb.
+So memory spanning two runs — more than the seven days an alarm can see — has to
+be persisted somewhere. This design puts the smallest possible amount of it in
+SSM and keeps the alarm dumb.
 
 [putmetricalarm]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_PutMetricAlarm.html
 
@@ -57,8 +62,12 @@ year per stage, far inside the SSM quota).
 first, recomputed from scratch every run: count contiguous **present**
 zero-offer records ending at the current week. An **absent** record does not
 extend the streak — the semantics are asserted rather than left implicit,
-because the natural mistake (skip the gap and keep counting) turns a missing
-week into a silent false negative.
+because the natural mistake (skip the gap and keep counting) would *invent*
+contiguity: a week whose record was never written would then be treated as quiet,
+and two real quiet weeks either side of it would page as a streak of three. That
+is a false **positive**, and the issue text called it a false negative; the
+direction matters, because it is the reason absence breaks the streak rather than
+being tolerated.
 
 One `isoWeek` function serves both the writer and the reader. A W52/W53
 disagreement between two implementations would produce a *permanent* false
@@ -126,7 +135,8 @@ so it is not "restored" by analogy.
 
 ## Rejected
 
-- **A single alarm with a 14-day window** — over the hard cap.
+- **A single alarm whose window spans two runs** — it would have to exceed seven
+  days, which is over the hard cap.
 - **A counter parameter** — read-modify-write on a path with retries.
 - **An independent scheduled evaluator** reading metrics instead of the scan
   deriving its own count. It would decouple watcher from watched, but costs a

--- a/docs/designs/quiet-scan-alarm.md
+++ b/docs/designs/quiet-scan-alarm.md
@@ -126,6 +126,26 @@ concrete breaching value, which `treatMissingData` cannot do
 precedent). It arms only on stages whose schedule state is `ENABLED` — today
 `prod` — or every other stage would page continuously.
 
+Its actions hang off a composite alarm with an `actionsSuppressor`, following the
+same three-resource split as the ingest precedent: the metric alarm carries no
+actions, an always-OK guard alarm exists only to be waited on, and
+`ActionsSuppressorWaitPeriod` delays notification by a bounded hour. That absorbs
+the transients worth absorbing — a deploy landing while a scan is in flight, and
+the hourly re-evaluation of a multi-day window. It is deliberately an hour rather
+than a cadence: a suppressor that never enters `ALARM` delays actions
+*unconditionally*, so a week-long wait would postpone every real page by a week.
+
+**One expected page at first enablement, accepted rather than papered over.**
+Until the first scheduled run publishes a datapoint, nothing distinguishes "no
+scan was due yet" from "the scan stopped" — that distinction needs memory older
+than the seven days an alarm can evaluate, which is the same wall the streak hit.
+The state that could answer it is the SSM week history, and reading it from
+outside the scan means a second scheduled principal with
+`cloudwatch:GetMetricData`, which #154 puts out of scope. So the alarm fires once
+when a stage first enables the schedule and clears after that stage's first
+Saturday; the alarm description says so, so an operator reading the page knows
+which of the two it is.
+
 **No volume guard, deliberately.** A volume guard protects a *rate's*
 denominator; `quietWeeks` is a count of consecutive discrete runs with exactly
 one run per period by construction, so the "high zero rate on low volume"

--- a/docs/test-cases/slack-approval-loop.md
+++ b/docs/test-cases/slack-approval-loop.md
@@ -2364,8 +2364,11 @@ degrades to a static `>= 2`.
   mode arriving as data rather than as an error. The reader therefore shape-checks
   every record (integer non-negative `offered`, and an `isoWeek`/`stage` that match
   the key it was found under) and treats a failure the way it treats an unreadable
-  parameter: no count published, reported for a non-zero exit, offer untouched. Eight
-  shapes are covered — string, missing, fractional and negative counts, another week,
+  parameter: no count published, reported for a non-zero exit, offer untouched. A
+  value that will not parse at all is reported with a FIXED message: Node quotes a
+  slice of the input in its own `JSON.parse` error, and this text is logged, so
+  forwarding it would put unreviewed stored bytes into CloudWatch through the very
+  path that refused to trust them. Eight shapes are covered — string, missing, fractional and negative counts, another week,
   another stage, a bare number, `null` — plus the converse, that a well-formed record
   is still accepted and counted, so the validator cannot be satisfied by rejecting
   everything. The refusal names the fields it judged, never the stored value.
@@ -2381,6 +2384,17 @@ degrades to a static `>= 2`.
   published. Exit 0 on the first would leave the streak alarm a gap it reads as
   `notBreaching`; exit non-zero on the second would page for a healthy run most
   weeks of the year.
+- **TC-SLACKAPP-239** — an **off-schedule** run stays out of the week history
+  entirely. `MEM9_CLEANUP_SCHEDULED=1` is set on the Scheduler container override and
+  nowhere else — never on the task definition (asserted in TC-SLACKAPP-150/227's
+  neighbourhood), so the apply half and the operator CLI are unmarked. Without the
+  gate a hand-run would be a datapoint about the schedule in both directions: one
+  that offered nothing could supply the **second** quiet week and page for a healthy
+  classifier, and *any* hand-run would publish `ScanRan`, holding the liveness alarm
+  green for another seven days while the Scheduler was dead. The case asserts the
+  offer still happens (the `approvals/offered` write, which is what invalidates a
+  previous offer) and that nothing else does: no week record, no history read, no
+  metric line, and no `outcome` for `runCleanup` to change an exit code over.
 - **TC-SLACKAPP-237** — the production emitter writes the line **unprefixed** to
   stdout, asserted on the real `createCleanupDeps` wiring. `log` prefixes every line
   with `[memory-cleanup <iso>]`, and a `{ $.event = ... }` filter needs the event to

--- a/docs/test-cases/slack-approval-loop.md
+++ b/docs/test-cases/slack-approval-loop.md
@@ -2268,6 +2268,105 @@ fail the run.
   over-size refusal is covered too: it is the one error on the offer side that holds
   the bytes when it is raised.
 
+## The scan's outcome signal (#154)
+
+A scheduled scan whose consensus DELETE set is empty writes the record, posts
+nothing, exits 0, and nothing reports it — correct for a quiet week, and
+indistinguishable from a classifier that degraded far enough to collapse the
+consensus without tripping `classifierBroken` (which needs **every** batch to
+fail). Design: [`docs/designs/quiet-scan-alarm.md`](../designs/quiet-scan-alarm.md).
+
+The 14-day judgement cannot live in an alarm at all: `Period` ×
+`EvaluationPeriods` is capped at 604800s, so one alarm sees at most one weekly
+scan. The streak is therefore derived in the scan from one immutable record per
+ISO week, and the alarm degrades to a static `>= 2`.
+
+- **TC-SLACKAPP-227** — two `LogMetricFilter`s read the **same** JSON line off the
+  scan's own task log group: `QuietScanWeeks` from `$.quietWeeks` and `ScanRan`
+  from `$.scanRan`, both dimensioned on `$.stage`, both matching
+  `{ $.event = "cleanup_scan_outcome" && $.stage = "<stage>" }`. The group is the
+  TASK's, not the `task-failures` group the EventBridge rule delivers into — a
+  filter there would match nothing and leave both alarms green with no datapoints,
+  which is this issue's own defect reproduced in its wiring. The metric value is
+  the derived count rather than a constant `1` because no alarm can accumulate
+  across two weekly runs.
+- **TC-SLACKAPP-228** — the streak alarm fires at **2** and not at 1, with
+  `statistic: Maximum`, `period: 604800`, `evaluationPeriods: 1`,
+  `datapointsToAlarm: 1`, `treatMissingData: notBreaching`, and the existing alerts
+  topic. `Maximum`, not `Sum`: the value is a level, so summing two runs in one
+  window would page at 1 + 1 — two ordinary quiet weeks that were not consecutive.
+  604800 × 1 is exactly at the cap, therefore legal. The case also asserts there
+  are **no** `metricQueries` and no `IF(`: a volume guard protects a *rate's*
+  denominator, and this value is a count of consecutive discrete runs with one run
+  per period, so a guard could only suppress genuine signal. Asserted so it is not
+  "restored" later by analogy to the ingest zero-fact alarm.
+- **TC-SLACKAPP-229** — the liveness alarm uses `FILL(scan_ran, 0) < 1` and is armed
+  **only** where the schedule's state is `ENABLED`. Without it the streak alarm
+  fails open: a scan that never runs publishes nothing, and `notBreaching` reads
+  that silence as health forever — the same defect one layer up, and the ECS
+  task-exit alarm cannot see a task that never started. `treatMissingData` cannot
+  express "missing is a breach" for a metric absent from the whole window; `FILL`
+  can. The stage gating shares ONE expression with the schedule's own `state`, and
+  the case asserts a preview stage gets the streak alarm but not the liveness alarm
+  — otherwise every preview pages every seven days for a scan it never runs.
+- **TC-SLACKAPP-230** — the whole signal costs the task **no new IAM**: no
+  `cloudwatch:*` and no `logs:*` on the task role, and the week records land under
+  the `approvals/*` grant that already exists (`ssm:GetParameters` +
+  `ssm:PutParameter`, unchanged). That is why the signal is a log line rather than a
+  metric the task publishes — a publish grant would need room in the workload
+  permissions boundary, which renders near IAM's 6144-character hard ceiling.
+- **TC-SLACKAPP-231** — ISO week numbering, asserted against literals across four
+  real year boundaries (2026-W01, 2026-W53 from a 2027 date, 2020-W53, 2022-W52,
+  2025-W01 from a 2024 date). One function serves the writer and the reader, because
+  a W52/W53 disagreement between two implementations is not an off-by-one — it is a
+  reader looking up keys nothing writes, and an alarm that never fires again. UTC
+  only: the scan runs 03:00 Saturday UTC, and a local reading west of Greenwich
+  would file that instant under the previous week. `recentIsoWeeks` walks back by
+  whole weeks and re-derives each key rather than decrementing a week number, and
+  reads four weeks — headroom over the threshold of 2, and inside
+  `GetParameters`' ten-name limit.
+- **TC-SLACKAPP-232** — the streak counts only **contiguous, present, zero-offer**
+  weeks ending at the current one: 0 for a busy week, 1 after one quiet week (the
+  boundary that must NOT breach), 2 and 3 as they accumulate, reset to 1 by a
+  non-zero week in between. An **absent** record breaks it, asserted explicitly:
+  the tempting alternative — skip the gap and keep counting — invents contiguity
+  that never existed, and one never-written record would then push the count over
+  the threshold on its own.
+- **TC-SLACKAPP-233** — end to end through the real offer: the week record is
+  written as a plain `String` with `Overwrite: true` (a SecureString write is denied
+  by the boundary; `Overwrite: false` would make a same-week retry fail with
+  `ParameterAlreadyExists`), only the PRIOR weeks are read, and one JSON object is
+  emitted carrying both metrics. A same-week **retry** rewrites the one key and
+  derives the same count — the reason the record is keyed per week instead of being
+  a counter, so there is no read-modify-write to race. A week that offered ids
+  publishes its count with a streak of 0.
+- **TC-SLACKAPP-234** — a failed history read publishes **nothing** and is reported
+  for a non-zero exit; the offer itself is written, posted, and returned intact. The
+  mechanism partly watches itself, so the failure to design against is not a crash
+  but a read that quietly yields a SMALLER count and suppresses the page. A record
+  whose value will not parse is treated as a read failure too, not as absence:
+  absence legitimately breaks the streak, and corruption lowering it silently would
+  be the same defect wearing a different hat.
+- **TC-SLACKAPP-235** — the week bookkeeping runs **last** — after the record, the
+  post, and the stamp — and never throws. Both properties keep one ordering true: an
+  alarm's input must not be able to cost an operator their review list. A throttled
+  `PutParameter` on the week record leaves the offer posted, publishes no count, and
+  is reported; run earlier, or allowed to throw, it would either block the post or
+  surface as "failed to offer the review list to Slack".
+- **TC-SLACKAPP-236** — `runCleanup` exits **1** when the count could not be
+  derived, naming the week and not claiming the offer failed, with the decision list
+  still on disk; and exits **0** for a genuinely quiet week whose count was
+  published. Exit 0 on the first would leave the streak alarm a gap it reads as
+  `notBreaching`; exit non-zero on the second would page for a healthy run most
+  weeks of the year.
+- **TC-SLACKAPP-237** — the production emitter writes the line **unprefixed** to
+  stdout, asserted on the real `createCleanupDeps` wiring. `log` prefixes every line
+  with `[memory-cleanup <iso>]`, and a `{ $.event = ... }` filter needs the event to
+  BE the JSON object — so a prefixed line matches nothing, publishes no datapoint,
+  and leaves both alarms green with nothing to show they went blind. The case also
+  pins that the human-readable lines are still prefixed and still on stderr, so
+  nothing changed for consumers parsing that format.
+
 ## Exit codes
 
 The cleanup script's existing vocabulary is unchanged (0 ok, 1 error, 2
@@ -2276,3 +2375,8 @@ done). Consensus adds no code: a run with no usable consensus offered nothing
 and did nothing wrong, so it exits 0 with the disagreement rate in its summary —
 the number the operator is meant to act on, not an exit code the scheduler would
 have to interpret.
+
+#154 adds no code either. A scan that cannot derive its quiet-week count exits
+**1** — the existing "error" code, which the ECS task-exit alarm already watches
+— rather than a new one the scheduler would have to interpret. A genuinely quiet
+week still exits 0 (TC-SLACKAPP-236).

--- a/docs/test-cases/slack-approval-loop.md
+++ b/docs/test-cases/slack-approval-loop.md
@@ -2276,10 +2276,11 @@ indistinguishable from a classifier that degraded far enough to collapse the
 consensus without tripping `classifierBroken` (which needs **every** batch to
 fail). Design: [`docs/designs/quiet-scan-alarm.md`](../designs/quiet-scan-alarm.md).
 
-The 14-day judgement cannot live in an alarm at all: `Period` ×
-`EvaluationPeriods` is capped at 604800s, so one alarm sees at most one weekly
-scan. The streak is therefore derived in the scan from one immutable record per
-ISO week, and the alarm degrades to a static `>= 2`.
+A judgement spanning two runs cannot live in an alarm at all: `Period` ×
+`EvaluationPeriods` is capped at 604800s — seven days — and a window guaranteed to
+hold two consecutive weekly runs would have to be longer than that. The streak is
+therefore derived in the scan from one immutable record per ISO week, and the alarm
+degrades to a static `>= 2`.
 
 - **TC-SLACKAPP-227** — two `LogMetricFilter`s read the **same** JSON line off the
   scan's own task log group: `QuietScanWeeks` from `$.quietWeeks` and `ScanRan`
@@ -2347,6 +2348,17 @@ ISO week, and the alarm degrades to a static `>= 2`.
   whose value will not parse is treated as a read failure too, not as absence:
   absence legitimately breaks the streak, and corruption lowering it silently would
   be the same defect wearing a different hat.
+- **TC-SLACKAPP-238** — a stored record that **parses** but is not a week record is
+  refused, not absorbed. `{"offered":"0"}` is valid JSON and reads as NOT zero, so it
+  would break the streak and publish a SMALLER count — this feature's own failure
+  mode arriving as data rather than as an error. The reader therefore shape-checks
+  every record (integer non-negative `offered`, and an `isoWeek`/`stage` that match
+  the key it was found under) and treats a failure the way it treats an unreadable
+  parameter: no count published, reported for a non-zero exit, offer untouched. Eight
+  shapes are covered — string, missing, fractional and negative counts, another week,
+  another stage, a bare number, `null` — plus the converse, that a well-formed record
+  is still accepted and counted, so the validator cannot be satisfied by rejecting
+  everything. The refusal names the fields it judged, never the stored value.
 - **TC-SLACKAPP-235** — the week bookkeeping runs **last** — after the record, the
   post, and the stamp — and never throws. Both properties keep one ordering true: an
   alarm's input must not be able to cost an operator their review list. A throttled

--- a/docs/test-cases/slack-approval-loop.md
+++ b/docs/test-cases/slack-approval-loop.md
@@ -2308,8 +2308,18 @@ degrades to a static `>= 2`.
   task-exit alarm cannot see a task that never started. `treatMissingData` cannot
   express "missing is a breach" for a metric absent from the whole window; `FILL`
   can. The stage gating shares ONE expression with the schedule's own `state`, and
-  the case asserts a preview stage gets the streak alarm but not the liveness alarm
-  — otherwise every preview pages every seven days for a scan it never runs.
+  the case asserts a preview stage gets the streak alarm but not the liveness alarm,
+  nor its guard, nor its composite — otherwise every preview pages every seven days
+  for a scan it never runs. The metric alarm carries **no** actions: they hang off a
+  composite alarm whose `actionsSuppressor` is an always-OK guard with a one-hour
+  `waitPeriod`, which absorbs a deploy landing while a scan is in flight and the
+  hourly re-evaluation of a multi-day window. One hour and not one cadence, because a
+  suppressor that never enters ALARM delays actions unconditionally — a week-long
+  wait would postpone every real page by a week. The case also asserts the
+  description records the one page that is **not** suppressible: at first enablement,
+  before any datapoint exists, nothing distinguishes "not due yet" from "stopped"
+  inside a window capped below the scan's own cadence, so the alarm fires once and
+  clears after that stage's first scheduled run.
 - **TC-SLACKAPP-230** — the whole signal costs the task **no new IAM**: no
   `cloudwatch:*` and no `logs:*` on the task role, and the week records land under
   the `approvals/*` grant that already exists (`ssm:GetParameters` +

--- a/infra/consolidation.ts
+++ b/infra/consolidation.ts
@@ -94,6 +94,45 @@ export function consolidationSchedulerRoleName(stage: string): string {
   return name;
 }
 
+/**
+ * The `awslogs-group` an `sst.aws.Task`'s container writes to.
+ *
+ * SST names the group itself and exposes no accessor for it, so the only reliable
+ * source is the container definition it rendered. Shared by the two stacks that
+ * attach CloudWatch resources to a task's own output — consolidation's failure
+ * wiring and the cleanup scan's outcome filters (#154) — because a second copy of
+ * this read is a second place for the container-name lookup to silently return
+ * undefined and take a metric filter with it.
+ *
+ * Throws rather than returning undefined: a filter or subscription pointed at an
+ * empty group name deploys fine and matches nothing forever.
+ */
+export function taskContainerLogGroupName(
+  task: sst.aws.Task,
+  containerName: string,
+  what: string,
+): Output<string> {
+  return task.nodes.taskDefinition
+    .apply(
+      (definition) =>
+        (definition as { containerDefinitions: Output<string> })
+          .containerDefinitions,
+    )
+    .apply((raw) => {
+      const definitions = JSON.parse(raw) as {
+        name: string;
+        logConfiguration?: { options?: Record<string, string> };
+      }[];
+      const name = definitions.find(
+        (container) => container.name === containerName,
+      )?.logConfiguration?.options?.["awslogs-group"];
+      if (!name) {
+        throw new Error(`${what} awslogs-group not found in task definition`);
+      }
+      return name;
+    });
+}
+
 export function consolidation(
   ecsOut: EcsOutputs,
   dbOut: DbOutputs,
@@ -183,25 +222,11 @@ export function consolidation(
     },
   });
 
-  const taskLogGroupName = task.nodes.taskDefinition
-    .apply(
-      (definition) =>
-        (definition as { containerDefinitions: Output<string> })
-          .containerDefinitions,
-    )
-    .apply((raw) => {
-      const definitions = JSON.parse(raw) as {
-        name: string;
-        logConfiguration?: { options?: Record<string, string> };
-      }[];
-      const name = definitions.find(
-        (container) => container.name === CONSOLIDATION_CONTAINER_NAME,
-      )?.logConfiguration?.options?.["awslogs-group"];
-      if (!name) {
-        throw new Error("consolidation awslogs-group not found in task definition");
-      }
-      return name;
-    });
+  const taskLogGroupName = taskContainerLogGroupName(
+    task,
+    CONSOLIDATION_CONTAINER_NAME,
+    "consolidation",
+  );
 
   if (ecsOut.alertsTopicArn) {
     taskFailureAlarm({

--- a/infra/slack-approval.test.ts
+++ b/infra/slack-approval.test.ts
@@ -1255,14 +1255,22 @@ describe("slack approval infrastructure", () => {
     expect(baseUrlIndex).toBeGreaterThan(0);
     expect(command[baseUrlIndex + 1]).toBe("http://mnemo.mem9-prod.local:8080");
 
-    // No environment override at all. MEM9_SLACK_APPROVAL_CHANNEL is already in
-    // the definition and is what makes `buildPostApproval` return a poster, so the
-    // scan offers by virtue of being configured for Slack. MEM9_APPROVAL_HASH must
-    // NOT appear: it means "this run came from a click", and setting it with no
-    // `--ids` is a hard error in `createCleanupDeps`.
-    expect(override.environment).toBeUndefined();
+    // ONE environment entry, and it marks provenance rather than changing behaviour:
+    // #154's week history and outcome metrics are evidence about the SCHEDULE, so an
+    // operator's off-schedule dry run must not contribute to them
+    // (TC-SLACKAPP-239). MEM9_SLACK_APPROVAL_CHANNEL is already in the definition and
+    // is what makes `buildPostApproval` return a poster, so the scan still offers by
+    // virtue of being configured for Slack. MEM9_APPROVAL_HASH must NOT appear: it
+    // means "this run came from a click", and setting it with no `--ids` is a hard
+    // error in `createCleanupDeps`.
+    expect(override.environment).toEqual([
+      { name: "MEM9_CLEANUP_SCHEDULED", value: "1" },
+    ]);
     const taskArgs = materialize(one("Task", "Mem9Cleanup").args) as
       Record<string, any>;
+    // NEVER on the task definition: that is what keeps the apply half and the
+    // operator CLI unmarked, so only an invocation the Scheduler made counts.
+    expect(Object.keys(taskArgs.environment)).not.toContain("MEM9_CLEANUP_SCHEDULED");
     expect(Object.keys(taskArgs.environment)).not.toContain("MEM9_APPROVAL_HASH");
     expect(taskArgs.environment.MEM9_SLACK_APPROVAL_CHANNEL).toBe(CHANNEL_ID);
     expect(JSON.stringify(override)).not.toContain("MEM9_APPROVAL_HASH");

--- a/infra/slack-approval.test.ts
+++ b/infra/slack-approval.test.ts
@@ -1432,10 +1432,51 @@ describe("slack approval infrastructure", () => {
       threshold: 1,
       comparisonOperator: "LessThanThreshold",
       treatMissingData: "breaching",
-      alarmActions: [
-        "arn:aws:sns:ap-northeast-1:123456789012:mem9-on-aws-prod-alerts",
-      ],
     });
+    // NO actions on the raw alarm: they hang off the composite, which is what gives
+    // them a bounded grace. Actions here would page straight through it.
+    expect(alarm.alarmActions).toBeUndefined();
+
+    // The grace, and its bound. A never-alarming suppressor delays actions by
+    // exactly `waitPeriod` and no longer, so this absorbs a deploy landing while a
+    // scan is in flight — and is deliberately an hour rather than a cadence, since a
+    // week-long wait would delay every real page by a week.
+    const guard = materialize(
+      one("MetricAlarm", "CleanupScanLivenessActionDelayGuard").args,
+    ) as Record<string, any>;
+    expect(guard).toMatchObject({
+      namespace: "mem9-on-aws/CleanupScan",
+      metricName: "ScanRan",
+      statistic: "Minimum",
+      threshold: 0,
+      comparisonOperator: "LessThanThreshold",
+      treatMissingData: "notBreaching",
+    });
+    expect(guard.alarmActions).toBeUndefined();
+    const composite = materialize(
+      one("CompositeAlarm", "CleanupScanLivenessNotification").args,
+    ) as Record<string, any>;
+    expect(composite.alarmRule).toBe(
+      'ALARM("arn:aws:cloudwatch:ap-northeast-1:123456789012:alarm:' +
+        'mem9-on-aws-prod-CleanupScanLivenessAlarm")',
+    );
+    expect(composite.actionsSuppressor).toEqual({
+      alarm:
+        "arn:aws:cloudwatch:ap-northeast-1:123456789012:alarm:" +
+        "mem9-on-aws-prod-CleanupScanLivenessActionDelayGuard",
+      waitPeriod: 3600,
+      extensionPeriod: 0,
+    });
+    expect(composite.alarmActions).toEqual([
+      "arn:aws:sns:ap-northeast-1:123456789012:mem9-on-aws-prod-alerts",
+    ]);
+    // No okActions: CloudWatch restarts the wait on a state change during
+    // suppression, so a recovery could be delivered with no prior page.
+    expect(composite.okActions).toBeUndefined();
+    // The description says the first-enablement page is expected, because it is not
+    // suppressible: until the first run publishes, nothing distinguishes "not due
+    // yet" from "stopped" inside a window capped below the scan's own cadence.
+    expect(String(composite.alarmDescription)).toMatch(/EXPECTED ONCE/u);
 
     // A preview stage runs no scan — its schedule is created DISABLED — so an
     // unconditional liveness alarm would page it every seven days for a task it was
@@ -1452,6 +1493,12 @@ describe("slack approval infrastructure", () => {
     expect(
       all("MetricAlarm").map((alarmResource) => alarmResource.logicalName),
     ).not.toContain("CleanupScanLivenessAlarm");
+    // Its guard and its notification go with it, or a preview would carry an alarm
+    // whose rule names an alarm that does not exist.
+    expect(
+      all("MetricAlarm").map((alarmResource) => alarmResource.logicalName),
+    ).not.toContain("CleanupScanLivenessActionDelayGuard");
+    expect(all("CompositeAlarm")).toEqual([]);
     expect(
       all("MetricAlarm").map((alarmResource) => alarmResource.logicalName),
     ).toContain("CleanupScanQuietWeeksAlarm");

--- a/infra/slack-approval.test.ts
+++ b/infra/slack-approval.test.ts
@@ -1323,6 +1323,171 @@ describe("slack approval infrastructure", () => {
     expect(all("Role")).toHaveLength(1);
   });
 
+  it("TC-SLACKAPP-227: filters the scan's own log group for both outcome metrics", async () => {
+    installGlobals("prod");
+    enable();
+    enableScan();
+    await loadAndRun();
+
+    const filters = all("LogMetricFilter").map(
+      (filter) => [filter.logicalName, materialize(filter.args) as Record<string, any>] as const,
+    );
+    const outcome = filters.filter(([name]) => name.startsWith("CleanupScan"));
+    expect(outcome.map(([name]) => name)).toEqual([
+      "CleanupScanQuietWeeksFilter",
+      "CleanupScanRanFilter",
+    ]);
+
+    for (const [, args] of outcome) {
+      // The TASK's group, not the `task-failures` group the EventBridge rule
+      // delivers into: the scan writes its outcome line to its own stdout, so a
+      // filter on the failures group would match nothing and both alarms would sit
+      // green with no datapoints — the failure this whole feature exists to prevent,
+      // reproduced in its own wiring.
+      expect(args.logGroupName).toBe("/sst/cleanup");
+      // JSON form, which is the entire reason the scan emits an unprefixed line: the
+      // human-readable lines carry a `[memory-cleanup <iso>]` prefix and no
+      // `{ $.field = ... }` pattern can read them.
+      expect(args.pattern).toBe(
+        '{ $.event = "cleanup_scan_outcome" && $.stage = "prod" }',
+      );
+      expect(args.metricTransformation.namespace).toBe("mem9-on-aws/CleanupScan");
+      expect(args.metricTransformation.dimensions).toEqual({ stage: "$.stage" });
+    }
+
+    // The DERIVED count, not a constant 1: the 604800s evaluation cap means no alarm
+    // can accumulate across two weekly runs, so the scan computes the streak and the
+    // metric carries it.
+    const [, quietWeeks] = outcome[0];
+    expect(quietWeeks.metricTransformation.name).toBe("QuietScanWeeks");
+    expect(quietWeeks.metricTransformation.value).toBe("$.quietWeeks");
+    // Read off the SAME line, which is what keeps the liveness metric free of task
+    // IAM — nothing here publishes a metric directly.
+    const [, scanRan] = outcome[1];
+    expect(scanRan.metricTransformation.name).toBe("ScanRan");
+    expect(scanRan.metricTransformation.value).toBe("$.scanRan");
+  });
+
+  it("TC-SLACKAPP-228: alarms at two consecutive quiet weeks and not at one, with no volume guard", async () => {
+    installGlobals("prod");
+    enable();
+    enableScan();
+    await loadAndRun();
+
+    const alarm = materialize(one("MetricAlarm", "CleanupScanQuietWeeksAlarm").args) as
+      Record<string, any>;
+    expect(alarm).toMatchObject({
+      namespace: "mem9-on-aws/CleanupScan",
+      metricName: "QuietScanWeeks",
+      // Maximum, not Sum: the value is a LEVEL (this run's streak). Summing two runs
+      // inside one window would page at 1 + 1, which is two ordinary quiet weeks
+      // that were not consecutive.
+      statistic: "Maximum",
+      // Exactly at CloudWatch's 604800s cap for `Period` × `EvaluationPeriods`, and
+      // therefore legal — one more evaluation period would be rejected outright.
+      period: 604_800,
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
+      threshold: 2,
+      comparisonOperator: "GreaterThanOrEqualToThreshold",
+      // A stage whose scan has not run yet publishes nothing, and `missing` would
+      // hold this in INSUFFICIENT_DATA forever. Silence is the liveness alarm's job.
+      treatMissingData: "notBreaching",
+      alarmActions: [
+        "arn:aws:sns:ap-northeast-1:123456789012:mem9-on-aws-prod-alerts",
+      ],
+    });
+    expect(alarm.dimensions).toEqual({ stage: "prod" });
+    // NO volume guard, asserted so it cannot be "restored" by analogy to the ingest
+    // zero-fact alarm (which needs `succeeded > 50` because a rate needs a
+    // denominator). This value is a count of consecutive discrete runs with exactly
+    // one run per period, so a guard would only ever SUPPRESS real signal.
+    expect(alarm.metricQueries).toBeUndefined();
+    expect(JSON.stringify(alarm)).not.toContain("IF(");
+  });
+
+  it("TC-SLACKAPP-229: FILLs the liveness gap and arms only where the schedule is ENABLED", async () => {
+    installGlobals("prod");
+    enable();
+    enableScan();
+    await loadAndRun();
+
+    const alarm = materialize(one("MetricAlarm", "CleanupScanLivenessAlarm").args) as
+      Record<string, any>;
+    // The streak alarm fails OPEN on its own: no scan means no datapoint, and
+    // `notBreaching` then reads silence as health forever. `treatMissingData` cannot
+    // express "missing is a breach" for a metric that has never been published in
+    // the window — `FILL` can, by turning the gap into a concrete 0.
+    expect(alarm.metricQueries[0].metric).toMatchObject({
+      namespace: "mem9-on-aws/CleanupScan",
+      metricName: "ScanRan",
+      stat: "Sum",
+      period: 604_800,
+    });
+    expect(alarm.metricQueries[0].returnData).toBe(false);
+    expect(alarm.metricQueries[1].expression).toBe("FILL(scan_ran, 0)");
+    expect(alarm.metricQueries[1].returnData).toBe(true);
+    expect(alarm).toMatchObject({
+      evaluationPeriods: 1,
+      threshold: 1,
+      comparisonOperator: "LessThanThreshold",
+      treatMissingData: "breaching",
+      alarmActions: [
+        "arn:aws:sns:ap-northeast-1:123456789012:mem9-on-aws-prod-alerts",
+      ],
+    });
+
+    // A preview stage runs no scan — its schedule is created DISABLED — so an
+    // unconditional liveness alarm would page it every seven days for a task it was
+    // never meant to run. The streak filters and alarm still exist there (they cost
+    // nothing and page on nothing), which is what keeps the two conditions separate.
+    resources = [];
+    installGlobals("pr-123");
+    enable();
+    enableScan();
+    await loadAndRun();
+    const schedule = materialize(one("Schedule", "Mem9CleanupScan").args) as
+      Record<string, any>;
+    expect(schedule.state).toBe("DISABLED");
+    expect(
+      all("MetricAlarm").map((alarmResource) => alarmResource.logicalName),
+    ).not.toContain("CleanupScanLivenessAlarm");
+    expect(
+      all("MetricAlarm").map((alarmResource) => alarmResource.logicalName),
+    ).toContain("CleanupScanQuietWeeksAlarm");
+  });
+
+  it("TC-SLACKAPP-230: buys both outcome metrics with no new task IAM", async () => {
+    installGlobals("prod");
+    enable();
+    enableScan();
+    await loadAndRun();
+
+    // The whole reason the signal is a log line rather than a metric the task
+    // publishes: `cloudwatch:PutMetricData` on the task role would need room in the
+    // workload permissions boundary, which renders near IAM's 6144-character hard
+    // ceiling — a limit that cannot be raised and cannot be split across a second
+    // policy. A log-filter metric costs the task nothing.
+    const taskArgs = materialize(one("Task", "Mem9Cleanup").args) as Record<string, any>;
+    const actions = (taskArgs.permissions as Array<Record<string, any>>).flatMap(
+      (statement) => list(statement.actions),
+    );
+    expect(actions.filter((action) => action.startsWith("cloudwatch:"))).toEqual([]);
+    expect(actions.filter((action) => action.startsWith("logs:"))).toEqual([]);
+    // And the week records land under the grant that already exists, so no statement
+    // was added either: `approvals/*` covers `approvals/scan-outcome-<iso-week>`.
+    const ssmStatement = (taskArgs.permissions as Array<Record<string, any>>).find(
+      (statement) => list(statement.actions).includes("ssm:PutParameter"),
+    );
+    expect(list(ssmStatement!.actions).sort()).toEqual([
+      "ssm:GetParameters",
+      "ssm:PutParameter",
+    ]);
+    expect(list(ssmStatement!.resources)).toEqual([
+      "arn:aws:ssm:ap-northeast-1:123456789012:parameter/mem9-on-aws/prod/approvals/*",
+    ]);
+  });
+
   it("TC-SLACKAPP-153: keeps the task role's approval write inside the DEPLOYED boundary", async () => {
     installGlobals("prod");
     enable();

--- a/infra/slack-approval.ts
+++ b/infra/slack-approval.ts
@@ -828,6 +828,18 @@ export function slackApproval(
                 "--out",
                 CLEANUP_SCAN_OUT_DIR,
               ],
+              // The ONE variable this override adds, and it marks provenance rather
+              // than changing behaviour: #154's week history and outcome metrics are
+              // evidence about the SCHEDULE, so an operator's off-schedule dry run
+              // must not contribute to them. Without it a hand-run offering nothing
+              // could supply the second quiet week, and any hand-run would publish
+              // `ScanRan` and hold the liveness alarm green for another seven days
+              // while the Scheduler was dead. It is set HERE, on the override, and
+              // never on the task definition — which is what keeps the apply half and
+              // the operator CLI unmarked.
+              environment: [
+                { name: "MEM9_CLEANUP_SCHEDULED", value: "1" },
+              ],
               // MEM9_SLACK_APPROVAL_CHANNEL is already in the definition's
               // `environment`, and it is what makes `buildPostApproval` return a
               // poster at all — so the scan offers by virtue of being configured

--- a/infra/slack-approval.ts
+++ b/infra/slack-approval.ts
@@ -978,7 +978,7 @@ export function slackApproval(
       // scan by design, so an unconditional liveness alarm would page continuously
       // on each preview.
       if (scanScheduleState === "ENABLED") {
-        new aws.cloudwatch.MetricAlarm("CleanupScanLivenessAlarm", {
+        const livenessAlarm = new aws.cloudwatch.MetricAlarm("CleanupScanLivenessAlarm", {
           alarmDescription:
             "No weekly memory cleanup scan reported an outcome in the last seven " +
             "days, so the quiet-week alarm has no input and cannot page.",
@@ -1009,7 +1009,66 @@ export function slackApproval(
           // older healthy datapoint from CloudWatch's wider sliding range cannot
           // defer it.
           treatMissingData: "breaching",
+          // NO actions here. They hang off the composite below, which is what gives
+          // them a bounded grace — the same split `DurableIngestTelemetryLiveness*`
+          // uses in infra/observability.ts.
+        });
+
+        // An always-OK alarm whose only job is to be something the composite can
+        // wait on: `ActionsSuppressorWaitPeriod` is "the maximum time the composite
+        // waits for the suppressor to go into ALARM", so a suppressor that never
+        // alarms delays actions by exactly that period and no longer. `Minimum` of a
+        // metric that only ever publishes 1 is never below 0, and an empty window
+        // reads notBreaching, so this is OK in every state by construction.
+        const livenessDelayGuard = new aws.cloudwatch.MetricAlarm(
+          "CleanupScanLivenessActionDelayGuard",
+          {
+            alarmDescription:
+              "Always-OK guard that gives the cleanup scan liveness alarm one " +
+              "bounded grace period before it notifies.",
+            namespace: SCAN_METRIC_NAMESPACE,
+            metricName: SCAN_RAN_METRIC,
+            dimensions: { stage: $app.stage },
+            statistic: "Minimum",
+            period: SCAN_ALARM_PERIOD_SECONDS,
+            evaluationPeriods: 1,
+            threshold: 0,
+            comparisonOperator: "LessThanThreshold",
+            treatMissingData: "notBreaching",
+          },
+        );
+
+        new aws.cloudwatch.CompositeAlarm("CleanupScanLivenessNotification", {
+          alarmName: `mem9-on-aws-${$app.stage}-cleanup-scan-liveness`,
+          alarmDescription:
+            "No weekly memory cleanup scan reported an outcome in the last seven " +
+            "days. EXPECTED ONCE when the schedule is first enabled on a stage: " +
+            "until the first scheduled run publishes a datapoint there is no way " +
+            "for CloudWatch to tell 'not due yet' from 'stopped', and it clears " +
+            "itself after that run.",
+          alarmRule: livenessAlarm.arn.apply((arn) => `ALARM("${arn}")`),
+          // The grace is deliberately ONE HOUR and not one cadence. It absorbs the
+          // transients that are worth absorbing — a deploy landing while a scan is
+          // in flight, and the hourly re-evaluation of a multi-day window — while a
+          // cadence-long wait would delay every REAL page by a week, since a
+          // never-alarming suppressor delays actions unconditionally rather than
+          // only at enablement.
+          //
+          // What it does NOT do is suppress the first-enablement page above. That
+          // would need to distinguish "no scan was due yet" from "the scan stopped",
+          // which is not derivable from a metric whose evaluation window is capped
+          // below the scan's own cadence. The state that could answer it is the SSM
+          // week history, and reading that from outside the scan means a second
+          // scheduled principal with `cloudwatch:GetMetricData` — explicitly out of
+          // scope for #154, and revisitable if the noise ever justifies it.
+          actionsSuppressor: {
+            alarm: livenessDelayGuard.arn,
+            waitPeriod: 3600,
+            extensionPeriod: 0,
+          },
           alarmActions: [ecsOut.alertsTopicArn],
+          // No okActions: CloudWatch restarts the wait after a state change during
+          // suppression, so a recovery could be delivered without a prior page.
         });
       }
     }

--- a/infra/slack-approval.ts
+++ b/infra/slack-approval.ts
@@ -93,9 +93,10 @@ const SCAN_QUIET_WEEKS_METRIC = "QuietScanWeeks";
 const SCAN_RAN_METRIC = "ScanRan";
 const SCAN_OUTCOME_EVENT = "cleanup_scan_outcome";
 // The alarm's whole judgement, and the reason the streak is derived in the scan
-// rather than by an alarm: `Period` × `EvaluationPeriods` is capped at 604800s, so
-// a WEEKLY metric gives one alarm at most one datapoint and ">= 2 consecutive
-// weeks" cannot be expressed here at all. See docs/designs/quiet-scan-alarm.md.
+// rather than by an alarm: `Period` × `EvaluationPeriods` is capped at 604800s —
+// seven days — while a window guaranteed to hold two consecutive weekly runs would
+// have to be longer than that, so ">= 2 consecutive weeks" cannot be expressed here
+// at all. See docs/designs/quiet-scan-alarm.md.
 const SCAN_QUIET_WEEKS_THRESHOLD = 2;
 // Exactly at the cap, therefore legal, and the longest window that can hold the
 // one datapoint a weekly scan produces.
@@ -914,9 +915,10 @@ export function slackApproval(
         metricTransformation: {
           name: SCAN_QUIET_WEEKS_METRIC,
           namespace: SCAN_METRIC_NAMESPACE,
-          // The DERIVED count, not `1`: the 14-day judgement cannot live in the
-          // alarm, so the scan computes it from its own per-week records and the
-          // alarm only compares it to a static threshold.
+          // The DERIVED count, not `1`: a judgement spanning two weekly runs cannot
+          // live in an alarm whose window is capped at seven days, so the scan
+          // computes it from its own per-week records and the alarm only compares it
+          // to a static threshold.
           value: "$.quietWeeks",
           dimensions: { stage: "$.stage" },
         },

--- a/infra/slack-approval.ts
+++ b/infra/slack-approval.ts
@@ -65,7 +65,12 @@ import type { OauthFacadeOutputs } from "./oauth-facade";
 import type { TenantIdentityOutputs } from "./tenant-identity";
 import { taskFailureAlarm } from "./task-failure-alarm";
 import { accountId, applicationRegion, ecrImage } from "./ecr";
-import { boundedNamePrefix, IAM_ROLE_NAME_MAX, SCHEDULE_GROUP_NAME_PREFIX_MAX } from "./consolidation";
+import {
+  boundedNamePrefix,
+  IAM_ROLE_NAME_MAX,
+  SCHEDULE_GROUP_NAME_PREFIX_MAX,
+  taskContainerLogGroupName,
+} from "./consolidation";
 import { resolveVpc } from "./vpc";
 
 const IMAGE_TAG = process.env.MEM9_IMAGE_TAG || "latest";
@@ -77,6 +82,24 @@ const RESPONSES_REGION = process.env.MEM9_LLM_RESPONSES_REGION || "us-west-2";
 // one place; the metric name distinguishes them.
 const CLEANUP_FAILURE_METRIC = "CleanupApplyTaskFailures";
 const SCAN_TARGET_ERROR_METRIC = "TargetErrorCount";
+
+// #154's two metrics, both sourced from ONE JSON log line the scan emits
+// (`SCAN_OUTCOME_EVENT` in scripts/memory-cleanup.mjs). A metric sourced from a log
+// filter needs no publish grant, so neither alarm costs the scan task any IAM — and
+// it must not acquire any: the workload permissions boundary renders near IAM's
+// non-adjustable 6144-character ceiling.
+const SCAN_METRIC_NAMESPACE = "mem9-on-aws/CleanupScan";
+const SCAN_QUIET_WEEKS_METRIC = "QuietScanWeeks";
+const SCAN_RAN_METRIC = "ScanRan";
+const SCAN_OUTCOME_EVENT = "cleanup_scan_outcome";
+// The alarm's whole judgement, and the reason the streak is derived in the scan
+// rather than by an alarm: `Period` × `EvaluationPeriods` is capped at 604800s, so
+// a WEEKLY metric gives one alarm at most one datapoint and ">= 2 consecutive
+// weeks" cannot be expressed here at all. See docs/designs/quiet-scan-alarm.md.
+const SCAN_QUIET_WEEKS_THRESHOLD = 2;
+// Exactly at the cap, therefore legal, and the longest window that can hold the
+// one datapoint a weekly scan produces.
+const SCAN_ALARM_PERIOD_SECONDS = 604_800;
 
 export const SLACK_APPROVAL_ENABLED_ENV = "MEM9_SLACK_APPROVAL_ENABLED";
 export const SLACK_APPROVAL_CHANNEL_ENV = "MEM9_SLACK_APPROVAL_CHANNEL";
@@ -627,6 +650,22 @@ export function slackApproval(
     },
   });
 
+  // The scan writes its outcome line to the TASK's own log group, so #154's metric
+  // filters have to attach to that group rather than to the `task-failures` group
+  // the EventBridge rule delivers into. SST names the group itself, and the only
+  // reliable way to learn the name is the container definition it rendered — the
+  // same read `infra/consolidation.ts` does for the same reason.
+  const scanLogGroupName = taskContainerLogGroupName(
+    task,
+    CLEANUP_CONTAINER_NAME,
+    "cleanup",
+  );
+
+  // ONE source for the schedule's state and for whether #154's liveness alarm is
+  // armed. Two independent copies of this condition is how you get a preview stage
+  // paging every seven days for a scan it was never meant to run.
+  const scanScheduleState = $app.stage === "prod" ? "ENABLED" : "DISABLED";
+
   // --- The four inputs `readTaskInputs` reads to start the task ---
   // Keyed by the field each one populates. Both the cluster name and the task-def
   // ARN are non-empty strings, so swapping them passes the handler's own
@@ -749,7 +788,7 @@ export function slackApproval(
       groupName: scanScheduleGroup.name,
       scheduleExpression: CLEANUP_SCAN_CRON,
       scheduleExpressionTimezone: "UTC",
-      state: $app.stage === "prod" ? "ENABLED" : "DISABLED",
+      state: scanScheduleState,
       flexibleTimeWindow: { mode: "OFF" },
       target: {
         arn: ecsOut.cluster.nodes.cluster.arn,
@@ -850,6 +889,127 @@ export function slackApproval(
         treatMissingData: "notBreaching",
         alarmActions: [ecsOut.alertsTopicArn],
       });
+    }
+
+    // --- The scan's OUTCOME signals (#154) ---
+    //
+    // What every alarm above cannot see: a scan that runs, succeeds, and offers
+    // NOTHING. `consensusDecisions` needs >= 2 usable passes agreeing, and one pass
+    // reproduced only 66% of its own DELETE set on re-run — so a partial classifier
+    // degradation can collapse the intersection to zero without tripping
+    // `classifierBroken` (which needs EVERY batch to fail). The run then exits 0,
+    // which the task-exit alarm cannot see by construction.
+    //
+    // Both filters read the SAME line, so the scan emits once and neither metric
+    // needs task IAM. The stage is matched in the pattern as well as carried as a
+    // dimension: the apply half of this task definition shares the log group, and a
+    // pattern that matched only on `event` would count another stage's line if the
+    // group were ever shared further.
+    if (ecsOut.alertsTopicArn) {
+      const scanOutcomePattern =
+        `{ $.event = "${SCAN_OUTCOME_EVENT}" && $.stage = "${$app.stage}" }`;
+      new aws.cloudwatch.LogMetricFilter("CleanupScanQuietWeeksFilter", {
+        logGroupName: scanLogGroupName,
+        pattern: scanOutcomePattern,
+        metricTransformation: {
+          name: SCAN_QUIET_WEEKS_METRIC,
+          namespace: SCAN_METRIC_NAMESPACE,
+          // The DERIVED count, not `1`: the 14-day judgement cannot live in the
+          // alarm, so the scan computes it from its own per-week records and the
+          // alarm only compares it to a static threshold.
+          value: "$.quietWeeks",
+          dimensions: { stage: "$.stage" },
+        },
+      });
+      new aws.cloudwatch.LogMetricFilter("CleanupScanRanFilter", {
+        logGroupName: scanLogGroupName,
+        pattern: scanOutcomePattern,
+        metricTransformation: {
+          name: SCAN_RAN_METRIC,
+          namespace: SCAN_METRIC_NAMESPACE,
+          value: "$.scanRan",
+          dimensions: { stage: "$.stage" },
+        },
+      });
+
+      new aws.cloudwatch.MetricAlarm("CleanupScanQuietWeeksAlarm", {
+        alarmDescription:
+          "The weekly memory cleanup scan offered zero ids for two consecutive " +
+          "weeks, which a collapsed classifier consensus produces silently.",
+        namespace: SCAN_METRIC_NAMESPACE,
+        metricName: SCAN_QUIET_WEEKS_METRIC,
+        dimensions: { stage: $app.stage },
+        // Maximum, not Sum: the value is a level (this run's streak), so summing two
+        // runs inside one window would page at 1 + 1.
+        statistic: "Maximum",
+        period: SCAN_ALARM_PERIOD_SECONDS,
+        evaluationPeriods: 1,
+        datapointsToAlarm: 1,
+        threshold: SCAN_QUIET_WEEKS_THRESHOLD,
+        comparisonOperator: "GreaterThanOrEqualToThreshold",
+        // A stage whose scan has not run yet emits nothing, and `missing` would hold
+        // this in INSUFFICIENT_DATA forever. Silence is covered by the liveness
+        // alarm below, deliberately and not by this one.
+        treatMissingData: "notBreaching",
+        // NO volume guard, and this is not an omission. A volume guard protects a
+        // RATE's denominator (see observability.ts's zero-fact-rate alarm, which
+        // needs `succeeded > 50` because ingest runs thousands of jobs a day). This
+        // value is a count of consecutive discrete runs with exactly one run per
+        // period by construction, so the "high zero rate on low volume" failure it
+        // guards against cannot arise — and a guard here would SUPPRESS the genuine
+        // consecutive-quiet signal, since there is no denominator to protect.
+        alarmActions: [ecsOut.alertsTopicArn],
+      });
+
+      // The streak alarm fails OPEN on its own: if the scan never runs — schedule
+      // flipped to DISABLED, a task definition deleted by a teardown, scheduler
+      // misconfiguration — no datapoint is published and `notBreaching` keeps it
+      // green forever. That is the same "silence reads as health" defect this whole
+      // section exists to close, one layer up, and the ECS task-exit alarm cannot
+      // see a task that never started.
+      //
+      // `FILL(scan_ran, 0)` converts a missing period into a concrete breaching
+      // value, which `treatMissingData` cannot do — the pattern
+      // `DurableIngestTelemetryLivenessAlarm` (infra/observability.ts) establishes.
+      //
+      // Armed ONLY where the schedule's state is ENABLED. Every other stage runs no
+      // scan by design, so an unconditional liveness alarm would page continuously
+      // on each preview.
+      if (scanScheduleState === "ENABLED") {
+        new aws.cloudwatch.MetricAlarm("CleanupScanLivenessAlarm", {
+          alarmDescription:
+            "No weekly memory cleanup scan reported an outcome in the last seven " +
+            "days, so the quiet-week alarm has no input and cannot page.",
+          metricQueries: [
+            {
+              id: "scan_ran",
+              metric: {
+                namespace: SCAN_METRIC_NAMESPACE,
+                metricName: SCAN_RAN_METRIC,
+                dimensions: { stage: $app.stage },
+                stat: "Sum",
+                period: SCAN_ALARM_PERIOD_SECONDS,
+              },
+              returnData: false,
+            },
+            {
+              id: "scan_ran_present",
+              expression: `FILL(scan_ran, 0)`,
+              label: "Scan outcome reported",
+              returnData: true,
+            },
+          ],
+          evaluationPeriods: 1,
+          datapointsToAlarm: 1,
+          threshold: 1,
+          comparisonOperator: "LessThanThreshold",
+          // FILL makes every currently missing period an explicit breach, so an
+          // older healthy datapoint from CloudWatch's wider sliding range cannot
+          // defer it.
+          treatMissingData: "breaching",
+          alarmActions: [ecsOut.alertsTopicArn],
+        });
+      }
     }
   }
 

--- a/infra/task-failure-alarm.test-fixtures.ts
+++ b/infra/task-failure-alarm.test-fixtures.ts
@@ -7,10 +7,10 @@
  * keep their own `record`/`out` (each owns its own resource log), so those are
  * passed in rather than imported.
  *
- * Only `EventRule` and `LogGroup` expose attributes, and only the ones the helper
- * reads back — `logGroup.arn` for the resource policy, `rule.name` for the target.
- * A stub with more attributes than the real code consumes invites an assertion on
- * a value nothing produces.
+ * Only the attributes the real code reads back are exposed — `logGroup.arn` for the
+ * resource policy, `rule.name` for the target, and `metricAlarm.arn` for a composite
+ * alarm's rule and suppressor (#154). A stub with more attributes than the real code
+ * consumes invites an assertion on a value nothing produces.
  */
 export interface TaskFailureAlarmStubOptions {
   /** Recorder the host harness uses to log created resources. */
@@ -58,8 +58,22 @@ export function cloudwatchStubs(options: TaskFailureAlarmStubOptions) {
       }
     },
     MetricAlarm: class {
+      // The ARN is read back by a composite alarm's `alarmRule` and by its
+      // `actionsSuppressor` (#154), the same way observability.test.ts's stub
+      // exposes it. Derived from the logical name so a rule naming the wrong alarm
+      // is visible in the assertion rather than matching by accident.
+      arn: unknown;
       constructor(logicalName: string, args: Record<string, unknown>) {
+        this.arn = out(
+          `arn:aws:cloudwatch:ap-northeast-1:123456789012:alarm:` +
+            `mem9-on-aws-prod-${logicalName}`,
+        );
         record("MetricAlarm", logicalName, args);
+      }
+    },
+    CompositeAlarm: class {
+      constructor(logicalName: string, args: Record<string, unknown>) {
+        record("CompositeAlarm", logicalName, args);
       }
     },
   };

--- a/scripts/memory-cleanup.mjs
+++ b/scripts/memory-cleanup.mjs
@@ -1128,6 +1128,207 @@ export function decisionArtifactHash(serialized) {
 }
 
 /**
+ * The scheduled scan's week history (#154), and the reason it exists in SSM at all.
+ *
+ * A CloudWatch alarm's evaluation window is capped at 604800s (`Period` ×
+ * `EvaluationPeriods`), and the scan is WEEKLY — so two consecutive scans are 14
+ * days apart and one alarm can observe at most one of them. ">= 2 consecutive
+ * zero-offer weeks" is therefore not expressible in any single alarm, by any
+ * combination of period, evaluationPeriods, datapointsToAlarm, or metric math.
+ * The 14-day memory has to be persisted, so it lives here as the smallest thing
+ * that works: one immutable record per ISO week, and a pure function over the last
+ * few of them. The alarm stays dumb (`>= 2` on a static threshold).
+ *
+ * A per-week KEY, deliberately not a counter. A same-week retry is then an
+ * idempotent rewrite of one key — no read-modify-write, so no double-increment
+ * race to defend — and a corrupted or deleted key costs one week of history rather
+ * than the series. It also costs NO new IAM: the scan task role already holds
+ * `ssm:GetParameters` and `ssm:PutParameter` on `{prefix}/approvals/*`, and the
+ * workload permissions boundary renders near IAM's non-adjustable 6144-character
+ * ceiling, which is not a budget this feature may spend.
+ *
+ * These records are the alarm's ONLY memory. Nothing prunes them (~52 small
+ * parameters per year per stage, far inside the SSM quota) and nothing should:
+ * deleting them as "stale" silently resets the streak and the alarm goes quiet.
+ */
+const SCAN_OUTCOME_WEEKS = 4;
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+/**
+ * The `event` field the log-metric filters match on.
+ *
+ * DUPLICATED as a literal in `infra/slack-approval.ts`, which cannot import it: that
+ * file runs in the Pulumi program, and importing this module would drag the AWS SDK
+ * and the whole CLI into synth. Both sides are therefore pinned to the literal by
+ * their own tests (TC-SLACKAPP-227 on the filter pattern, TC-SLACKAPP-233 and
+ * TC-SLACKAPP-237 on the emitted line), so a rename on either side turns a test red
+ * rather than leaving the filters matching nothing and both alarms silently dark.
+ */
+export const SCAN_OUTCOME_EVENT = "cleanup_scan_outcome";
+
+/**
+ * The ISO-8601 week-numbering key (`2026-W33`) for a timestamp.
+ *
+ * ONE function for the writer and the reader, because an off-by-one or a W52/W53
+ * year-boundary disagreement between two implementations is not a wrong number —
+ * it is a permanent false negative, where the reader looks up weeks the writer
+ * never writes and the alarm never fires again.
+ *
+ * The week-numbering YEAR is taken from the THURSDAY of the week (ISO-8601 §3.17),
+ * which is what makes the year boundary fall out instead of needing special cases:
+ * 2027-01-01 is a Friday, so its Thursday is 2026-12-31 and the key is `2026-W53`.
+ * UTC throughout — the schedule is a UTC cron, and a local-time reading would move
+ * a Saturday 03:00 run into a different week west of the prime meridian.
+ */
+export function isoWeek(ms) {
+  const date = new Date(ms);
+  const thursday = new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+  );
+  // Mon=1..Sun=7, so `+ 4 - isoDay` lands on this ISO week's Thursday.
+  const isoDay = thursday.getUTCDay() || 7;
+  thursday.setUTCDate(thursday.getUTCDate() + 4 - isoDay);
+  const year = thursday.getUTCFullYear();
+  const week = Math.ceil(
+    ((thursday.getTime() - Date.UTC(year, 0, 1)) / 86_400_000 + 1) / 7,
+  );
+  return `${year}-W${String(week).padStart(2, "0")}`;
+}
+
+/**
+ * This week's key and the `count - 1` before it, newest first.
+ *
+ * Derived by subtracting whole weeks from the timestamp and re-deriving each key
+ * through `isoWeek`, NOT by decrementing a week number: the latter has to know
+ * whether the previous year had 52 or 53 weeks, which is the arithmetic this
+ * function exists to avoid duplicating.
+ */
+export function recentIsoWeeks(ms, count = SCAN_OUTCOME_WEEKS) {
+  return Array.from({ length: count }, (_, index) => isoWeek(ms - index * WEEK_MS));
+}
+
+export function scanOutcomeParameterName(ssmPrefix, week) {
+  return `${ssmPrefix}/approvals/scan-outcome-${week}`;
+}
+
+/**
+ * Consecutive zero-offer weeks ending at the current one, recomputed from scratch.
+ *
+ * Never incremented, so a re-run cannot double-count and a lost record cannot
+ * corrupt a running total. `weeks` is newest-first (`recentIsoWeeks`).
+ *
+ * An ABSENT record does not extend the streak, and that is a decision rather than
+ * an accident of the loop: the tempting alternative — skip the gap and keep
+ * counting — turns a week whose record never got written into a silent false
+ * positive on the alarm's own input. A gap breaks it, the scan-liveness alarm
+ * covers the never-ran case that produces gaps, and the count then only ever
+ * describes contiguous, present, zero-offer weeks.
+ */
+export function quietWeekStreak(weeks, records) {
+  let streak = 0;
+  for (const week of weeks) {
+    const record = records[week];
+    if (!record || record.offered !== 0) break;
+    streak += 1;
+  }
+  return streak;
+}
+
+/**
+ * Write this week's record, derive the streak from the weeks before it, and report
+ * both to the caller.
+ *
+ * The write comes FIRST and is unconditional: the record is history for future runs
+ * and must not be lost because this run's read of older weeks failed. The current
+ * week is then taken from the in-memory value rather than read back, which keeps
+ * the derivation independent of read-after-write timing on a parameter this same
+ * call just wrote.
+ *
+ * A failed read is NOT reported as absence. The scan computes the number its own
+ * alarm reads, so the failure mode worth designing against is a read that silently
+ * yields a LOWER count and suppresses the page. Absence is legitimate and breaks
+ * the streak; a thrown read, or a record whose value will not parse, publishes NO
+ * streak value at all and is reported as `failed` for the caller to exit non-zero
+ * on, so the existing task-exit alarm fires instead.
+ *
+ * Nothing here THROWS, and that is deliberate: this is bookkeeping for an alarm,
+ * and the caller runs it after the review list is already offered and posted. A
+ * throw would propagate into `runCleanup`'s offer-failure branch and report a
+ * telemetry fault as "failed to offer the review list to Slack" — while also, if it
+ * ran earlier, letting a failed parameter write stop an operator's review list from
+ * being posted at all. Both failures are reported instead, and both still exit
+ * non-zero.
+ */
+export async function recordScanOutcome({
+  ssm,
+  ssmPrefix,
+  stage,
+  offered,
+  now = Date.now,
+  log = () => {},
+}) {
+  const { GetParametersCommand, PutParameterCommand } = await import(
+    "@aws-sdk/client-ssm"
+  );
+  const at = new Date(now()).toISOString();
+  const weeks = recentIsoWeeks(now());
+  const [week] = weeks;
+  const current = { stage, isoWeek: week, offered, at };
+  try {
+    await ssm.send(
+      new PutParameterCommand({
+        // Plain `String` with `Overwrite: true`, for the same two runtime reasons as
+        // `approvals/offered`: the boundary denies a `SecureString` write, and
+        // `Overwrite: false` would make a same-week retry fail with
+        // `ParameterAlreadyExists` instead of rewriting one week idempotently.
+        Name: scanOutcomeParameterName(ssmPrefix, week),
+        Type: "String",
+        Overwrite: true,
+        Value: JSON.stringify(current),
+      }),
+    );
+  } catch (err) {
+    log(
+      `this week's scan-outcome record (${week}) could not be written ` +
+        `(${err.message}), so no quiet-week count was published and next week's ` +
+        `streak will read this week as absent`,
+    );
+    return { isoWeek: week, offered, failed: "write" };
+  }
+
+  const prior = weeks.slice(1);
+  const records = { [week]: current };
+  try {
+    const response = await ssm.send(
+      // Plural, not `GetParameter`: the two are distinct IAM actions and the
+      // boundary admits only this one. `SCAN_OUTCOME_WEEKS` is also what keeps this
+      // to a single call — `GetParameters` takes at most 10 names.
+      new GetParametersCommand({
+        Names: prior.map((each) => scanOutcomeParameterName(ssmPrefix, each)),
+      }),
+    );
+    for (const parameter of response.Parameters ?? []) {
+      const found = prior.find(
+        (each) => scanOutcomeParameterName(ssmPrefix, each) === parameter.Name,
+      );
+      if (!found) continue;
+      // A value that will not parse is treated as a read FAILURE, not as absence.
+      // Absence lowers the streak legitimately; a corrupt record lowering it would
+      // be this issue's own failure mode — a silently smaller number suppressing
+      // the page — so it is reported loudly and the count is withheld.
+      records[found] = JSON.parse(parameter.Value);
+    }
+  } catch (err) {
+    log(
+      `the scan-outcome history for ${stage} could not be read (${err.message}), ` +
+        `so no quiet-week count was published for ${week}; this week's own record ` +
+        `was written`,
+    );
+    return { isoWeek: week, offered, failed: "read" };
+  }
+  return { isoWeek: week, offered, quietWeeks: quietWeekStreak(weeks, records) };
+}
+
+/**
  * The `{prefix}/approvals/offered` record: what the callback Lambda compares a
  * button click against, and where the apply task reads its ids from (#123).
  *
@@ -2005,6 +2206,13 @@ export async function postApprovalRequest({
   artifactBucketOwner,
   now = Date.now,
   log = () => {},
+  // Separate from `log` because the CONSUMER is different: `log` prefixes every
+  // line with `[memory-cleanup <iso>]`, which is exactly what forecloses a
+  // CloudWatch `{ $.field = ... }` metric filter. `emit` writes one unprefixed
+  // JSON object, which is what the two #154 filters read. Noop by default so a
+  // caller that has no metric surface prints nothing; `buildPostApproval` wires
+  // the real emitter for the deployed scan.
+  emit = () => {},
 }) {
   const { PutParameterCommand } = await import("@aws-sdk/client-ssm");
   const name = `${ssmPrefix}/approvals/offered`;
@@ -2104,11 +2312,51 @@ export async function postApprovalRequest({
 
   await write(record);
   log(`offered ${record.ids.length} id(s) for approval as ${record.hash}`);
+
+  // LAST in every branch, after the offer is written and (when non-empty) posted:
+  // this is bookkeeping for an alarm, and it must not be able to stop a review list
+  // from reaching the operator. `recordScanOutcome` returns its failures rather than
+  // throwing for the same reason. The count published is what was OFFERED, which is
+  // the number a collapsed consensus drives to zero (#154).
+  const withOutcome = async (offer) => {
+    const outcome = await recordScanOutcome({
+      ssm,
+      ssmPrefix,
+      stage,
+      offered: record.ids.length,
+      now,
+      log,
+    });
+    if (!outcome.failed) {
+      // One JSON object per run, IN ADDITION to the plain-text lines around it,
+      // which survive verbatim because other consumers parse that format. Nothing
+      // is published when the history failed: a filter reading `$.quietWeeks` from
+      // a line that lacks it would publish a lower value, which is the alarm
+      // suppression this whole path exists to prevent. The non-zero exit is the
+      // signal there instead.
+      //
+      // `scanRan: 1` rides the SAME line as the count so the liveness alarm's
+      // metric costs no extra IAM — a metric sourced from a log filter needs no
+      // publish grant at all, and the scan task role must never acquire one. There
+      // is deliberately no metric client in this file; TC-SLACKAPP-210 scans for
+      // one, and this line is the whole emission surface it has to cover.
+      emit({
+        event: SCAN_OUTCOME_EVENT,
+        stage,
+        isoWeek: outcome.isoWeek,
+        offered: outcome.offered,
+        quietWeeks: outcome.quietWeeks,
+        scanRan: 1,
+      });
+    }
+    return { ...offer, outcome };
+  };
+
   if (record.ids.length === 0) {
     // Nothing to approve, so nothing to post — but the record above still
     // overwrote last week's list, which is the point.
     log("no deletions to offer; posted nothing to Slack");
-    return { record, posted: false };
+    return withOutcome({ record, posted: false });
   }
 
   const message = buildApprovalMessage({ record, decisions, channel });
@@ -2123,7 +2371,12 @@ export async function postApprovalRequest({
         `the apply will not be able to update the Slack message`,
     );
   }
-  return { record, posted: true, messageTs: posted.ts, messageChannel: posted.channel };
+  return withOutcome({
+    record,
+    posted: true,
+    messageTs: posted.ts,
+    messageChannel: posted.channel,
+  });
 }
 
 /**
@@ -2975,6 +3228,21 @@ export async function runCleanup(opts, deps) {
           `offered ${offer.record.ids.length} id(s) to Slack as ${offer.record.hash}` +
             (offer.posted ? "" : " (nothing posted)"),
         );
+        if (offer.outcome?.failed) {
+          // Exit 1 with the offer itself intact: the list was written and (when
+          // non-empty) posted, so this is not an offer failure. What failed is the
+          // input to the quiet-week alarm, and a run that cannot compute that number
+          // must not exit 0 — a silent zero-offer streak is the exact condition
+          // #154 exists to surface, and the task-exit alarm is what covers the scan
+          // when its own signal is unavailable. `recordScanOutcome` logged which
+          // week and why.
+          log(
+            `exiting non-zero: the quiet-week count for ` +
+              `${offer.outcome.isoWeek} could not be derived, so its alarm has no ` +
+              `input for this run`,
+          );
+          return result({ exitCode: 1, decisions, decisionPath });
+        }
       } catch (err) {
         // Exit 1, not 0. A scheduled review run whose post failed has done its
         // audit and offered nothing, and exit 0 would make that indistinguishable
@@ -4320,6 +4588,12 @@ async function buildPostApproval(opts, region, runtime) {
       fetchImpl: runtime.fetchImpl ?? fetch,
       log: (message) =>
         console.error(`[memory-cleanup ${new Date().toISOString()}] ${message}`),
+      // `console.log` and nothing else on the line: the awslogs driver ships stdout
+      // and stderr to the same group, and the #154 metric filters need the whole
+      // event to BE the JSON object. Any prefix — including the timestamped one
+      // `log` adds — makes `{ $.event = ... }` stop matching, silently, with the
+      // alarms then reading no datapoints and sitting green forever.
+      emit: (event) => console.log(JSON.stringify(event)),
     });
 }
 

--- a/scripts/memory-cleanup.mjs
+++ b/scripts/memory-cleanup.mjs
@@ -107,6 +107,19 @@ const SLACK_MAX_HEADER_CHARS = 150;
 const SLACK_TIMEOUT_MS = 15_000;
 /** Set by infra/slack-approval.ts; its presence is what enables the offer. */
 const MEM9_SLACK_CHANNEL_ENV = "MEM9_SLACK_APPROVAL_CHANNEL";
+/**
+ * Set to "1" by the EventBridge Scheduler override in infra/slack-approval.ts, and
+ * by nothing else (#154).
+ *
+ * It gates the week history and the outcome metrics, because an operator's
+ * off-schedule dry run is not evidence about the schedule. Without the gate a
+ * hand-run that offered nothing could supply the SECOND quiet week and page for a
+ * classifier that is fine, and any hand-run would publish `ScanRan` — holding the
+ * liveness alarm green for another seven days while the Scheduler was in fact dead.
+ * The offer itself is unaffected: a hand-run still writes and posts exactly as it
+ * did before.
+ */
+const MEM9_CLEANUP_SCHEDULED_ENV = "MEM9_CLEANUP_SCHEDULED";
 // Set by infra/slack-approval.ts to the bucket it provisions (#150). Its ABSENCE
 // is meaningful rather than an error: it is what keeps #102's operator CLI, and any
 // stage deployed before that bucket existed, writing the id-only record they always
@@ -1251,7 +1264,17 @@ export function quietWeekStreak(weeks, records) {
  * message are this run's own, not the record's.
  */
 function parseWeekRecord({ week, stage, value }) {
-  const record = JSON.parse(value);
+  let record;
+  try {
+    record = JSON.parse(value);
+  } catch {
+    // The parse error is DISCARDED rather than forwarded. Node quotes a slice of the
+    // input in its message ("Unexpected token 'x', \"{not json\" is not valid JSON"),
+    // and this text is logged — so forwarding it would put unreviewed stored bytes
+    // into CloudWatch on exactly the path that exists because the record cannot be
+    // trusted.
+    throw new Error(`the scan-outcome record for ${week} is not valid JSON`);
+  }
   const shaped = record !== null && typeof record === "object";
   const failed = shaped
     ? [
@@ -2256,6 +2279,10 @@ export async function postApprovalRequest({
   // caller that has no metric surface prints nothing; `buildPostApproval` wires
   // the real emitter for the deployed scan.
   emit = () => {},
+  // Whether this invocation came from the SCHEDULE. Only a scheduled run keeps week
+  // history and publishes metrics; see MEM9_CLEANUP_SCHEDULED_ENV for why an
+  // operator's dry run must not.
+  scheduled = false,
 }) {
   const { PutParameterCommand } = await import("@aws-sdk/client-ssm");
   const name = `${ssmPrefix}/approvals/offered`;
@@ -2362,6 +2389,10 @@ export async function postApprovalRequest({
   // throwing for the same reason. The count published is what was OFFERED, which is
   // the number a collapsed consensus drives to zero (#154).
   const withOutcome = async (offer) => {
+    // An off-schedule run returns here untouched: no week record, no metrics, no
+    // exit-code change. Its offer is real and its list is real, but it is not a
+    // datapoint about the schedule (MEM9_CLEANUP_SCHEDULED_ENV).
+    if (!scheduled) return offer;
     const outcome = await recordScanOutcome({
       ssm,
       ssmPrefix,
@@ -4637,6 +4668,7 @@ async function buildPostApproval(opts, region, runtime) {
       // `log` adds — makes `{ $.event = ... }` stop matching, silently, with the
       // alarms then reading no datapoints and sitting green forever.
       emit: (event) => console.log(JSON.stringify(event)),
+      scheduled: process.env[MEM9_CLEANUP_SCHEDULED_ENV] === "1",
     });
 }
 

--- a/scripts/memory-cleanup.mjs
+++ b/scripts/memory-cleanup.mjs
@@ -1130,14 +1130,15 @@ export function decisionArtifactHash(serialized) {
 /**
  * The scheduled scan's week history (#154), and the reason it exists in SSM at all.
  *
- * A CloudWatch alarm's evaluation window is capped at 604800s (`Period` ×
- * `EvaluationPeriods`), and the scan is WEEKLY — so two consecutive scans are 14
- * days apart and one alarm can observe at most one of them. ">= 2 consecutive
- * zero-offer weeks" is therefore not expressible in any single alarm, by any
- * combination of period, evaluationPeriods, datapointsToAlarm, or metric math.
- * The 14-day memory has to be persisted, so it lives here as the smallest thing
- * that works: one immutable record per ISO week, and a pure function over the last
- * few of them. The alarm stays dumb (`>= 2` on a static threshold).
+ * A CloudWatch alarm's total evaluation window is capped at 604800s — seven days —
+ * for `Period` × `EvaluationPeriods`, and the scan is WEEKLY. A window guaranteed to
+ * contain two consecutive runs would have to be longer than seven days, which the cap
+ * rejects (`period=604800, evaluationPeriods=2` is 1209600s), so ">= 2 consecutive
+ * zero-offer weeks" is not expressible in any single alarm, by any combination of
+ * period, evaluationPeriods, datapointsToAlarm, or metric math. Memory spanning two
+ * runs therefore has to be persisted, and it lives here as the smallest thing that
+ * works: one immutable record per ISO week, and a pure function over the last few of
+ * them. The alarm stays dumb (`>= 2` on a static threshold).
  *
  * A per-week KEY, deliberately not a counter. A same-week retry is then an
  * idempotent rewrite of one key — no read-modify-write, so no double-increment
@@ -1234,6 +1235,40 @@ export function quietWeekStreak(weeks, records) {
 }
 
 /**
+ * A stored week record, or a throw.
+ *
+ * Shape-checked, not merely parsed, and the difference is the whole point:
+ * `{"offered":"0"}` is valid JSON, reads as NOT zero, and would break the streak —
+ * publishing a LOWER count than the truth and suppressing the page. That is this
+ * feature's own failure mode arriving as data rather than as an error, so a record
+ * that does not describe its own week with an integer count is treated the way an
+ * unreadable one is: loudly, with no count published at all.
+ *
+ * The error names the two fields it judged and never the raw value. Neither field
+ * carries memory content (a stage, an ISO week and a count), so this stays inside
+ * the same no-content rule the offered record and the log lines follow.
+ */
+function parseWeekRecord({ week, stage, value }) {
+  const record = JSON.parse(value);
+  const usable =
+    record !== null &&
+    typeof record === "object" &&
+    record.isoWeek === week &&
+    record.stage === stage &&
+    Number.isInteger(record.offered) &&
+    record.offered >= 0;
+  if (!usable) {
+    throw new Error(
+      `the scan-outcome record for ${week} does not describe that week for ` +
+        `${stage} (isoWeek=${JSON.stringify(record?.isoWeek)}, ` +
+        `stage=${JSON.stringify(record?.stage)}, ` +
+        `offered=${JSON.stringify(record?.offered)})`,
+    );
+  }
+  return record;
+}
+
+/**
  * Write this week's record, derive the streak from the weeks before it, and report
  * both to the caller.
  *
@@ -1311,17 +1346,22 @@ export async function recordScanOutcome({
         (each) => scanOutcomeParameterName(ssmPrefix, each) === parameter.Name,
       );
       if (!found) continue;
-      // A value that will not parse is treated as a read FAILURE, not as absence.
-      // Absence lowers the streak legitimately; a corrupt record lowering it would
-      // be this issue's own failure mode — a silently smaller number suppressing
-      // the page — so it is reported loudly and the count is withheld.
-      records[found] = JSON.parse(parameter.Value);
+      // A value that will not parse — or parses into something that is not a week
+      // record — is treated as a read FAILURE, not as absence. Absence lowers the
+      // streak legitimately; a corrupt record lowering it would be this issue's own
+      // failure mode, a silently smaller number suppressing the page, so it is
+      // reported loudly and the count is withheld.
+      records[found] = parseWeekRecord({
+        week: found,
+        stage,
+        value: parameter.Value,
+      });
     }
   } catch (err) {
     log(
-      `the scan-outcome history for ${stage} could not be read (${err.message}), ` +
-        `so no quiet-week count was published for ${week}; this week's own record ` +
-        `was written`,
+      `the scan-outcome history for ${stage} could not be used ` +
+        `(${err.message}), so no quiet-week count was published for ${week}; ` +
+        `this week's own record was written`,
     );
     return { isoWeek: week, offered, failed: "read" };
   }

--- a/scripts/memory-cleanup.mjs
+++ b/scripts/memory-cleanup.mjs
@@ -1244,25 +1244,28 @@ export function quietWeekStreak(weeks, records) {
  * that does not describe its own week with an integer count is treated the way an
  * unreadable one is: loudly, with no count published at all.
  *
- * The error names the two fields it judged and never the raw value. Neither field
- * carries memory content (a stage, an ISO week and a count), so this stays inside
- * the same no-content rule the offered record and the log lines follow.
+ * The error names WHICH fields failed and never their values. A record that failed
+ * validation is by definition not known to hold what this code put there, and the
+ * error text reaches CloudWatch — so echoing the stored bytes back would be the one
+ * way this path could publish content nobody reviewed. The week and stage in the
+ * message are this run's own, not the record's.
  */
 function parseWeekRecord({ week, stage, value }) {
   const record = JSON.parse(value);
-  const usable =
-    record !== null &&
-    typeof record === "object" &&
-    record.isoWeek === week &&
-    record.stage === stage &&
-    Number.isInteger(record.offered) &&
-    record.offered >= 0;
-  if (!usable) {
+  const shaped = record !== null && typeof record === "object";
+  const failed = shaped
+    ? [
+        record.isoWeek === week ? undefined : "isoWeek",
+        record.stage === stage ? undefined : "stage",
+        Number.isInteger(record.offered) && record.offered >= 0
+          ? undefined
+          : "offered",
+      ].filter(Boolean)
+    : ["the record itself"];
+  if (failed.length > 0) {
     throw new Error(
       `the scan-outcome record for ${week} does not describe that week for ` +
-        `${stage} (isoWeek=${JSON.stringify(record?.isoWeek)}, ` +
-        `stage=${JSON.stringify(record?.stage)}, ` +
-        `offered=${JSON.stringify(record?.offered)})`,
+        `${stage}: ${failed.join(", ")} did not validate`,
     );
   }
   return record;

--- a/scripts/memory-cleanup.test.mjs
+++ b/scripts/memory-cleanup.test.mjs
@@ -6407,6 +6407,10 @@ describe("offering the list to Slack (#123)", () => {
         // pass their own `now`.
         now: overrides.now ?? (() => Date.parse("2026-08-05T03:00:00.000Z")),
         emit,
+        // These cases model the SCHEDULED scan, which is the only run that keeps week
+        // history (#154). TC-SLACKAPP-239 covers the operator-CLI side, where the
+        // marker is absent and none of it happens.
+        scheduled: overrides.scheduled ?? true,
         log: overrides.log ?? vi.fn(),
       }),
     };
@@ -6938,11 +6942,23 @@ describe("offering the list to Slack (#123)", () => {
     // be this issue's own failure mode wearing a different hat.
     const corrupt = offerFakes(
       {},
-      { weeks: { [SCAN_OUTCOME("2026-W31")]: "{not json" } },
+      { weeks: { [SCAN_OUTCOME("2026-W31")]: "{not json SENTINEL-STORED-BYTES" } },
     );
-    const corrupted = offer({ fakes: corrupt, decisions: [del("m-1")] });
+    const corruptLog = vi.fn();
+    const corrupted = offer({
+      fakes: corrupt,
+      log: corruptLog,
+      decisions: [del("m-1")],
+    });
     expect((await corrupted.promise).outcome.failed).toBe("read");
     expect(corrupted.emit).not.toHaveBeenCalled();
+    // Node quotes a slice of the input in its own `JSON.parse` message, and this text
+    // is logged — so the parse error is discarded and replaced. The stored bytes of a
+    // record that could not be trusted must not reach CloudWatch through the very
+    // path that refused to trust it.
+    const corruptLogged = corruptLog.mock.calls.flat().join("\n");
+    expect(corruptLogged).toMatch(/is not valid JSON/u);
+    expect(corruptLogged).not.toContain("SENTINEL-STORED-BYTES");
   });
 
   it("TC-SLACKAPP-238 refuses a week record that PARSES but is not a week record (#154)", async () => {
@@ -8051,6 +8067,7 @@ describe("offering the list to Slack (#123)", () => {
 describe("wiring the offer into the review run (#123)", () => {
   const environmentKeys = [
     "AWS_REGION",
+    "MEM9_CLEANUP_SCHEDULED",
     "MEM9_DB_HOST",
     "MEM9_DB_NAME",
     "MEM9_DB_PORT",
@@ -8106,6 +8123,9 @@ describe("wiring the offer into the review run (#123)", () => {
     reviewEnv({
       MEM9_SLACK_APPROVAL_CHANNEL: "C0APPROVAL",
       SLACK_BOT_TOKEN: "xoxb-injected",
+      // The marker the Scheduler override sets. Without it there is no week history
+      // and no metric line at all, which is TC-SLACKAPP-239's half of this contract.
+      MEM9_CLEANUP_SCHEDULED: "1",
     });
     const production = await createCleanupDeps(
       { stage: "prod", apply: false, cap: 50 },
@@ -8138,6 +8158,54 @@ describe("wiring the offer into the review run (#123)", () => {
       const prefixed = stderr.mock.calls.flat().filter((each) => typeof each === "string");
       expect(prefixed.length).toBeGreaterThan(0);
       for (const each of prefixed) expect(each).toMatch(/^\[memory-cleanup /u);
+    } finally {
+      stdout.mockRestore();
+      stderr.mockRestore();
+      await production.close();
+    }
+  });
+
+  it("TC-SLACKAPP-239 keeps an off-schedule run out of the week history entirely (#154)", async () => {
+    // An operator's hand-run dry run with Slack configured is a real offer and a real
+    // list, and it is NOT a datapoint about the schedule. Two failure modes if it
+    // were: a hand-run that offered nothing could supply the SECOND quiet week and
+    // page for a classifier that is fine, and ANY hand-run would publish `ScanRan`,
+    // holding the liveness alarm green for another seven days while the Scheduler was
+    // dead. So the marker gates the bookkeeping, and the offer is untouched by it.
+    reviewEnv({
+      MEM9_SLACK_APPROVAL_CHANNEL: "C0APPROVAL",
+      SLACK_BOT_TOKEN: "xoxb-injected",
+    });
+    expect(process.env.MEM9_CLEANUP_SCHEDULED).toBeUndefined();
+    const ssm = ssmFake();
+    const production = await createCleanupDeps(
+      { stage: "prod", apply: false, cap: 50 },
+      { ssm, getToken: vi.fn(), fromNodeProviderChain: vi.fn() },
+    );
+    const stdout = vi.spyOn(console, "log").mockImplementation(() => {});
+    const stderr = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const offered = await production.deps.postApproval({
+        decisions: [],
+        generatedAt: "2026-08-05T03:00:00.000Z",
+        issuedAt: "2026-08-05T03:00:00.000Z",
+      });
+      // The offer happened: the record was written, which is what invalidates a
+      // previous offer, and the run reports it exactly as before.
+      const writes = ssm.sent.filter((input) => input.Name);
+      expect(writes.map((input) => input.Name)).toEqual([
+        "/mem9-on-aws/prod/approvals/offered",
+      ]);
+      expect(offered.record.ids).toEqual([]);
+      // And nothing else: no week record, no history read, no metric line, and no
+      // `outcome` for `runCleanup` to change an exit code over.
+      expect(
+        ssm.sent.filter((input) =>
+          JSON.stringify(input).includes("scan-outcome"),
+        ),
+      ).toEqual([]);
+      expect(stdout).not.toHaveBeenCalled();
+      expect(offered.outcome).toBeUndefined();
     } finally {
       stdout.mockRestore();
       stderr.mockRestore();

--- a/scripts/memory-cleanup.test.mjs
+++ b/scripts/memory-cleanup.test.mjs
@@ -6929,7 +6929,7 @@ describe("offering the list to Slack (#123)", () => {
     // lower value for `$.quietWeeks`, which is the suppression this guards against.
     expect(run.emit).not.toHaveBeenCalled();
     const logged = log.mock.calls.flat().join("\n");
-    expect(logged).toMatch(/scan-outcome history for prod could not be read/u);
+    expect(logged).toMatch(/scan-outcome history for prod could not be used/u);
     expect(logged).toContain("2026-W32");
 
     // A record whose value will not PARSE is a read failure too, not an absence.
@@ -6942,6 +6942,68 @@ describe("offering the list to Slack (#123)", () => {
     const corrupted = offer({ fakes: corrupt, decisions: [del("m-1")] });
     expect((await corrupted.promise).outcome.failed).toBe("read");
     expect(corrupted.emit).not.toHaveBeenCalled();
+  });
+
+  it("TC-SLACKAPP-238 refuses a week record that PARSES but is not a week record (#154)", async () => {
+    // The gap `JSON.parse` alone leaves, and the most dangerous shape in this
+    // feature: `{"offered":"0"}` is valid JSON and reads as NOT zero, so it would
+    // break the streak and publish a SMALLER count — silently suppressing the page
+    // this issue exists to raise. Same for a record that describes a different week
+    // or a different stage: it is not evidence about the week it was found under.
+    // Every case here must be reported, not absorbed.
+    const cases = {
+      "a string count": { stage: "prod", isoWeek: "2026-W31", offered: "0" },
+      "a missing count": { stage: "prod", isoWeek: "2026-W31" },
+      "a fractional count": { stage: "prod", isoWeek: "2026-W31", offered: 0.5 },
+      "a negative count": { stage: "prod", isoWeek: "2026-W31", offered: -1 },
+      "another week": { stage: "prod", isoWeek: "2026-W12", offered: 0 },
+      "another stage": { stage: "pr-9", isoWeek: "2026-W31", offered: 0 },
+      "a bare number": 0,
+      "null": null,
+    };
+    for (const [what, value] of Object.entries(cases)) {
+      const fakes = offerFakes(
+        {},
+        { weeks: { [SCAN_OUTCOME("2026-W31")]: JSON.stringify(value) } },
+      );
+      const log = vi.fn();
+      const run = offer({ fakes, log, decisions: [del("m-1")] });
+      const offered = await run.promise;
+      // No count published, and the run is flagged for a non-zero exit — never a
+      // lower number derived from a record nothing can vouch for.
+      expect(offered.outcome, what).toMatchObject({ failed: "read" });
+      expect(offered.outcome.quietWeeks, what).toBeUndefined();
+      expect(run.emit, what).not.toHaveBeenCalled();
+      // And the offer still stood: this is bookkeeping, and the operator's list was
+      // written and posted before any of it ran.
+      expect(offered.posted, what).toBe(true);
+      const logged = log.mock.calls.flat().join("\n");
+      expect(logged, what).toMatch(/does not describe that week/u);
+      // The refusal names the fields it judged, not the stored value verbatim.
+      expect(logged, what).toContain("2026-W31");
+    }
+
+    // The converse, so the validator cannot be satisfied by rejecting everything: a
+    // well-formed record is still accepted and still counted.
+    const good = offerFakes(
+      {},
+      {
+        weeks: {
+          [SCAN_OUTCOME("2026-W31")]: JSON.stringify({
+            stage: "prod",
+            isoWeek: "2026-W31",
+            offered: 0,
+            at: "2026-07-29T03:00:00.000Z",
+          }),
+        },
+      },
+    );
+    const accepted = offer({
+      fakes: good,
+      decisions: [{ id: "m-keep", verdict: "KEEP", reason: "durable" }],
+    });
+    await accepted.promise;
+    expect(accepted.emit.mock.calls[0][0].quietWeeks).toBe(2);
   });
 
   it("TC-SLACKAPP-235 keeps the week bookkeeping last, so it cannot cost an offer (#154)", async () => {

--- a/scripts/memory-cleanup.test.mjs
+++ b/scripts/memory-cleanup.test.mjs
@@ -6211,8 +6211,9 @@ describe("the scheduled scan's week history (#154)", () => {
 
   it("TC-SLACKAPP-232 counts only contiguous, present, zero-offer weeks", () => {
     // The alarm's whole input, as a pure function, because the 604800s evaluation
-    // cap means no alarm can derive it: two weekly scans are 14 days apart, so one
-    // alarm sees at most one of them.
+    // cap means no alarm can derive it: consecutive weekly scans are seven days
+    // apart, and a window guaranteed to contain two of them has to be longer than
+    // the seven-day maximum for `Period` × `EvaluationPeriods`.
     const weeks = ["2026-W32", "2026-W31", "2026-W30", "2026-W29"];
     const quiet = (week) => [week, { offered: 0 }];
     const busy = (week, offered = 3) => [week, { offered }];
@@ -6979,8 +6980,15 @@ describe("offering the list to Slack (#123)", () => {
       expect(offered.posted, what).toBe(true);
       const logged = log.mock.calls.flat().join("\n");
       expect(logged, what).toMatch(/does not describe that week/u);
-      // The refusal names the fields it judged, not the stored value verbatim.
+      expect(logged, what).toMatch(/did not validate/u);
+      // The week and stage named are THIS RUN's, and no stored field VALUE is echoed:
+      // a record that failed validation is not known to hold what this code wrote, and
+      // the error text reaches CloudWatch.
       expect(logged, what).toContain("2026-W31");
+      if (value && typeof value === "object" && typeof value.isoWeek === "string") {
+        expect(logged, what).not.toContain("2026-W12");
+      }
+      expect(logged, what).not.toContain("pr-9");
     }
 
     // The converse, so the validator cannot be satisfied by rejecting everything: a

--- a/scripts/memory-cleanup.test.mjs
+++ b/scripts/memory-cleanup.test.mjs
@@ -29,6 +29,11 @@ import {
   parseArgs,
   postApprovalRequest,
   putDecisionArtifact,
+  isoWeek,
+  recentIsoWeeks,
+  scanOutcomeParameterName,
+  quietWeekStreak,
+  recordScanOutcome,
   serializeDecisionArtifact,
   updateApprovalMessage,
   consensusDecisions,
@@ -6156,10 +6161,111 @@ describe("replaying the reviewed list instead of re-classifying (#150)", () => {
   });
 });
 
+describe("the scheduled scan's week history (#154)", () => {
+  it("TC-SLACKAPP-231 numbers ISO weeks the way both the writer and the reader must agree on", () => {
+    // ONE function serves the write and the read, so a W52/W53 disagreement here is
+    // not an off-by-one — it is a reader looking up weeks nothing ever writes, and
+    // an alarm that never fires again. Every case below is a real year boundary,
+    // asserted against literals rather than against a second implementation.
+    //
+    // ISO-8601 takes the week-numbering YEAR from the week's Thursday (§3.17), which
+    // is why a January date can belong to the previous year's W52 or W53.
+    const week = (iso) => isoWeek(Date.parse(iso));
+    expect(week("2026-01-01T00:00:00Z")).toBe("2026-W01"); // a Thursday: its own W01
+    expect(week("2026-08-05T03:00:00Z")).toBe("2026-W32"); // the fixture clock
+    expect(week("2026-12-31T23:59:59Z")).toBe("2026-W53"); // Thu 2026-12-31 → W53
+    expect(week("2027-01-01T00:00:00Z")).toBe("2026-W53"); // Friday: still 2026
+    expect(week("2021-01-01T00:00:00Z")).toBe("2020-W53"); // Friday: 2020 had 53
+    expect(week("2023-01-01T00:00:00Z")).toBe("2022-W52"); // Sunday: 2022 had 52
+    expect(week("2024-12-30T00:00:00Z")).toBe("2025-W01"); // Monday: next year's W01
+
+    // The scan runs at 03:00 UTC on a Saturday, so the arithmetic is UTC-only. A
+    // local-time reading west of the prime meridian would put that instant in the
+    // previous week and the record would be written under a key the next run does
+    // not look up.
+    expect(week("2026-08-08T03:00:00Z")).toBe("2026-W32");
+    expect(week("2026-08-10T03:00:00Z")).toBe("2026-W33");
+
+    // Walked back by whole weeks and re-derived, NOT by decrementing a week number,
+    // which would have to know whether the previous year had 52 or 53 weeks.
+    expect(recentIsoWeeks(Date.parse("2026-08-05T03:00:00Z"))).toEqual([
+      "2026-W32",
+      "2026-W31",
+      "2026-W30",
+      "2026-W29",
+    ]);
+    expect(recentIsoWeeks(Date.parse("2027-01-07T03:00:00Z"))).toEqual([
+      "2027-W01",
+      "2026-W53",
+      "2026-W52",
+      "2026-W51",
+    ]);
+    // Four weeks read, and that bound matters twice: `GetParameters` takes at most
+    // ten names, and the threshold this feeds is 2 — so four is headroom, not a
+    // number to grow casually.
+    expect(recentIsoWeeks(Date.now())).toHaveLength(4);
+    expect(scanOutcomeParameterName("/mem9-on-aws/prod", "2026-W32")).toBe(
+      "/mem9-on-aws/prod/approvals/scan-outcome-2026-W32",
+    );
+  });
+
+  it("TC-SLACKAPP-232 counts only contiguous, present, zero-offer weeks", () => {
+    // The alarm's whole input, as a pure function, because the 604800s evaluation
+    // cap means no alarm can derive it: two weekly scans are 14 days apart, so one
+    // alarm sees at most one of them.
+    const weeks = ["2026-W32", "2026-W31", "2026-W30", "2026-W29"];
+    const quiet = (week) => [week, { offered: 0 }];
+    const busy = (week, offered = 3) => [week, { offered }];
+
+    expect(quietWeekStreak(weeks, Object.fromEntries([busy("2026-W32")]))).toBe(0);
+    // ONE quiet week is the boundary that must NOT breach: it is a normal week with
+    // nothing to clean, and paging on it would page most weeks.
+    expect(quietWeekStreak(weeks, Object.fromEntries([quiet("2026-W32")]))).toBe(1);
+    expect(
+      quietWeekStreak(weeks, Object.fromEntries([quiet("2026-W32"), quiet("2026-W31")])),
+    ).toBe(2);
+    expect(
+      quietWeekStreak(
+        weeks,
+        Object.fromEntries([quiet("2026-W32"), quiet("2026-W31"), quiet("2026-W30")]),
+      ),
+    ).toBe(3);
+
+    // A non-zero week RESETS it rather than being skipped: the signal is
+    // consecutive, so one week that offered something means the classifier was
+    // producing a consensus that recently.
+    expect(
+      quietWeekStreak(
+        weeks,
+        Object.fromEntries([quiet("2026-W32"), busy("2026-W31"), quiet("2026-W30")]),
+      ),
+    ).toBe(1);
+
+    // An ABSENT record breaks the streak. Asserted explicitly because the tempting
+    // alternative — skip the gap and keep counting — invents contiguity that never
+    // existed, and a week whose record was never written would then push the count
+    // over the threshold on its own.
+    expect(
+      quietWeekStreak(
+        weeks,
+        Object.fromEntries([quiet("2026-W32"), quiet("2026-W30"), quiet("2026-W29")]),
+      ),
+    ).toBe(1);
+    // Including the current week: no record at all is a count of 0, never a
+    // pessimistic guess.
+    expect(quietWeekStreak(weeks, {})).toBe(0);
+  });
+});
+
 describe("offering the list to Slack (#123)", () => {
   const BOT_TOKEN = "xoxb-fixture-not-a-real-token";
   const CHANNEL = "C0APPROVAL";
   const OFFERED = "/mem9-on-aws/prod/approvals/offered";
+  // Spelled out rather than built with the module's own `scanOutcomeParameterName`:
+  // a fixture that derived the name the same way the code does would follow a rename
+  // into a set of weeks nothing writes. The ISO week keys come from the fixture clock
+  // (2026-08-05 → W32); TC-SLACKAPP-231 is what pins the arithmetic itself.
+  const SCAN_OUTCOME = (week) => `/mem9-on-aws/prod/approvals/scan-outcome-${week}`;
   const SNIPPET = "SENTINEL-MEMORY-SNIPPET";
   const MERGED = "SENTINEL-MERGED-CONTENT";
   // Slack's own per-section ceiling, spelled as the literal it is on the wire
@@ -6182,7 +6288,7 @@ describe("offering the list to Slack (#123)", () => {
    * before the record it is validated against is a promise the backend cannot
    * keep.
    */
-  function offerFakes(slackBodies = {}, { pending } = {}) {
+  function offerFakes(slackBodies = {}, { pending, weeks = {}, failRead, failWrite } = {}) {
     const events = [];
     const ssm = {
       puts: [],
@@ -6196,6 +6302,18 @@ describe("offering the list to Slack (#123)", () => {
         const names = command?.input?.Names;
         if (names) {
           events.push(["ssm-get", ...names]);
+          // #154's week history is answered by NAME, so a case can seed one week and
+          // leave the next absent. Answering every name with `pending` — which this
+          // fake did while `approvals/offered` was the only read — would have made
+          // every week look present and the streak untestable.
+          if (names.every((name) => name.includes("/scan-outcome-"))) {
+            if (failRead) throw new Error("ssm unavailable");
+            const found = names.filter((name) => name in weeks);
+            return {
+              Parameters: found.map((name) => ({ Name: name, Value: weeks[name] })),
+              InvalidParameters: names.filter((name) => !(name in weeks)),
+            };
+          }
           // The shape SSM really returns, as `fakeSsm` above models it: an absent
           // name is echoed in `InvalidParameters` and simply MISSING from
           // `Parameters`, never present with an empty value.
@@ -6204,6 +6322,9 @@ describe("offering the list to Slack (#123)", () => {
             Parameters: names.map((name) => ({ Name: name, Value: pending })),
             InvalidParameters: [],
           };
+        }
+        if (failWrite && command.input.Name.includes("/scan-outcome-")) {
+          throw new Error("ssm throttled");
         }
         events.push(["ssm", command.input.Name]);
         ssm.puts.push(command.input);
@@ -6249,11 +6370,16 @@ describe("offering the list to Slack (#123)", () => {
 
   function offer(overrides = {}) {
     const { ssm, slack, s3, events } = overrides.fakes ?? offerFakes();
+    // Always a spy, never the real emitter: #154's JSON line is a fourth
+    // destination for run data, and every case that asserts what a destination may
+    // carry needs to be able to read it (TC-SLACKAPP-210).
+    const emit = overrides.emit ?? vi.fn();
     return {
       events,
       ssm,
       slack,
       s3,
+      emit,
       log: overrides.log,
       promise: postApprovalRequest({
         ssm,
@@ -6274,7 +6400,12 @@ describe("offering the list to Slack (#123)", () => {
           ? EXPECTED_BUCKET_OWNER
           : undefined,
         fetchImpl: slack.fetchImpl,
-        now: overrides.now,
+        // A FIXED default clock, not `Date.now`. The week keys #154's records are
+        // named for come from this value, so a real clock would make every asserted
+        // parameter name drift once a week. Cases that exercise the offer TTL still
+        // pass their own `now`.
+        now: overrides.now ?? (() => Date.parse("2026-08-05T03:00:00.000Z")),
+        emit,
         log: overrides.log ?? vi.fn(),
       }),
     };
@@ -6293,11 +6424,21 @@ describe("offering the list to Slack (#123)", () => {
     // The READ comes first (#149): overwriting a record an operator is still
     // deciding on destroys their pending approval, so the scan checks before it
     // clobbers. Everything after it is the original #123 order.
+    // #154's week bookkeeping is LAST, after the post and the stamp, and that
+    // position is a property: it is input to an alarm, so it must never be able to
+    // stop a review list from reaching the operator (TC-SLACKAPP-235).
     expect(fakes.events).toEqual([
       ["ssm-get", OFFERED],
       ["ssm", OFFERED],
       ["slack", "chat.postMessage"],
       ["ssm", OFFERED],
+      ["ssm", SCAN_OUTCOME("2026-W32")],
+      [
+        "ssm-get",
+        SCAN_OUTCOME("2026-W31"),
+        SCAN_OUTCOME("2026-W30"),
+        SCAN_OUTCOME("2026-W29"),
+      ],
     ]);
     const [first] = fakes.ssm.puts;
     expect(first.Name).toBe(OFFERED);
@@ -6675,11 +6816,159 @@ describe("offering the list to Slack (#123)", () => {
       ],
     }).promise;
 
-    expect(fakes.ssm.puts).toHaveLength(1);
+    // Two writes: the empty offered record, then #154's week record. The empty
+    // record is still written — that is what invalidates last week's button — and
+    // the week record is what a zero-offer streak is later derived from.
+    expect(fakes.ssm.puts).toHaveLength(2);
     expect(JSON.parse(fakes.ssm.puts[0].Value).ids).toEqual([]);
+    expect(fakes.ssm.puts[1].Name).toBe(SCAN_OUTCOME("2026-W32"));
+    expect(JSON.parse(fakes.ssm.puts[1].Value).offered).toBe(0);
     expect(fakes.slack.fetchImpl).not.toHaveBeenCalled();
     expect(result.posted).toBe(false);
     expect(result.messageTs).toBeUndefined();
+  });
+
+  it("TC-SLACKAPP-233 writes the week record and publishes the derived streak (#154)", async () => {
+    // The signal a zero-offer week produces, end to end through the real offer. What
+    // it is for: `consensusDecisions` needs >= 2 usable passes to AGREE, and one pass
+    // reproduced only 66% of its own DELETE set on re-run — so a partial classifier
+    // degradation can empty the intersection while every batch still succeeds, and
+    // the run then exits 0, which no task-exit alarm can see.
+    const weekRecord = (week, offered) =>
+      JSON.stringify({ stage: "prod", isoWeek: week, offered, at: `${week}-fixture` });
+    const seeded = () =>
+      offerFakes(
+        {},
+        { weeks: { [SCAN_OUTCOME("2026-W31")]: weekRecord("2026-W31", 0) } },
+      );
+    const nothingToOffer = [
+      { id: "m-keep", verdict: "KEEP", reason: "durable" },
+      { id: "m-unstable", verdict: "UNSTABLE", reason: "passes disagreed on deletion" },
+    ];
+
+    const fakes = seeded();
+    const quiet = offer({ fakes, decisions: nothingToOffer });
+    await quiet.promise;
+
+    const weekPut = fakes.ssm.puts.find((put) => put.Name === SCAN_OUTCOME("2026-W32"));
+    expect(JSON.parse(weekPut.Value)).toMatchObject({
+      stage: "prod",
+      isoWeek: "2026-W32",
+      offered: 0,
+    });
+    // Same two runtime constraints as `approvals/offered`: the boundary denies a
+    // SecureString write, and `Overwrite: false` would make a same-week retry fail
+    // with `ParameterAlreadyExists` instead of rewriting one week.
+    expect(weekPut.Type).toBe("String");
+    expect(weekPut.Overwrite).toBe(true);
+    // Only the PRIOR weeks are read: the current week is the value this run just
+    // computed, so reading it back would make the derivation depend on
+    // read-after-write timing for no gain.
+    const historyRead = fakes.ssm.send.mock.calls
+      .map(([command]) => command.input.Names)
+      .find((names) => names?.some((name) => name.includes("/scan-outcome-")));
+    expect(historyRead).toEqual([
+      SCAN_OUTCOME("2026-W31"),
+      SCAN_OUTCOME("2026-W30"),
+      SCAN_OUTCOME("2026-W29"),
+    ]);
+
+    // ONE JSON object, carrying both metrics the two alarms read. Asserted whole:
+    // an extra field would be a new destination for run data, and a missing one is
+    // an alarm with no input.
+    expect(quiet.emit.mock.calls).toHaveLength(1);
+    // The event name as the LITERAL, not the imported constant: it is a contract
+    // with `infra/slack-approval.ts`'s filter pattern, which cannot import from this
+    // file (it runs in the Pulumi program, not the container). Pinned by literal on
+    // both sides, a rename turns one of the two red instead of leaving them
+    // disagreeing with every alarm silently dark.
+    expect(quiet.emit.mock.calls[0][0]).toEqual({
+      event: "cleanup_scan_outcome",
+      stage: "prod",
+      isoWeek: "2026-W32",
+      offered: 0,
+      quietWeeks: 2,
+      scanRan: 1,
+    });
+
+    // A same-week RETRY — the schedule has maximumRetryAttempts 1 — rewrites the one
+    // key and derives the same count. This is why the record is keyed per week
+    // rather than being a counter: there is no read-modify-write to race.
+    const retryFakes = seeded();
+    const retry = offer({ fakes: retryFakes, decisions: nothingToOffer });
+    await retry.promise;
+    expect(retry.emit.mock.calls[0][0].quietWeeks).toBe(2);
+    expect(
+      retryFakes.ssm.puts.filter((put) => put.Name.includes("/scan-outcome-")),
+    ).toHaveLength(1);
+
+    // A week that DID offer publishes its count and a streak of 0: the classifier
+    // produced a consensus, which is the condition the alarm must not fire on.
+    const busyFakes = seeded();
+    const busy = offer({ fakes: busyFakes, decisions: [del("m-1"), del("m-2")] });
+    await busy.promise;
+    expect(busy.emit.mock.calls[0][0]).toMatchObject({ offered: 2, quietWeeks: 0 });
+  });
+
+  it("TC-SLACKAPP-234 withholds the count when the history cannot be read, and never rounds it down (#154)", async () => {
+    // The mechanism partly watches itself: the scan computes the number its own
+    // alarm reads. So the failure to design against is not a crash, it is a read
+    // that quietly yields a SMALLER count and suppresses the page. A failed read
+    // publishes NOTHING and is reported for a non-zero exit instead.
+    const failing = offerFakes({}, { failRead: true });
+    const log = vi.fn();
+    const run = offer({ fakes: failing, log, decisions: [del("m-1")] });
+    const offered = await run.promise;
+
+    // The offer itself is untouched: written, posted, and returned as posted. The
+    // history is bookkeeping and must not cost the operator their review list.
+    expect(offered.posted).toBe(true);
+    expect(failing.slack.calls).toHaveLength(1);
+    expect(offered.outcome).toMatchObject({ isoWeek: "2026-W32", failed: "read" });
+    // NOTHING published. A line without `quietWeeks` would make the filter publish a
+    // lower value for `$.quietWeeks`, which is the suppression this guards against.
+    expect(run.emit).not.toHaveBeenCalled();
+    const logged = log.mock.calls.flat().join("\n");
+    expect(logged).toMatch(/scan-outcome history for prod could not be read/u);
+    expect(logged).toContain("2026-W32");
+
+    // A record whose value will not PARSE is a read failure too, not an absence.
+    // Absence legitimately breaks the streak; corruption lowering it silently would
+    // be this issue's own failure mode wearing a different hat.
+    const corrupt = offerFakes(
+      {},
+      { weeks: { [SCAN_OUTCOME("2026-W31")]: "{not json" } },
+    );
+    const corrupted = offer({ fakes: corrupt, decisions: [del("m-1")] });
+    expect((await corrupted.promise).outcome.failed).toBe("read");
+    expect(corrupted.emit).not.toHaveBeenCalled();
+  });
+
+  it("TC-SLACKAPP-235 keeps the week bookkeeping last, so it cannot cost an offer (#154)", async () => {
+    // ORDER, asserted as a property rather than inherited from where the call
+    // happens to sit: the week record is written after the offered record, after the
+    // post, and after the stamp. Earlier, a throttled `PutParameter` on a telemetry
+    // parameter would stop an operator's review list from being posted at all.
+    const failing = offerFakes({}, { failWrite: true });
+    const log = vi.fn();
+    const run = offer({ fakes: failing, log, decisions: [del("m-1")] });
+    const offered = await run.promise;
+
+    expect(offered.posted).toBe(true);
+    expect(failing.slack.calls).toHaveLength(1);
+    // The offered record and its stamp both landed; only the week record failed.
+    expect(failing.ssm.puts.map((put) => put.Name)).toEqual([
+      "/mem9-on-aws/prod/approvals/offered",
+      "/mem9-on-aws/prod/approvals/offered",
+    ]);
+    expect(offered.outcome).toMatchObject({ failed: "write" });
+    expect(run.emit).not.toHaveBeenCalled();
+    // Reported, not swallowed: next week's derivation will read this week as absent,
+    // so the run must not exit 0 — `runCleanup` maps this to exit 1
+    // (TC-SLACKAPP-236).
+    expect(log.mock.calls.flat().join("\n")).toMatch(
+      /scan-outcome record \(2026-W32\) could not be written/u,
+    );
   });
 
   it("TC-SLACKAPP-110 stamps the message timestamp onto the record without failing the offer", async () => {
@@ -6689,7 +6978,8 @@ describe("offering the list to Slack (#123)", () => {
     // `ts` does not exist until the post returns.
     const fakes = offerFakes();
     const result = await offer({ fakes }).promise;
-    expect(fakes.ssm.puts).toHaveLength(2);
+    // Three writes now: the record, the stamp, and #154's week record last.
+    expect(fakes.ssm.puts).toHaveLength(3);
     const stamped = JSON.parse(fakes.ssm.puts[1].Value);
     expect(stamped.messageTs).toBe("1754400000.000100");
     expect(stamped.messageChannel).toBe(CHANNEL);
@@ -6811,6 +7101,53 @@ describe("offering the list to Slack (#123)", () => {
     expect(offeredLog).toMatch(/offered 1 id\(s\) to Slack/u);
     expect(offeredLog).not.toMatch(/skipping the Slack offer/u);
     expect(offeredLog).not.toContain("MEM9_SLACK_APPROVAL_CHANNEL");
+  });
+
+  it("TC-SLACKAPP-236 exits non-zero when the quiet-week count is missing, and 0 when the week is merely quiet (#154)", async () => {
+    // The scan derives the number its own alarm reads, so a run that could not derive
+    // it has to say so through the one channel that already pages: the task-exit
+    // alarm. Exit 0 there would leave the streak alarm with a gap it reads as
+    // `notBreaching` — silence standing in for health, which is the defect #154 was
+    // filed against.
+    const server = fakeServer([memory("del-1", "session noise")]);
+    const llm = fakeLlm([[{ id: "del-1", verdict: "DELETE", reason: "session-state" }]]);
+    const deps = {
+      ...baseDeps(server, llm, tempDir()),
+      // The offer SUCCEEDED — written and posted — and only the bookkeeping failed.
+      // That is the case a `posted`-based exit code would score as a clean week.
+      postApproval: vi.fn(async () => ({
+        record: { ids: ["del-1"], hash: "sha256:x" },
+        posted: true,
+        outcome: { isoWeek: "2026-W32", offered: 1, failed: "read" },
+      })),
+    };
+    const failed = await runCleanup(baseOpts(), deps);
+    expect(failed.exitCode).toBe(1);
+    const logged = deps.log.mock.calls.flat().join("\n");
+    // Names the week and says what is missing, rather than reporting it as an offer
+    // failure — the offer is fine, and TC-SLACKAPP-113's line would send the
+    // operator looking at Slack.
+    expect(logged).toMatch(/quiet-week count for 2026-W32 could not be derived/u);
+    expect(logged).not.toMatch(/failed to offer the review list/u);
+    // The decision list still survives, as on every other exit-1 path.
+    expect(existsSync(failed.decisionPath)).toBe(true);
+
+    // And the whole point of the exit code being conditional: a genuinely quiet week
+    // — zero ids offered, streak derived and published — is NOT a failure. Exiting
+    // non-zero here would page for a healthy run every time there was nothing to
+    // clean, which is most weeks.
+    const quietServer = fakeServer([memory("keep-1", "durable decision")]);
+    const quietDeps = {
+      ...baseDeps(quietServer, fakeLlm([[{ id: "keep-1", verdict: "KEEP", reason: "durable" }]]), tempDir()),
+      postApproval: vi.fn(async () => ({
+        record: { ids: [], hash: "sha256:y" },
+        posted: false,
+        outcome: { isoWeek: "2026-W32", offered: 0, quietWeeks: 2 },
+      })),
+    };
+    const quiet = await runCleanup(baseOpts(), quietDeps);
+    expect(quiet.exitCode).toBe(0);
+    expect(quietDeps.log.mock.calls.flat().join("\n")).not.toMatch(/exiting non-zero/u);
   });
 
   it("TC-SLACKAPP-113 fails the run when the offer fails, naming the decision list it kept", async () => {
@@ -6968,7 +7305,8 @@ describe("offering the list to Slack (#123)", () => {
     const dead = offerFakes({}, { pending: pendingRecord({ issuedAt }) });
     const result = await offer({ fakes: dead, now: at(OFFER_TTL_MS + 1) }).promise;
     expect(result.posted).toBe(true);
-    expect(dead.ssm.puts).toHaveLength(2);
+    // Record, stamp, and #154's week record.
+    expect(dead.ssm.puts).toHaveLength(3);
     expect(JSON.parse(dead.ssm.puts[0].Value).ids).toEqual(["m-1", "m-2"]);
   });
 
@@ -7224,6 +7562,15 @@ describe("offering the list to Slack (#123)", () => {
       ["ssm", OFFERED],
       ["slack", "chat.postMessage"],
       ["ssm", OFFERED],
+      // #154's week bookkeeping, last on purpose: an alarm's input must not be able
+      // to stop the artifact, the record, or the post (TC-SLACKAPP-235).
+      ["ssm", SCAN_OUTCOME("2026-W32")],
+      [
+        "ssm-get",
+        SCAN_OUTCOME("2026-W31"),
+        SCAN_OUTCOME("2026-W30"),
+        SCAN_OUTCOME("2026-W29"),
+      ],
     ]);
     // The record names WHERE, and the key is the content-addressed one the writer
     // derived — so the apply can find the object from the record alone.
@@ -7411,9 +7758,11 @@ describe("offering the list to Slack (#123)", () => {
     const decisions = [del("m-1"), merge("surv", ["frag-1"], { content: CONTENT })];
     const fakes = offerFakes();
     const offerLog = vi.fn();
+    const emit = vi.fn();
     const offered = await offer({
       fakes,
       log: offerLog,
+      emit,
       decisions,
       artifactBucket: ARTIFACT.artifactBucket,
     }).promise;
@@ -7433,12 +7782,30 @@ describe("offering the list to Slack (#123)", () => {
 
     // 3. THE SSM RECORD DOES NOT, on either write. Asserted over the serialized
     // value, so a nested field added later cannot slip past a field-by-field check.
-    expect(fakes.ssm.puts).toHaveLength(2);
+    // Three writes since #154 — the record, the stamp, and the week record — and the
+    // sweep runs over ALL of them, which is what keeps a later field on the newest
+    // write from carrying memory text into a parameter.
+    expect(fakes.ssm.puts).toHaveLength(3);
     for (const put of fakes.ssm.puts) expect(put.Value).not.toContain(CONTENT);
 
     // 4. NO OFFER-SIDE LOG LINE DOES. `putDecisionArtifact` logs the key, the hash
     // and the byte count; `postApprovalRequest` logs the id count and the hash.
     expect(offerLog.mock.calls.flat().join("\n")).not.toContain(CONTENT);
+
+    // 4b. NOR DOES #154's JSON LINE, the destination this feature added. It carries
+    // an ISO week, two counts and a stage — no id, and certainly no merged text —
+    // and it goes to stdout where the metric filters read it, so a field added later
+    // would put memory content into CloudWatch metrics as a dimension value.
+    expect(JSON.stringify(emit.mock.calls)).not.toContain(CONTENT);
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(Object.keys(emit.mock.calls[0][0]).sort()).toEqual([
+      "event",
+      "isoWeek",
+      "offered",
+      "quietWeeks",
+      "scanRan",
+      "stage",
+    ]);
 
     // Now the APPLY side, replaying that same artifact through `runCleanup` — the
     // half where the bytes are read back, written to a memory, and reported on.
@@ -7658,6 +8025,55 @@ describe("wiring the offer into the review run (#123)", () => {
     };
     return client;
   }
+
+  it("TC-SLACKAPP-237 emits the scan-outcome line UNPREFIXED, on its own stream (#154)", async () => {
+    // The whole reason #154 has a second emission surface. `log` prefixes every line
+    // with `[memory-cleanup <iso>]`, and a CloudWatch `{ $.event = ... }` filter
+    // needs the log event to BE the JSON object — so a prefixed line matches
+    // nothing, publishes no datapoint, and leaves both alarms sitting green forever
+    // with nothing to show that they went blind. Asserted on the REAL production
+    // wiring, because that is where the prefix would be reintroduced.
+    reviewEnv({
+      MEM9_SLACK_APPROVAL_CHANNEL: "C0APPROVAL",
+      SLACK_BOT_TOKEN: "xoxb-injected",
+    });
+    const production = await createCleanupDeps(
+      { stage: "prod", apply: false, cap: 50 },
+      { ssm: ssmFake(), getToken: vi.fn(), fromNodeProviderChain: vi.fn() },
+    );
+    const stdout = vi.spyOn(console, "log").mockImplementation(() => {});
+    const stderr = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      // An empty decision list: nothing to post, so this exercises the offer path
+      // without needing Slack, and it is also the exact input the alarm is about.
+      await production.deps.postApproval({
+        decisions: [],
+        generatedAt: "2026-08-05T03:00:00.000Z",
+        issuedAt: "2026-08-05T03:00:00.000Z",
+      });
+      expect(stdout).toHaveBeenCalledTimes(1);
+      const [line] = stdout.mock.calls[0];
+      expect(line.startsWith("{")).toBe(true);
+      expect(line).not.toMatch(/^\[memory-cleanup/u);
+      expect(JSON.parse(line)).toMatchObject({
+        // The literal, for the reason TC-SLACKAPP-233 records.
+        event: "cleanup_scan_outcome",
+        stage: "prod",
+        offered: 0,
+        scanRan: 1,
+      });
+      // And the two surfaces stay separate: the human-readable lines are still
+      // prefixed and still on stderr, so nothing here changed what other consumers
+      // parse.
+      const prefixed = stderr.mock.calls.flat().filter((each) => typeof each === "string");
+      expect(prefixed.length).toBeGreaterThan(0);
+      for (const each of prefixed) expect(each).toMatch(/^\[memory-cleanup /u);
+    } finally {
+      stdout.mockRestore();
+      stderr.mockRestore();
+      await production.close();
+    }
+  });
 
   it("TC-SLACKAPP-114 builds no offer dep when Slack is not configured, so the #102 CLI is unchanged", async () => {
     // The operator CLI at #102 has no Slack anything. An offer dep that existed


### PR DESCRIPTION
## Summary

- One immutable SSM record per ISO week (`approvals/scan-outcome-<iso-week>`), a pure
  function over the last four of them, and one unprefixed JSON log line per run.
- Two `LogMetricFilter`s off that line, a streak alarm at `>= 2`, and a
  `FILL(scan_ran, 0)` liveness alarm armed only where the schedule is `ENABLED`.
- No new IAM action, no permissions-boundary growth, no change to
  `consensusDecisions`' quorum or its 66%-agreement handling.

Design: [`docs/designs/quiet-scan-alarm.md`](docs/designs/quiet-scan-alarm.md).

## Why the shape is what it is

A CloudWatch alarm's total evaluation window is capped at 604800s — seven days — for
`Period` × `EvaluationPeriods`, and the scan is weekly. Consecutive runs are seven
days apart, so a window *guaranteed* to contain two of them has to be longer than
seven days: `period=604800, evaluationPeriods=2` is 1,209,600s and is rejected, and
`period=86400, evaluationPeriods=7, datapointsToAlarm=2` is a seven-day window that
holds one weekly run, so the second breaching datapoint never exists. ">= 2
consecutive zero-offer weeks" is therefore not expressible in any single alarm:
latching flips on the first quiet week, and a composite alarm combines instantaneous
child states (`ALARM(A) AND ALARM(A)` is `A`) with no accumulator. Memory spanning
two runs has to be persisted, so this is the smallest amount that works, with the
alarm kept dumb.

A per-week **key** rather than a counter: a same-week retry is then an idempotent
rewrite with no read-modify-write to race, and a corrupted key costs one week of
history instead of the series. It lands under the `approvals/*` grant the scan task
already holds, so the boundary — which renders near IAM's non-adjustable
6144-character ceiling — is untouched.

The count is **derived**, never incremented, and counts only contiguous *present*
zero-offer weeks. An absent record breaks the streak, asserted explicitly, because
the tempting alternative (skip the gap, keep counting) invents contiguity that
never existed.

## Only the schedule contributes

`MEM9_CLEANUP_SCHEDULED=1` is set on the Scheduler container override and nowhere
else — never on the task definition, so the apply half and the operator CLI stay
unmarked — and it gates the week record and the metric line only. An off-schedule dry
run still writes and posts its offer exactly as before.

Without the gate a hand-run would be a datapoint about the schedule in both
directions: one that offered nothing could supply the **second** quiet week and page
for a healthy classifier, and *any* hand-run would publish `ScanRan`, holding the
liveness alarm green for another seven days while the Scheduler was dead.

## The liveness alarm's grace, and the one page it does not suppress

Actions hang off a `CompositeAlarm` with an `actionsSuppressor` — the same
three-resource split `DurableIngestTelemetryLiveness*` uses: the metric alarm carries
no actions, an always-OK guard exists only to be waited on, and
`ActionsSuppressorWaitPeriod` delays notification by one hour. That absorbs a deploy
landing while a scan is in flight and the hourly re-evaluation of a multi-day window.
One hour and not one cadence, deliberately: a suppressor that never enters `ALARM`
delays actions unconditionally, so a week-long wait would postpone every real page by
a week.

**One expected page at first enablement, accepted and documented rather than hidden.**
Until the first scheduled run publishes a datapoint, nothing distinguishes "no scan
was due yet" from "the scan stopped" — that needs memory older than the seven days an
alarm can evaluate, the same wall the streak hit. The state that could answer it is
the SSM week history, and reading it from outside the scan means a second scheduled
principal with `cloudwatch:GetMetricData`, which this issue puts out of scope. So the
alarm fires once per stage enablement and clears after that stage's first Saturday;
the alarm description says exactly that, so the operator reading the page knows which
of the two it is.

## Three decisions worth reviewing

1. **Bookkeeping runs last and never throws.** The week record and the streak are
   handled after the offered record is written and, when non-empty, after the post;
   `recordScanOutcome` returns failures instead of throwing. An alarm's input must
   not be able to cost an operator their review list — run earlier, a throttled
   `PutParameter` would block the post; allowed to throw, it would surface through
   `runCleanup`'s offer-failure branch as "failed to offer the review list to Slack".
2. **A failed read is never reported as absence, and neither is a corrupt record.**
   The scan computes the number its own alarm reads, so the failure mode to design
   against is a read that quietly yields a *lower* count. Absence is legitimate and
   breaks the streak; a thrown read or an unparseable value publishes **no** count
   and exits 1. A failed *write* of this week's record is treated the same way, since
   next week would read this week as absent. A genuinely quiet week still exits 0.
3. **The event name is duplicated as a literal across the runtime boundary.**
   `infra/slack-approval.ts` cannot import from `scripts/memory-cleanup.mjs` — it runs
   in the Pulumi program, and the import would drag the AWS SDK into synth. Both
   sides are pinned to the literal by their own tests, so a rename turns a test red
   instead of leaving the filters matching nothing and both alarms silently dark.

## Mutation evidence

Every new condition was reverted in isolation and the suite re-run; both touched
files were md5-verified back to their pre-mutation state after each round.

| Mutation | Test that turns RED |
|---|---|
| absent week records skipped instead of breaking the streak | `TC-SLACKAPP-232` |
| a failed history read reported as absence (count published anyway) | `TC-SLACKAPP-234` |
| a failed week-record write rethrown instead of returned | `TC-SLACKAPP-235` |
| `runCleanup` exits 0 when the count is missing | `TC-SLACKAPP-236` |
| the emitted line carries the `[memory-cleanup …]` prefix | `TC-SLACKAPP-237` |
| streak threshold 2 → 1 | `TC-SLACKAPP-228` |
| streak alarm `notBreaching` → `missing` | `TC-SLACKAPP-228` |
| `FILL(scan_ran, 0)` → a plain metric | `TC-SLACKAPP-229` |
| liveness armed on every stage instead of `ENABLED` only | `TC-SLACKAPP-229` |
| the suppressor's `waitPeriod` raised from one hour to one cadence | `TC-SLACKAPP-229` |
| `JSON.parse` accepted without a shape check | `TC-SLACKAPP-238` |
| the schedule-only gate on the bookkeeping removed | `TC-SLACKAPP-239` |
| Node's `JSON.parse` message forwarded instead of replaced | `TC-SLACKAPP-234` |

## Scenario coverage

`TC-SLACKAPP-227`–`239`, documented in `docs/test-cases/slack-approval-loop.md`:
both filters and their metric values; the streak alarm's threshold, period,
statistic and the **absence** of a volume guard; the liveness `FILL` and its
stage gating (a preview gets the streak alarm and not the liveness alarm); no new
task IAM; ISO week arithmetic against literals across four real year boundaries
(2026-W01, 2026-W53 from a 2027 date, 2020-W53, 2022-W52, 2025-W01 from a 2024
date); the streak's 0/1/2/3 boundaries, reset, and gap semantics; a zero-id scan
writing its week record and emitting the line; a same-week retry not raising the
count; a non-zero week resetting it; the read-error and write-error paths; the
exit codes; and the unprefixed emitter asserted on the real `createCleanupDeps`
wiring.

`TC-SLACKAPP-210`'s no-memory-content sweep was extended to the new emission
surface — the JSON line is a fourth destination for run data, and it now has its
field set asserted whole so a later addition cannot put memory text into a
CloudWatch dimension.

## Simplification note

The task log-group read (`awslogs-group` out of the rendered container definition)
is now `taskContainerLogGroupName` in `infra/consolidation.ts`, shared with the
consolidation stack instead of copied. A second copy is a second place for the
container-name lookup to return undefined and take a metric filter with it.

## Ordering

- #173 (TC-SLACKAPP-215..223, boundary rewrite) has merged; TC ids here start at
  **227**, after the ids claimed by the two open PRs #174 (224/225) and #175 (226).
  Worth a parity re-check after those land.
- PR #171 — the old ordering constraint — was closed; #174 supersedes it and does
  not touch the `record.ids.length === 0` branch this PR edits.

## Test Plan

- [x] Design canvas (`docs/designs/quiet-scan-alarm.md`)
- [x] Test cases documented (`docs/test-cases/slack-approval-loop.md`, TC-SLACKAPP-227..237)
- [x] Typecheck passes (root + `infra`)
- [x] Unit tests pass (root 25 files / 1154 tests; infra 30 files / 423 tests)
- [x] Mutation-verified (table above)
- [x] Public-artifact scan clean over the pushed range
- [x] Code simplification review passed
- [x] PR review passed
- [ ] CI checks pass — including `Deploy PR Preview`, which is what proves the two
      filters and two alarms actually deploy rather than merely typecheck
- [x] E2E: **not applicable** — no UI; `scripts/run-slack-approval-e2e.sh` needs no
      change, stated explicitly rather than silently skipped.

Closes #154


---

## Review round-trip

Reviewed with the local `codex` CLI (Bedrock), four passes:

1. **[P1]** a malformed-but-parseable week record (`{"offered":"0"}`) silently lowered
   the streak and suppressed the page. Fixed: `parseWeekRecord` shape-checks every
   record; `TC-SLACKAPP-238` covers eight bad shapes.
2. **[P1]** the "14 days apart" rationale was wrong. Corrected everywhere.
3. **[P1]** the absent-week failure direction was described as a false negative; it is
   a false **positive**. Corrected (the implementation was already right).
4. **[P1]** the liveness alarm paged at first enablement and could page while a scan
   was in flight. Fixed with the guard + composite suppressor above; the
   first-enablement page is documented as unavoidable within the evaluation cap rather
   than papered over.
5. **[P2]** the validation error echoed stored field values into CloudWatch. Fixed:
   it names which fields failed, never their values — and a value that will not parse
   gets a fixed message, since Node quotes a slice of the input in its own error.
6. **[P2]** an off-schedule dry run contributed to the week history and the liveness
   metric. Fixed with `MEM9_CLEANUP_SCHEDULED` above; `TC-SLACKAPP-239` pins it.

Fourth pass: no remaining P1/P2, merge-ready. Every new condition above is
mutation-verified.
