### PR TITLE
fix(cleanup): extend manual scan observation window

### DIFF
--- a/README.md
+++ b/README.md
@@ -1251,6 +1251,14 @@ the private Slack message and click Approve there to exercise the real
 signature, claim, artifact replay, cap, LWW fence, soft-delete, and shared
 advisory-mutex path.
 
+The runner's observation budget defaults to six hours because a two-pass scan of
+a production corpus with thousands of active memories can exceed 90 minutes.
+Set `CLEANUP_SCAN_WAIT_SECONDS` to an integer from 60 to 43200 to override
+that budget. This bounds only how long the local runner waits; EventBridge
+Scheduler invokes the ECS task directly, and an expired observer does not stop
+an in-flight task. If the runner times out, do not start a second scan: inspect
+the task started by `mem9-cleanup-operator-prod` and its offer before retrying.
+
 After that production drill succeeds, enable and deploy the weekly scan:
 
 ```bash

--- a/docs/test-cases/slack-approval-loop.md
+++ b/docs/test-cases/slack-approval-loop.md
@@ -2420,7 +2420,11 @@ commands copied from the Scheduler resource.
   `pr-N` stages, and production additionally requires
   `CONFIRM_PROD_SCAN=prod` before the first AWS call. The scan is read-only with
   respect to memories but writes an offer and may replace an expired one, so an
-  accidental production invocation is still operationally significant.
+  accidental production invocation is still operationally significant. Its
+  observer budget defaults to six hours and accepts only an explicit integer
+  from 60 to 43200 seconds; malformed, shorter, or unbounded values fail
+  before any AWS call. The budget controls the local observer only, not the ECS
+  task that Scheduler invokes directly.
 - **TC-SLACKAPP-242** — the runner reads the four deployed cleanup task inputs,
   reads the task definition, and requires its `--base-url` to equal the exact
   stage-scoped private Cloud Map URL before starting Fargate in those private

--- a/scripts/run-cleanup-scan-task.sh
+++ b/scripts/run-cleanup-scan-task.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 
 STAGE="${STAGE:?STAGE is required (prod or pr-N)}"
 CONFIRM_PROD_SCAN="${CONFIRM_PROD_SCAN:-}"
+CLEANUP_SCAN_WAIT_SECONDS="${CLEANUP_SCAN_WAIT_SECONDS:-21600}"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 REGION="${AWS_REGION:-$(node "$REPO_ROOT/scripts/resolve-application-region.mjs")}"
 PREFIX="/mem9-on-aws/${STAGE}"
@@ -20,6 +21,11 @@ if [[ "$STAGE" != "prod" && ! "$STAGE" =~ ^pr-[1-9][0-9]*$ ]]; then
 fi
 if [[ "$STAGE" == "prod" && "$CONFIRM_PROD_SCAN" != "prod" ]]; then
   echo "::error::set CONFIRM_PROD_SCAN=prod to start a production approval scan" >&2
+  exit 1
+fi
+if ! [[ "$CLEANUP_SCAN_WAIT_SECONDS" =~ ^[1-9][0-9]*$ ]] ||
+   (( CLEANUP_SCAN_WAIT_SECONDS < 60 || CLEANUP_SCAN_WAIT_SECONDS > 43200 )); then
+  echo "::error::CLEANUP_SCAN_WAIT_SECONDS must be an integer from 60 to 43200" >&2
   exit 1
 fi
 
@@ -153,7 +159,7 @@ if [[ -z "$TASK_ARN" ]]; then
 fi
 
 echo "run-cleanup-scan: waiting for the dry-run task to stop"
-DEADLINE=$((SECONDS + 5400))
+DEADLINE=$((SECONDS + CLEANUP_SCAN_WAIT_SECONDS))
 TASK_STATE=""
 while [[ $SECONDS -lt $DEADLINE ]]; do
   if ! TASK_STATE=$(aws ecs describe-tasks \
@@ -170,7 +176,7 @@ while [[ $SECONDS -lt $DEADLINE ]]; do
   sleep 10
 done
 if [[ "$(jq -r '.tasks[0].lastStatus // empty' <<<"$TASK_STATE")" != "STOPPED" ]]; then
-  echo "::error::cleanup scan task did not stop within 90 minutes" >&2
+  echo "::error::cleanup scan task did not stop within ${CLEANUP_SCAN_WAIT_SECONDS}s; task remains running, do not start another scan" >&2
   exit 1
 fi
 

--- a/scripts/run-cleanup-scan-task.test.mjs
+++ b/scripts/run-cleanup-scan-task.test.mjs
@@ -30,6 +30,7 @@ function runFixture({
   baseUrl = `http://mnemo.mem9-${stage}.local:8080`,
   offer,
   offerModified = 4_102_444_800,
+  waitSeconds,
 } = {}) {
   const directory = mkdtempSync(join(tmpdir(), "mem9-cleanup-scan-runner-"));
   temporaryPaths.push(directory);
@@ -139,22 +140,27 @@ if (command === "ssm get-parameters") {
     { mode: 0o755 },
   );
 
+  const env = {
+    ...process.env,
+    AWS_CALLS: calls,
+    CONFIRM_PROD_SCAN: confirmProd,
+    MOCK_BASE_URL: baseUrl,
+    MOCK_EXIT_CODE: String(exitCode),
+    MOCK_INVALID_PARAMETERS: JSON.stringify(invalidParameters),
+    MOCK_OFFER: JSON.stringify(offered),
+    MOCK_OFFER_MODIFIED: String(offerModified),
+    MOCK_RUN_FAILURES: JSON.stringify(runFailures),
+    MOCK_STAGE: stage,
+    PATH: `${bin}${delimiter}${process.env.PATH}`,
+    STAGE: stage,
+  };
+  if (waitSeconds !== undefined) {
+    env.CLEANUP_SCAN_WAIT_SECONDS = String(waitSeconds);
+  }
+
   const result = spawnSync("bash", [script], {
     encoding: "utf8",
-    env: {
-      ...process.env,
-      AWS_CALLS: calls,
-      CONFIRM_PROD_SCAN: confirmProd,
-      MOCK_BASE_URL: baseUrl,
-      MOCK_EXIT_CODE: String(exitCode),
-      MOCK_INVALID_PARAMETERS: JSON.stringify(invalidParameters),
-      MOCK_OFFER: JSON.stringify(offered),
-      MOCK_OFFER_MODIFIED: String(offerModified),
-      MOCK_RUN_FAILURES: JSON.stringify(runFailures),
-      MOCK_STAGE: stage,
-      PATH: `${bin}${delimiter}${process.env.PATH}`,
-      STAGE: stage,
-    },
+    env,
   });
   const callRecords = (existsSync(calls) ? readFileSync(calls, "utf8") : "")
     .trim()
@@ -180,6 +186,19 @@ describe("manual cleanup scan ECS runner", () => {
 
     const preview = runFixture({ stage: "pr-42", confirmProd: "" });
     expect(preview.result.status, preview.result.stderr).toBe(0);
+
+    for (const waitSeconds of ["0", "59", "43201", "1.5", "invalid"]) {
+      const invalid = runFixture({ waitSeconds });
+      expect(invalid.result.status).toBe(1);
+      expect(invalid.callRecords).toEqual([]);
+      expect(invalid.result.stderr).toContain(
+        "CLEANUP_SCAN_WAIT_SECONDS must be an integer from 60 to 43200",
+      );
+    }
+    for (const waitSeconds of ["60", "3600", "43200"]) {
+      const valid = runFixture({ waitSeconds });
+      expect(valid.result.status, valid.result.stderr).toBe(0);
+    }
   });
 
   it("TC-SLACKAPP-242: starts only the deployed dry-run command in private networking", () => {
@@ -231,6 +250,15 @@ describe("manual cleanup scan ECS runner", () => {
     expect(JSON.stringify(overrides)).not.toMatch(
       /--apply|--ids|MEM9_CLEANUP_SCHEDULED/u,
     );
+
+    const source = readFileSync(script, "utf8");
+    expect(source).toContain(
+      'CLEANUP_SCAN_WAIT_SECONDS="${CLEANUP_SCAN_WAIT_SECONDS:-21600}"',
+    );
+    expect(source).toContain(
+      "DEADLINE=$((SECONDS + CLEANUP_SCAN_WAIT_SECONDS))",
+    );
+    expect(source).not.toContain("SECONDS + 5400");
   });
 
   it("TC-SLACKAPP-243: verifies a fresh artifact-backed offer without leaking it", () => {


### PR DESCRIPTION
## Summary
- raise the manual cleanup scan observer default from 90 minutes to 6 hours
- allow a validated 60-43200 second override without changing the ECS task or Scheduler runtime
- document timeout recovery and cover valid/invalid observer budgets

## Verification
- `npm test` (1180 tests)
- `npm test -- --run scripts/run-cleanup-scan-task.test.mjs`
- `npm test -- --run scripts/deployment-workflow.test.mjs`
- `shellcheck scripts/run-cleanup-scan-task.sh`
- cc review: no blocking findings