### PR TITLE
fix(cleanup): cover long manual scans

### DIFF
--- a/README.md
+++ b/README.md
@@ -1251,7 +1251,7 @@ the private Slack message and click Approve there to exercise the real
 signature, claim, artifact replay, cap, LWW fence, soft-delete, and shared
 advisory-mutex path.
 
-The runner's observation budget defaults to six hours because a two-pass scan of
+The runner's observation budget defaults to twelve hours because a two-pass scan of
 a production corpus with thousands of active memories can exceed 90 minutes.
 Set `CLEANUP_SCAN_WAIT_SECONDS` to an integer from 60 to 43200 to override
 that budget. This bounds only how long the local runner waits; EventBridge

--- a/docs/test-cases/slack-approval-loop.md
+++ b/docs/test-cases/slack-approval-loop.md
@@ -2421,7 +2421,7 @@ commands copied from the Scheduler resource.
   `CONFIRM_PROD_SCAN=prod` before the first AWS call. The scan is read-only with
   respect to memories but writes an offer and may replace an expired one, so an
   accidental production invocation is still operationally significant. Its
-  observer budget defaults to six hours and accepts only an explicit integer
+  observer budget defaults to twelve hours and accepts only an explicit integer
   from 60 to 43200 seconds; malformed, shorter, or unbounded values fail
   before any AWS call. The budget controls the local observer only, not the ECS
   task that Scheduler invokes directly.

--- a/scripts/run-cleanup-scan-task.sh
+++ b/scripts/run-cleanup-scan-task.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 
 STAGE="${STAGE:?STAGE is required (prod or pr-N)}"
 CONFIRM_PROD_SCAN="${CONFIRM_PROD_SCAN:-}"
-CLEANUP_SCAN_WAIT_SECONDS="${CLEANUP_SCAN_WAIT_SECONDS:-21600}"
+CLEANUP_SCAN_WAIT_SECONDS="${CLEANUP_SCAN_WAIT_SECONDS:-43200}"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 REGION="${AWS_REGION:-$(node "$REPO_ROOT/scripts/resolve-application-region.mjs")}"
 PREFIX="/mem9-on-aws/${STAGE}"

--- a/scripts/run-cleanup-scan-task.test.mjs
+++ b/scripts/run-cleanup-scan-task.test.mjs
@@ -253,7 +253,7 @@ describe("manual cleanup scan ECS runner", () => {
 
     const source = readFileSync(script, "utf8");
     expect(source).toContain(
-      'CLEANUP_SCAN_WAIT_SECONDS="${CLEANUP_SCAN_WAIT_SECONDS:-21600}"',
+      'CLEANUP_SCAN_WAIT_SECONDS="${CLEANUP_SCAN_WAIT_SECONDS:-43200}"',
     );
     expect(source).toContain(
       "DEADLINE=$((SECONDS + CLEANUP_SCAN_WAIT_SECONDS))",


### PR DESCRIPTION
## Summary
- default the manual cleanup scan observer to the existing 12-hour maximum
- keep the configurable 60..43200-second validation unchanged
- align the runner contract test and operator documentation

The observer only waits for the ECS task. It does not stop the task, and the weekly Scheduler path does not use it.

## Verification
- `npm test` (1180 passed)
- focused runner tests (4 passed)
- `shellcheck scripts/run-cleanup-scan-task.sh`
- `git diff --check`
- cc review: no blocking findings