### PR TITLE
fix(cleanup): batch large approval offers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1198,9 +1198,15 @@ What a click can and cannot do is the whole design:
   `taskArn`. Both approval records are plain `String` parameters holding **ids
   and a hash only, never memory content**; snippets go to Slack and CloudWatch
   Logs.
-- `--cap` still bounds a single click's blast radius (50 by default, passed
-  explicitly by the task definition), and the apply task holds the same advisory
-  mutex as scheduled consolidation.
+- `--cap` bounds both the offered batch and a single click's blast radius (50 by
+  default, passed explicitly by the task definition and scheduled/manual scan
+  commands). The full decision artifact is unchanged; the offer deterministically
+  packs complete DELETE/MERGE decisions in original order until their footprint
+  reaches the cap, never splits a MERGE, and may use a later smaller decision to
+  fill remaining capacity. Slack reports offered, total, and deferred counts.
+- Apply verifies the full artifact hash and then uses the immutable claim ids to
+  filter that artifact, so deferred decisions cannot be applied by the current
+  click. A later weekly scan reclassifies the remaining backlog.
 
 The whole feature is **absent** unless `MEM9_SLACK_APPROVAL_ENABLED=1` at deploy
 time: disabled means no task definition and no grants, because a task definition
@@ -1242,14 +1248,29 @@ CONFIRM_PROD_SCAN=prod STAGE=prod \
 ```
 
 The runner reads the deployed task and private-network inputs from SSM, verifies
-the task's Cloud Map URL belongs to the requested stage, starts the same
-two-consensus-pass command the weekly schedule uses, waits for exit zero, and
-requires a fresh artifact-backed offer. It never passes `--apply`, `--ids`, or
-`MEM9_CLEANUP_SCHEDULED`; the hand-run cannot mutate memories and cannot satisfy
-the weekly liveness signal. Its output contains only the offered count. Review
-the private Slack message and click Approve there to exercise the real
-signature, claim, artifact replay, cap, LWW fence, soft-delete, and shared
-advisory-mutex path.
+the task's Cloud Map URL belongs to the requested stage, inherits the deployed
+apply command's `--cap`, starts the same two-consensus-pass command the weekly
+schedule uses, waits for exit zero, and requires a fresh artifact-backed offer.
+It never passes `--apply`, `--ids`, or `MEM9_CLEANUP_SCHEDULED`; the hand-run
+cannot mutate memories and cannot satisfy the weekly liveness signal. Its output
+contains only the offered count. Review the private Slack message and click
+Approve there to exercise the real signature, claim, artifact replay, cap, LWW
+fence, soft-delete, and shared advisory-mutex path.
+
+If a completed scan wrote its artifact but failed before creating the offer, the
+same runner can replay that trusted artifact without scanning or classifying
+again. Supply both machine-local values; either one alone, a non-content hash, a
+cross-stage key, or any replay combined with `--apply` is refused:
+
+```bash
+MEM9_REVIEW_ARTIFACT_KEY="decisions/prod/sha256-<hash>.json" \
+MEM9_REVIEW_ARTIFACT_HASH="sha256:<hash>" \
+CONFIRM_PROD_SCAN=prod STAGE=prod \
+  bash scripts/run-cleanup-scan-task.sh
+```
+
+Recover those coordinates only from the private log of the completed trusted
+scan. Do not publish the key or hash.
 
 The runner's observation budget defaults to twelve hours because a two-pass scan of
 a production corpus with thousands of active memories can exceed 90 minutes.

--- a/docs/test-cases/slack-approval-loop.md
+++ b/docs/test-cases/slack-approval-loop.md
@@ -50,11 +50,11 @@ them instead of re-classifying.
 Both records are plain `String`, not `SecureString`: the ceiling admits neither
 `kms:Encrypt` nor `kms:GenerateDataKey`, so a SecureString write would be denied
 at runtime. That bounds what may go in them — **ids and a hash only, never
-memory content** (TC-SLACKAPP-023). Snippets go to Slack and CloudWatch Logs,
-which is also why `--cap` bounds the offered list: a cap-50 record is ~2 KB
-against the standard tier's 4096-byte limit, and a run that would exceed the
-parameter limit must fail loud rather than truncate the list it is asking the
-operator to approve (TC-SLACKAPP-024).
+memory content** (TC-SLACKAPP-023). Snippets go to Slack and CloudWatch Logs.
+The full artifact remains the durable source, while `--cap` bounds the offered
+SSM/Slack batch and the apply to the same complete-decision footprint. The
+low-level record builder still fails loud rather than truncate oversized input
+(TC-SLACKAPP-024).
 
 ## Why the record is claimed before the task is started
 
@@ -207,8 +207,8 @@ concurrent applies of the same ids.
   length, not an id count: a limit expressed as "N ids" drifts from the real
   constraint as soon as ids get longer, and bytes are what SSM rejects. The
   advanced tier's 8 KB is deliberately not the answer — it incurs a charge and
-  cannot be reverted to standard without data loss, so the offered set has to fit
-  here, and what has to shrink is the scan (TC-SLACKAPP-224), not the cap.
+  cannot be reverted to standard without data loss, so every selected batch still
+  has to fit here (TC-SLACKAPP-224).
 - **TC-SLACKAPP-024b** — the size guard measures the artifact coordinates **inside**
   the limit it enforces. The two coordinates add ~151 bytes, so a caller that
   assigned them onto an already-validated record opened a window where the guard
@@ -229,28 +229,19 @@ concurrent applies of the same ids.
   fixture is sized by search against the **real** record rather than a hand-built
   approximation, and the window's existence (under the limit in code units, over it
   in bytes) is asserted before the refusal is.
-- **TC-SLACKAPP-224** — the parameter-limit refusal names the **scanned set**, and
-  no flag at all (#155). `--cap` never reaches this throw: it is not a parameter of
-  `buildOfferedRecord`, it is read only inside `applyDecisions` at apply time, and
-  the guard fires before an apply exists — measured, the byte-identical error at
-  `--cap 50` and `--cap 10`. So the old "lower `--cap`" clause was *false* on the
-  operator CLI, not merely inert on the scheduled scan, and it was the whole
-  diagnosis at the one moment it is the only one available. The replacement names
-  what actually drives the bytes (every id a destructive decision touches) and points
-  at a lever that EXISTS on both paths: the decision list survives the throw, and a
-  hand-run `--apply --ids` over a reviewed subset is the documented way through —
-  which is also what `runCleanup`'s exit-1 line already names. Deliberately **not**
-  "narrow the scan", the wording the adjacent artifact refusal uses: there is no scan
-  bound to turn down (`scanActiveMemories` exhausts every page and `--limit` is
-  list-only), so that would have replaced one inert clause with another. The same
-  reason the diagnosis says "offered set" rather than "consensus set": these builders
-  also serve the single-pass operator dry run, where there is no quorum to blame.
-  Asserted against **any** flag, not just `--cap`: a later `--consensus-passes` or
-  `--protected-topics` clause would reintroduce the defect under a new name on the
-  path that can pass neither. Also asserted through the real offer, where this
-  refusal fires **before** the write, so a scan that cannot offer leaves last
-  week's button as it found it rather than invalidating it and then refusing to
-  replace it.
+- **TC-SLACKAPP-224** — the low-level record builder keeps its 4096-byte refusal
+  and never truncates direct input, while the real offer writes the **complete**
+  artifact and selects one cap-bounded SSM/Slack batch. The test starts with 200
+  realistic DELETE ids: direct construction refuses, but `postApprovalRequest`
+  writes all 200 decisions to S3, offers only the first 50 ids, keeps the parameter
+  under 4096 bytes, and renders offered/total/deferred decision and id counts.
+  The first deferred id and snippet are absent from Slack.
+- **TC-SLACKAPP-246** — batch selection is deterministic in original order,
+  preserves every non-destructive row for full-scan RETAIN/UNSTABLE counts, never
+  splits a MERGE, and allows a later smaller decision to fill capacity left by an
+  earlier decision that did not fit.
+- **TC-SLACKAPP-247** — one decision whose complete footprint exceeds the cap is
+  refused loudly. A MERGE cannot be split across approvals.
 - **TC-SLACKAPP-025** — the record is stage-bound, and a hash whose record names
   another stage is refused. Same reasoning as #102's decision-file stage guard: a
   preview approval must never apply to prod.
@@ -1131,8 +1122,9 @@ contend with the weekly consolidation and cannot delete.
   conditioned on `iam:PassedToService = ecs-tasks.amazonaws.com`. The action set is
   pinned exactly, so a third action cannot be added silently.
 - **TC-SLACKAPP-150** — the container override is a dry run: **no** `--apply`, no
-  `--ids`, no `--cap`; `--consensus-passes` present and at least 2; and `--out`
-  outside `/app`. Each of those is a distinct failure. `--apply` on a schedule is an
+  `--ids`; `--consensus-passes` present and at least 2; `--cap` equal to the apply
+  task's exported `CLEANUP_CAP`; and `--out` outside `/app`. Each is a distinct
+  contract. `--apply` on a schedule is an
   unattended deletion with no human in the loop at all. `--ids` is worse than it
   looks: `readApprovedIds` treats an absent file as "no filter", so `--ids` on a path
   that writes nothing would apply *everything* — which is only safe because both
@@ -1369,10 +1361,9 @@ the offer now also writes the reviewed list itself to S3 and hashes **that**.
   one. The remedy must **not** name `--cap`, and that is a correctness claim about
   the message rather than a wording preference: the artifact carries one row per
   *scanned* memory (KEEPs included), while `--cap` bounds only how many mutations an
-  apply may spend and never reaches this path. Advice to lower it is inert, and
-  doubly so on the scheduled scan, which has no operator at the keyboard and no
-  `--cap` override wired into its task definition. When the alarm says only "task
-  failed", this string is the entire diagnosis.
+  apply may spend and never reaches this path. Advice to lower it is inert even
+  though the scheduled scan now carries the same explicit cap as apply. When the
+  alarm says only "task failed", this string is the entire diagnosis.
 - **TC-SLACKAPP-174b** — the artifact is measured in **bytes**, not UTF-16 code
   units. This is the one place memory *text* lives at rest, so the difference is not
   academic: a CJK `mergedContent` is 3 bytes per character and 1 `.length` unit, and
@@ -1726,6 +1717,15 @@ and therefore the withholding.
   a tampered-but-hash-valid artifact — impossible today, but the guard is not
   conditional on that — from reaching a memory the click never covered. This is why
   the ids file is written on the replay path at all.
+- **TC-SLACKAPP-248** — the same property at the real batch boundary: a full
+  51-decision artifact plus a 50-id claim applies exactly 50, leaves the deferred
+  memory active, and never calls the classifier.
+- **TC-SLACKAPP-249** — review-only replay requires a paired key/hash, a canonical
+  SHA-256 hash, the configured artifact bucket, and the exact stage/hash-derived
+  key. It cannot be combined with `MEM9_APPROVAL_HASH` or `--apply`, and invalid
+  input is refused before an S3 read.
+- **TC-SLACKAPP-250** — a valid review-only replay loads and validates the full
+  artifact through the normal hash/stage path without invoking the classifier.
 - **TC-SLACKAPP-194** — a refused artifact **aborts the run** and applies nothing.
   `loadDecisions` deliberately has no `try` around the replay branch, so every
   refusal above propagates out of `runCleanup`. The lock file is never even created,
@@ -2429,9 +2429,11 @@ commands copied from the Scheduler resource.
   reads the task definition, and requires its `--base-url` to equal the exact
   stage-scoped private Cloud Map URL before starting Fargate in those private
   subnets and security group. Its full command is the scheduled scan command:
-  two consensus passes and an output directory outside `/app`, with no
-  `--apply`, `--ids`, or `MEM9_CLEANUP_SCHEDULED`. A hand-run must not mutate
-  memories or publish evidence that the weekly schedule ran.
+  two consensus passes, the `--cap` extracted from the deployed apply task, and
+  an output directory outside `/app`, with no `--apply`, `--ids`, or
+  `MEM9_CLEANUP_SCHEDULED`. A missing or malformed deployed cap fails before
+  RunTask. A hand-run must not mutate memories or publish evidence that the weekly
+  schedule ran.
 - **TC-SLACKAPP-243** — after exit zero the runner requires a fresh, shaped
   `approvals/offered` record for the requested stage with artifact coordinates.
   It reports only the offered count. Memory ids, the full hash, bucket, key, and
@@ -2440,6 +2442,10 @@ commands copied from the Scheduler resource.
   failures, non-zero or absent container exits, and a missing, stale, malformed,
   wrong-stage, or artifact-less offer all fail closed. None is translated into a
   successful drill.
+- **TC-SLACKAPP-245** — paired `MEM9_REVIEW_ARTIFACT_KEY` /
+  `MEM9_REVIEW_ARTIFACT_HASH` values are passed only as ECS environment overrides,
+  retain the deployed cap, and never appear in runner output. One missing value or
+  a malformed hash fails before any AWS call. The command remains review-only.
 
 ## Exit codes
 

--- a/infra/slack-approval.test.ts
+++ b/infra/slack-approval.test.ts
@@ -1222,7 +1222,9 @@ describe("slack approval infrastructure", () => {
     // on a path that writes nothing.
     expect(command).not.toContain("--apply");
     expect(command).not.toContain("--ids");
-    expect(command).not.toContain("--cap");
+    const capIndex = command.indexOf("--cap");
+    expect(capIndex).toBeGreaterThan(0);
+    expect(Number(command[capIndex + 1])).toBe(module.CLEANUP_CAP);
 
     // With no human reading the list before it is offered, the quorum is the only
     // thing narrowing it: one pass reproduced just 66% of its own DELETE set on

--- a/infra/slack-approval.ts
+++ b/infra/slack-approval.ts
@@ -823,6 +823,11 @@ export function slackApproval(
                 // quorum is the only thing narrowing it.
                 "--consensus-passes",
                 String(CLEANUP_SCAN_CONSENSUS_PASSES),
+                // The offer selector and the apply task share one footprint
+                // contract. A scheduled scan that omitted this would silently
+                // fall back to the script default if CLEANUP_CAP ever changed.
+                "--cap",
+                String(CLEANUP_CAP),
                 // Outside /app, which `snippetLogDir` requires — see
                 // CLEANUP_SCAN_OUT_DIR.
                 "--out",

--- a/scripts/memory-cleanup.mjs
+++ b/scripts/memory-cleanup.mjs
@@ -86,14 +86,13 @@ const MAX_PARAMETER_BYTES = 4096;
 // does not admit. So the writer must stay on one PutObject, and this is the size
 // at which it says so instead of discovering it in production.
 //
-// What scales it is the SCANNED corpus, NOT `--cap`: the artifact carries one row
-// per decision, KEEPs included, because a replay has to reproduce the reviewed list
-// and not just its destructive half — while `--cap` bounds only how many mutations
-// an apply may spend. Measured, a KEEP row is ~139 bytes, so ~30k scanned memories
-// reach 4 MiB with ZERO deletions. That is a real store rather than an operator
-// mistake, which is why the error names the corpus and offers no `--cap` remedy: it
-// would be advice nobody can act on, and the scheduled scan has no operator at the
-// keyboard to act anyway.
+// What scales it is the SCANNED corpus, NOT the selected approval batch: the
+// artifact carries one row per decision, KEEPs included, because a replay has to
+// reproduce the reviewed list and not just its destructive half. `--cap` bounds
+// the SSM/Slack batch and the apply, but cannot shrink this durable source.
+// Measured, a KEEP row is ~139 bytes, so ~30k scanned memories reach 4 MiB with
+// ZERO deletions. That is a real store rather than an operator mistake, which is
+// why the artifact-size error names the corpus and offers no `--cap` remedy.
 const MAX_ARTIFACT_BYTES = 4 * 1024 * 1024;
 // Slack's own hard ceilings on a `chat.postMessage` payload
 // (api.slack.com/reference/block-kit/blocks). A message over ANY of them is
@@ -128,6 +127,8 @@ const MEM9_CLEANUP_SCHEDULED_ENV = "MEM9_CLEANUP_SCHEDULED";
 const MEM9_DECISION_BUCKET_ENV = "MEM9_DECISION_ARTIFACT_BUCKET";
 const MEM9_DECISION_BUCKET_OWNER_ENV =
   "MEM9_DECISION_ARTIFACT_BUCKET_OWNER";
+const MEM9_REVIEW_ARTIFACT_KEY_ENV = "MEM9_REVIEW_ARTIFACT_KEY";
+const MEM9_REVIEW_ARTIFACT_HASH_ENV = "MEM9_REVIEW_ARTIFACT_HASH";
 const REQUEST_TIMEOUT_MS = 30_000; // REST calls; the LLM call sets its own
 const LLM_TIMEOUT_MS = 120_000;
 // Reasoning models consume output tokens on hidden reasoning BEFORE emitting
@@ -789,6 +790,54 @@ function decisionIds(decision) {
  */
 function destructiveCost(decision) {
   return decisionFootprint(decision).length;
+}
+
+/**
+ * Select one complete approval batch under the same footprint cap the apply
+ * path enforces. The full decision list remains in the artifact; only the ids
+ * selected here enter the offered record and Slack message.
+ */
+export function selectApprovalBatch(decisions, cap = DEFAULT_CAP) {
+  if (!Number.isSafeInteger(cap) || cap <= 0) {
+    throw new Error(`approval batch cap must be a positive whole integer, got ${cap}`);
+  }
+
+  const destructive = decisions.filter((decision) => destructiveCost(decision) > 0);
+  const oversized = destructive.find((decision) => destructiveCost(decision) > cap);
+  if (oversized) {
+    const cost = destructiveCost(oversized);
+    throw new Error(
+      `one ${oversized.verdict} decision touches ${cost} ids, over the approval ` +
+        `and apply cap of ${cap}; a decision cannot be split across approvals`,
+    );
+  }
+
+  const selected = new Set();
+  let offeredIds = 0;
+  let totalIds = 0;
+  for (const decision of destructive) {
+    const cost = destructiveCost(decision);
+    totalIds += cost;
+    if (offeredIds + cost <= cap) {
+      selected.add(decision);
+      offeredIds += cost;
+    }
+  }
+
+  const offeredDecisions = destructive.filter((decision) => selected.has(decision));
+  return {
+    // Preserve every non-destructive row so the Slack withheld counts still
+    // describe the complete scan while destructive lines stay batch-bounded.
+    decisions: decisions.filter(
+      (decision) => destructiveCost(decision) === 0 || selected.has(decision),
+    ),
+    offeredDecisions: offeredDecisions.length,
+    totalDecisions: destructive.length,
+    deferredDecisions: destructive.length - offeredDecisions.length,
+    offeredIds,
+    totalIds,
+    deferredIds: totalIds - offeredIds,
+  };
 }
 
 /** Build the REST client. Counts every non-GET request so dry-run can assert 0. */
@@ -1530,13 +1579,9 @@ export function buildOfferedRecord({
     // expressed as "N ids" drifts from the real constraint as soon as ids get
     // longer, and bytes are what SSM rejects.
     //
-    // Deliberately not `--cap` (#155): this record holds every id a destructive
-    // decision touches, so it scales with what the scan found, while `cap` is read
-    // only inside `applyDecisions` and is not even a parameter of this builder.
-    // Measured, the identical error at `--cap 50` and `--cap 10` — the throw precedes
-    // the apply the cap would bound. So "lower --cap" was false on the operator CLI,
-    // and inert as well on the scheduled scan, which passes no flags and has no
-    // operator at the keyboard to pass one.
+    // Deliberately not `--cap` (#155): this low-level builder has no authority to
+    // select or truncate its input. `postApprovalRequest` passes it one already
+    // selected batch; direct callers must do the same or handle this refusal.
     //
     // What the remedy names instead is something that EXISTS on both paths. Not
     // "narrow the scan": there is no scan bound to turn down — `scanActiveMemories`
@@ -1544,7 +1589,7 @@ export function buildOfferedRecord({
     // inert clause. The decision list on disk is the real lever: it survives this
     // throw, and a hand-run `--apply --ids` over a reviewed subset is the documented
     // way through, which is also what `runCleanup`'s exit-1 line already points at.
-    // "offered set", not "consensus set": these builders serve the single-pass
+    // "offered set", not "consensus set": this builder serves the single-pass
     // operator dry run too, where there is no quorum to blame.
     throw new Error(
       `the offered approval list is ${bytes} bytes, over the ` +
@@ -1636,7 +1681,7 @@ export function formatHours(ms) {
  * 120-character slices: a snippet identifies a memory being removed, and the
  * merged text IS the change being approved.
  */
-export function buildApprovalMessage({ record, decisions, channel }) {
+export function buildApprovalMessage({ record, decisions, channel, batch }) {
   const withheld = { RETAIN: 0, UNSTABLE: 0 };
   for (const d of decisions) {
     if (d.verdict in withheld) withheld[d.verdict] += 1;
@@ -1728,6 +1773,20 @@ export function buildApprovalMessage({ record, decisions, channel }) {
           `Generated ${record.generatedAt}.`,
       },
     },
+    ...(batch?.deferredDecisions > 0
+      ? [{
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text:
+              `*Approval batch:* ${batch.offeredDecisions} of ` +
+              `${batch.totalDecisions} destructive decision(s), touching ` +
+              `${batch.offeredIds} of ${batch.totalIds} id(s). ` +
+              `${batch.deferredDecisions} decision(s), touching ` +
+              `${batch.deferredIds} id(s), are deferred to a later scan.`,
+          },
+        }]
+      : []),
     ...chunkSections(lines),
     {
       type: "actions",
@@ -2030,10 +2089,9 @@ export async function putDecisionArtifact({
     //
     // The remedy names the CORPUS, deliberately not `--cap`. The artifact carries
     // every decision including KEEPs, so it scales with what was scanned, while
-    // `--cap` bounds only an apply's destructive spend and never reaches this path
-    // — measured, a 30k-memory store with zero deletions breaches this. Advice to
-    // lower `--cap` would be inert here, and inert on the scheduled scan twice over,
-    // since no operator is at the keyboard to take it.
+    // `--cap` bounds only the selected offer and apply — measured, a 30k-memory
+    // store with zero deletions breaches this. Advice to lower `--cap` would be
+    // inert here.
     throw new Error(
       `the decision artifact is ${bytes} bytes, over the ` +
         `${MAX_ARTIFACT_BYTES}-byte single-PutObject bound for ${decisions.length} ` +
@@ -2279,6 +2337,7 @@ export async function postApprovalRequest({
   // caller that has no metric surface prints nothing; `buildPostApproval` wires
   // the real emitter for the deployed scan.
   emit = () => {},
+  approvalCap = DEFAULT_CAP,
   // Whether this invocation came from the SCHEDULE. Only a scheduled run keeps week
   // history and publishes metrics; see MEM9_CLEANUP_SCHEDULED_ENV for why an
   // operator's dry run must not.
@@ -2306,6 +2365,16 @@ export async function postApprovalRequest({
             `list another run may be posting right now; retry after ` +
               `${formatHours(UNPOSTED_GRACE_MS)}, after which an unposted list is ` +
               `treated as a failed post and replaced`),
+    );
+  }
+  const batch = selectApprovalBatch(decisions, approvalCap);
+  if (batch.deferredDecisions > 0) {
+    log(
+      `approval batch selected ${batch.offeredDecisions} of ` +
+        `${batch.totalDecisions} destructive decision(s), touching ` +
+        `${batch.offeredIds} of ${batch.totalIds} id(s); ` +
+        `${batch.deferredDecisions} decision(s), touching ` +
+        `${batch.deferredIds} id(s), are deferred`,
     );
   }
   const write = (value) =>
@@ -2372,7 +2441,7 @@ export async function postApprovalRequest({
   // (TC-SLACKAPP-169).
   const record = buildOfferedRecord({
     stage,
-    decisions,
+    decisions: batch.decisions,
     generatedAt,
     issuedAt,
     artifactBucket: artifact ? artifactBucket : undefined,
@@ -2430,10 +2499,15 @@ export async function postApprovalRequest({
     // Nothing to approve, so nothing to post — but the record above still
     // overwrote last week's list, which is the point.
     log("no deletions to offer; posted nothing to Slack");
-    return withOutcome({ record, posted: false });
+    return withOutcome({ record, posted: false, batch });
   }
 
-  const message = buildApprovalMessage({ record, decisions, channel });
+  const message = buildApprovalMessage({
+    record,
+    decisions: batch.decisions,
+    channel,
+    batch,
+  });
   const posted = await slackCall("chat.postMessage", message, { botToken, fetchImpl });
 
   try {
@@ -2450,6 +2524,7 @@ export async function postApprovalRequest({
     posted: true,
     messageTs: posted.ts,
     messageChannel: posted.channel,
+    batch,
   });
 }
 
@@ -4669,6 +4744,7 @@ async function buildPostApproval(opts, region, runtime) {
       // alarms then reading no datapoints and sitting green forever.
       emit: (event) => console.log(JSON.stringify(event)),
       scheduled: process.env[MEM9_CLEANUP_SCHEDULED_ENV] === "1",
+      approvalCap: opts.cap,
     });
 }
 
@@ -4760,6 +4836,27 @@ export async function createCleanupDeps(opts, runtime = {}) {
   // The approval hash is the ECS container override the callback Lambda sets, and
   // it is the ONLY thing that reaches the task from the click.
   const approvalHash = process.env.MEM9_APPROVAL_HASH;
+  const reviewArtifactKey = process.env[MEM9_REVIEW_ARTIFACT_KEY_ENV];
+  const reviewArtifactHash = process.env[MEM9_REVIEW_ARTIFACT_HASH_ENV];
+  if (Boolean(reviewArtifactKey) !== Boolean(reviewArtifactHash)) {
+    throw new Error(
+      `${MEM9_REVIEW_ARTIFACT_KEY_ENV} and ${MEM9_REVIEW_ARTIFACT_HASH_ENV} ` +
+        `must be set together`,
+    );
+  }
+  if (approvalHash && reviewArtifactKey) {
+    throw new Error(
+      `${MEM9_REVIEW_ARTIFACT_KEY_ENV} cannot be combined with MEM9_APPROVAL_HASH`,
+    );
+  }
+  if (
+    reviewArtifactHash &&
+    !/^sha256:[0-9a-f]{64}$/u.test(reviewArtifactHash)
+  ) {
+    throw new Error(
+      `${MEM9_REVIEW_ARTIFACT_HASH_ENV} must be a sha256 content hash`,
+    );
+  }
   /** What the claim said, for the outcome update. Absent on a review run. */
   let claim;
   /**
@@ -4830,6 +4927,40 @@ export async function createCleanupDeps(opts, runtime = {}) {
             console.error(`[memory-cleanup ${new Date().toISOString()}] ${message}`),
         });
     }
+  } else if (reviewArtifactKey) {
+    if (opts.apply) {
+      throw new Error(
+        `${MEM9_REVIEW_ARTIFACT_KEY_ENV} is review-only and cannot be combined ` +
+          `with --apply`,
+      );
+    }
+    const artifactBucket = process.env[MEM9_DECISION_BUCKET_ENV];
+    if (!artifactBucket) {
+      throw new Error(
+        `${MEM9_REVIEW_ARTIFACT_KEY_ENV} requires ${MEM9_DECISION_BUCKET_ENV}`,
+      );
+    }
+    const expectedKey = decisionArtifactKey(opts.stage, reviewArtifactHash);
+    if (reviewArtifactKey !== expectedKey) {
+      throw new Error(
+        `${MEM9_REVIEW_ARTIFACT_KEY_ENV} does not match the requested stage and hash`,
+      );
+    }
+    const expectedBucketOwner = requireDecisionArtifactBucketOwner(
+      process.env[MEM9_DECISION_BUCKET_OWNER_ENV],
+    );
+    const { s3 } = await s3Client(region, runtime);
+    loadReviewedDecisions = () =>
+      loadDecisionArtifact({
+        s3,
+        bucket: artifactBucket,
+        expectedBucketOwner,
+        key: reviewArtifactKey,
+        hash: reviewArtifactHash,
+        stage: opts.stage,
+        log: (message) =>
+          console.error(`[memory-cleanup ${new Date().toISOString()}] ${message}`),
+      });
   }
 
   const databaseMutex = opts.apply

--- a/scripts/memory-cleanup.test.mjs
+++ b/scripts/memory-cleanup.test.mjs
@@ -42,6 +42,7 @@ import {
   runCleanup,
   runListInactive,
   runRestore,
+  selectApprovalBatch,
   snippetLogDir,
   verdictSummary,
   ARG_SPECS,
@@ -4218,6 +4219,41 @@ describe("the offered approval record (#123)", () => {
     issuedAt: "2026-08-05T00:00:00.000Z",
   };
 
+  it("TC-SLACKAPP-246 selects deterministic whole decisions under the apply footprint cap", () => {
+    const keep = { id: "keep", verdict: "KEEP", reason: "durable" };
+    const retain = { id: "retain", verdict: "RETAIN", reason: "protected" };
+    const first = mergeOf("surv-a", ["frag-a1", "frag-a2"]);
+    const deferred = mergeOf("surv-b", ["frag-b1", "frag-b2"]);
+    const filler = del("delete-a");
+    const tail = del("delete-b");
+    const decisions = [keep, first, deferred, retain, filler, tail];
+
+    const batch = selectApprovalBatch(decisions, 4);
+
+    // Original order is retained. The second cost-3 MERGE does not fit after the
+    // first, but the later cost-1 DELETE fills the remaining capacity.
+    expect(batch.decisions).toEqual([keep, first, retain, filler]);
+    expect(batch).toMatchObject({
+      offeredDecisions: 2,
+      totalDecisions: 4,
+      deferredDecisions: 2,
+      offeredIds: 4,
+      totalIds: 8,
+      deferredIds: 4,
+    });
+    // Every non-destructive row survives so the message's withheld counts still
+    // describe the full scan, not just this approval batch.
+    expect(batch.decisions).toContain(keep);
+    expect(batch.decisions).toContain(retain);
+  });
+
+  it("TC-SLACKAPP-247 refuses one destructive decision larger than the apply cap", () => {
+    const oversized = mergeOf("survivor", ["a", "b", "c", "d"]);
+    expect(() => selectApprovalBatch([oversized, del("later")], 4)).toThrow(
+      /one MERGE decision touches 5 ids.*cannot be split/iu,
+    );
+  });
+
   it("TC-SLACKAPP-199 the offered ids cover a merge's survivor AND every absorbed id", () => {
     // The bound the apply enforces. A survivor-only id list is an approval for a
     // rewrite plus N deletions the list never named — the same defect that made
@@ -5496,8 +5532,11 @@ describe("the apply task's in-container runtime (#123)", () => {
     "MEM9_DB_NAME",
     "MEM9_DB_PORT",
     "MEM9_DB_SECRET",
+    "MEM9_DECISION_ARTIFACT_BUCKET",
     "MEM9_DECISION_ARTIFACT_BUCKET_OWNER",
     "MEM9_LLM_MODEL",
+    "MEM9_REVIEW_ARTIFACT_HASH",
+    "MEM9_REVIEW_ARTIFACT_KEY",
     "MEM9_SSM_PREFIX",
     "MEM9_TENANT_ID",
   ];
@@ -5811,6 +5850,108 @@ describe("the apply task's in-container runtime (#123)", () => {
     expect(legacy.deps.loadReviewedDecisions).toBeUndefined();
     await legacy.close();
   });
+
+  it("TC-SLACKAPP-249 validates review-only artifact replay before any AWS read", async () => {
+    const hash = `sha256:${"f".repeat(64)}`;
+    const key = decisionArtifactKey("prod", hash);
+    const runtime = {
+      s3: { send: vi.fn() },
+      getToken: vi.fn(),
+      fromNodeProviderChain: vi.fn(),
+    };
+
+    containerEnv({ MEM9_REVIEW_ARTIFACT_KEY: key });
+    await expect(
+      createCleanupDeps({ stage: "prod", apply: false, cap: 50 }, runtime),
+    ).rejects.toThrow(/must be set together/u);
+    expect(runtime.s3.send).not.toHaveBeenCalled();
+
+    delete process.env.MEM9_REVIEW_ARTIFACT_KEY;
+    containerEnv({
+      MEM9_REVIEW_ARTIFACT_KEY: key,
+      MEM9_REVIEW_ARTIFACT_HASH: "not-a-hash",
+    });
+    await expect(
+      createCleanupDeps({ stage: "prod", apply: false, cap: 50 }, runtime),
+    ).rejects.toThrow(/sha256 content hash/u);
+
+    containerEnv({
+      MEM9_REVIEW_ARTIFACT_KEY: key,
+      MEM9_REVIEW_ARTIFACT_HASH: hash,
+      MEM9_DECISION_ARTIFACT_BUCKET: "mem9-audit-123456789012",
+    });
+    await expect(
+      createCleanupDeps({ stage: "prod", apply: true, cap: 50 }, runtime),
+    ).rejects.toThrow(/review-only.*--apply/iu);
+
+    containerEnv({
+      MEM9_APPROVAL_HASH: hash,
+      MEM9_REVIEW_ARTIFACT_KEY: key,
+      MEM9_REVIEW_ARTIFACT_HASH: hash,
+    });
+    await expect(
+      createCleanupDeps({ stage: "prod", apply: false, cap: 50 }, runtime),
+    ).rejects.toThrow(/cannot be combined with MEM9_APPROVAL_HASH/u);
+
+    delete process.env.MEM9_APPROVAL_HASH;
+    delete process.env.MEM9_DECISION_ARTIFACT_BUCKET;
+    await expect(
+      createCleanupDeps({ stage: "prod", apply: false, cap: 50 }, runtime),
+    ).rejects.toThrow(/requires MEM9_DECISION_ARTIFACT_BUCKET/u);
+
+    containerEnv({
+      MEM9_REVIEW_ARTIFACT_KEY: decisionArtifactKey("pr-42", hash),
+      MEM9_REVIEW_ARTIFACT_HASH: hash,
+      MEM9_DECISION_ARTIFACT_BUCKET: "mem9-audit-123456789012",
+    });
+    await expect(
+      createCleanupDeps({ stage: "prod", apply: false, cap: 50 }, runtime),
+    ).rejects.toThrow(/does not match the requested stage and hash/u);
+    expect(runtime.s3.send).not.toHaveBeenCalled();
+  });
+
+  it("TC-SLACKAPP-250 loads a review artifact without constructing a classifier pass", async () => {
+    const decisions = [{
+      id: "reviewed-1",
+      verdict: "DELETE",
+      reason: "session-state",
+      version: 1,
+      contentHash: contentHash("reviewed content"),
+    }];
+    const body = serializeDecisionArtifact({
+      stage: "prod",
+      generatedAt: "2026-08-05T03:00:00.000Z",
+      decisions,
+    });
+    const hash = decisionArtifactHash(body);
+    const key = decisionArtifactKey("prod", hash);
+    const s3 = {
+      send: vi.fn(async () => ({
+        Body: { transformToString: async () => body },
+      })),
+    };
+    const getToken = vi.fn();
+    containerEnv({
+      MEM9_DECISION_ARTIFACT_BUCKET: "mem9-audit-123456789012",
+      MEM9_REVIEW_ARTIFACT_KEY: key,
+      MEM9_REVIEW_ARTIFACT_HASH: hash,
+    });
+
+    const production = await createCleanupDeps(
+      { stage: "prod", apply: false, cap: 50 },
+      {
+        s3,
+        getToken,
+        fromNodeProviderChain: vi.fn(),
+      },
+    );
+    const loaded = await production.deps.loadReviewedDecisions();
+
+    expect(loaded.decisions).toEqual(JSON.parse(body).decisions);
+    expect(s3.send).toHaveBeenCalledTimes(1);
+    expect(getToken).not.toHaveBeenCalled();
+    await production.close();
+  });
 });
 
 describe("replaying the reviewed list instead of re-classifying (#150)", () => {
@@ -5918,6 +6059,48 @@ describe("replaying the reviewed list instead of re-classifying (#150)", () => {
     // Filtered by the ids file, not by the artifact.
     expect(server.store.get("smuggled-1").state).toBe("active");
     expect(result.skippedByFilter).toBe(1);
+  });
+
+  it("TC-SLACKAPP-248 applies only one claimed batch from a larger artifact", async () => {
+    const memories = Array.from(
+      { length: 51 },
+      (_, index) => memory(`batched-${index}`, `content-${index}`),
+    );
+    const server = fakeServer(memories);
+    const dir = tempDir();
+    const idsFile = join(dir, "approved.txt");
+    writeFileSync(
+      idsFile,
+      `${memories.slice(0, 50).map(({ id }) => id).join("\n")}\n`,
+      { mode: 0o600 },
+    );
+    const llm = fakeLlm([[]]);
+
+    const result = await runCleanup(
+      baseOpts({ apply: true, cap: 50, idsFile }),
+      {
+        ...baseDeps(server, llm, dir),
+        loadReviewedDecisions: async () => ({
+          generatedAt: "2026-08-05T03:00:00.000Z",
+          decisions: memories.map(({ id, content, version }) => ({
+            id,
+            verdict: "DELETE",
+            reason: "session-state",
+            version,
+            contentHash: contentHash(content),
+          })),
+        }),
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.capUsed).toBe(50);
+    expect(result.skippedByFilter).toBe(1);
+    for (const { id } of memories.slice(0, 50)) {
+      expect(server.store.get(id).state).toBe("deleted");
+    }
+    expect(server.store.get("batched-50").state).toBe("active");
+    expect(llm).not.toHaveBeenCalled();
   });
 
   it("TC-SLACKAPP-194 a refused artifact aborts the run and applies nothing", async () => {
@@ -6411,6 +6594,7 @@ describe("offering the list to Slack (#123)", () => {
         // history (#154). TC-SLACKAPP-239 covers the operator-CLI side, where the
         // marker is absent and none of it happens.
         scheduled: overrides.scheduled ?? true,
+        approvalCap: overrides.approvalCap,
         log: overrides.log ?? vi.fn(),
       }),
     };
@@ -6673,13 +6857,9 @@ describe("offering the list to Slack (#123)", () => {
     expect(thrown.message).not.toContain(long);
   });
 
-  it("TC-SLACKAPP-224 the parameter-limit refusal names the scanned set, not a flag (#155)", async () => {
-    // `--cap` never reaches this throw. `buildOfferedRecord` is not given a cap —
-    // `cap` is read only inside `applyDecisions`, at apply time — and the guard
-    // fires before any apply exists to spend one, so the SAME error came back
-    // byte-for-byte at `--cap 50` and `--cap 10` (measured on #155). The old
-    // "lower --cap" clause was therefore false on the operator CLI, not merely
-    // inert on the scheduled scan, whose container override passes no flags at all.
+  it("TC-SLACKAPP-224 keeps the pure size fence while the real offer batches a large scan", async () => {
+    // The low-level builder still refuses oversized input. It has no artifact to
+    // retain the deferred decisions and must never silently truncate a caller.
     const many = Array.from({ length: 200 }, (_, i) => del(`memory-with-a-realistic-id-${i}`));
     let thrown;
     try {
@@ -6698,21 +6878,41 @@ describe("offering the list to Slack (#123)", () => {
     // "offered set", never "consensus set": the same builders serve the single-pass
     // operator dry run, where there is no quorum to blame for the size.
     expect(thrown.message).not.toMatch(/consensus set/u);
-    // No FLAG at all, not merely no `--cap`: the scheduled scan is the path that
-    // cannot act on one, so a later `--consensus-passes` or `--protected-topics`
-    // clause would reintroduce this defect under a new name.
     expect(thrown.message).not.toMatch(/--[a-z]/u);
 
-    // Reachable from the real offer, where it fails BEFORE the write — unlike the
-    // block-limit refusal, which fires with the record already in place. Nothing
-    // was written, so a scan that cannot offer leaves last week's button as it
-    // found it instead of invalidating it and then refusing to replace it.
+    // The real offer owns both stores, so it writes the complete artifact and
+    // derives one operable batch for SSM/Slack under the same cap apply enforces.
     const fakes = offerFakes();
-    await expect(offer({ fakes, decisions: many }).promise).rejects.toThrow(
-      /review it in batches from the kept decision list/u,
+    const result = await offer({
+      fakes,
+      decisions: many,
+      artifactBucket: ARTIFACT.artifactBucket,
+      approvalCap: 50,
+    }).promise;
+    expect(result.record.ids).toEqual(many.slice(0, 50).map((decision) => decision.id));
+    expect(result.batch).toMatchObject({
+      offeredDecisions: 50,
+      totalDecisions: 200,
+      deferredDecisions: 150,
+      offeredIds: 50,
+      totalIds: 200,
+      deferredIds: 150,
+    });
+    expect(fakes.ssm.puts.length).toBeGreaterThanOrEqual(2);
+    expect(Buffer.byteLength(fakes.ssm.puts[0].Value, "utf8")).toBeLessThanOrEqual(4096);
+    expect(fakes.s3.puts).toHaveLength(1);
+    const artifact = JSON.parse(fakes.s3.puts[0].Body);
+    expect(artifact.decisions).toHaveLength(200);
+
+    const rendered = JSON.stringify(fakes.slack.calls[0].body.blocks);
+    expect(rendered).toContain(many[49].id);
+    expect(rendered).not.toContain(many[50].id);
+    expect(rendered).toContain(
+      "50 of 200 destructive decision(s), touching 50 of 200 id(s)",
     );
-    expect(fakes.ssm.puts).toHaveLength(0);
-    expect(fakes.slack.fetchImpl).not.toHaveBeenCalled();
+    expect(rendered).toContain(
+      "150 decision(s), touching 150 id(s), are deferred",
+    );
   });
 
   it("TC-SLACKAPP-225 the block-limit refusal names the reviewed decisions, not a flag (#155)", async () => {

--- a/scripts/run-cleanup-scan-task.sh
+++ b/scripts/run-cleanup-scan-task.sh
@@ -8,6 +8,8 @@ set -euo pipefail
 STAGE="${STAGE:?STAGE is required (prod or pr-N)}"
 CONFIRM_PROD_SCAN="${CONFIRM_PROD_SCAN:-}"
 CLEANUP_SCAN_WAIT_SECONDS="${CLEANUP_SCAN_WAIT_SECONDS:-43200}"
+REVIEW_ARTIFACT_KEY="${MEM9_REVIEW_ARTIFACT_KEY:-}"
+REVIEW_ARTIFACT_HASH="${MEM9_REVIEW_ARTIFACT_HASH:-}"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 REGION="${AWS_REGION:-$(node "$REPO_ROOT/scripts/resolve-application-region.mjs")}"
 PREFIX="/mem9-on-aws/${STAGE}"
@@ -26,6 +28,16 @@ fi
 if ! [[ "$CLEANUP_SCAN_WAIT_SECONDS" =~ ^[1-9][0-9]*$ ]] ||
    (( CLEANUP_SCAN_WAIT_SECONDS < 60 || CLEANUP_SCAN_WAIT_SECONDS > 43200 )); then
   echo "::error::CLEANUP_SCAN_WAIT_SECONDS must be an integer from 60 to 43200" >&2
+  exit 1
+fi
+if [[ ( -n "$REVIEW_ARTIFACT_KEY" && -z "$REVIEW_ARTIFACT_HASH" ) ||
+      ( -z "$REVIEW_ARTIFACT_KEY" && -n "$REVIEW_ARTIFACT_HASH" ) ]]; then
+  echo "::error::MEM9_REVIEW_ARTIFACT_KEY and MEM9_REVIEW_ARTIFACT_HASH must be set together" >&2
+  exit 1
+fi
+if [[ -n "$REVIEW_ARTIFACT_HASH" &&
+      ! "$REVIEW_ARTIFACT_HASH" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+  echo "::error::MEM9_REVIEW_ARTIFACT_HASH must be a sha256 content hash" >&2
   exit 1
 fi
 
@@ -109,9 +121,25 @@ BASE_URL=$(jq -r --arg name "$CONTAINER_NAME" '
   ]
   | if length == 1 then .[0] else empty end
 ' <<<"$TASK_DEFINITION")
+CAP=$(jq -r --arg name "$CONTAINER_NAME" '
+  [
+    .taskDefinition.containerDefinitions[]
+    | select(.name == $name)
+    | .command as $command
+    | ($command | index("--cap")) as $index
+    | select($index != null and ($index + 1) < ($command | length))
+    | $command[$index + 1]
+    | select(type == "string")
+  ]
+  | if length == 1 then .[0] else empty end
+' <<<"$TASK_DEFINITION")
 EXPECTED_BASE_URL="http://mnemo.mem9-${STAGE}.local:8080"
 if [[ "$BASE_URL" != "$EXPECTED_BASE_URL" ]]; then
   echo "::error::deployed cleanup task base URL does not match stage ${STAGE}" >&2
+  exit 1
+fi
+if ! [[ "$CAP" =~ ^[1-9][0-9]*$ ]]; then
+  echo "::error::deployed cleanup task has no valid --cap" >&2
   exit 1
 fi
 
@@ -119,6 +147,9 @@ OVERRIDES=$(jq -cn \
   --arg name "$CONTAINER_NAME" \
   --arg stage "$STAGE" \
   --arg baseUrl "$BASE_URL" \
+  --arg cap "$CAP" \
+  --arg reviewArtifactKey "$REVIEW_ARTIFACT_KEY" \
+  --arg reviewArtifactHash "$REVIEW_ARTIFACT_HASH" \
   '{
     containerOverrides: [{
       name: $name,
@@ -130,14 +161,29 @@ OVERRIDES=$(jq -cn \
         $baseUrl,
         "--consensus-passes",
         "2",
+        "--cap",
+        $cap,
         "--out",
         "/tmp/mem9-cleanup-scan"
       ]
-    }]
+    } + (
+      if $reviewArtifactKey == "" then {}
+      else {
+        environment: [
+          {name: "MEM9_REVIEW_ARTIFACT_KEY", value: $reviewArtifactKey},
+          {name: "MEM9_REVIEW_ARTIFACT_HASH", value: $reviewArtifactHash}
+        ]
+      }
+      end
+    )]
   }')
 START_TIME_SECONDS=$(date +%s)
 
-echo "run-cleanup-scan: starting manual dry-run task"
+if [[ -n "$REVIEW_ARTIFACT_KEY" ]]; then
+  echo "run-cleanup-scan: starting manual artifact replay task"
+else
+  echo "run-cleanup-scan: starting manual dry-run task"
+fi
 RUN_OUT=$(aws ecs run-task \
   --cluster "$CLUSTER" \
   --task-definition "$TASK_DEF" \

--- a/scripts/run-cleanup-scan-task.test.mjs
+++ b/scripts/run-cleanup-scan-task.test.mjs
@@ -28,8 +28,11 @@ function runFixture({
   invalidParameters = [],
   runFailures = [],
   baseUrl = `http://mnemo.mem9-${stage}.local:8080`,
+  deployedCap = "50",
   offer,
   offerModified = 4_102_444_800,
+  reviewArtifactKey,
+  reviewArtifactHash,
   waitSeconds,
 } = {}) {
   const directory = mkdtempSync(join(tmpdir(), "mem9-cleanup-scan-runner-"));
@@ -90,7 +93,7 @@ if (command === "ssm get-parameters") {
           "--ids",
           "/tmp/approved-ids.txt",
           "--cap",
-          "50"
+          process.env.MOCK_DEPLOYED_CAP
         ],
       }],
     },
@@ -145,6 +148,7 @@ if (command === "ssm get-parameters") {
     AWS_CALLS: calls,
     CONFIRM_PROD_SCAN: confirmProd,
     MOCK_BASE_URL: baseUrl,
+    MOCK_DEPLOYED_CAP: deployedCap,
     MOCK_EXIT_CODE: String(exitCode),
     MOCK_INVALID_PARAMETERS: JSON.stringify(invalidParameters),
     MOCK_OFFER: JSON.stringify(offered),
@@ -154,6 +158,14 @@ if (command === "ssm get-parameters") {
     PATH: `${bin}${delimiter}${process.env.PATH}`,
     STAGE: stage,
   };
+  delete env.MEM9_REVIEW_ARTIFACT_KEY;
+  delete env.MEM9_REVIEW_ARTIFACT_HASH;
+  if (reviewArtifactKey !== undefined) {
+    env.MEM9_REVIEW_ARTIFACT_KEY = reviewArtifactKey;
+  }
+  if (reviewArtifactHash !== undefined) {
+    env.MEM9_REVIEW_ARTIFACT_HASH = reviewArtifactHash;
+  }
   if (waitSeconds !== undefined) {
     env.CLEANUP_SCAN_WAIT_SECONDS = String(waitSeconds);
   }
@@ -199,6 +211,20 @@ describe("manual cleanup scan ECS runner", () => {
       const valid = runFixture({ waitSeconds });
       expect(valid.result.status, valid.result.stderr).toBe(0);
     }
+
+    for (const replay of [
+      { reviewArtifactKey: "decisions/prod/private.json" },
+      { reviewArtifactHash: `sha256:${"a".repeat(64)}` },
+      {
+        reviewArtifactKey: "decisions/prod/private.json",
+        reviewArtifactHash: "not-a-hash",
+      },
+    ]) {
+      const invalid = runFixture(replay);
+      expect(invalid.result.status).toBe(1);
+      expect(invalid.callRecords).toEqual([]);
+      expect(invalid.result.stderr).toContain("MEM9_REVIEW_ARTIFACT");
+    }
   });
 
   it("TC-SLACKAPP-242: starts only the deployed dry-run command in private networking", () => {
@@ -242,6 +268,8 @@ describe("manual cleanup scan ECS runner", () => {
           "http://mnemo.mem9-prod.local:8080",
           "--consensus-passes",
           "2",
+          "--cap",
+          "50",
           "--out",
           "/tmp/mem9-cleanup-scan",
         ],
@@ -259,6 +287,39 @@ describe("manual cleanup scan ECS runner", () => {
       "DEADLINE=$((SECONDS + CLEANUP_SCAN_WAIT_SECONDS))",
     );
     expect(source).not.toContain("SECONDS + 5400");
+  });
+
+  it("TC-SLACKAPP-245: replays a paired private artifact under the deployed cap", () => {
+    const reviewArtifactKey =
+      `decisions/prod/sha256-${"b".repeat(64)}.json`;
+    const reviewArtifactHash = `sha256:${"b".repeat(64)}`;
+    const { callRecords, result } = runFixture({
+      reviewArtifactKey,
+      reviewArtifactHash,
+    });
+    expect(result.status, result.stderr).toBe(0);
+
+    const runCall = callRecords.find(
+      ([service, operation]) =>
+        service === "ecs" && operation === "run-task",
+    );
+    const overrides = JSON.parse(
+      runCall[runCall.indexOf("--overrides") + 1],
+    );
+    expect(overrides.containerOverrides[0].environment).toEqual([
+      { name: "MEM9_REVIEW_ARTIFACT_KEY", value: reviewArtifactKey },
+      { name: "MEM9_REVIEW_ARTIFACT_HASH", value: reviewArtifactHash },
+    ]);
+    const command = overrides.containerOverrides[0].command;
+    expect(
+      command.slice(command.indexOf("--cap"), command.indexOf("--cap") + 2),
+    ).toEqual(["--cap", "50"]);
+    expect(command).not.toContain("--apply");
+
+    const output = `${result.stdout}\n${result.stderr}`;
+    expect(output).toContain("artifact replay task");
+    expect(output).not.toContain(reviewArtifactKey);
+    expect(output).not.toContain(reviewArtifactHash);
   });
 
   it("TC-SLACKAPP-243: verifies a fresh artifact-backed offer without leaking it", () => {
@@ -301,6 +362,18 @@ describe("manual cleanup scan ECS runner", () => {
     });
     expect(crossStage.result.status).toBe(1);
     expect(crossStage.result.stderr).toContain("base URL");
+
+    for (const deployedCap of ["", "0", "1.5", "invalid"]) {
+      const badCap = runFixture({ deployedCap });
+      expect(badCap.result.status).toBe(1);
+      expect(badCap.result.stderr).toContain("no valid --cap");
+      expect(
+        badCap.callRecords.some(
+          ([service, operation]) =>
+            service === "ecs" && operation === "run-task",
+        ),
+      ).toBe(false);
+    }
 
     const launch = runFixture({
       runFailures: [{ arn: "redacted", reason: "RESOURCE:CPU" }],


### PR DESCRIPTION
## Summary
- keep the complete content-addressed cleanup artifact while selecting one deterministic, cap-bounded approval batch
- add review-only artifact replay so a completed scan can be re-offered without classification
- synchronize the cleanup cap across apply, scheduled scan, and the manual ECS runner
- show offered, total, and deferred counts without exposing deferred IDs or content

## Verification
- root typecheck and 1,186 tests
- cleanup coverage suite: 259 tests, all thresholds passed
- infra typecheck and 423 tests
- infra consolidation coverage suite: all thresholds passed
- ShellCheck, diff check, and public-artifact scan
- independent cc review: no blocking findings