### PR TITLE
fix(infra): disable consolidation task TTY

### DIFF
--- a/docs/test-cases/weekly-memory-consolidation.md
+++ b/docs/test-cases/weekly-memory-consolidation.md
@@ -19,7 +19,7 @@ Preview E2E runs the deployed task in report-only mode.
 | TC-CONSOL-010 | Auto actions would cost 21 mutations | At most 20 mutations execute; the overflow action is review-deferred before its first write |
 | TC-CONSOL-011 | Report-only run has MERGE/archive/stale decisions | No REST, SQL mutation, mutex, or SNS publish occurs |
 | TC-CONSOL-012 | Review records are emitted | Each has kind, ids, snippets, and rationale; the list summary is always emitted |
-| TC-CONSOL-013 | Run completes with mixed outcomes | EMF uses namespace `mem9-on-aws`, only the `stage` dimension, and the six documented metric names |
+| TC-CONSOL-013 | Run completes with mixed outcomes | EMF uses namespace `mem9-on-aws`, only the `stage` dimension, and the seven documented metric names |
 | TC-CONSOL-014 | Manual cleanup and consolidation attempt apply concurrently | The shared PostgreSQL advisory mutex admits one holder and the other exits without mutation |
 | TC-CONSOL-015 | SNS review summary is published | Payload contains counts/stage only and no ids, snippets, rationale, content, embeddings, or tenant key |
 | TC-CONSOL-016 | Production adapters are exercised with fake DB/REST/Mantle/SNS clients | TLS DB config, bearer refresh, mutex/archive SQL, REST LWW headers, redacted SNS payload, and shutdown are verified |
@@ -82,6 +82,7 @@ Preview E2E runs the deployed task in report-only mode.
 | TC-CONSOL-069 | Inspect consolidation task IAM and workload boundary | The task has only stage-scoped digest `s3:GetObject`/`s3:PutObject`, no list/delete, matching KMS context permissions, and the existing boundary admits the path |
 | TC-CONSOL-070 | Inspect the operator-owned bucket lifecycle | `decisions/` retains its three-day expiry, `consolidation-digests/` has a separate expiry of at least 70 days, and both prefixes abort incomplete multipart uploads after one day |
 | TC-CONSOL-076 | Inspect rollout documentation for an existing decision-artifact bucket | Before schedule enablement, the operator is told to re-run `scripts/deploy-decision-artifact-bucket.sh`, require its two-rule lifecycle read-back, and expect the first scheduled run to degrade once when a missing key is masked as 403 |
+| TC-CONSOL-079 | Inspect the synthesized consolidation task definition | The exact `Mem9Consolidation` container has `pseudoTerminal: false`, leaves `interactive` unset, and preserves its `awslogs` configuration while the task transform also preserves and adds tags |
 
 ## Preview E2E
 

--- a/infra/consolidation.test.ts
+++ b/infra/consolidation.test.ts
@@ -296,7 +296,7 @@ afterEach(() => {
 });
 
 describe("consolidation task and schedule", () => {
-  it("TC-CONSOL-020/023/028: always defines a report task but omits the ungated schedule", async () => {
+  it("TC-CONSOL-020/023/028/079: always defines a report task but omits the ungated schedule", async () => {
     installGlobals("prod");
     await loadAndRun();
 
@@ -358,13 +358,37 @@ describe("consolidation task and schedule", () => {
       resources.filter((resource) => resource.kind === "ScheduleGroup"),
     ).toEqual([]);
     expect(resources.filter((resource) => resource.kind === "Role")).toEqual([]);
-    const transformed = { tags: { Existing: "tag" } };
+    const originalDefinition = {
+      name: "Mem9Consolidation",
+      pseudoTerminal: true,
+      logConfiguration: {
+        logDriver: "awslogs",
+        options: {
+          "awslogs-group": "/sst/consolidation",
+          "awslogs-region": "ap-northeast-1",
+          "awslogs-stream-prefix": "/task",
+        },
+      },
+    };
+    const transformed = {
+      tags: { Existing: "tag" },
+      containerDefinitions: out(JSON.stringify([originalDefinition])),
+    };
     args.transform.taskDefinition(transformed);
     expect(transformed.tags).toMatchObject({
       Existing: "tag",
+      ManagedBy: "sst",
       Project: "mem9-on-aws",
       Stage: "prod",
     });
+    expect(
+      JSON.parse(String(materialize(transformed.containerDefinitions))),
+    ).toEqual([
+      {
+        ...originalDefinition,
+        pseudoTerminal: false,
+      },
+    ]);
 
     const parameterNames = resources
       .filter((resource) => resource.kind === "Parameter")

--- a/infra/consolidation.ts
+++ b/infra/consolidation.ts
@@ -9,6 +9,7 @@ import {
   consolidationDigestKey,
   decisionArtifactBucketName,
 } from "./decision-artifact";
+import { disableTaskContainerPseudoTerminal } from "./ecs-task-definition";
 
 const IMAGE_TAG = process.env.MEM9_IMAGE_TAG || "latest";
 const BEDROCK_PROJECT = process.env.MEM9_BEDROCK_PROJECT;
@@ -267,6 +268,10 @@ export function consolidation(
     logging: { retention: "1 month" },
     transform: {
       taskDefinition: (args) => {
+        disableTaskContainerPseudoTerminal(
+          args,
+          CONSOLIDATION_CONTAINER_NAME,
+        );
         args.tags = { ...(args.tags ?? {}), ...tags };
       },
     },

--- a/infra/ecs-task-definition.test.mjs
+++ b/infra/ecs-task-definition.test.mjs
@@ -7,7 +7,10 @@ import {
 } from "../.sst/platform/node_modules/@pulumi/pulumi/index.js";
 import { createTaskDefinition } from "../.sst/platform/src/components/aws/fargate.ts";
 import { bootstrap } from "../.sst/platform/src/components/aws/helpers/bootstrap.ts";
-import { disableMnemoServerPseudoTerminal } from "./ecs-task-definition";
+import {
+  disableMnemoServerPseudoTerminal,
+  disableTaskContainerPseudoTerminal,
+} from "./ecs-task-definition";
 
 const registered = [];
 
@@ -53,6 +56,21 @@ describe("real SST task-definition synthesis", () => {
     ).toThrow("task definition containerDefinitions output not found");
   });
 
+  it("fails when the synthesized container definitions are malformed JSON", () => {
+    const containerDefinitions = {
+      apply(callback) {
+        return callback("{");
+      },
+    };
+
+    expect(() =>
+      disableTaskContainerPseudoTerminal(
+        { containerDefinitions },
+        "Mem9Consolidation",
+      ),
+    ).toThrow(SyntaxError);
+  });
+
   it("fails when the synthesized task omits mnemo-server", () => {
     const containerDefinitions = {
       apply(callback) {
@@ -68,6 +86,21 @@ describe("real SST task-definition synthesis", () => {
     expect(() =>
       disableMnemoServerPseudoTerminal({ containerDefinitions }),
     ).toThrow("mnemo-server container not found in task definition");
+  });
+
+  it("fails when a requested named container is absent", () => {
+    const containerDefinitions = {
+      apply(callback) {
+        return callback(JSON.stringify([{ name: "another-container" }]));
+      },
+    };
+
+    expect(() =>
+      disableTaskContainerPseudoTerminal(
+        { containerDefinitions },
+        "Mem9Consolidation",
+      ),
+    ).toThrow("Mem9Consolidation container not found in task definition");
   });
 
   it("TC-EMF-004: disables only mnemo-server TTY and preserves awslogs", async () => {
@@ -151,5 +184,83 @@ describe("real SST task-definition synthesis", () => {
         },
       });
     }
+  });
+
+  it("TC-CONSOL-079: disables the named consolidation TTY in real SST synthesis", async () => {
+    registered.length = 0;
+    const parent = new ComponentResource(
+      "test:index:Parent",
+      "consolidation-parent",
+    );
+    const taskDefinition = createTaskDefinition(
+      "Mem9Consolidation",
+      {
+        cluster: {
+          nodes: {
+            cluster: {
+              name: output("mem9-cluster"),
+            },
+          },
+        },
+        transform: {
+          taskDefinition: (args) => {
+            disableTaskContainerPseudoTerminal(args, "Mem9Consolidation");
+            args.tags = {
+              ...(args.tags ?? {}),
+              ManagedBy: "sst",
+              Project: "mem9-on-aws",
+              Stage: "prod",
+            };
+          },
+        },
+      },
+      {},
+      parent,
+      output([
+        {
+          name: "Mem9Consolidation",
+          image: "example.com/consolidation:test",
+          logging: {
+            name: "/sst/cluster/test/task/Mem9Consolidation",
+            retention: "1 month",
+          },
+          environment: {},
+          ssm: {},
+        },
+      ]),
+      output("arm64"),
+      output("1 vCPU"),
+      output("2 GB"),
+      output("20 GB"),
+      { arn: output("arn:aws:iam::123456789012:role/task") },
+      { arn: output("arn:aws:iam::123456789012:role/execution") },
+    );
+    const task = await taskDefinition.promise();
+    await task.urn.promise();
+
+    const resource = registered.find(
+      (candidate) =>
+        candidate.type === "aws:ecs/taskDefinition:TaskDefinition",
+    );
+    const definitions = JSON.parse(
+      String(resource?.inputs.containerDefinitions),
+    );
+
+    expect(resource?.inputs.tags).toMatchObject({
+      ManagedBy: "sst",
+      Project: "mem9-on-aws",
+      Stage: "prod",
+    });
+    expect(definitions).toHaveLength(1);
+    expect(definitions[0].pseudoTerminal).toBe(false);
+    expect(definitions[0]).not.toHaveProperty("interactive");
+    expect(definitions[0].logConfiguration).toEqual({
+      logDriver: "awslogs",
+      options: {
+        "awslogs-group": "/sst/cluster/test/task/Mem9Consolidation",
+        "awslogs-region": "ap-northeast-1",
+        "awslogs-stream-prefix": "/service",
+      },
+    });
   });
 });

--- a/infra/ecs-task-definition.ts
+++ b/infra/ecs-task-definition.ts
@@ -4,11 +4,12 @@ interface StringOutput {
 
 /**
  * SST enables a pseudo-terminal for every Fargate container. Disable it only
- * for the non-interactive process whose stdout carries one EMF document per
- * line; all other synthesized container settings remain SST-owned.
+ * for a named non-interactive process; all other synthesized container
+ * settings remain SST-owned.
  */
-export function disableMnemoServerPseudoTerminal(
+export function disableTaskContainerPseudoTerminal(
   args: Record<string, unknown>,
+  containerName: string,
 ): void {
   const definitions = args.containerDefinitions as StringOutput | undefined;
   if (!definitions || typeof definitions.apply !== "function") {
@@ -20,11 +21,21 @@ export function disableMnemoServerPseudoTerminal(
       name: string;
       pseudoTerminal?: boolean;
     }[];
-    const mnemo = parsed.find((container) => container.name === "mnemo-server");
-    if (!mnemo) {
-      throw new Error("mnemo-server container not found in task definition");
+    const target = parsed.find(
+      (container) => container.name === containerName,
+    );
+    if (!target) {
+      throw new Error(
+        `${containerName} container not found in task definition`,
+      );
     }
-    mnemo.pseudoTerminal = false;
+    target.pseudoTerminal = false;
     return JSON.stringify(parsed);
   });
+}
+
+export function disableMnemoServerPseudoTerminal(
+  args: Record<string, unknown>,
+): void {
+  disableTaskContainerPseudoTerminal(args, "mnemo-server");
 }


### PR DESCRIPTION
## Summary

- generalize the existing task-definition transform to disable the pseudo-terminal on an exact named container
- apply it to `Mem9Consolidation` while preserving generated logging options and task tags
- add malformed/missing-container guards, real SST synthesis coverage, production transform coverage, and the seven-metric test-case update

## Verification

- `npm test` (1207 tests)
- `pnpm -C infra test` (428 tests)
- `npm run typecheck`
- `pnpm -C infra run typecheck`
- root and infra consolidation coverage gates
- cleanup coverage gate
- public artifact scan over `origin/main...HEAD`
- independent review: no Critical, High, or Medium findings

Closes #185