### PR TITLE
fix(iam): authorize Cognito group lifecycle

### DIFF
--- a/infra/cloudformation/github-actions-role.yaml
+++ b/infra/cloudformation/github-actions-role.yaml
@@ -1190,8 +1190,13 @@ Resources:
               - cognito-idp:DescribeUserPoolClient
               - cognito-idp:UpdateUserPoolClient
               - cognito-idp:DeleteUserPoolClient
+              - cognito-idp:CreateGroup
+              - cognito-idp:GetGroup
+              - cognito-idp:UpdateGroup
+              - cognito-idp:DeleteGroup
               - cognito-idp:ListUserPools
               - cognito-idp:ListUserPoolClients
+              - cognito-idp:ListGroups
               - cognito-idp:ListResourceServers
               - cognito-idp:TagResource
               - cognito-idp:UntagResource

--- a/scripts/deployment-workflow.test.mjs
+++ b/scripts/deployment-workflow.test.mjs
@@ -251,6 +251,22 @@ describe("workflow integration", () => {
     }
   });
 
+  it("grants the deploy role only the Cognito group lifecycle used by IaC", () => {
+    const role = readFileSync(rolePath, "utf8");
+    const actions = actionSetForSid(role, "Cognito");
+
+    expect(actions).toEqual(
+      expect.arrayContaining([
+        "cognito-idp:CreateGroup",
+        "cognito-idp:GetGroup",
+        "cognito-idp:UpdateGroup",
+        "cognito-idp:DeleteGroup",
+        "cognito-idp:ListGroups",
+      ]),
+    );
+    expect(actions.some((action) => action.includes("Admin"))).toBe(false);
+  });
+
   it("TC-SLACKAPP-218: gates and lints the decision-artifact bucket template", () => {
     const workflow = parse(readFileSync(workflowPath, "utf8"));
     const templates = [


### PR DESCRIPTION
## Summary

- authorize the GitHub deploy role to create, inspect, update, list, and delete Cognito user-pool groups
- keep Cognito user administration actions out of the deployment role
- add a regression test for the exact IaC group lifecycle surface

This is the deployment-plane prerequisite for declaring the two disposable PR-stage namespace groups in infrastructure.

## Verification

- `vitest run --passWithNoTests scripts/deployment-workflow.test.mjs` (28 passed)
- CloudFormation owner-stack preview required before live update
