### PR TITLE
fix(infra): default empty namespace gate to compatibility

### DIFF
--- a/infra/ecs.test.ts
+++ b/infra/ecs.test.ts
@@ -651,6 +651,18 @@ describe("ecs stack", () => {
     );
   });
 
+  it("treats an unset GitHub repository variable as compatibility mode", async () => {
+    process.env.MEM9_NAMESPACE_REQUIRED = "";
+    installGlobals("prod");
+    const ecs = await loadEcs();
+    ecs(fakeDbOut());
+
+    expect(
+      (containersByName()["mnemo-server"].environment as Record<string, unknown>)
+        .MNEMO_NAMESPACE_REQUIRED,
+    ).toBe("0");
+  });
+
   it("wires the mnemo-server terminal override into SST task synthesis", async () => {
     installGlobals("prod");
     const ecs = await loadEcs();

--- a/infra/ecs.ts
+++ b/infra/ecs.ts
@@ -72,7 +72,7 @@ const region = applicationRegion();
 const IMAGE_TAG = process.env.MEM9_IMAGE_TAG || "latest";
 const DURABLE_INGEST_ENABLED =
   process.env.MEM9_DURABLE_INGEST_ENABLED === "1" ? "1" : "0";
-const NAMESPACE_REQUIRED = process.env.MEM9_NAMESPACE_REQUIRED ?? "0";
+const NAMESPACE_REQUIRED = process.env.MEM9_NAMESPACE_REQUIRED || "0";
 if (!["0", "1"].includes(NAMESPACE_REQUIRED)) {
   throw new Error("MEM9_NAMESPACE_REQUIRED must be 0 or 1");
 }


### PR DESCRIPTION
## Summary

- treat an empty `MEM9_NAMESPACE_REQUIRED` value from an unset GitHub repository variable as compatibility mode (`0`)
- keep explicit `1` cutover behavior and reject other non-empty values
- add a regression test for the production workflow environment shape

## Testing

- `pnpm -C infra exec vitest run ecs.test.ts -t "namespace-required mode|unset GitHub repository variable"`
- `pnpm -C infra test`
- `pnpm -C infra typecheck`
- `npm test`
- `npm run typecheck`
- `node scripts/scan-public-artifacts.mjs`

Closes #211